### PR TITLE
Fallback support for implicit VRs in Explicit VR files. Connected to #47

### DIFF
--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -77,6 +77,7 @@
     <Compile Include="Helpers\SerializationExtensions.cs" />
     <Compile Include="Imaging\Codec\DicomTranscoderTest.cs" />
     <Compile Include="Imaging\Mathematics\Point2Tests.cs" />
+    <Compile Include="IO\Reader\DicomReaderTest.cs" />
     <Compile Include="Network\PDUTest.cs" />
     <Compile Include="Logging\MessageNameFormatToOrdinalFormatTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/DICOM [Unit Tests]/IO/Reader/DicomReaderTest.cs
+++ b/DICOM [Unit Tests]/IO/Reader/DicomReaderTest.cs
@@ -17,7 +17,7 @@ namespace Dicom.IO.Reader
 
         [Theory]
         [MemberData("ValidExplicitVRData")]
-        public void Read_ValidExplicitVR_YieldsSuccess(DicomTag tag, DicomVR vr, string data, byte[] bytes)
+        public void Read_ValidExplicitVRData_YieldsSuccess(DicomTag tag, DicomVR vr, string data, byte[] bytes)
         {
             var stream = new MemoryStream(bytes);
             var source = new StreamByteSource(stream);
@@ -30,6 +30,20 @@ namespace Dicom.IO.Reader
             Assert.Equal(tag, observer.Tag);
             Assert.Equal(vr, observer.VR);
             Assert.Equal(data, observer.Data);
+        }
+
+        [Theory]
+        [MemberData("ValidExplicitVRSequences")]
+        public void Read_ValidExplicitVRSequence_YieldsSuccess(byte[] bytes)
+        {
+            var stream = new MemoryStream(bytes);
+            var source = new StreamByteSource(stream);
+            var reader = new DicomReader { IsExplicitVR = true };
+
+            var observer = new MockObserver();
+            var result = reader.Read(source, observer);
+
+            Assert.Equal(DicomReaderResult.Success, result);
         }
 
         #endregion
@@ -61,6 +75,36 @@ namespace Dicom.IO.Reader
                         {
                             DicomTag.BeamDose, DicomVR.DS, "2.015 ",
                             new byte[] { 0x0a, 0x30, 0x84, 0x00, 0x06, 0x00, 0x00, 0x00, 0x32, 0x2e, 0x30, 0x31, 0x35, 0x20 }
+                        };
+            }
+        }
+
+        public static IEnumerable<object[]> ValidExplicitVRSequences
+        {
+            get
+            {
+                yield return
+                    new object[]
+                        {
+                            new byte[]
+                                {
+                                    0x54, 0x00, 0x63, 0x00, 0x53, 0x51, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0xfe, 0xff,
+                                    0x00, 0xe0, 0x1c, 0x00, 0x00, 0x00, 0x08, 0x00, 0x16, 0x00, 0x55, 0x49, 0x06, 0x00,
+                                    0x31, 0x2e, 0x32, 0x2e, 0x38, 0x34, 0x08, 0x00, 0x18, 0x00, 0x55, 0x49, 0x06, 0x00,
+                                    0x31, 0x2e, 0x33, 0x2e, 0x34, 0x00
+                                }
+                        };
+                yield return
+                    new object[]
+                        {
+                            new byte[]
+                                {
+                                    0x0b, 0x20, 0x9f, 0x70, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0x00, 0xe0, 0xff, 0xff,
+                                    0xff, 0xff, 0x08, 0x00, 0x16, 0x00, 0x06, 0x00, 0x00, 0x00, 0x31, 0x2e, 0x32, 0x2e,
+                                    0x38, 0x34, 0x08, 0x00, 0x18, 0x00, 0x06, 0x00, 0x00, 0x00, 0x31, 0x2e, 0x33, 0x2e,
+                                    0x34, 0x00, 0xfe, 0xff, 0x0d, 0xe0, 0x00, 0x00, 0x00, 0x00, 0xfe, 0xff, 0xdd, 0xe0,
+                                    0x00, 0x00, 0x00, 0x00
+                                }
                         };
             }
         }

