### PR TITLE
Prevent non-socket related exceptions from being swallowed

### DIFF
--- a/DICOM/DicomEncoding.cs
+++ b/DICOM/DicomEncoding.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Dicom {
 	public static class DicomEncoding {
-		public readonly static Encoding Default = Encoding.ASCII;
+		public static Encoding Default = Encoding.ASCII;
 
 		public static Encoding GetEncoding(string charset) {
 			if (String.IsNullOrWhiteSpace(charset))

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -25,7 +25,7 @@ namespace Dicom.Network {
 		public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason) {
 		}
 
-		public void OnConnectionClosed(int errorCode) {
+		public void OnConnectionClosed(Exception exception) {
 		}
 
 		public DicomCEchoResponse OnCEchoRequest(DicomCEchoRequest request) {

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -281,12 +281,11 @@ namespace Dicom.Network {
 				_client._async.Set();
 			}
 
-			public void OnConnectionClosed(int errorCode) {
+			public void OnConnectionClosed(Exception exception) {
 				if (_timer != null)
 					_timer.Change(Timeout.Infinite, Timeout.Infinite);
 
-				if (errorCode != 0)
-					_client._exception = new SocketException(errorCode);
+				_client._exception = exception;
 
 				try {
 					if (_client._async != null)

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -101,7 +101,7 @@ namespace Dicom.Network {
 			try { _network.Close(); } catch { }
 
 			if (exception != null)
-				Logger.Error("Connection closed with error: {errorCode}", exception.Message);
+				Logger.Error("Connection closed with error: {@error}", exception);
 			else
 				Logger.Info("Connection closed");
 
@@ -124,9 +124,7 @@ namespace Dicom.Network {
 				// connection already closed; silently ignore
 				CloseConnection(null);
 			} catch (IOException e) {
-				int error = 0;
 				if (e.InnerException is SocketException) {
-					error = (e.InnerException as SocketException).ErrorCode;
 					Logger.Error("Socket error while reading PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
 				} else if (!(e.InnerException is ObjectDisposedException))
 					Logger.Error("IO exception while reading PDU: {@error}", e);
@@ -168,9 +166,7 @@ namespace Dicom.Network {
 				// connection already closed; silently ignore
 				CloseConnection(null);
 			} catch (IOException e) {
-				int error = 0;
 				if (e.InnerException is SocketException) {
-					error = (e.InnerException as SocketException).ErrorCode;
 					Logger.Error("Socket error while reading PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
 				} else if (!(e.InnerException is ObjectDisposedException))
 					Logger.Error("IO exception while reading PDU: {@error}", e);
@@ -276,9 +272,7 @@ namespace Dicom.Network {
 
 				BeginReadPDUHeader();
 			} catch (IOException e) {
-				int error = 0;
 				if (e.InnerException is SocketException) {
-					error = (e.InnerException as SocketException).ErrorCode;
 					Logger.Error("Socket error while reading PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
 				} else if (!(e.InnerException is ObjectDisposedException))
 					Logger.Error("IO exception while reading PDU: {@error}", e);
@@ -664,9 +658,7 @@ namespace Dicom.Network {
 			try {
 				_network.BeginWrite(buffer, 0, (int)ms.Length, OnEndSendPDU, buffer);
 			} catch (IOException e) {
-				int error = 0;
 				if (e.InnerException is SocketException) {
-					error = (e.InnerException as SocketException).ErrorCode;
 					Logger.Error("Socket error while writing PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
 				} else if (!(e.InnerException is ObjectDisposedException))
 					Logger.Error("IO exception while writing PDU: {@error}", e);
@@ -681,9 +673,7 @@ namespace Dicom.Network {
 			try {
 				_network.EndWrite(ar);
 			} catch (IOException e) {
-				int error = 0;
 				if (e.InnerException is SocketException) {
-					error = (e.InnerException as SocketException).ErrorCode;
 					Logger.Error("Socket error while writing PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
 				} else if (!(e.InnerException is ObjectDisposedException))
 					Logger.Error("IO exception while writing PDU: {@error}", e);

--- a/DICOM/Network/IDicomServiceProvider.cs
+++ b/DICOM/Network/IDicomServiceProvider.cs
@@ -8,6 +8,6 @@ namespace Dicom.Network {
 		void OnReceiveAssociationRequest(DicomAssociation association);
 		void OnReceiveAssociationReleaseRequest();
 		void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
-		void OnConnectionClosed(int errorCode);
+		void OnConnectionClosed(Exception exception);
 	}
 }

--- a/DICOM/Network/IDicomServiceUser.cs
+++ b/DICOM/Network/IDicomServiceUser.cs
@@ -9,6 +9,6 @@ namespace Dicom.Network {
 		void OnReceiveAssociationReject(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason);
 		void OnReceiveAssociationReleaseResponse();
 		void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
-		void OnConnectionClosed(int errorCode);
+		void OnConnectionClosed(Exception exception);
 	}
 }

--- a/Examples/C-Store SCP/Program.cs
+++ b/Examples/C-Store SCP/Program.cs
@@ -79,7 +79,7 @@ namespace Dicom.CStoreSCP {
 			public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason) {
 			}
 
-			public void OnConnectionClosed(int errorCode) {
+			public void OnConnectionClosed(Exception exception) {
 			}
 
 			public DicomCStoreResponse OnCStoreRequest(DicomCStoreRequest request) {

--- a/Examples/Print SCP/PrintService.cs
+++ b/Examples/Print SCP/PrintService.cs
@@ -127,7 +127,7 @@ namespace Dicom.Printing
             this.Logger.Error("Received abort from {0}, reason is {1}", source, reason);
         }
 
-        public void OnConnectionClosed(int errorCode)
+        public void OnConnectionClosed(Exception exception)
         {
             Clean();
         }


### PR DESCRIPTION
Allow useful exception messages to be passed out of fo-dicom to calling application.