### PR TITLE
Switch to xUnit unit test framework. Connects to #16

### DIFF
--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -18,7 +19,7 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>5e0542ec</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>9a935214</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -102,6 +103,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -41,22 +41,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="PresentationCore" />
     <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ServiceModel" />
     <Reference Include="System.XML" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -15,6 +16,9 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>5e0542ec</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -52,6 +56,15 @@
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert">
+      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
@@ -78,7 +91,18 @@
       <Name>DICOM</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DICOM [Unit Tests]/DicomElementTest.cs
+++ b/DICOM [Unit Tests]/DicomElementTest.cs
@@ -1,47 +1,49 @@
-﻿namespace Dicom
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
 {
     using System;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Xunit;
 
-    [TestClass]
     public class DicomElementTest
     {
-        [TestMethod]
+        [Fact]
         public void DicomSignedShort_Array_GetDefaultValue()
         {
             DicomSignedShort element = new DicomSignedShort(DicomTag.SynchronizationChannel, 5, 8);
-            Assert.AreEqual((short)5, element.Get<short>());
+            Assert.Equal((short)5, element.Get<short>());
         }
 
-        [TestMethod]
+        [Fact]
         public void DicomSignedShortAsDicomElement_Array_GetDefaultValue()
         {
             DicomElement element = new DicomSignedShort(DicomTag.SynchronizationChannel, 5, 8);
-            Assert.AreEqual((short)5, element.Get<short>());
+            Assert.Equal((short)5, element.Get<short>());
         }
 
-        [TestMethod]
+        [Fact]
         public void AttributeTagAsDicomElement_Array_GetDefaultValue()
         {
             var expected = DicomTag.ALinePixelSpacing;
             DicomElement element = new DicomAttributeTag(DicomTag.DimensionIndexPointer, DicomTag.ALinePixelSpacing);
             var actual = element.Get<DicomTag>();
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [TestMethod]
+        [Fact]
         public void DicomUnsignedShort_Array_ExplicitMinus1InterpretAs0()
         {
             var element = new DicomUnsignedShort(DicomTag.ReferencedFrameNumbers, 1, 2, 3, 4, 5);
-            Assert.AreEqual(element.Get<ushort>(-1), element.Get<ushort>(0));
+            Assert.Equal(element.Get<ushort>(-1), element.Get<ushort>(0));
         }
 
-        [TestMethod, ExpectedException(typeof(ArgumentOutOfRangeException))]
+        [Fact]
         public void DicomUnsignedShort_Array_ExplicitMinus2Throws()
         {
             var element = new DicomUnsignedShort(DicomTag.ReferencedFrameNumbers, 1, 2, 3, 4, 5);
-            Console.WriteLine(element.Get<ushort>(-2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => element.Get<ushort>(-2));
         }
     }
 }

--- a/DICOM [Unit Tests]/DicomEncodingTest.cs
+++ b/DICOM [Unit Tests]/DicomEncodingTest.cs
@@ -1,26 +1,28 @@
-﻿namespace Dicom
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
 {
     using System.Text;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Xunit;
 
-    [TestClass]
     public class DicomEncodingTest
     {
-        [TestMethod]
+        [Fact]
         public void Default_Getter_ReturnsUSASCII()
         {
             var expected = Encoding.ASCII.CodePage;
             var actual = DicomEncoding.Default.CodePage;
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetEncoding_NonMatchingCharset_ReturnsUSASCII()
         {
             var expected = Encoding.ASCII.CodePage;
             var actual = DicomEncoding.GetEncoding("GBK").CodePage;
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/DICOM [Unit Tests]/DicomPersonNameTest.cs
+++ b/DICOM [Unit Tests]/DicomPersonNameTest.cs
@@ -1,12 +1,9 @@
-﻿using Dicom;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Text;
-
-namespace DICOM__Unit_Tests_
+﻿namespace Dicom
 {
-    
-    
+    using System.Text;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     /// <summary>
     ///This is a test class for DicomPersonNameTest and is intended
     ///to contain all DicomPersonNameTest Unit Tests
@@ -26,11 +23,11 @@ namespace DICOM__Unit_Tests_
         {
             get
             {
-                return testContextInstance;
+                return this.testContextInstance;
             }
             set
             {
-                testContextInstance = value;
+                this.testContextInstance = value;
             }
         }
 

--- a/DICOM [Unit Tests]/DicomPersonNameTest.cs
+++ b/DICOM [Unit Tests]/DicomPersonNameTest.cs
@@ -1,170 +1,121 @@
-﻿namespace Dicom
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
 {
     using System.Text;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Xunit;
 
     /// <summary>
     ///This is a test class for DicomPersonNameTest and is intended
     ///to contain all DicomPersonNameTest Unit Tests
     ///</summary>
-    [TestClass()]
     public class DicomPersonNameTest
     {
-
-
-        private TestContext testContextInstance;
-
-        /// <summary>
-        ///Gets or sets the test context which provides
-        ///information about and functionality for the current test run.
-        ///</summary>
-        public TestContext TestContext
-        {
-            get
-            {
-                return this.testContextInstance;
-            }
-            set
-            {
-                this.testContextInstance = value;
-            }
-        }
-
-        #region Additional test attributes
-        // 
-        //You can use the following additional attributes as you write your tests:
-        //
-        //Use ClassInitialize to run code before running the first test in the class
-        //[ClassInitialize()]
-        //public static void MyClassInitialize(TestContext testContext)
-        //{
-        //}
-        //
-        //Use ClassCleanup to run code after all tests in a class have run
-        //[ClassCleanup()]
-        //public static void MyClassCleanup()
-        //{
-        //}
-        //
-        //Use TestInitialize to run code before running each test
-        //[TestInitialize()]
-        //public void MyTestInitialize()
-        //{
-        //}
-        //
-        //Use TestCleanup to run code after each test has run
-        //[TestCleanup()]
-        //public void MyTestCleanup()
-        //{
-        //}
-        //
-        #endregion
-
-
         /// <summary>
         ///A test for DicomPersonName Constructor
         ///</summary>
-        [TestMethod()]
+        [Fact]
         public void DicomPersonNameConstructorTest()
         {
             DicomPersonName target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "Middle", "Prefix", "Suffix");
-            Assert.AreEqual("Last^First^Middle^Prefix^Suffix", target.Get<string>());
+            Assert.Equal("Last^First^Middle^Prefix^Suffix", target.Get<string>());
             target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "Middle", "", "");
-            Assert.AreEqual("Last^First^Middle", target.Get<string>());
+            Assert.Equal("Last^First^Middle", target.Get<string>());
             target = new DicomPersonName(DicomTag.PatientName, "Last", "First", null, "");
-            Assert.AreEqual("Last^First", target.Get<string>());
+            Assert.Equal("Last^First", target.Get<string>());
             target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "", null, "Suffix");
-            Assert.AreEqual("Last^First^^^Suffix", target.Get<string>());
+            Assert.Equal("Last^First^^^Suffix", target.Get<string>());
             target = new DicomPersonName(DicomTag.PatientName, "", "", "", null, null);
-            Assert.AreEqual("", target.Get<string>());
+            Assert.Equal("", target.Get<string>());
         }
 
         /// <summary>
         ///A test for DicomPersonName Constructor
         ///</summary>
-        [TestMethod()]
+        [Fact]
         public void DicomPersonNameConstructorTest1()
         {
             DicomPersonName target = new DicomPersonName(DicomTag.PatientName, DicomEncoding.GetEncoding("ISO IR 144"), "Тарковский", "Андрей", "Арсеньевич");
             byte[] b = target.Buffer.GetByteRange(0, (int)target.Buffer.Size);
             byte[] c = Encoding.GetEncoding("iso-8859-5").GetBytes("Тарковский^Андрей^Арсеньевич");
-            CollectionAssert.AreEqual(c, b);
+            Assert.Equal(c, b);
             // foloowing test checks also padding with space!
             target = new DicomPersonName(DicomTag.PatientName, DicomEncoding.GetEncoding("ISO IR 144"), "Тарковский", "Андрей");
             b = target.Buffer.GetByteRange(0, (int)target.Buffer.Size);
             c = Encoding.GetEncoding("iso-8859-5").GetBytes("Тарковский^Андрей ");
-            CollectionAssert.AreEqual(c, b);
+            Assert.Equal(c, b);
         }
 
         /// <summary>
         ///A test for Last
         ///</summary>
-        [TestMethod()]
+        [Fact]
         public void LastTest()
         {
             DicomPersonName target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "Middle", "Prefix", "Suffix");
-            Assert.AreEqual("Last", target.Last);
+            Assert.Equal("Last", target.Last);
             target = new DicomPersonName(DicomTag.PatientName, "");
-            Assert.AreEqual("", target.Last);
+            Assert.Equal("", target.Last);
             target = new DicomPersonName(DicomTag.PatientName, "=Doe^John");
-            Assert.AreEqual("", target.Last);
+            Assert.Equal("", target.Last);
         }
 
         /// <summary>
         ///A test for First
         ///</summary>
-        [TestMethod()]
+        [Fact]
         public void FirstTest()
         {
             DicomPersonName target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "Middle", "Prefix", "Suffix");
-            Assert.AreEqual("First", target.First);
+            Assert.Equal("First", target.First);
             target = new DicomPersonName(DicomTag.PatientName, "Last");
-            Assert.AreEqual("", target.First);
+            Assert.Equal("", target.First);
             target = new DicomPersonName(DicomTag.PatientName, "Last=Doe^John");
-            Assert.AreEqual("", target.First);
+            Assert.Equal("", target.First);
         }
 
         /// <summary>
         ///A test for Middle
         ///</summary>
-        [TestMethod()]
+        [Fact]
         public void MiddleTest()
         {
             DicomPersonName target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "Middle", "Prefix", "Suffix");
-            Assert.AreEqual("Middle", target.Middle);
+            Assert.Equal("Middle", target.Middle);
             target = new DicomPersonName(DicomTag.PatientName, "Last^First");
-            Assert.AreEqual("", target.Middle);
+            Assert.Equal("", target.Middle);
             target = new DicomPersonName(DicomTag.PatientName, "Last^First=Doe^John^Peter");
-            Assert.AreEqual("", target.Middle);
+            Assert.Equal("", target.Middle);
         }
 
         /// <summary>
         ///A test for Prefix
         ///</summary>
-        [TestMethod()]
+        [Fact]
         public void PrefixTest()
         {
             DicomPersonName target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "Middle", "Prefix", "Suffix");
-            Assert.AreEqual("Prefix", target.Prefix);
+            Assert.Equal("Prefix", target.Prefix);
             target = new DicomPersonName(DicomTag.PatientName, "Last");
-            Assert.AreEqual("", target.Prefix);
+            Assert.Equal("", target.Prefix);
             target = new DicomPersonName(DicomTag.PatientName, "Last^First^Middle=Doe^John^Peter^MD^xx");
-            Assert.AreEqual("", target.Prefix);
+            Assert.Equal("", target.Prefix);
         }
 
         /// <summary>
         ///A test for Suffix
         ///</summary>
-        [TestMethod()]
+        [Fact]
         public void SuffixTest()
         {
             DicomPersonName target = new DicomPersonName(DicomTag.PatientName, "Last", "First", "Middle", "Prefix", "Suffix");
-            Assert.AreEqual("Suffix", target.Suffix);
+            Assert.Equal("Suffix", target.Suffix);
             target = new DicomPersonName(DicomTag.PatientName, "Last");
-            Assert.AreEqual("", target.Suffix);
+            Assert.Equal("", target.Suffix);
             target = new DicomPersonName(DicomTag.PatientName, "Last^First^Middle^Prefix=Doe^John^Peter^MD");
-            Assert.AreEqual("", target.Suffix);
+            Assert.Equal("", target.Suffix);
         }
     }
 }