--- a/DICOM [Unit Tests]/IO/Reader/DicomReaderTest.cs
+++ b/DICOM [Unit Tests]/IO/Reader/DicomReaderTest.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.IO.Reader
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+
+    using Dicom.IO.Buffer;
+
+    using Xunit;
+
+    public class DicomReaderTest
+    {
+        #region Unit tests
+
+        [Theory]
+        [MemberData("ValidExplicitVRData")]
+        public void Read_ValidExplicitVR_YieldsSuccess(DicomTag tag, DicomVR vr, string data, byte[] bytes)
+        {
+            var stream = new MemoryStream(bytes);
+            var source = new StreamByteSource(stream);
+            var reader = new DicomReader { IsExplicitVR = true };
+
+            var observer = new LastElementObserver();
+            var result = reader.Read(source, observer);
+
+            Assert.Equal(DicomReaderResult.Success, result);
+            Assert.Equal(tag, observer.Tag);
+            Assert.Equal(vr, observer.VR);
+            Assert.Equal(data, observer.Data);
+        }
+
+        #endregion
+
+        #region Support data
+
+        public static IEnumerable<object[]> ValidExplicitVRData
+        {
+            get
+            {
+                yield return
+                    new object[]
+                        {
+                            DicomTag.StudyDate, DicomVR.DA, "20150721",
+                            new byte[]
+                                {
+                                    0x08, 0x00, 0x20, 0x00, 0x44, 0x41, 0x08, 0x00, 0x32, 0x30, 0x31, 0x35, 0x30, 0x37, 0x32,
+                                    0x31
+                                }
+                        };
+                yield return
+                    new object[]
+                        {
+                            DicomTag.BeamDose, DicomVR.DS, "2.015 ",
+                            new byte[] { 0x0a, 0x30, 0x84, 0x00, 0x44, 0x53, 0x06, 0x00, 0x32, 0x2e, 0x30, 0x31, 0x35, 0x20 }
+                        };
+                yield return    // Same as previous, but VR data omitted
+                    new object[]
+                        {
+                            DicomTag.BeamDose, DicomVR.DS, "2.015 ",
+                            new byte[] { 0x0a, 0x30, 0x84, 0x00, 0x06, 0x00, 0x32, 0x2e, 0x30, 0x31, 0x35, 0x20 }
+                        };
+            }
+        }
+
+        #endregion
+
+        #region Support types
+
+        private class LastElementObserver : IDicomReaderObserver
+        {
+            #region Properties
+
+            public DicomTag Tag { get; private set; }
+
+            public DicomVR VR { get; private set; }
+
+            public string Data { get; private set; }
+
+            #endregion
+
+            #region Interface implementation
+
+            public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data)
+            {
+                this.Tag = tag;
+                this.VR = vr;
+                this.Data = Encoding.UTF8.GetString(data.Data);
+            }
+
+            public void OnBeginSequence(IByteSource source, DicomTag tag, uint length)
+            {
+            }
+
+            public void OnBeginSequenceItem(IByteSource source, uint length)
+            {
+            }
+
+            public void OnEndSequenceItem()
+            {
+            }
+
+            public void OnEndSequence()
+            {
+            }
+
+            public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr)
+            {
+            }
+
+            public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data)
+            {
+            }
+
+            public void OnEndFragmentSequence()
+            {
+            }
+
+            #endregion
+        }
+
+        #endregion
+    }
+}

--- a/DICOM [Unit Tests]/IO/Reader/DicomReaderTest.cs
+++ b/DICOM [Unit Tests]/IO/Reader/DicomReaderTest.cs
@@ -56,11 +56,11 @@ namespace Dicom.IO.Reader
                             DicomTag.BeamDose, DicomVR.DS, "2.015 ",
                             new byte[] { 0x0a, 0x30, 0x84, 0x00, 0x44, 0x53, 0x06, 0x00, 0x32, 0x2e, 0x30, 0x31, 0x35, 0x20 }
                         };
-                yield return    // Same as previous, but VR data omitted
+                yield return    // Same as previous, but VR data omitted and length spans 4 bytes
                     new object[]
                         {
                             DicomTag.BeamDose, DicomVR.DS, "2.015 ",
-                            new byte[] { 0x0a, 0x30, 0x84, 0x00, 0x06, 0x00, 0x32, 0x2e, 0x30, 0x31, 0x35, 0x20 }
+                            new byte[] { 0x0a, 0x30, 0x84, 0x00, 0x06, 0x00, 0x00, 0x00, 0x32, 0x2e, 0x30, 0x31, 0x35, 0x20 }
                         };
             }
         }

--- a/DICOM/DicomVR.cs
+++ b/DICOM/DicomVR.cs
@@ -153,19 +153,7 @@ namespace Dicom {
         }
 
         /// <summary>Implicit VR in Explicit VR context</summary>
