### PR TITLE
Enable output of multi-valued LO, PN, SH and UI elements from DicomDataset.Add. Connected to #51

### DIFF
--- a/DICOM [Unit Tests]/DicomDatasetTest.cs
+++ b/DICOM [Unit Tests]/DicomDatasetTest.cs
@@ -4,6 +4,7 @@
 namespace Dicom
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
 
     using Xunit;
@@ -66,6 +67,83 @@ namespace Dicom
             var data = dataset.Get<string[]>(DicomTag.URNCodeValue);
             Assert.Equal(1, data.Length);
             Assert.Equal("a", data.First());
+        }
+
+        [Fact]
+        public void Add_PersonName_MultipleNames_YieldsMultipleValues()
+        {
+            var dataset = new DicomDataset();
+            dataset.Add(
+                DicomTag.PerformingPhysicianName,
+                "Gustafsson^Anders^L",
+                "Yates^Ian",
+                "Desouky^Hesham",
+                "Horn^Chris");
+
+            var data = dataset.Get<string[]>(DicomTag.PerformingPhysicianName);
+            Assert.Equal(4, data.Length);
+            Assert.Equal("Desouky^Hesham", data[2]);
+        }
+
+        [Theory]
+        [MemberData("MultiVMStringTags")]
+        public void Add_MultiVMStringTags_YieldsMultipleValues(DicomTag tag, string[] values, Type expectedType)
+        {
+            var dataset = new DicomDataset();
+            dataset.Add(tag, values);
+
+            Assert.IsType(expectedType, dataset.First());
+
+            var data = dataset.Get<string[]>(tag);
+            Assert.Equal(values.Length, data.Length);
+            Assert.Equal(values.Last(), data.Last());
+        }
+
+        #endregion
+
+        #region Support data
+
+        public static IEnumerable<object[]> MultiVMStringTags
+        {
+            get
+            {
+                yield return
+                    new object[]
+                        {
+                            DicomTag.ReferencedFrameNumber, new[] { "3", "5", "8" },
+                            typeof(DicomIntegerString)
+                        };
+                yield return
+                    new object[]
+                        {
+                            DicomTag.EventElapsedTimes, new[] { "3.2", "5.8", "8.7" },
+                            typeof(DicomDecimalString)
+                        };
+                yield return
+                new object[]
+                        {
+                            DicomTag.PatientTelephoneNumbers, new[] { "0271-22117", "070-669 5073", "0270-11204" },
+                            typeof(DicomShortString)
+                        };
+                yield return
+                new object[]
+                        {
+                            DicomTag.EventTimerNames, new[] { "a", "b", "c", "e", "f" },
+                            typeof(DicomLongString)
+                        };
+                yield return
+                new object[]
+                        {
+                            DicomTag.ConsultingPhysicianName, new[] { "a", "b", "c", "e", "f" },
+                            typeof(DicomPersonName)
+                        };
+                yield return
+                new object[]
+                        {
+                            DicomTag.SOPClassesSupported, new[] { "1.2.3", "4.5.6", "7.8.8.9" },
+                            typeof(DicomUniqueIdentifier)
+                        };
+            }
         }
 
         #endregion

--- a/DICOM [Unit Tests]/DicomElementTest.cs
+++ b/DICOM [Unit Tests]/DicomElementTest.cs
@@ -77,7 +77,7 @@ namespace Dicom
         [Fact]
         public void DicomPersonName_TwoNames_YieldsTwoValues()
         {
-            var element = new DicomPersonName(DicomTag.ConsultingPhysicianName, "Doe^John", "Bar^Foo");
+            var element = new DicomPersonName(DicomTag.ConsultingPhysicianName, new [] { "Doe^John", "Bar^Foo"});
             var actual = element.Get<string[]>();
             Assert.Equal(2, actual.Length);
             Assert.Equal("Bar^Foo", actual[1]);

--- a/DICOM [Unit Tests]/DicomElementTest.cs
+++ b/DICOM [Unit Tests]/DicomElementTest.cs
@@ -11,6 +11,8 @@ namespace Dicom
 
     public class DicomElementTest
     {
+        #region Unit tests
+
         [Fact]
         public void DicomSignedShort_Array_GetDefaultValue()
         {
@@ -63,5 +65,24 @@ namespace Dicom
             var actual = element.Get<string>();
             Assert.Equal(@"a\b\c", actual);
         }
+
+        [Fact]
+        public void DicomPersonName_FamilyAndSurname_YieldsCompositeName()
+        {
+            var element = new DicomPersonName(DicomTag.ConsultingPhysicianName, "Doe", "John");
+            var actual = element.Get<string>(0);
+            Assert.Equal("Doe^John", actual);
+        }
+
+        [Fact]
+        public void DicomPersonName_TwoNames_YieldsTwoValues()
+        {
+            var element = new DicomPersonName(DicomTag.ConsultingPhysicianName, "Doe^John", "Bar^Foo");
+            var actual = element.Get<string[]>();
+            Assert.Equal(2, actual.Length);
+            Assert.Equal("Bar^Foo", actual[1]);
+        }
+
+        #endregion
     }
 }

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -263,7 +263,7 @@ namespace Dicom {
 				if (values == null)
 					return Add(new DicomLongString(tag, DicomEncoding.Default, EmptyBuffer.Value));
 				if (typeof(T) == typeof(string))
-					return Add(new DicomLongString(tag, values.Cast<string>().First()));
+					return Add(new DicomLongString(tag, values.Cast<string>().ToArray()));
 			}
 
 			if (vr == DicomVR.LT) {
@@ -305,14 +305,14 @@ namespace Dicom {
 				if (values == null)
 					return Add(new DicomPersonName(tag, DicomEncoding.Default, EmptyBuffer.Value));
 				if (typeof(T) == typeof(string))
-					return Add(new DicomPersonName(tag, values.Cast<string>().First()));
+					return Add(new DicomPersonName(tag, values.Cast<string>().ToArray()));
 			}
 
 			if (vr == DicomVR.SH) {
 				if (values == null)
 					return Add(new DicomShortString(tag, DicomEncoding.Default, EmptyBuffer.Value));
 				if (typeof(T) == typeof(string))
-					return Add(new DicomShortString(tag, values.Cast<string>().First()));
+					return Add(new DicomShortString(tag, values.Cast<string>().ToArray()));
 			}
 
 			if (vr == DicomVR.SL) {
@@ -367,7 +367,7 @@ namespace Dicom {
 				if (values == null)
 					return Add(new DicomUniqueIdentifier(tag, EmptyBuffer.Value));
 				if (typeof(T) == typeof(string))
-					return Add(new DicomUniqueIdentifier(tag, values.Cast<string>().First()));
+					return Add(new DicomUniqueIdentifier(tag, values.Cast<string>().ToArray()));
 				if (typeof(T) == typeof(DicomUID))
 					return Add(new DicomUniqueIdentifier(tag, values.Cast<DicomUID>().ToArray()));
 				if (typeof(T) == typeof(DicomTransferSyntax))


### PR DESCRIPTION
In issue #51, it is also suggested that the signature of the `DicomPersonName(params string[])` constructor should be modified. However, it is revealed during these tests that this would break other expected behaviors for the `DicomPersonName` class. 

No code change w.r.t. this sub-issue is therefore made. Users are instead advised to use the construct `new DicomPersonName(string[])` construct instead of `new DicomPersonName(string, string, string,...)` when creating multi-valued `DicomPersonName` instances.

Please review this PR.