--- a/DICOM [Unit Tests]/DicomTagTest.cs
+++ b/DICOM [Unit Tests]/DicomTagTest.cs
@@ -1,58 +1,22 @@
-﻿namespace Dicom
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
 {
     using System;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Xunit;
 
     /// <summary>
     ///     This is a test class for DicomTagTest and is intended
     ///     to contain all DicomTagTest Unit Tests
     /// </summary>
-    [TestClass]
     public class DicomTagTest
     {
         /// <summary>
-        ///     Gets or sets the test context which provides
-        ///     information about and functionality for the current test run.
-        /// </summary>
-        public TestContext TestContext { get; set; }
-
-        #region Additional test attributes
-
-        // 
-        //You can use the following additional attributes as you write your tests:
-        //
-        //Use ClassInitialize to run code before running the first test in the class
-        //[ClassInitialize()]
-        //public static void MyClassInitialize(TestContext testContext)
-        //{
-        //}
-        //
-        //Use ClassCleanup to run code after all tests in a class have run
-        //[ClassCleanup()]
-        //public static void MyClassCleanup()
-        //{
-        //}
-        //
-        //Use TestInitialize to run code before running each test
-        //[TestInitialize()]
-        //public void MyTestInitialize()
-        //{
-        //}
-        //
-        //Use TestCleanup to run code after each test has run
-        //[TestCleanup()]
-        //public void MyTestCleanup()
-        //{
-        //}
-        //
-
-        #endregion
-
-        /// <summary>
         ///     A test for ToString
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void ToJsonStringTest()
         {
             const ushort @group = 0x7FE0;
@@ -63,7 +27,7 @@
             const string expected = "7FE000FF";
             string actual = string.Empty;
             actual = target.ToString(format, formatProvider);
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/DICOM [Unit Tests]/DicomTagTest.cs
+++ b/DICOM [Unit Tests]/DicomTagTest.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Dicom;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace DICOM__Unit_Tests_
+﻿namespace Dicom
 {
+    using System;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     /// <summary>
     ///     This is a test class for DicomTagTest and is intended
     ///     to contain all DicomTagTest Unit Tests

--- a/DICOM [Unit Tests]/Helpers/SerializationExtensions.cs
+++ b/DICOM [Unit Tests]/Helpers/SerializationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2012 Anders Gustafsson, Cureos AB.
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System.IO;

--- a/DICOM [Unit Tests]/Imaging/Mathematics/Point2Tests.cs
+++ b/DICOM [Unit Tests]/Imaging/Mathematics/Point2Tests.cs
@@ -1,31 +1,29 @@
-﻿// Copyright (c) 2012 Anders Gustafsson, Cureos AB.
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
-
-using System.Runtime.Serialization;
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Dicom.Helpers;
 
 namespace Dicom.Imaging.Mathematics
 {
-    [TestClass]
+    using System.Runtime.Serialization;
+
+    using Dicom.Helpers;
+
+    using Xunit;
+
     public class Point2Tests
     {
-		[TestMethod]
+        [Fact]
         public void Serialization_RegularPoint_CanBeDeserialized()
         {
             var expected = new Point2(3, -5);
             var actual = expected.GetDataContractSerializerDeserializedObject();
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [TestMethod, ExpectedException(typeof(SerializationException))]
+        [Fact]
         public void Serialization_BinaryFormatter_Throws()
         {
-            var expected = new Point2(-2, 12);
-            var actual = expected.GetBinaryFormatterDeserializedObject();
-            Assert.AreEqual(expected, actual);
+            var point = new Point2(-2, 12);
+            Assert.Throws<SerializationException>(() => point.GetBinaryFormatterDeserializedObject());
         }
     }
 }

--- a/DICOM [Unit Tests]/Logging/MessageNameFormatToOrdinalFormatTests.cs
+++ b/DICOM [Unit Tests]/Logging/MessageNameFormatToOrdinalFormatTests.cs
@@ -1,16 +1,18 @@
-﻿namespace Dicom.Logging
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Logging
 {
     using System;
 
     using Dicom.Log;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Xunit;
 
-    [TestClass]
-    public class MesageNameFormatToOrdinalFormatTests
+    public class MessageNameFormatToOrdinalFormatTests
     {
 
-        [TestMethod]
+        [Fact]
         public void ComplexMessageIsCorrectlyReformatted()
         {
             var complexMessage =
@@ -23,21 +25,21 @@
             var dummyLogger = new ExposesProtectedLogMessageReformatter();
             var actualReformattedMessage = dummyLogger.NameFormatToPositionalFormat(complexMessage);
 
-            Assert.AreEqual(expectedReformattedMessage, actualReformattedMessage);
+            Assert.Equal(expectedReformattedMessage, actualReformattedMessage);
         }
 
-        [TestMethod]
+        [Fact]
         public void MessageUsingClassicOrdinalPositionsFormatsToItself()
         {
             var message =
                 "The element at {0} using {1} and {2} was causing grief because {2} and {1} dislike {0} except {1} secretly likes {2}";
 
             var dummyLogger = new ExposesProtectedLogMessageReformatter();
-            Assert.AreEqual(message, dummyLogger.NameFormatToPositionalFormat(message));
+            Assert.Equal(message, dummyLogger.NameFormatToPositionalFormat(message));
 
         }
 
-        [TestMethod]
+        [Fact]
         public void MessageUsingOrdinalPositionsOutOfOrderDoesNotRearrangeTheOrder()
         {
             var message = "The elements in reverse {2}, {1}, {0} are out of order";
@@ -45,10 +47,10 @@
             var dummyLogger = new ExposesProtectedLogMessageReformatter();
             var actualReformattedMessage = dummyLogger.NameFormatToPositionalFormat(message);
 
-            Assert.AreEqual(message, actualReformattedMessage);
+            Assert.Equal(message, actualReformattedMessage);
         }
 
-        [TestMethod]
+        [Fact]
         public void MessageUsingMixedOrdinalThenNamedPositionsIsHandled()
         {
             var message =
@@ -59,10 +61,10 @@
             var dummyLogger = new ExposesProtectedLogMessageReformatter();
             var actualReformattedMessage = dummyLogger.NameFormatToPositionalFormat(message);
 
-            Assert.AreEqual(expectedMessage, actualReformattedMessage);
+            Assert.Equal(expectedMessage, actualReformattedMessage);
         }
 
-        [TestMethod]
+        [Fact]
         public void MessageUsingMixedOrdinalAndNamedPositionsIsHandled()
         {
             var message =
@@ -73,7 +75,7 @@
             var dummyLogger = new ExposesProtectedLogMessageReformatter();
             var actualReformattedMessage = dummyLogger.NameFormatToPositionalFormat(message);
 
-            Assert.AreEqual(expected, actualReformattedMessage);
+            Assert.Equal(expected, actualReformattedMessage);
         }
 
         /// <summary>

--- a/DICOM [Unit Tests]/Logging/MessageNameFormatToOrdinalFormatTests.cs
+++ b/DICOM [Unit Tests]/Logging/MessageNameFormatToOrdinalFormatTests.cs
@@ -1,9 +1,11 @@
-﻿using System;
-using Dicom.Log;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace DICOM__Unit_Tests_.Logging
+﻿namespace Dicom.Logging
 {
+    using System;
+
+    using Dicom.Log;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class MesageNameFormatToOrdinalFormatTests
     {

--- a/DICOM [Unit Tests]/Network/PDUTest.cs
+++ b/DICOM [Unit Tests]/Network/PDUTest.cs
@@ -1,17 +1,15 @@
-﻿// Copyright (c) 2010-2015 Anders Gustafsson, Cureos AB.
-// All rights reserved. Any unauthorised reproduction of this 
-// material will constitute an infringement of copyright.
+﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
 namespace Dicom.Network
 {
     using System.IO;
 
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Xunit;
 
-    [TestClass]
     public class PDUTest
     {
-        [TestMethod]
+        [Fact]
         public void Write_AeWithNonAsciiCharacters_ShouldBeAsciified()
         {
             var notExpected = "GÖTEBORG";
@@ -35,7 +33,7 @@ namespace Dicom.Network
             readPdu.SkipBytes("Unknown", 10);
             var actual = readPdu.ReadString("Called AE", 16);
 
-            Assert.AreNotEqual(notExpected, actual);
+            Assert.NotEqual(notExpected, actual);
         }
     }
 }

--- a/DICOM [Unit Tests]/packages.config
+++ b/DICOM [Unit Tests]/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+</packages>

--- a/DICOM [Unit Tests]/packages.config
+++ b/DICOM [Unit Tests]/packages.config
@@ -5,4 +5,5 @@
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
   <package id="xunit.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/DICOM.sln
+++ b/DICOM.sln
@@ -34,12 +34,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documents", "Documents", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1E86A172-B9C5-4BBF-BD0F-22507432C8A5}"
 	ProjectSection(SolutionItems) = preProject
-		DICOM.vsmdi = DICOM.vsmdi
 		fo-dicom.nuspec = fo-dicom.nuspec
 		fo-dicom.targets = fo-dicom.targets
-		Local.testsettings = Local.testsettings
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
-		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{96052E4E-90EF-431F-A599-8723506A424B}"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Fellow Oak DICOM for .NET
 
 [![Join the chat at https://gitter.im/fo-dicom/fo-dicom](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fo-dicom/fo-dicom?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
-[![Stories in Ready](https://badge.waffle.io/fo-dicom/fo-dicom.svg?label=ready&title=Ready)](http://waffle.io/fo-dicom/fo-dicom)  
-[![Build status](https://ci.appveyor.com/api/projects/status/lhi29h08v4c2519a?svg=true)](https://ci.appveyor.com/project/fo-dicom/fo-dicom)
-
-Binaries are available from [NuGet](http://www.nuget.org/packages/fo-dicom).
+[![NuGet](https://img.shields.io/nuget/v/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/)  
+[![Build status](https://ci.appveyor.com/api/projects/status/lhi29h08v4c2519a?svg=true)](https://ci.appveyor.com/project/fo-dicom/fo-dicom)  
+[![Stories in Ready](https://badge.waffle.io/fo-dicom/fo-dicom.svg?label=ready&title=Ready)](http://waffle.io/fo-dicom/fo-dicom)
 
 ### Features
 * High-performance, fully asynchronous, .NET 4.0 API

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
   <repository path="..\ConsoleTest\packages.config" />
+  <repository path="..\DICOM [Unit Tests]\packages.config" />
   <repository path="..\Examples\C-Store SCP\packages.config" />
   <repository path="..\Logging\DICOM.NLog\packages.config" />
   <repository path="..\logging\DICOM.Serilog\packages.config" />


### PR DESCRIPTION
I have exchanged *MSTest* with *xUnit* version 2 in all unit tests, and at the same time applied a little namespace and solution clean-up.

Please take a look at this PR. If you have any concerns or objections, do not hesitate to post a comment.