-        internal readonly static DicomVR Implicit = new DicomVR {
-            Code = "IMPLICIT",
-            Name = "Implicit Value Representation in Explicit VR context",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = false,
-            PaddingValue = PadZero,
-            MaximumLength = 0,
-            UnitSize = 0,
-            ByteSwap = 0,
-            ValueType = typeof(object)
-        };
+        internal readonly static DicomVR Implicit = new DicomVR();
 
         /// <summary>No VR</summary>
         public readonly static DicomVR NONE = new DicomVR {

--- a/DICOM/DicomVR.cs
+++ b/DICOM/DicomVR.cs
@@ -152,6 +152,21 @@ namespace Dicom {
             }
         }
 
+        /// <summary>Implicit VR in Explicit VR context</summary>
+        internal readonly static DicomVR Implicit = new DicomVR {
+            Code = "IMPLICIT",
+            Name = "Implicit Value Representation in Explicit VR context",
+            IsString = false,
+            IsStringEncoded = false,
+            Is16bitLength = false,
+            IsMultiValue = false,
+            PaddingValue = PadZero,
+            MaximumLength = 0,
+            UnitSize = 0,
+            ByteSwap = 0,
+            ValueType = typeof(object)
+        };
+
         /// <summary>No VR</summary>
         public readonly static DicomVR NONE = new DicomVR {
             Code = "NONE",

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -201,7 +201,7 @@ namespace Dicom.IO.Reader {
 
 								_length = source.GetUInt32();
 
-								// assume that undefined length in implicit dataset is SQ
+								// assume that undefined length in implicit VR element is SQ
 								if (_length == UndefinedLength)
 									_vr = DicomVR.SQ;
 							} else if (_vr.Is16bitLength) {
@@ -243,7 +243,7 @@ namespace Dicom.IO.Reader {
 
 						// check dictionary for VR after reading length to handle 16-bit lengths
 						// check before reading value to handle SQ elements
-						if ((_vr == DicomVR.Implicit || _vr == DicomVR.UN) && IsExplicitVR) {
+						if (_vr == DicomVR.Implicit || (_vr == DicomVR.UN && IsExplicitVR)) {
 							var entry = Dictionary[_tag];
 							if (entry != null)
 								_vr = entry.ValueRepresentations.FirstOrDefault();

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -200,6 +200,10 @@ namespace Dicom.IO.Reader {
 								}
 
 								_length = source.GetUInt32();
+
+								// assume that undefined length in implicit dataset is SQ
+								if (_length == UndefinedLength)
+									_vr = DicomVR.SQ;
 							} else if (_vr.Is16bitLength) {
 								if (!source.Require(2, ParseDataset, state)) {
 									_result = DicomReaderResult.Suspended;

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -139,11 +139,13 @@ namespace Dicom.IO.Reader {
 								return;
 							}
 
+							source.Mark();
 							byte[] bytes = source.GetBytes(2);
 							string vr = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
 							if (!DicomVR.TryParse(vr, out _vr)) {
-								// unable to parse VR
-								_vr = DicomVR.UN;
+								// unable to parse VR; rewind VR bytes for continued attempt to interpret the data.
+								_vr = DicomVR.Implicit;
+							    source.Rewind();
 							}
 						} else {
 							if (_entry != null) {
@@ -191,7 +193,14 @@ namespace Dicom.IO.Reader {
 						}
 
 						if (IsExplicitVR) {
-							if (_vr.Is16bitLength) {
+							if (_vr == DicomVR.Implicit) {
+								if (!source.Require(4, ParseDataset, state)) {
+									_result = DicomReaderResult.Suspended;
+									return;
+								}
+
+								_length = source.GetUInt32();
+							} else if (_vr.Is16bitLength) {
 								if (!source.Require(2, ParseDataset, state)) {
 									_result = DicomReaderResult.Suspended;
 									return;
@@ -230,7 +239,7 @@ namespace Dicom.IO.Reader {
 
 						// check dictionary for VR after reading length to handle 16-bit lengths
 						// check before reading value to handle SQ elements
-						if (_vr == DicomVR.UN && IsExplicitVR) {
+						if ((_vr == DicomVR.Implicit || _vr == DicomVR.UN) && IsExplicitVR) {
 							var entry = Dictionary[_tag];
 							if (entry != null)
 								_vr = entry.ValueRepresentations.FirstOrDefault();


### PR DESCRIPTION
Added fallback support to handle Explicit VR DICOM files where one or more elements use implicit VR notation.

Also handles the scenario in Explicit VR files where a sequence with undefined length is identified (originally observed within issue #42).

For minimal intrusion of already functional use cases, the code temporarily uses an `internal` declared `DicomVR` field `Implicit`. This VR is never "released" from the parsing procedure, but is re-interpreted as some kind of publicly available VR upon exit.

Please review.