### PR TITLE
Optional fallback encoding when parsing datasets. Connected to #54

### DIFF
--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -70,6 +70,7 @@
     <Compile Include="DicomDictionaryTest.cs" />
     <Compile Include="DicomElementTest.cs" />
     <Compile Include="DicomEncodingTest.cs" />
+    <Compile Include="DicomFileTest.cs" />
     <Compile Include="DicomPersonNameTest.cs" />
     <Compile Include="DicomTagTest.cs" />
     <Compile Include="DicomUIDTest.cs" />

--- a/DICOM [Unit Tests]/DicomFileTest.cs
+++ b/DICOM [Unit Tests]/DicomFileTest.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
+{
+    using System.IO;
+
+    using Dicom.IO.Buffer;
+
+    using Xunit;
+
+    public class DicomFileTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void DicomFile_OpenDefaultEncoding_SwedishCharactersNotMaintained()
+        {
+            var expected = "Händer Å Fötter";
+            var tag = DicomTag.DoseComment;
+
+            var dataset = new DicomDataset(
+                new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.RTDoseStorage),
+                new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3"),
+                new DicomLongString(tag, DicomEncoding.GetEncoding("ISO IR 192"), expected));
+            var outFile = new DicomFile(dataset);
+            var stream = new MemoryStream();
+            outFile.Save(stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var inFile = DicomFile.Open(stream);
+            var actual = inFile.Dataset.Get<string>(tag);
+
+            Assert.NotEqual(expected, actual);
+        }
+
+        [Fact]
+        public void DicomFile_OpenUtf8Encoding_SwedishCharactersMaintained()
+        {
+            var expected = "Händer Å Fötter";
+            var tag = DicomTag.DoseComment;
+
+            var dataset = new DicomDataset(
+                new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.RTDoseStorage),
+                new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3"),
+                new DicomLongString(tag, DicomEncoding.GetEncoding("ISO IR 192"), expected));
+            var outFile = new DicomFile(dataset);
+            var stream = new MemoryStream();
+            outFile.Save(stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var inFile = DicomFile.Open(stream, DicomEncoding.GetEncoding("ISO IR 192"));
+            var actual = inFile.Dataset.Get<string>(tag);
+
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/IO/Reader/DicomDatasetReaderObserver.cs
+++ b/DICOM/IO/Reader/DicomDatasetReaderObserver.cs
@@ -13,12 +13,19 @@ namespace Dicom.IO.Reader {
 		private Stack<DicomSequence> _sequences;
 		private DicomFragmentSequence _fragment;
 
-		public DicomDatasetReaderObserver(DicomDataset dataset) {
-			_datasets = new Stack<DicomDataset>();
+	    public DicomDatasetReaderObserver(DicomDataset dataset) : this(dataset, DicomEncoding.Default) {
+	    }
+
+	    public DicomDatasetReaderObserver(DicomDataset dataset, Encoding fallbackEncoding) {
+	        if (fallbackEncoding == null)
+	        {
+	            throw new ArgumentNullException("fallbackEncoding");
+	        }
+	        _datasets = new Stack<DicomDataset>();
 			_datasets.Push(dataset);
 
 			_encodings = new Stack<Encoding>();
-			_encodings.Push(DicomEncoding.Default);
+			_encodings.Push(fallbackEncoding);
 
 			_sequences = new Stack<DicomSequence>();
 		}
@@ -60,7 +67,7 @@ namespace Dicom.IO.Reader {
 			}
 
 			if (element.Tag == DicomTag.SpecificCharacterSet) {
-				Encoding encoding = DicomEncoding.Default;
+				Encoding encoding = _encodings.Peek();
 				if (element.Count > 0)
 					encoding = DicomEncoding.GetEncoding(element.Get<string>(0));
 				_encodings.Pop();

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 using Dicom.IO;
 using Dicom.IO.Reader;
 using Dicom.IO.Writer;
 
 namespace Dicom.Media {
-	public class DicomDirectory : DicomFile {
+    public class DicomDirectory : DicomFile {
 		#region Properties and Attributes
 
 		private DicomSequence _directoryRecordSequence;
@@ -120,8 +121,17 @@ namespace Dicom.Media {
 			}
 		}
 
-		public new static DicomDirectory Open(string fileName) {
-			var df = new DicomDirectory();
+	    public static new DicomDirectory Open(string fileName)
+	    {
+	        return Open(fileName, DicomEncoding.Default);
+	    }
+
+	    public new static DicomDirectory Open(string fileName, Encoding fallbackEncoding) {
+	        if (fallbackEncoding == null)
+	        {
+	            throw new ArgumentNullException("fallbackEncoding");
+	        }
+	        var df = new DicomDirectory();
 
 			// reset datasets
 			df.FileMetaInfo.Clear();
@@ -133,7 +143,7 @@ namespace Dicom.Media {
 				using (var source = new FileByteSource(df.File)) {
 					DicomFileReader reader = new DicomFileReader();
 
-					var datasetObserver = new DicomDatasetReaderObserver(df.Dataset);
+					var datasetObserver = new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding);
 					var dirObserver = new DicomDirectoryReaderObserver(df.Dataset);
 
 					reader.Read(source,
@@ -154,7 +164,11 @@ namespace Dicom.Media {
 			}
 		}
 
-		public new static IAsyncResult BeginOpen(string fileName, AsyncCallback callback, object state) {
+        public static new IAsyncResult BeginOpen(string fileName, AsyncCallback callback, object state) {
+            return BeginOpen(fileName, DicomEncoding.Default, callback, state);
+        }
+
+        public new static IAsyncResult BeginOpen(string fileName, Encoding fallbackEncoding, AsyncCallback callback, object state) {
 			var df = new DicomDirectory();
 
 			// reset datasets
@@ -169,7 +183,7 @@ namespace Dicom.Media {
 
 			DicomFileReader reader = new DicomFileReader();
 
-			var datasetObserver = new DicomDatasetReaderObserver(df.Dataset);
+			var datasetObserver = new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding);
 			var dirObserver = new DicomDirectoryReaderObserver(df.Dataset);
 
 			reader.BeginRead(source,


### PR DESCRIPTION
I have now added a set of overloaded constructors and methods to make it possible to specify a fallback encoding other than ASCII to be used when parsing DICOM datasets. The added overloads are:

    DicomDatasetReaderObserver(DicomDataset, Encoding)  // constructor
    protected DicomService(Stream, Encoding, Logger)  // constructor
    static DicomFile DicomFile.Open(string, Encoding)
    static DicomFile DicomFile.Open(Stream, Encoding)
    static IAsyncResult DicomFile.BeginOpen(string, Encoding, AsyncCallback, object)
    static DicomDirectory DicomDirectory.Open(string, Encoding)
    static IAsyncResult DicomDirectory DicomDirectory.BeginOpen(string, Encoding, AsyncCallback, object)

These constructors and methods now hold the implementation, and the pre-existing constructors/methods without the `Encoding` argument simply invokes the corresponding overload with `Encoding = DicomEncoding.Default`.

This means that existing code consuming the *fo-dicom* library will behave exactly like before, there is no impact on the *fo-dicom*  usage as long as any of the `Encoding` containing overloads are not invoked.

Implementation detail: I am only applying the alternative fallback encoding in the main dataset parsing, since it is only in that part of the DICOM object non-ASCII character sets should be expected. Meta info, DIMSE messages etc. are always parsed using the default (ASCII) encoding.

`DicomService` is the abstract base class for DICOM services like Store SCP, Print SCP etc. In order to use another fallback encoding than `DicomEncoding.Default` (ASCII) when *Specific Character Set* is not specified in the DICOM object (rationale for the encoding commit in #45), it is thus necessary to instantiate the implementation service class using the new base class constructor `DicomService(Stream, Encoding, Logger)`.

Even though this PR adds quite a few constructor/method overloads I maintain that this is preferable to allow any-time changes of the `DicomEncoding.Default` field. As I see it, changing the default value may potentially have side-effects that cannot easily be foreseen, whereas the proposed PR allows for isolated application of alternative encodings without affecting any other part of the assembly.

Please review.