### PR TITLE
Use ASCII encoding for RawPDU writing

### DIFF
--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -68,6 +68,7 @@
     <Compile Include="DicomTagTest.cs" />
     <Compile Include="Helpers\SerializationExtensions.cs" />
     <Compile Include="Imaging\Mathematics\Point2Tests.cs" />
+    <Compile Include="Network\PDUTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DICOM [Unit Tests]/Network/PDUTest.cs
+++ b/DICOM [Unit Tests]/Network/PDUTest.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) 2010-2015 Anders Gustafsson, Cureos AB.
+// All rights reserved. Any unauthorised reproduction of this 
+// material will constitute an infringement of copyright.
+
+namespace Dicom.Network
+{
+    using System.IO;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class PDUTest
+    {
+        [TestMethod]
+        public void Write_AeWithNonAsciiCharacters_ShouldBeAsciified()
+        {
+            var notExpected = "GÖTEBORG";
+            var request = new AAssociateRQ(new DicomAssociation("MALMÖ", notExpected));
+
+            var writePdu = request.Write();
+
+            RawPDU readPdu;
+            using (var stream = new MemoryStream())
+            {
+                writePdu.WritePDU(stream);
+
+                var length = (int)writePdu.Length;
+                var buffer = new byte[length];
+                stream.Seek(0, SeekOrigin.Begin);
+                stream.Read(buffer, 0, length);
+                readPdu = new RawPDU(buffer);
+            }
+
+            readPdu.Reset();
+            readPdu.SkipBytes("Unknown", 10);
+            var actual = readPdu.ReadString("Called AE", 16);
+
+            Assert.AreNotEqual(notExpected, actual);
+        }
+    }
+}

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -16,7 +16,6 @@ namespace Dicom.Network {
 		private BinaryWriter _bw;
 		private Stack<long> _m16;
 		private Stack<long> _m32;
-		private Encoding _encoding;
 		#endregion
 
 		#region Public Constructors
@@ -28,10 +27,9 @@ namespace Dicom.Network {
 			_type = type;
 			_ms = new MemoryStream();
 			_ms.Seek(0, SeekOrigin.Begin);
-			_bw = EndianBinaryWriter.Create(_ms, _encoding, Endian.Big);
+			_bw = EndianBinaryWriter.Create(_ms, Encoding.ASCII, Endian.Big);
 			_m16 = new Stack<long>();
 			_m32 = new Stack<long>();
-			_encoding = Encoding.UTF8;
 		}
 
 		/// <summary>
@@ -40,7 +38,7 @@ namespace Dicom.Network {
 		/// <param name="buffer">Buffer</param>
 		public RawPDU(byte[] buffer) {
 			_ms = new MemoryStream(buffer);
-			_br = EndianBinaryReader.Create(_ms, _encoding, Endian.Big);
+			_br = EndianBinaryReader.Create(_ms, Endian.Big);
 			_type = _br.ReadByte();
 			_ms.Seek(6, SeekOrigin.Begin);
 		}


### PR DESCRIPTION
To ensure (to a larger extent) that `RawPDU` only writes content encoded in the DICOM supported character set for PDUs (ISO 646:1990-Basic G0 Set, i.e. ASCII codes 32-127), encoding for the writer is set to ASCII.

In the earlier versions of *fo-dicom* (even when the `_encoding` field was set to `Encoding.ASCII`), `_encoding` was not defined when the binary writer was created, so the default *UTF-8* encoding was then selected.

To allow for maximum flexibility in `RawPDU` reading, the binary reader encoding is maintained at *UTF-8*.