### PR TITLE
Change ByteBufferEnumerator<T>.Create(...).ToArray() to IO.ByteConver…

### DIFF
--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -335,7 +335,7 @@ namespace Dicom {
 			get {
 				if (_values == null) {
 					var values = new List<DicomTag>();
-					var parts = ByteBufferEnumerator<ushort>.Create(Buffer).ToArray();
+                    var parts = IO.ByteConverter.ToArray<ushort>(Buffer);
 					for (int i = 0; i < parts.Length; i += 2) {
 						var group = parts[i + 0];
 						var element = parts[i + 1];
@@ -683,40 +683,40 @@ namespace Dicom {
 				item = 0;
 
 			if (typeof(T) == typeof(short))
-				return (T)(object)ByteBufferEnumerator<short>.Create(Buffer).ToArray().GetValue(item);
+				return (T)(object)IO.ByteConverter.ToArray<short>(Buffer).GetValue(item);
 
-			if (typeof(T) == typeof(short[]))
-				return (T)(object)ByteBufferEnumerator<short>.Create(Buffer).ToArray();
+		    if (typeof (T) == typeof (short[]))
+		        return (T) (object) IO.ByteConverter.ToArray<short>(Buffer);
 
 			if (typeof(T) == typeof(ushort))
-				return (T)(object)ByteBufferEnumerator<ushort>.Create(Buffer).ToArray().GetValue(item);
+				return (T)(object)IO.ByteConverter.ToArray<ushort>(Buffer).GetValue(item);
 
 			if (typeof(T) == typeof(ushort[]))
-				return (T)(object)ByteBufferEnumerator<ushort>.Create(Buffer).ToArray();
+				return (T)(object)IO.ByteConverter.ToArray<ushort>(Buffer);
 
 			if (typeof(T) == typeof(int))
-				return (T)(object)ByteBufferEnumerator<int>.Create(Buffer).ToArray().GetValue(item);
+				return (T)(object)IO.ByteConverter.ToArray<int>(Buffer).GetValue(item);
 
 			if (typeof(T) == typeof(int[]))
-				return (T)(object)ByteBufferEnumerator<int>.Create(Buffer).ToArray();
+				return (T)(object)IO.ByteConverter.ToArray<int>(Buffer);
 
 			if (typeof(T) == typeof(uint))
-				return (T)(object)ByteBufferEnumerator<uint>.Create(Buffer).ToArray().GetValue(item);
+				return (T)(object)IO.ByteConverter.ToArray<uint>(Buffer).GetValue(item);
 
 			if (typeof(T) == typeof(uint[]))
-				return (T)(object)ByteBufferEnumerator<uint>.Create(Buffer).ToArray();
+				return (T)(object)IO.ByteConverter.ToArray<uint>(Buffer);
 
 			if (typeof(T) == typeof(float))
-				return (T)(object)ByteBufferEnumerator<float>.Create(Buffer).ToArray().GetValue(item);
+				return (T)(object)IO.ByteConverter.ToArray<float>(Buffer).GetValue(item);
 
 			if (typeof(T) == typeof(float[]))
-				return (T)(object)ByteBufferEnumerator<float>.Create(Buffer).ToArray();
+				return (T)(object)IO.ByteConverter.ToArray<float>(Buffer);
 
 			if (typeof(T) == typeof(double))
-				return (T)(object)ByteBufferEnumerator<double>.Create(Buffer).ToArray().GetValue(item);
+				return (T)(object)IO.ByteConverter.ToArray<double>(Buffer).GetValue(item);
 
 			if (typeof(T) == typeof(double[]))
-				return (T)(object)ByteBufferEnumerator<double>.Create(Buffer).ToArray();
+				return (T)(object)IO.ByteConverter.ToArray<double>(Buffer);
 
 			return base.Get<T>(item);
 		}

--- a/DICOM/DicomFragmentSequence.cs
+++ b/DICOM/DicomFragmentSequence.cs
@@ -28,8 +28,9 @@ namespace Dicom {
 		}
 
 		internal void Add(IByteBuffer fragment) {
-			if (_offsetTable == null) {
-				var en = ByteBufferEnumerator<uint>.Create(fragment);
+			if (_offsetTable == null)
+			{
+			    var en = IO.ByteConverter.ToArray<uint>(fragment);
 				_offsetTable = new List<uint>(en);
 				return;
 			}

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -292,8 +292,9 @@ namespace Dicom.Imaging {
 				bits.Capacity = Rows * Columns;
 				int mask = 1 << BitPosition;
 
-				if (pixels.BitsAllocated == 8) {
-					var data = ByteBufferEnumerator<byte>.Create(frame).ToArray();
+				if (pixels.BitsAllocated == 8)
+				{
+				    var data = IO.ByteConverter.ToArray<byte>(frame);
 
 					for (int y = oy; y < oh; y++) {
 						int n = (y * pixels.Width) + ox;
@@ -307,7 +308,7 @@ namespace Dicom.Imaging {
 					}
 				} else if (pixels.BitsAllocated == 16) {
 					// we don't really care if the pixel data is signed or not
-					var data = ByteBufferEnumerator<ushort>.Create(frame).ToArray();
+				    var data = IO.ByteConverter.ToArray<ushort>(frame);
 
 					for (int y = oy; y < oh; y++) {
 						int n = (y * pixels.Width) + ox;

--- a/DICOM/Imaging/Render/PixelData.cs
+++ b/DICOM/Imaging/Render/PixelData.cs
@@ -302,7 +302,7 @@ namespace Dicom.Imaging.Render {
 			_bits = bitDepth;
 			_width = width;
 			_height = height;
-			_data = ByteBufferEnumerator<short>.Create(data).ToArray();
+            _data = IO.ByteConverter.ToArray<short>(data);
 
 			if (bitDepth.BitsStored != 16) {
 				int sign = 1 << bitDepth.HighBit;
@@ -419,7 +419,8 @@ namespace Dicom.Imaging.Render {
 			_bits = bitDepth;
 			_width = width;
 			_height = height;
-			_data = ByteBufferEnumerator<ushort>.Create(data).ToArray();
+		    _data = IO.ByteConverter.ToArray<ushort>(data);
+
 
 			if (bitDepth.BitsStored != 16) {
 				int mask = (1 << (bitDepth.HighBit + 1)) - 1;
@@ -529,7 +530,7 @@ namespace Dicom.Imaging.Render {
         public GrayscalePixelDataS32(int width, int height, BitDepth bitDepth, IByteBuffer data) {
             _width = width;
             _height = height;
-            _data = ByteBufferEnumerator<int>.Create(data).ToArray();
+            _data = IO.ByteConverter.ToArray<int>(data);
 
             int sign = 1 << bitDepth.HighBit;
 			uint mask = (UInt32.MaxValue >> (bitDepth.BitsAllocated - bitDepth.BitsStored));
@@ -647,7 +648,7 @@ namespace Dicom.Imaging.Render {
         {
             _width = width;
             _height = height;
-            _data = ByteBufferEnumerator<uint>.Create(data).ToArray();
+            _data = IO.ByteConverter.ToArray<uint>(data);
 
             if (bitDepth.BitsStored != 32)
             {


### PR DESCRIPTION
…ter.ToArray<T>(...) throughout the codebase

I think we could still improve on the code in DicomElement.cs since, in several of the cases, .ToArray() is being called to then just throw away the array to fetch a single item.  This change is certainly no worse than the old code (and is indeed better perf-wise) but I suspect we could sometimes keep the ByteBufferEnumerator and use Linq to apply .Skip(item-1).First() on the IEnumerable<T>.

I figured I'd jump in and make this change after seeing a bit of a discussion in gitter.