### PR TITLE
Use default value -1 in all Get<T> overrides. Connects to #10

### DIFF
--- a/DICOM [Unit Tests]/DicomElementTest.cs
+++ b/DICOM [Unit Tests]/DicomElementTest.cs
@@ -18,5 +18,14 @@
             DicomElement element = new DicomSignedShort(DicomTag.SynchronizationChannel, 5, 8);
             Assert.AreEqual((short)5, element.Get<short>());
         }
+
+        [TestMethod]
+        public void AttributeTagAsDicomElement_Array_GetDefaultValue()
+        {
+            var expected = DicomTag.ALinePixelSpacing;
+            DicomElement element = new DicomAttributeTag(DicomTag.DimensionIndexPointer, DicomTag.ALinePixelSpacing);
+            var actual = element.Get<DicomTag>();
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/DICOM [Unit Tests]/DicomElementTest.cs
+++ b/DICOM [Unit Tests]/DicomElementTest.cs
@@ -1,5 +1,7 @@
 ﻿namespace Dicom
 {
+    using System;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -26,6 +28,20 @@
             DicomElement element = new DicomAttributeTag(DicomTag.DimensionIndexPointer, DicomTag.ALinePixelSpacing);
             var actual = element.Get<DicomTag>();
             Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void DicomUnsignedShort_Array_ExplicitMinus1InterpretAs0()
+        {
+            var element = new DicomUnsignedShort(DicomTag.ReferencedFrameNumbers, 1, 2, 3, 4, 5);
+            Assert.AreEqual(element.Get<ushort>(-1), element.Get<ushort>(0));
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void DicomUnsignedShort_Array_ExplicitMinus2Throws()
+        {
+            var element = new DicomUnsignedShort(DicomTag.ReferencedFrameNumbers, 1, 2, 3, 4, 5);
+            Console.WriteLine(element.Get<ushort>(-2));
         }
     }
 }

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -232,7 +232,9 @@ namespace Dicom {
 		}
 
 		#region Public Members
-		public override T Get<T>(int item = 0) {
+		public override T Get<T>(int item = -1) {
+            if (item == -1) item = 0;
+
 			if (typeof(T) == typeof(Tv)) {
 				if (item < 0 || item >= Count)
 					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
@@ -361,7 +363,8 @@ namespace Dicom {
 		#endregion
 
 		#region Public Members
-		public override T Get<T>(int item = 0) {
+		public override T Get<T>(int item = -1) {
+            if (item == -1) item = 0;
 			var tags = Values.ToArray();
 
 			if (typeof(T) == typeof(DicomTag))
@@ -915,7 +918,7 @@ namespace Dicom {
 		#endregion
 
 		#region Public Members
-		public override T Get<T>(int item = 0) {
+		public override T Get<T>(int item = -1) {
 			if (typeof(T) == typeof(int) || typeof(T) == typeof(int[]))
 				return (T)(object)base.Get<T>(item);
 
@@ -1115,7 +1118,7 @@ namespace Dicom {
 		#endregion
 
 		#region Public Members
-		public override T Get<T>(int item = 0) {
+		public override T Get<T>(int item = -1) {
 			if (typeof(T) == typeof(int) || typeof(T) == typeof(int[]))
 				return (T)(object)base.Get<T>(item);
 


### PR DESCRIPTION
I have now implemented a solution for the inconsistent default values in the `DicomElement.Get<T>` overides issue (#10).

Issue is solved by setting `item` default value to -1 in *all* overrides, and in those overrides that contain the actual implementation, interpret `item` -1 as 0.

One side effect of this change is that if for example `DicomUnsignedShort.Get<ushort>(-1)` is called with `item` explicitly set to -1, the new implementation will accept this `item` value and interpret it as `item` 0, whereas in the previous implementation the same call would throw. I would consider this a rare corner case, and the new behavior might even be desired. However, do not hesitate to object if you oppose of this change.