### PR TITLE
Re-format code to match common VS tabbing and indentation settings. Connected to #61

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-#### v1.1.0 (TBD)
+#### v1.1.0 (8/17/2015)
 * Enable configuration of default encoding in the DicomDatasetReaderObserver (#54)
 * DicomDataset.Add(DicomTag, ...) method does not support multi-valued LO, PN, SH and UI tags (#51)
 * Explicit VR file parsing failures due to strictness (#47)

--- a/ConsoleTest/Program.cs
+++ b/ConsoleTest/Program.cs
@@ -1,136 +1,135 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Sockets;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using NLog;
+using System;
+using System.IO;
+
 using NLog.Config;
 using NLog.Targets;
 
 using Dicom;
-using Dicom.Imaging;
-using Dicom.Imaging.Codec;
-using Dicom.IO;
-using Dicom.IO.Buffer;
-using Dicom.IO.Reader;
-using Dicom.IO.Writer;
-using Dicom.Log;
 using Dicom.Network;
 
-namespace ConsoleTest {
-	class Program {
-		static void Main(string[] args) {
-			try {
-				DicomException.OnException += delegate(object sender, DicomExceptionEventArgs ea) {
-					ConsoleColor old = Console.ForegroundColor;
-					Console.ForegroundColor = ConsoleColor.Yellow;
-					Console.WriteLine(ea.Exception);
-					Console.ForegroundColor = old;
-				};
+namespace ConsoleTest
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            try
+            {
+                DicomException.OnException += delegate(object sender, DicomExceptionEventArgs ea)
+                    {
+                        ConsoleColor old = Console.ForegroundColor;
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        Console.WriteLine(ea.Exception);
+                        Console.ForegroundColor = old;
+                    };
 
-				var config = new LoggingConfiguration();
+                var config = new LoggingConfiguration();
 
-				var target = new ColoredConsoleTarget();
-				target.Layout = @"${date:format=HH\:mm\:ss}  ${message}";
-				config.AddTarget("Console", target);
-				config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Debug, target));
+                var target = new ColoredConsoleTarget();
+                target.Layout = @"${date:format=HH\:mm\:ss}  ${message}";
+                config.AddTarget("Console", target);
+                config.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Debug, target));
 
-				NLog.LogManager.Configuration = config;
+                NLog.LogManager.Configuration = config;
 
                 //Not necessary due to inclusion of the Dicom.Nlog assembly
                 //Dicom.Log.LogManager.Default = new Dicom.Log.NLogManager();
 
-				//var server = new DicomServer<DicomCEchoProvider>(12345);
+                //var server = new DicomServer<DicomCEchoProvider>(12345);
 
 
-				var client = new DicomClient();
-				//client.NegotiateAsyncOps();
-				//for (int i = 0; i < 10; i++)
-				//    client.AddRequest(new DicomCEchoRequest());
-				client.AddRequest(new DicomCStoreRequest(@"Z:\test1.dcm"));
-				client.AddRequest(new DicomCStoreRequest(@"Z:\test2.dcm"));
-				client.Send("127.0.0.1", 104,false, "SCU", "ANY-SCP");
+                var client = new DicomClient();
+                //client.NegotiateAsyncOps();
+                //for (int i = 0; i < 10; i++)
+                //    client.AddRequest(new DicomCEchoRequest());
+                client.AddRequest(new DicomCStoreRequest(@"Z:\test1.dcm"));
+                client.AddRequest(new DicomCStoreRequest(@"Z:\test2.dcm"));
+                client.Send("127.0.0.1", 104, false, "SCU", "ANY-SCP");
 
-				var samplesDir = Path.Combine(Path.GetPathRoot(Environment.CurrentDirectory), "Development", "fo-dicom-samples");
-				var testDir = Path.Combine(samplesDir, "Test");
+                var samplesDir = Path.Combine(
+                    Path.GetPathRoot(Environment.CurrentDirectory),
+                    "Development",
+                    "fo-dicom-samples");
+                var testDir = Path.Combine(samplesDir, "Test");
 
-				if (!Directory.Exists(testDir))
-				    Directory.CreateDirectory(testDir);
+                if (!Directory.Exists(testDir)) Directory.CreateDirectory(testDir);
 
-				//var img = new DicomImage(samplesDir + @"\ClearCanvas\CRStudy\1.3.51.5145.5142.20010109.1105627.1.0.1.dcm");
-				//img.RenderImage().Save(testDir + @"\test.jpg");
+                //var img = new DicomImage(samplesDir + @"\ClearCanvas\CRStudy\1.3.51.5145.5142.20010109.1105627.1.0.1.dcm");
+                //img.RenderImage().Save(testDir + @"\test.jpg");
 
-				//var df = DicomFile.Open(samplesDir + @"\User Submitted\overlays.dcm");
+                //var df = DicomFile.Open(samplesDir + @"\User Submitted\overlays.dcm");
 
-				//Console.WriteLine(df.FileMetaInfo.Get<DicomTransferSyntax>(DicomTag.TransferSyntaxUID).UID.Name);
-				//Console.WriteLine(df.Dataset.Get<PlanarConfiguration>(DicomTag.PlanarConfiguration));
+                //Console.WriteLine(df.FileMetaInfo.Get<DicomTransferSyntax>(DicomTag.TransferSyntaxUID).UID.Name);
+                //Console.WriteLine(df.Dataset.Get<PlanarConfiguration>(DicomTag.PlanarConfiguration));
 
-				//var img = new DicomImage(df.Dataset);
-				//img.RenderImage().Save(testDir + @"\test.jpg");
+                //var img = new DicomImage(df.Dataset);
+                //img.RenderImage().Save(testDir + @"\test.jpg");
 
-				//df = df.ChangeTransferSyntax(DicomTransferSyntax.JPEGLSLossless);
-				//df.Save(testDir + @"\test-jls.dcm");
+                //df = df.ChangeTransferSyntax(DicomTransferSyntax.JPEGLSLossless);
+                //df.Save(testDir + @"\test-jls.dcm");
 
-				//df = df.ChangeTransferSyntax(DicomTransferSyntax.JPEG2000Lossless);
-				//df.Save(testDir + @"\test-j2k.dcm");
+                //df = df.ChangeTransferSyntax(DicomTransferSyntax.JPEG2000Lossless);
+                //df.Save(testDir + @"\test-j2k.dcm");
 
-				//df = df.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess14SV1);
-				//df.Save(testDir + @"\test-jll.dcm");
+                //df = df.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess14SV1);
+                //df.Save(testDir + @"\test-jll.dcm");
 
-				//df = df.ChangeTransferSyntax(DicomTransferSyntax.RLELossless);
-				//df.Save(testDir + @"\test-rle.dcm");
+                //df = df.ChangeTransferSyntax(DicomTransferSyntax.RLELossless);
+                //df.Save(testDir + @"\test-rle.dcm");
 
-				//df = df.ChangeTransferSyntax(DicomTransferSyntax.ExplicitVRLittleEndian);
-				//df.Save(testDir + @"\test-ele.dcm");
+                //df = df.ChangeTransferSyntax(DicomTransferSyntax.ExplicitVRLittleEndian);
+                //df.Save(testDir + @"\test-ele.dcm");
 
-				//df = df.ChangeTransferSyntax(DicomTransferSyntax.ExplicitVRBigEndian);
-				//df.Save(testDir + @"\test-ebe.dcm");
+                //df = df.ChangeTransferSyntax(DicomTransferSyntax.ExplicitVRBigEndian);
+                //df.Save(testDir + @"\test-ebe.dcm");
 
-				//df = df.ChangeTransferSyntax(DicomTransferSyntax.ImplicitVRLittleEndian);
-				//df.Save(testDir + @"\test-ile.dcm");
+                //df = df.ChangeTransferSyntax(DicomTransferSyntax.ImplicitVRLittleEndian);
+                //df.Save(testDir + @"\test-ile.dcm");
 
-				//Console.WriteLine("End...");
-				//Console.ReadLine();
+                //Console.WriteLine("End...");
+                //Console.ReadLine();
 
-				//df.WriteToLog(LogManager.GetCurrentClassLogger(), LogLevel.Info);
+                //df.WriteToLog(LogManager.GetCurrentClassLogger(), LogLevel.Info);
 
-				//Console.WriteLine(DicomValueMultiplicity.Parse("1"));
-				//Console.WriteLine(DicomValueMultiplicity.Parse("3"));
-				//Console.WriteLine(DicomValueMultiplicity.Parse("1-3"));
-				//Console.WriteLine(DicomValueMultiplicity.Parse("1-n"));
-				//Console.WriteLine(DicomValueMultiplicity.Parse("2-2n"));
+                //Console.WriteLine(DicomValueMultiplicity.Parse("1"));
+                //Console.WriteLine(DicomValueMultiplicity.Parse("3"));
+                //Console.WriteLine(DicomValueMultiplicity.Parse("1-3"));
+                //Console.WriteLine(DicomValueMultiplicity.Parse("1-n"));
+                //Console.WriteLine(DicomValueMultiplicity.Parse("2-2n"));
 
-				//Console.WriteLine(DicomTag.Parse("00200020"));
-				//Console.WriteLine(DicomTag.Parse("0008,0040"));
-				//Console.WriteLine(DicomTag.Parse("(3000,0012)"));
-				//Console.WriteLine(DicomTag.Parse("2000,2000:TEST CREATOR"));
-				//Console.WriteLine(DicomTag.Parse("(4000,4000:TEST_CREATOR:2)"));
+                //Console.WriteLine(DicomTag.Parse("00200020"));
+                //Console.WriteLine(DicomTag.Parse("0008,0040"));
+                //Console.WriteLine(DicomTag.Parse("(3000,0012)"));
+                //Console.WriteLine(DicomTag.Parse("2000,2000:TEST CREATOR"));
+                //Console.WriteLine(DicomTag.Parse("(4000,4000:TEST_CREATOR:2)"));
 
-				//Console.WriteLine(DicomMaskedTag.Parse("(30xx,xx90)"));
-				//Console.WriteLine(DicomMaskedTag.Parse("(3000-3021,0016)"));
+                //Console.WriteLine(DicomMaskedTag.Parse("(30xx,xx90)"));
+                //Console.WriteLine(DicomMaskedTag.Parse("(3000-3021,0016)"));
 
-				//DicomRange<DateTime> r = new DicomRange<DateTime>(DateTime.Now.AddSeconds(-5), DateTime.Now.AddSeconds(5));
-				//Console.WriteLine(r.Contains(DateTime.Now));
-				//Console.WriteLine(r.Contains(DateTime.Today));
-				//Console.WriteLine(r.Contains(DateTime.Now.AddSeconds(60)));
+                //DicomRange<DateTime> r = new DicomRange<DateTime>(DateTime.Now.AddSeconds(-5), DateTime.Now.AddSeconds(5));
+                //Console.WriteLine(r.Contains(DateTime.Now));
+                //Console.WriteLine(r.Contains(DateTime.Today));
+                //Console.WriteLine(r.Contains(DateTime.Now.AddSeconds(60)));
 
-				//DicomDictionary dict = new DicomDictionary();
-				//dict.Load(@"F:\Development\fo-dicom\DICOM\Dictionaries\dictionary.xml", DicomDictionaryFormat.XML);
+                //DicomDictionary dict = new DicomDictionary();
+                //dict.Load(@"F:\Development\fo-dicom\DICOM\Dictionaries\dictionary.xml", DicomDictionaryFormat.XML);
 
-				//string output = Dicom.Generators.DicomTagGenerator.Generate("Dicom", "DicomTag", dict);
-				//File.WriteAllText(@"F:\Development\fo-dicom\DICOM\DicomTagGenerated.cs", output);
+                //string output = Dicom.Generators.DicomTagGenerator.Generate("Dicom", "DicomTag", dict);
+                //File.WriteAllText(@"F:\Development\fo-dicom\DICOM\DicomTagGenerated.cs", output);
 
-				//output = Dicom.Generators.DicomDictionaryGenerator.Generate("Dicom", "DicomDictionary", "LoadInternalDictionary", dict);
-				//File.WriteAllText(@"F:\Development\fo-dicom\DICOM\DicomDictionaryGenerated.cs", output);
+                //output = Dicom.Generators.DicomDictionaryGenerator.Generate("Dicom", "DicomDictionary", "LoadInternalDictionary", dict);
+                //File.WriteAllText(@"F:\Development\fo-dicom\DICOM\DicomDictionaryGenerated.cs", output);
 
-				//string output = Dicom.Generators.DicomUIDGenerator.Process(@"F:\Development\fo-dicom\DICOM\Dictionaries\dictionary.xml");
-				//File.WriteAllText(@"F:\Development\fo-dicom\DICOM\DicomUIDGenerated.cs", output);
-			} catch (Exception e) {
-				if (!(e is DicomException))
-					Console.WriteLine(e.ToString());
-			}
-		}
-	}
+                //string output = Dicom.Generators.DicomUIDGenerator.Process(@"F:\Development\fo-dicom\DICOM\Dictionaries\dictionary.xml");
+                //File.WriteAllText(@"F:\Development\fo-dicom\DICOM\DicomUIDGenerated.cs", output);
+            }
+            catch (Exception e)
+            {
+                if (!(e is DicomException)) Console.WriteLine(e.ToString());
+            }
+        }
+    }
 }

--- a/ConsoleTest/Properties/AssemblyInfo.cs
+++ b/ConsoleTest/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/DICOM [Native]/AssemblyInfo.cpp
+++ b/DICOM [Native]/AssemblyInfo.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #include "../SharedAssemblyInfo.cs"
 
 ; // terminate cs "include"

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg.cpp
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg.cpp
@@ -1,23 +1,5 @@
-// mDCM: A C# DICOM library
-//
-// Copyright (c) 2008  Colby Dillion
-//
-// This library is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 2.1 of the License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public
-// License along with this library; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-//
-// Author:
-//    Colby Dillion (colby.dillion@gmail.com)
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
 #include "Dicom.Imaging.Codec.Jpeg.h"
 
@@ -29,75 +11,75 @@ using namespace Dicom;
 using namespace Dicom::Imaging::Codec::Jpeg;
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
+	namespace Imaging {
+		namespace Codec {
 
-void DicomJpegNativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters)
-{
-	if (oldPixelData->NumberOfFrames == 0)
-		return;
+			void DicomJpegNativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters)
+			{
+				if (oldPixelData->NumberOfFrames == 0)
+					return;
 
-	// IJG eats the extra padding bits. Is there a better way to test for this?
-	if (oldPixelData->BitsAllocated == 16 && oldPixelData->BitsStored <= 8) {
-		// check for embedded overlays?
-		newPixelData->BitsAllocated = 8;
-	}
+				// IJG eats the extra padding bits. Is there a better way to test for this?
+				if (oldPixelData->BitsAllocated == 16 && oldPixelData->BitsStored <= 8) {
+					// check for embedded overlays?
+					newPixelData->BitsAllocated = 8;
+				}
 
-	if (parameters == nullptr || parameters->GetType() != DicomJpegParams::typeid)
-		parameters = GetDefaultParameters();
+				if (parameters == nullptr || parameters->GetType() != DicomJpegParams::typeid)
+					parameters = GetDefaultParameters();
 
-	DicomJpegParams^ jparams = (DicomJpegParams^)parameters;
+				DicomJpegParams^ jparams = (DicomJpegParams^)parameters;
 
-	JpegNativeCodec^ codec = GetCodec(oldPixelData->BitsStored, jparams);
+				JpegNativeCodec^ codec = GetCodec(oldPixelData->BitsStored, jparams);
 
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		codec->Encode(oldPixelData, newPixelData, jparams, frame);
-	}
-}
+				for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+					codec->Encode(oldPixelData, newPixelData, jparams, frame);
+				}
+			}
 
-void DicomJpegNativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters)
-{
-	if (oldPixelData->NumberOfFrames == 0)
-		return;
+			void DicomJpegNativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters)
+			{
+				if (oldPixelData->NumberOfFrames == 0)
+					return;
 
-	// IJG eats the extra padding bits. Is there a better way to test for this?
-	if (newPixelData->BitsAllocated == 16 && newPixelData->BitsStored <= 8) {
-		// check for embedded overlays here or below?
-		newPixelData->BitsAllocated = 8;
-	}
+				// IJG eats the extra padding bits. Is there a better way to test for this?
+				if (newPixelData->BitsAllocated == 16 && newPixelData->BitsStored <= 8) {
+					// check for embedded overlays here or below?
+					newPixelData->BitsAllocated = 8;
+				}
 
-	if (parameters == nullptr || parameters->GetType() != DicomJpegParams::typeid)
-		parameters = GetDefaultParameters();
+				if (parameters == nullptr || parameters->GetType() != DicomJpegParams::typeid)
+					parameters = GetDefaultParameters();
 
-	DicomJpegParams^ jparams = (DicomJpegParams^)parameters;
+				DicomJpegParams^ jparams = (DicomJpegParams^)parameters;
 
-	int precision = 0;
-	try {
-		try {
-			precision = JpegHelper::ScanJpegForBitDepth(oldPixelData);
-		}
-		catch (...) {
-			// if the internal scanner chokes on an image, try again using ijg
-			Jpeg8Codec^ c = gcnew Jpeg8Codec(JpegMode::Baseline, 0, 0);
-			precision = c->ScanHeaderForPrecision(oldPixelData);
-		}
-	}
-	catch (...) {
-		// the old scanner choked on several valid images...
-		// assume the correct encoder was used and let libijg handle the rest
-		precision = oldPixelData->BitsStored;
-	}
+				int precision = 0;
+				try {
+					try {
+						precision = JpegHelper::ScanJpegForBitDepth(oldPixelData);
+					}
+					catch (...) {
+						// if the internal scanner chokes on an image, try again using ijg
+						Jpeg8Codec^ c = gcnew Jpeg8Codec(JpegMode::Baseline, 0, 0);
+						precision = c->ScanHeaderForPrecision(oldPixelData);
+					}
+				}
+				catch (...) {
+					// the old scanner choked on several valid images...
+					// assume the correct encoder was used and let libijg handle the rest
+					precision = oldPixelData->BitsStored;
+				}
 
-	if (newPixelData->BitsStored <= 8 && precision > 8)
-		newPixelData->BitsAllocated = 16; // embedded overlay?
+				if (newPixelData->BitsStored <= 8 && precision > 8)
+					newPixelData->BitsAllocated = 16; // embedded overlay?
 
-	JpegNativeCodec^ codec = GetCodec(precision, jparams);
+				JpegNativeCodec^ codec = GetCodec(precision, jparams);
 
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		codec->Decode(oldPixelData, newPixelData, jparams, frame);
-	}
-}
+				for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+					codec->Decode(oldPixelData, newPixelData, jparams, frame);
+				}
+			}
 
-} // Codec
-} // Imaging
+		} // Codec
+	} // Imaging
 } // Dicom

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg.h
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #ifndef __JPEGCODEC_H__
 #define __JPEGCODEC_H__
 
@@ -14,161 +17,161 @@ using namespace Dicom::Imaging::Codec;
 using namespace Dicom::IO;
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
-namespace Jpeg {
+	namespace Imaging {
+		namespace Codec {
+			namespace Jpeg {
 
-public enum class JpegMode : int {
-	Baseline,
-	Sequential,
-	SpectralSelection,
-	Progressive,
-	Lossless
-};
+				public enum class JpegMode : int {
+					Baseline,
+					Sequential,
+					SpectralSelection,
+					Progressive,
+					Lossless
+				};
 
-public ref class JpegNativeCodec abstract {
-public:
-	virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) abstract;
-	virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) abstract;
+				public ref class JpegNativeCodec abstract {
+				public:
+					virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) abstract;
+					virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) abstract;
 
-internal:
-	virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) abstract;
+				internal:
+					virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) abstract;
 
-	MemoryStream^ MemoryBuffer;
-	PinnedByteArray^ DataArray;
+					MemoryStream^ MemoryBuffer;
+					PinnedByteArray^ DataArray;
 
-	JpegMode Mode;
-	int Predictor;
-	int PointTransform;
-};
+					JpegMode Mode;
+					int Predictor;
+					int PointTransform;
+				};
 
-public ref class Jpeg16Codec : public JpegNativeCodec {
-public:
-	Jpeg16Codec(JpegMode mode, int predictor, int point_transform);
-	virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
-	virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
+				public ref class Jpeg16Codec : public JpegNativeCodec {
+				public:
+					Jpeg16Codec(JpegMode mode, int predictor, int point_transform);
+					virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
+					virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
 
-internal:
-	virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) override;
+				internal:
+					virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) override;
 
-	[ThreadStatic]
-	static Jpeg16Codec^ This;
-};
+					[ThreadStatic]
+					static Jpeg16Codec^ This;
+				};
 
-public ref class Jpeg12Codec : public JpegNativeCodec {
-public:
-	Jpeg12Codec(JpegMode mode, int predictor, int point_transform);
-	virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
-	virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
+				public ref class Jpeg12Codec : public JpegNativeCodec {
+				public:
+					Jpeg12Codec(JpegMode mode, int predictor, int point_transform);
+					virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
+					virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
 
-internal:
-	virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) override;
+				internal:
+					virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) override;
 
-	[ThreadStatic]
-	static Jpeg12Codec^ This;
-};
+					[ThreadStatic]
+					static Jpeg12Codec^ This;
+				};
 
-public ref class Jpeg8Codec : public JpegNativeCodec {
-public:
-	Jpeg8Codec(JpegMode mode, int predictor, int point_transform);
-	virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
-	virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
+				public ref class Jpeg8Codec : public JpegNativeCodec {
+				public:
+					Jpeg8Codec(JpegMode mode, int predictor, int point_transform);
+					virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
+					virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) override;
 
-internal:
-	virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) override;
+				internal:
+					virtual int ScanHeaderForPrecision(DicomPixelData^ pixelData) override;
 
-	[ThreadStatic]
-	static Jpeg8Codec^ This;
-};
-} // Jpeg
+					[ThreadStatic]
+					static Jpeg8Codec^ This;
+				};
+			} // Jpeg
 
-using namespace Dicom::Imaging::Codec::Jpeg;
+			using namespace Dicom::Imaging::Codec::Jpeg;
 
-public ref class DicomJpegNativeCodec abstract : public DicomJpegCodec {
-public:
-	virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
-	virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+			public ref class DicomJpegNativeCodec abstract : public DicomJpegCodec {
+			public:
+				virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+				virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
 
-protected:
-	virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) = 0;
-};
+			protected:
+				virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) = 0;
+			};
 
-[Export(IDicomCodec::typeid)]
-public ref class DicomJpegProcess1Codec : public DicomJpegNativeCodec {
-public:
-	virtual property DicomTransferSyntax^ TransferSyntax {
-		DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess1; }
-	}
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpegProcess1Codec : public DicomJpegNativeCodec {
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess1; }
+				}
 
-protected:
-	virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
-		if (bits == 8)
-			return gcnew Jpeg8Codec(JpegMode::Baseline, 0, 0);
-		else
-			throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 1 codec for bits stored == {0}", bits));
-	}
-};
+			protected:
+				virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
+					if (bits == 8)
+						return gcnew Jpeg8Codec(JpegMode::Baseline, 0, 0);
+					else
+						throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 1 codec for bits stored == {0}", bits));
+				}
+			};
 
-[Export(IDicomCodec::typeid)]
-public ref class DicomJpegProcess4Codec : public DicomJpegNativeCodec {
-public:
-	virtual property DicomTransferSyntax^ TransferSyntax {
-		DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess2_4; }
-	}
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpegProcess4Codec : public DicomJpegNativeCodec {
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess2_4; }
+				}
 
-protected:
-	virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
-		if (bits == 8)
-			return gcnew Jpeg8Codec(JpegMode::Sequential, 0, 0);
-		else if (bits <= 12)
-			return gcnew Jpeg12Codec(JpegMode::Sequential, 0, 0);
-		else
-			throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 4 codec for bits stored == {0}", bits));
-	}
-};
+			protected:
+				virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
+					if (bits == 8)
+						return gcnew Jpeg8Codec(JpegMode::Sequential, 0, 0);
+					else if (bits <= 12)
+						return gcnew Jpeg12Codec(JpegMode::Sequential, 0, 0);
+					else
+						throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 4 codec for bits stored == {0}", bits));
+				}
+			};
 
-[Export(IDicomCodec::typeid)]
-public ref class DicomJpegLossless14Codec : public DicomJpegNativeCodec {
-public:
-	virtual property DicomTransferSyntax^ TransferSyntax {
-		DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess14; }
-	}
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpegLossless14Codec : public DicomJpegNativeCodec {
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess14; }
+				}
 
-protected:
-	virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
-		if (bits <= 8)
-			return gcnew Jpeg8Codec(JpegMode::Lossless, jparams->Predictor, jparams->PointTransform);
-		else if (bits <= 12)
-			return gcnew Jpeg12Codec(JpegMode::Lossless, jparams->Predictor, jparams->PointTransform);
-		else if (bits <= 16)
-			return gcnew Jpeg16Codec(JpegMode::Lossless, jparams->Predictor, jparams->PointTransform);
-		else
-			throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 14 codec for bits stored == {0}", bits));
-	}
-};
+			protected:
+				virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
+					if (bits <= 8)
+						return gcnew Jpeg8Codec(JpegMode::Lossless, jparams->Predictor, jparams->PointTransform);
+					else if (bits <= 12)
+						return gcnew Jpeg12Codec(JpegMode::Lossless, jparams->Predictor, jparams->PointTransform);
+					else if (bits <= 16)
+						return gcnew Jpeg16Codec(JpegMode::Lossless, jparams->Predictor, jparams->PointTransform);
+					else
+						throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 14 codec for bits stored == {0}", bits));
+				}
+			};
 
-[Export(IDicomCodec::typeid)]
-public ref class DicomJpegLossless14SV1Codec : public DicomJpegNativeCodec {
-public:
-	virtual property DicomTransferSyntax^ TransferSyntax {
-		DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess14SV1; }
-	}
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpegLossless14SV1Codec : public DicomJpegNativeCodec {
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGProcess14SV1; }
+				}
 
-protected:
-	virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
-		if (bits <= 8)
-			return gcnew Jpeg8Codec(JpegMode::Lossless, 1, jparams->PointTransform);
-		else if (bits <= 12)
-			return gcnew Jpeg12Codec(JpegMode::Lossless, 1, jparams->PointTransform);
-		else if (bits <= 16)
-			return gcnew Jpeg16Codec(JpegMode::Lossless, 1, jparams->PointTransform);
-		else
-			throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 14 [SV1] codec for bits stored == {0}", bits));
-	}
-};
+			protected:
+				virtual JpegNativeCodec^ GetCodec(int bits, DicomJpegParams^ jparams) override {
+					if (bits <= 8)
+						return gcnew Jpeg8Codec(JpegMode::Lossless, 1, jparams->PointTransform);
+					else if (bits <= 12)
+						return gcnew Jpeg12Codec(JpegMode::Lossless, 1, jparams->PointTransform);
+					else if (bits <= 16)
+						return gcnew Jpeg16Codec(JpegMode::Lossless, 1, jparams->PointTransform);
+					else
+						throw gcnew DicomCodecException(String::Format("Unable to create JPEG Process 14 [SV1] codec for bits stored == {0}", bits));
+				}
+			};
 
-} // Codec
-} // Imaging
+		} // Codec
+	} // Imaging
 } // Dicom
 
 #endif

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg.i
@@ -1,557 +1,560 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #define IJGE_BLOCKSIZE 16384
 
 namespace IJGVERS {
-	// private error handler struct
-	struct ErrorStruct {
-	  // the standard IJG error handler object
-	  struct jpeg_error_mgr pub;
-	};
+    // private error handler struct
+    struct ErrorStruct {
+      // the standard IJG error handler object
+      struct jpeg_error_mgr pub;
+    };
 
-	// error handler, executes longjmp
-	void ErrorExit(j_common_ptr cinfo) {
-		ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
-	}
+    // error handler, executes longjmp
+    void ErrorExit(j_common_ptr cinfo) {
+        ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
+    }
 
-	// message handler for warning messages and the like
-	void OutputMessage(j_common_ptr cinfo) {
-		ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
-		char buffer[JMSG_LENGTH_MAX];
-		(*cinfo->err->format_message)((jpeg_common_struct *)cinfo, buffer); /* Create the message */
-		//DicomLog::Debug::Log->Info("IJG: {0}", gcnew String(buffer));
-	}
+    // message handler for warning messages and the like
+    void OutputMessage(j_common_ptr cinfo) {
+        ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
+        char buffer[JMSG_LENGTH_MAX];
+        (*cinfo->err->format_message)((jpeg_common_struct *)cinfo, buffer); /* Create the message */
+        //DicomLog::Debug::Log->Info("IJG: {0}", gcnew String(buffer));
+    }
 }
 
 
 JPEGCODEC::JPEGCODEC(JpegMode mode, int predictor, int point_transform) {
-	Mode = mode;
-	Predictor = predictor;
-	PointTransform = point_transform;
+    Mode = mode;
+    Predictor = predictor;
+    PointTransform = point_transform;
 }
 
 namespace IJGVERS {
-	J_COLOR_SPACE getJpegColorSpace(PhotometricInterpretation^ photometricInterpretation) {
-		if (photometricInterpretation == PhotometricInterpretation::Rgb)
-			return JCS_RGB;
-		else if (photometricInterpretation == PhotometricInterpretation::Monochrome1 || photometricInterpretation == PhotometricInterpretation::Monochrome2)
-			return JCS_GRAYSCALE;
-		else if (photometricInterpretation == PhotometricInterpretation::PaletteColor)
-			return JCS_UNKNOWN;
-		else if (photometricInterpretation == PhotometricInterpretation::YbrFull || photometricInterpretation == PhotometricInterpretation::YbrFull422 || PhotometricInterpretation::YbrPartial422)
-			return JCS_YCbCr;
-		else
-			return JCS_UNKNOWN;
-	}
+    J_COLOR_SPACE getJpegColorSpace(PhotometricInterpretation^ photometricInterpretation) {
+        if (photometricInterpretation == PhotometricInterpretation::Rgb)
+            return JCS_RGB;
+        else if (photometricInterpretation == PhotometricInterpretation::Monochrome1 || photometricInterpretation == PhotometricInterpretation::Monochrome2)
+            return JCS_GRAYSCALE;
+        else if (photometricInterpretation == PhotometricInterpretation::PaletteColor)
+            return JCS_UNKNOWN;
+        else if (photometricInterpretation == PhotometricInterpretation::YbrFull || photometricInterpretation == PhotometricInterpretation::YbrFull422 || PhotometricInterpretation::YbrPartial422)
+            return JCS_YCbCr;
+        else
+            return JCS_UNKNOWN;
+    }
 
-	// callbacks for compress-destination-manager
-	void initDestination(j_compress_ptr cinfo) {
-		JPEGCODEC^ thisPtr = (JPEGCODEC^)JPEGCODEC::This;
-		thisPtr->MemoryBuffer = gcnew MemoryStream();
-		thisPtr->DataArray = gcnew PinnedByteArray(IJGE_BLOCKSIZE);
-		cinfo->dest->next_output_byte = (unsigned char*)(void*)thisPtr->DataArray->Pointer;
-		cinfo->dest->free_in_buffer = IJGE_BLOCKSIZE;
-	}
+    // callbacks for compress-destination-manager
+    void initDestination(j_compress_ptr cinfo) {
+        JPEGCODEC^ thisPtr = (JPEGCODEC^)JPEGCODEC::This;
+        thisPtr->MemoryBuffer = gcnew MemoryStream();
+        thisPtr->DataArray = gcnew PinnedByteArray(IJGE_BLOCKSIZE);
+        cinfo->dest->next_output_byte = (unsigned char*)(void*)thisPtr->DataArray->Pointer;
+        cinfo->dest->free_in_buffer = IJGE_BLOCKSIZE;
+    }
 
-	ijg_boolean emptyOutputBuffer(j_compress_ptr cinfo) {
-		JPEGCODEC^ thisPtr = (JPEGCODEC^)JPEGCODEC::This;
-		thisPtr->MemoryBuffer->Write(thisPtr->DataArray->Data, 0, IJGE_BLOCKSIZE);
-		cinfo->dest->next_output_byte = (unsigned char*)(void*)thisPtr->DataArray->Pointer;
-		cinfo->dest->free_in_buffer = IJGE_BLOCKSIZE;
-		return TRUE;
-	}
+    ijg_boolean emptyOutputBuffer(j_compress_ptr cinfo) {
+        JPEGCODEC^ thisPtr = (JPEGCODEC^)JPEGCODEC::This;
+        thisPtr->MemoryBuffer->Write(thisPtr->DataArray->Data, 0, IJGE_BLOCKSIZE);
+        cinfo->dest->next_output_byte = (unsigned char*)(void*)thisPtr->DataArray->Pointer;
+        cinfo->dest->free_in_buffer = IJGE_BLOCKSIZE;
+        return TRUE;
+    }
 
-	void termDestination(j_compress_ptr cinfo) {
-		JPEGCODEC^ thisPtr = (JPEGCODEC^)JPEGCODEC::This;
-		int count = IJGE_BLOCKSIZE - cinfo->dest->free_in_buffer;
-		thisPtr->MemoryBuffer->Write(thisPtr->DataArray->Data, 0, count);
-		thisPtr->DataArray = nullptr;
-	}
+    void termDestination(j_compress_ptr cinfo) {
+        JPEGCODEC^ thisPtr = (JPEGCODEC^)JPEGCODEC::This;
+        int count = IJGE_BLOCKSIZE - cinfo->dest->free_in_buffer;
+        thisPtr->MemoryBuffer->Write(thisPtr->DataArray->Data, 0, count);
+        thisPtr->DataArray = nullptr;
+    }
 
-	// Borrowed from DCMTK djeijgXX.cxx
-	/*
-	 * jpeg_simple_spectral_selection() creates a scan script
-	 * for progressive JPEG with spectral selection only,
-	 * similar to jpeg_simple_progression() for full progression.
-	 * The scan sequence for YCbCr is as proposed in the IJG documentation.
-	 * The scan sequence for all other color models is somewhat arbitrary.
-	 */
-	void jpeg_simple_spectral_selection(j_compress_ptr cinfo) {
-		int ncomps = cinfo->num_components;
-		jpeg_scan_info *scanptr = NULL;
-		int nscans = 0;
+    // Borrowed from DCMTK djeijgXX.cxx
+    /*
+     * jpeg_simple_spectral_selection() creates a scan script
+     * for progressive JPEG with spectral selection only,
+     * similar to jpeg_simple_progression() for full progression.
+     * The scan sequence for YCbCr is as proposed in the IJG documentation.
+     * The scan sequence for all other color models is somewhat arbitrary.
+     */
+    void jpeg_simple_spectral_selection(j_compress_ptr cinfo) {
+        int ncomps = cinfo->num_components;
+        jpeg_scan_info *scanptr = NULL;
+        int nscans = 0;
 
-		/* Safety check to ensure start_compress not called yet. */
-		if (cinfo->global_state != CSTATE_START) ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
+        /* Safety check to ensure start_compress not called yet. */
+        if (cinfo->global_state != CSTATE_START) ERREXIT1(cinfo, JERR_BAD_STATE, cinfo->global_state);
 
-		if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) nscans = 7;
-		else nscans = 1 + 2 * ncomps;	/* 1 DC scan; 2 AC scans per component */
+        if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) nscans = 7;
+        else nscans = 1 + 2 * ncomps;	/* 1 DC scan; 2 AC scans per component */
 
-		/* Allocate space for script.
-		* We need to put it in the permanent pool in case the application performs
-		* multiple compressions without changing the settings.  To avoid a memory
-		* leak if jpeg_simple_spectral_selection is called repeatedly for the same JPEG
-		* object, we try to re-use previously allocated space, and we allocate
-		* enough space to handle YCbCr even if initially asked for grayscale.
-		*/
-		if (cinfo->script_space == NULL || cinfo->script_space_size < nscans) {
-		cinfo->script_space_size = nscans > 7 ? nscans : 7;
-		cinfo->script_space = (jpeg_scan_info *)
-		  (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, 
-		  JPOOL_PERMANENT, cinfo->script_space_size * sizeof(jpeg_scan_info));
-		}
-		scanptr = cinfo->script_space;
-		cinfo->scan_info = scanptr;
-		cinfo->num_scans = nscans;
+        /* Allocate space for script.
+        * We need to put it in the permanent pool in case the application performs
+        * multiple compressions without changing the settings.  To avoid a memory
+        * leak if jpeg_simple_spectral_selection is called repeatedly for the same JPEG
+        * object, we try to re-use previously allocated space, and we allocate
+        * enough space to handle YCbCr even if initially asked for grayscale.
+        */
+        if (cinfo->script_space == NULL || cinfo->script_space_size < nscans) {
+        cinfo->script_space_size = nscans > 7 ? nscans : 7;
+        cinfo->script_space = (jpeg_scan_info *)
+          (*cinfo->mem->alloc_small) ((j_common_ptr) cinfo, 
+          JPOOL_PERMANENT, cinfo->script_space_size * sizeof(jpeg_scan_info));
+        }
+        scanptr = cinfo->script_space;
+        cinfo->scan_info = scanptr;
+        cinfo->num_scans = nscans;
 
-		if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) {
-			/* Custom script for YCbCr color images. */
+        if (ncomps == 3 && cinfo->jpeg_color_space == JCS_YCbCr) {
+            /* Custom script for YCbCr color images. */
 
-			// Interleaved DC scan for Y,Cb,Cr:
-			scanptr[0].component_index[0] = 0;
-			scanptr[0].component_index[1] = 1;
-			scanptr[0].component_index[2] = 2;
-			scanptr[0].comps_in_scan = 3;
-			scanptr[0].Ss = 0;
-			scanptr[0].Se = 0;
-			scanptr[0].Ah = 0;
-			scanptr[0].Al = 0;
+            // Interleaved DC scan for Y,Cb,Cr:
+            scanptr[0].component_index[0] = 0;
+            scanptr[0].component_index[1] = 1;
+            scanptr[0].component_index[2] = 2;
+            scanptr[0].comps_in_scan = 3;
+            scanptr[0].Ss = 0;
+            scanptr[0].Se = 0;
+            scanptr[0].Ah = 0;
+            scanptr[0].Al = 0;
 
-			// AC scans
-			// First two Y AC coefficients
-			scanptr[1].component_index[0] = 0;
-			scanptr[1].comps_in_scan = 1;
-			scanptr[1].Ss = 1;
-			scanptr[1].Se = 2;
-			scanptr[1].Ah = 0;
-			scanptr[1].Al = 0;
+            // AC scans
+            // First two Y AC coefficients
+            scanptr[1].component_index[0] = 0;
+            scanptr[1].comps_in_scan = 1;
+            scanptr[1].Ss = 1;
+            scanptr[1].Se = 2;
+            scanptr[1].Ah = 0;
+            scanptr[1].Al = 0;
 
-			// Three more
-			scanptr[2].component_index[0] = 0;
-			scanptr[2].comps_in_scan = 1;
-			scanptr[2].Ss = 3;
-			scanptr[2].Se = 5;
-			scanptr[2].Ah = 0;
-			scanptr[2].Al = 0;
+            // Three more
+            scanptr[2].component_index[0] = 0;
+            scanptr[2].comps_in_scan = 1;
+            scanptr[2].Ss = 3;
+            scanptr[2].Se = 5;
+            scanptr[2].Ah = 0;
+            scanptr[2].Al = 0;
 
-			// All AC coefficients for Cb
-			scanptr[3].component_index[0] = 1;
-			scanptr[3].comps_in_scan = 1;
-			scanptr[3].Ss = 1;
-			scanptr[3].Se = 63;
-			scanptr[3].Ah = 0;
-			scanptr[3].Al = 0;
+            // All AC coefficients for Cb
+            scanptr[3].component_index[0] = 1;
+            scanptr[3].comps_in_scan = 1;
+            scanptr[3].Ss = 1;
+            scanptr[3].Se = 63;
+            scanptr[3].Ah = 0;
+            scanptr[3].Al = 0;
 
-			// All AC coefficients for Cr
-			scanptr[4].component_index[0] = 2;
-			scanptr[4].comps_in_scan = 1;
-			scanptr[4].Ss = 1;
-			scanptr[4].Se = 63;
-			scanptr[4].Ah = 0;
-			scanptr[4].Al = 0;
+            // All AC coefficients for Cr
+            scanptr[4].component_index[0] = 2;
+            scanptr[4].comps_in_scan = 1;
+            scanptr[4].Ss = 1;
+            scanptr[4].Se = 63;
+            scanptr[4].Ah = 0;
+            scanptr[4].Al = 0;
 
-			// More Y coefficients
-			scanptr[5].component_index[0] = 0;
-			scanptr[5].comps_in_scan = 1;
-			scanptr[5].Ss = 6;
-			scanptr[5].Se = 9;
-			scanptr[5].Ah = 0;
-			scanptr[5].Al = 0;
+            // More Y coefficients
+            scanptr[5].component_index[0] = 0;
+            scanptr[5].comps_in_scan = 1;
+            scanptr[5].Ss = 6;
+            scanptr[5].Se = 9;
+            scanptr[5].Ah = 0;
+            scanptr[5].Al = 0;
 
-			// Remaining Y coefficients
-			scanptr[6].component_index[0] = 0;
-			scanptr[6].comps_in_scan = 1;
-			scanptr[6].Ss = 10;
-			scanptr[6].Se = 63;
-			scanptr[6].Ah = 0;
-			scanptr[6].Al = 0;
-		}
-		else
-		{
-			/* All-purpose script for other color spaces. */
-			int j=0;
+            // Remaining Y coefficients
+            scanptr[6].component_index[0] = 0;
+            scanptr[6].comps_in_scan = 1;
+            scanptr[6].Ss = 10;
+            scanptr[6].Se = 63;
+            scanptr[6].Ah = 0;
+            scanptr[6].Al = 0;
+        }
+        else
+        {
+            /* All-purpose script for other color spaces. */
+            int j=0;
 
-			// Interleaved DC scan for all components
-			for (j=0; j<ncomps; j++) scanptr[0].component_index[j] = j;
-			scanptr[0].comps_in_scan = ncomps;
-			scanptr[0].Ss = 0;
-			scanptr[0].Se = 0;
-			scanptr[0].Ah = 0;
-			scanptr[0].Al = 0;
+            // Interleaved DC scan for all components
+            for (j=0; j<ncomps; j++) scanptr[0].component_index[j] = j;
+            scanptr[0].comps_in_scan = ncomps;
+            scanptr[0].Ss = 0;
+            scanptr[0].Se = 0;
+            scanptr[0].Ah = 0;
+            scanptr[0].Al = 0;
 
-			// first AC scan for each component
-			for (j=0; j<ncomps; j++) {
-				scanptr[j+1].component_index[0] = j;
-				scanptr[j+1].comps_in_scan = 1;
-				scanptr[j+1].Ss = 1;
-				scanptr[j+1].Se = 5;
-				scanptr[j+1].Ah = 0;
-				scanptr[j+1].Al = 0;
-			}
+            // first AC scan for each component
+            for (j=0; j<ncomps; j++) {
+                scanptr[j+1].component_index[0] = j;
+                scanptr[j+1].comps_in_scan = 1;
+                scanptr[j+1].Ss = 1;
+                scanptr[j+1].Se = 5;
+                scanptr[j+1].Ah = 0;
+                scanptr[j+1].Al = 0;
+            }
 
-			// second AC scan for each component
-			for (j=0; j<ncomps; j++) {
-				scanptr[j+ncomps+1].component_index[0] = j;
-				scanptr[j+ncomps+1].comps_in_scan = 1;
-				scanptr[j+ncomps+1].Ss = 6;
-				scanptr[j+ncomps+1].Se = 63;
-				scanptr[j+ncomps+1].Ah = 0;
-				scanptr[j+ncomps+1].Al = 0;
-			}
-		}
-	}
+            // second AC scan for each component
+            for (j=0; j<ncomps; j++) {
+                scanptr[j+ncomps+1].component_index[0] = j;
+                scanptr[j+ncomps+1].comps_in_scan = 1;
+                scanptr[j+ncomps+1].Ss = 6;
+                scanptr[j+ncomps+1].Se = 63;
+                scanptr[j+ncomps+1].Ah = 0;
+                scanptr[j+ncomps+1].Al = 0;
+            }
+        }
+    }
 }
 
 void JPEGCODEC::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) {
-	if ((oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrIct) ||
-		(oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrRct))
-		throw gcnew DicomCodecException("Photometric Interpretation '{0}' not supported by JPEG encoder!", oldPixelData->PhotometricInterpretation);
+    if ((oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrIct) ||
+        (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrRct))
+        throw gcnew DicomCodecException("Photometric Interpretation '{0}' not supported by JPEG encoder!", oldPixelData->PhotometricInterpretation);
 
-	PinnedByteArray^ frameArray = nullptr;
-	
-	if (oldPixelData->BitsAllocated == 16 && oldPixelData->BitsStored <= 8) {
-		IByteBuffer^ frameBuffer = oldPixelData->GetFrame(frame);
-		frameArray = gcnew PinnedByteArray(
-						ByteConverter::UnpackLow16(frameBuffer)->Data);
-	}
-	else
-		frameArray = gcnew PinnedByteArray(oldPixelData->GetFrame(frame)->Data);
+    PinnedByteArray^ frameArray = nullptr;
+    
+    if (oldPixelData->BitsAllocated == 16 && oldPixelData->BitsStored <= 8) {
+        IByteBuffer^ frameBuffer = oldPixelData->GetFrame(frame);
+        frameArray = gcnew PinnedByteArray(
+                        ByteConverter::UnpackLow16(frameBuffer)->Data);
+    }
+    else
+        frameArray = gcnew PinnedByteArray(oldPixelData->GetFrame(frame)->Data);
 
-	try {
-		if (oldPixelData->PlanarConfiguration == PlanarConfiguration::Planar && oldPixelData->SamplesPerPixel > 1) {
-			if (oldPixelData->SamplesPerPixel != 3 || oldPixelData->BitsStored > 8)
-				throw gcnew DicomCodecException("Planar reconfiguration only implemented for SamplesPerPixel=3 && BitsStores <= 8");
+    try {
+        if (oldPixelData->PlanarConfiguration == PlanarConfiguration::Planar && oldPixelData->SamplesPerPixel > 1) {
+            if (oldPixelData->SamplesPerPixel != 3 || oldPixelData->BitsStored > 8)
+                throw gcnew DicomCodecException("Planar reconfiguration only implemented for SamplesPerPixel=3 && BitsStores <= 8");
 
-			newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;
-			frameArray = gcnew PinnedByteArray(
-				PixelDataConverter::PlanarToInterleaved24(
-					gcnew MemoryByteBuffer(frameArray->Data))->Data);
-		}
+            newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;
+            frameArray = gcnew PinnedByteArray(
+                PixelDataConverter::PlanarToInterleaved24(
+                    gcnew MemoryByteBuffer(frameArray->Data))->Data);
+        }
 
-		struct jpeg_compress_struct cinfo;
-		struct IJGVERS::ErrorStruct jerr;
-		cinfo.err = jpeg_std_error(&jerr.pub);
-		jerr.pub.error_exit = IJGVERS::ErrorExit;
-		jerr.pub.output_message = IJGVERS::OutputMessage;
+        struct jpeg_compress_struct cinfo;
+        struct IJGVERS::ErrorStruct jerr;
+        cinfo.err = jpeg_std_error(&jerr.pub);
+        jerr.pub.error_exit = IJGVERS::ErrorExit;
+        jerr.pub.output_message = IJGVERS::OutputMessage;
 
-		jpeg_create_compress(&cinfo);
-		cinfo.client_data = nullptr;
-		
-		JPEGCODEC::This = this;
+        jpeg_create_compress(&cinfo);
+        cinfo.client_data = nullptr;
+        
+        JPEGCODEC::This = this;
 
-		// Specify destination manager
-		jpeg_destination_mgr dest;
-		dest.init_destination = IJGVERS::initDestination;
-		dest.empty_output_buffer = IJGVERS::emptyOutputBuffer;
-		dest.term_destination = IJGVERS::termDestination;
-		cinfo.dest = &dest;
+        // Specify destination manager
+        jpeg_destination_mgr dest;
+        dest.init_destination = IJGVERS::initDestination;
+        dest.empty_output_buffer = IJGVERS::emptyOutputBuffer;
+        dest.term_destination = IJGVERS::termDestination;
+        cinfo.dest = &dest;
 
-		cinfo.image_width = oldPixelData->Width;
-		cinfo.image_height = oldPixelData->Height;
-		cinfo.input_components = oldPixelData->SamplesPerPixel;
-		cinfo.in_color_space = IJGVERS::getJpegColorSpace(oldPixelData->PhotometricInterpretation);
+        cinfo.image_width = oldPixelData->Width;
+        cinfo.image_height = oldPixelData->Height;
+        cinfo.input_components = oldPixelData->SamplesPerPixel;
+        cinfo.in_color_space = IJGVERS::getJpegColorSpace(oldPixelData->PhotometricInterpretation);
 
-		jpeg_set_defaults(&cinfo);
+        jpeg_set_defaults(&cinfo);
 
-		cinfo.optimize_coding = true;
+        cinfo.optimize_coding = true;
 
-		if (Mode == JpegMode::Baseline || Mode == JpegMode::Sequential) {
-			jpeg_set_quality(&cinfo, params->Quality, 0);
-		}
-		else if (Mode == JpegMode::SpectralSelection) {
-			jpeg_set_quality(&cinfo, params->Quality, 0);
-			IJGVERS::jpeg_simple_spectral_selection(&cinfo);
-		}
-		else if (Mode == JpegMode::Progressive) {
-			jpeg_set_quality(&cinfo, params->Quality, 0);
-			jpeg_simple_progression(&cinfo);
-		}
-		else {
-			jpeg_simple_lossless(&cinfo, Predictor, PointTransform);
-		}
-		
-		cinfo.smoothing_factor = params->SmoothingFactor;
+        if (Mode == JpegMode::Baseline || Mode == JpegMode::Sequential) {
+            jpeg_set_quality(&cinfo, params->Quality, 0);
+        }
+        else if (Mode == JpegMode::SpectralSelection) {
+            jpeg_set_quality(&cinfo, params->Quality, 0);
+            IJGVERS::jpeg_simple_spectral_selection(&cinfo);
+        }
+        else if (Mode == JpegMode::Progressive) {
+            jpeg_set_quality(&cinfo, params->Quality, 0);
+            jpeg_simple_progression(&cinfo);
+        }
+        else {
+            jpeg_simple_lossless(&cinfo, Predictor, PointTransform);
+        }
+        
+        cinfo.smoothing_factor = params->SmoothingFactor;
 
-		if (Mode == JpegMode::Lossless) {
-			jpeg_set_colorspace(&cinfo, cinfo.in_color_space);
-			cinfo.comp_info[0].h_samp_factor = 1;
-			cinfo.comp_info[0].v_samp_factor = 1;
-		}
-		else {
-			// initialize sampling factors
-			if (cinfo.jpeg_color_space == JCS_YCbCr && params->SampleFactor != DicomJpegSampleFactor::Unknown) {
-				switch(params->SampleFactor) {
-				  case DicomJpegSampleFactor::SF444: /* 4:4:4 sampling (no subsampling) */
-					cinfo.comp_info[0].h_samp_factor = 1;
-					cinfo.comp_info[0].v_samp_factor = 1;
-					break;
-				  case DicomJpegSampleFactor::SF422: /* 4:2:2 sampling (horizontal subsampling of chroma components) */
-					cinfo.comp_info[0].h_samp_factor = 2;
-					cinfo.comp_info[0].v_samp_factor = 1;
-					break;
-				//case DicomJpegSampleFactor::SF411: /* 4:1:1 sampling (horizontal and vertical subsampling of chroma components) */
-				//	cinfo.comp_info[0].h_samp_factor = 2;
-				//	cinfo.comp_info[0].v_samp_factor = 2;
-				//	break;
-				}
-			}
-			else {
-				if (params->SampleFactor == DicomJpegSampleFactor::Unknown)
-					jpeg_set_colorspace(&cinfo, cinfo.in_color_space);
+        if (Mode == JpegMode::Lossless) {
+            jpeg_set_colorspace(&cinfo, cinfo.in_color_space);
+            cinfo.comp_info[0].h_samp_factor = 1;
+            cinfo.comp_info[0].v_samp_factor = 1;
+        }
+        else {
+            // initialize sampling factors
+            if (cinfo.jpeg_color_space == JCS_YCbCr && params->SampleFactor != DicomJpegSampleFactor::Unknown) {
+                switch(params->SampleFactor) {
+                  case DicomJpegSampleFactor::SF444: /* 4:4:4 sampling (no subsampling) */
+                    cinfo.comp_info[0].h_samp_factor = 1;
+                    cinfo.comp_info[0].v_samp_factor = 1;
+                    break;
+                  case DicomJpegSampleFactor::SF422: /* 4:2:2 sampling (horizontal subsampling of chroma components) */
+                    cinfo.comp_info[0].h_samp_factor = 2;
+                    cinfo.comp_info[0].v_samp_factor = 1;
+                    break;
+                //case DicomJpegSampleFactor::SF411: /* 4:1:1 sampling (horizontal and vertical subsampling of chroma components) */
+                //	cinfo.comp_info[0].h_samp_factor = 2;
+                //	cinfo.comp_info[0].v_samp_factor = 2;
+                //	break;
+                }
+            }
+            else {
+                if (params->SampleFactor == DicomJpegSampleFactor::Unknown)
+                    jpeg_set_colorspace(&cinfo, cinfo.in_color_space);
 
-				// JPEG color space is not YCbCr, disable subsampling.
-				cinfo.comp_info[0].h_samp_factor = 1;
-				cinfo.comp_info[0].v_samp_factor = 1;
-			}
-		}
+                // JPEG color space is not YCbCr, disable subsampling.
+                cinfo.comp_info[0].h_samp_factor = 1;
+                cinfo.comp_info[0].v_samp_factor = 1;
+            }
+        }
 
-		// all other components are set to 1x1
-		for (int sfi = 1; sfi < MAX_COMPONENTS; sfi++) {
-			cinfo.comp_info[sfi].h_samp_factor = 1;
-			cinfo.comp_info[sfi].v_samp_factor = 1;
-		}
+        // all other components are set to 1x1
+        for (int sfi = 1; sfi < MAX_COMPONENTS; sfi++) {
+            cinfo.comp_info[sfi].h_samp_factor = 1;
+            cinfo.comp_info[sfi].v_samp_factor = 1;
+        }
 
-		jpeg_start_compress(&cinfo, TRUE);
+        jpeg_start_compress(&cinfo, TRUE);
 
-		JSAMPROW row_pointer[1];
-		int row_stride = oldPixelData->Width * oldPixelData->SamplesPerPixel * (oldPixelData->BitsStored <= 8 ? 1 : oldPixelData->BytesAllocated);
+        JSAMPROW row_pointer[1];
+        int row_stride = oldPixelData->Width * oldPixelData->SamplesPerPixel * (oldPixelData->BitsStored <= 8 ? 1 : oldPixelData->BytesAllocated);
 
-		unsigned char* framePtr = (unsigned char*)(void*)frameArray->Pointer;
-		while (cinfo.next_scanline < cinfo.image_height) {
-			row_pointer[0] = (JSAMPLE *)(&framePtr[cinfo.next_scanline * row_stride]);
-			jpeg_write_scanlines(&cinfo, row_pointer, 1);
-		}
+        unsigned char* framePtr = (unsigned char*)(void*)frameArray->Pointer;
+        while (cinfo.next_scanline < cinfo.image_height) {
+            row_pointer[0] = (JSAMPLE *)(&framePtr[cinfo.next_scanline * row_stride]);
+            jpeg_write_scanlines(&cinfo, row_pointer, 1);
+        }
 
-		jpeg_finish_compress(&cinfo);
-		jpeg_destroy_compress(&cinfo);
+        jpeg_finish_compress(&cinfo);
+        jpeg_destroy_compress(&cinfo);
 
-		if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb && cinfo.jpeg_color_space == JCS_YCbCr) {
-			if (params->SampleFactor == DicomJpegSampleFactor::SF422)
-				newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull422;
-			else
-				newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
-		}
+        if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb && cinfo.jpeg_color_space == JCS_YCbCr) {
+            if (params->SampleFactor == DicomJpegSampleFactor::SF422)
+                newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull422;
+            else
+                newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
+        }
 
-		IByteBuffer^ buffer;
-		if (MemoryBuffer->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-			buffer = gcnew TempFileBuffer(MemoryBuffer->ToArray());
-		else
-			buffer = gcnew MemoryByteBuffer(MemoryBuffer->ToArray());
-		buffer = EvenLengthBuffer::Create(buffer);
-		newPixelData->AddFrame(buffer);
-	} finally {
-		MemoryBuffer = nullptr;
-		if(frameArray != nullptr){
-			delete frameArray;
-			frameArray = nullptr;
-		}
-	}
+        IByteBuffer^ buffer;
+        if (MemoryBuffer->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+            buffer = gcnew TempFileBuffer(MemoryBuffer->ToArray());
+        else
+            buffer = gcnew MemoryByteBuffer(MemoryBuffer->ToArray());
+        buffer = EvenLengthBuffer::Create(buffer);
+        newPixelData->AddFrame(buffer);
+    } finally {
+        MemoryBuffer = nullptr;
+        if(frameArray != nullptr){
+            delete frameArray;
+            frameArray = nullptr;
+        }
+    }
 }
 
 
 
 namespace IJGVERS {
-	// private source manager struct
-	struct SourceManagerStruct {
-		// the standard IJG source manager object
-		struct jpeg_source_mgr pub;
+    // private source manager struct
+    struct SourceManagerStruct {
+        // the standard IJG source manager object
+        struct jpeg_source_mgr pub;
 
-		// number of bytes to skip at start of buffer
-		long skip_bytes;
+        // number of bytes to skip at start of buffer
+        long skip_bytes;
 
-		// buffer from which reading will continue as soon as the current buffer is empty
-		unsigned char *next_buffer;
+        // buffer from which reading will continue as soon as the current buffer is empty
+        unsigned char *next_buffer;
 
-		// buffer size
-		unsigned int *next_buffer_size;
-	};
+        // buffer size
+        unsigned int *next_buffer_size;
+    };
 
-	void initSource(j_decompress_ptr /* cinfo */) {
-	}
+    void initSource(j_decompress_ptr /* cinfo */) {
+    }
 
-	ijg_boolean fillInputBuffer(j_decompress_ptr cinfo) {
-		SourceManagerStruct *src = (SourceManagerStruct *)(cinfo->src);
+    ijg_boolean fillInputBuffer(j_decompress_ptr cinfo) {
+        SourceManagerStruct *src = (SourceManagerStruct *)(cinfo->src);
 
-		// if we already have the next buffer, switch buffers
-		if (src->next_buffer) {
-			src->pub.next_input_byte    = src->next_buffer;
-			src->pub.bytes_in_buffer    = (unsigned int) src->next_buffer_size;
-			src->next_buffer            = NULL;
-			src->next_buffer_size       = 0;
+        // if we already have the next buffer, switch buffers
+        if (src->next_buffer) {
+            src->pub.next_input_byte    = src->next_buffer;
+            src->pub.bytes_in_buffer    = (unsigned int) src->next_buffer_size;
+            src->next_buffer            = NULL;
+            src->next_buffer_size       = 0;
 
-			// The suspension was caused by IJG16skipInputData iff src->skip_bytes > 0.
-			// In this case we must skip the remaining number of bytes here.
-			if (src->skip_bytes > 0) {
-				if (src->pub.bytes_in_buffer < (unsigned long) src->skip_bytes) {
-					src->skip_bytes            -= src->pub.bytes_in_buffer;
-					src->pub.next_input_byte   += src->pub.bytes_in_buffer;
-					src->pub.bytes_in_buffer    = 0;
-					// cause a suspension return
-					return FALSE;
-				}
-				else {
-					src->pub.bytes_in_buffer   -= (unsigned int) src->skip_bytes;
-					src->pub.next_input_byte   += src->skip_bytes;
-					src->skip_bytes             = 0;
-				}
-			}
-			return TRUE;
-		}
+            // The suspension was caused by IJG16skipInputData iff src->skip_bytes > 0.
+            // In this case we must skip the remaining number of bytes here.
+            if (src->skip_bytes > 0) {
+                if (src->pub.bytes_in_buffer < (unsigned long) src->skip_bytes) {
+                    src->skip_bytes            -= src->pub.bytes_in_buffer;
+                    src->pub.next_input_byte   += src->pub.bytes_in_buffer;
+                    src->pub.bytes_in_buffer    = 0;
+                    // cause a suspension return
+                    return FALSE;
+                }
+                else {
+                    src->pub.bytes_in_buffer   -= (unsigned int) src->skip_bytes;
+                    src->pub.next_input_byte   += src->skip_bytes;
+                    src->skip_bytes             = 0;
+                }
+            }
+            return TRUE;
+        }
 
-		// otherwise cause a suspension return
-		return FALSE;
-	}
+        // otherwise cause a suspension return
+        return FALSE;
+    }
 
-	void skipInputData(j_decompress_ptr cinfo, long num_bytes) {
-		SourceManagerStruct *src = (SourceManagerStruct *)(cinfo->src);
+    void skipInputData(j_decompress_ptr cinfo, long num_bytes) {
+        SourceManagerStruct *src = (SourceManagerStruct *)(cinfo->src);
 
-		if (src->pub.bytes_in_buffer < (size_t)num_bytes) {
-			src->skip_bytes             = num_bytes - src->pub.bytes_in_buffer;
-			src->pub.next_input_byte   += src->pub.bytes_in_buffer;
-			src->pub.bytes_in_buffer    = 0; // causes a suspension return
-		}
-		else {
-			src->pub.bytes_in_buffer   -= (unsigned int) num_bytes;
-			src->pub.next_input_byte   += num_bytes;
-			src->skip_bytes             = 0;
-		}
-	}
+        if (src->pub.bytes_in_buffer < (size_t)num_bytes) {
+            src->skip_bytes             = num_bytes - src->pub.bytes_in_buffer;
+            src->pub.next_input_byte   += src->pub.bytes_in_buffer;
+            src->pub.bytes_in_buffer    = 0; // causes a suspension return
+        }
+        else {
+            src->pub.bytes_in_buffer   -= (unsigned int) num_bytes;
+            src->pub.next_input_byte   += num_bytes;
+            src->skip_bytes             = 0;
+        }
+    }
 
-	void termSource(j_decompress_ptr /* cinfo */) {
-	}
+    void termSource(j_decompress_ptr /* cinfo */) {
+    }
 }
 
 void JPEGCODEC::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomJpegParams^ params, int frame) {
-	PinnedByteArray^ jpegArray = gcnew PinnedByteArray(oldPixelData->GetFrame(frame)->Data);
-	PinnedByteArray^ frameArray = nullptr;
-	try{
-		jpeg_decompress_struct dinfo;
-		memset(&dinfo, 0, sizeof(dinfo));
+    PinnedByteArray^ jpegArray = gcnew PinnedByteArray(oldPixelData->GetFrame(frame)->Data);
+    PinnedByteArray^ frameArray = nullptr;
+    try{
+        jpeg_decompress_struct dinfo;
+        memset(&dinfo, 0, sizeof(dinfo));
 
-		IJGVERS::SourceManagerStruct src;
-		memset(&src, 0, sizeof(IJGVERS::SourceManagerStruct));
-		src.pub.init_source       = IJGVERS::initSource;
-		src.pub.fill_input_buffer = IJGVERS::fillInputBuffer;
-		src.pub.skip_input_data   = IJGVERS::skipInputData;
-		src.pub.resync_to_restart = jpeg_resync_to_restart;
-		src.pub.term_source       = IJGVERS::termSource;
-		src.pub.bytes_in_buffer   = 0;
-		src.pub.next_input_byte   = NULL;
-		src.skip_bytes            = 0;
-		src.next_buffer           = (unsigned char*)(void*)jpegArray->Pointer;
-		src.next_buffer_size      = (unsigned int*)jpegArray->ByteSize;
+        IJGVERS::SourceManagerStruct src;
+        memset(&src, 0, sizeof(IJGVERS::SourceManagerStruct));
+        src.pub.init_source       = IJGVERS::initSource;
+        src.pub.fill_input_buffer = IJGVERS::fillInputBuffer;
+        src.pub.skip_input_data   = IJGVERS::skipInputData;
+        src.pub.resync_to_restart = jpeg_resync_to_restart;
+        src.pub.term_source       = IJGVERS::termSource;
+        src.pub.bytes_in_buffer   = 0;
+        src.pub.next_input_byte   = NULL;
+        src.skip_bytes            = 0;
+        src.next_buffer           = (unsigned char*)(void*)jpegArray->Pointer;
+        src.next_buffer_size      = (unsigned int*)jpegArray->ByteSize;
 
-		IJGVERS::ErrorStruct jerr;
-		memset(&jerr, 0, sizeof(IJGVERS::ErrorStruct));
-		dinfo.err = jpeg_std_error(&jerr.pub);
-		jerr.pub.error_exit = IJGVERS::ErrorExit;
-		jerr.pub.output_message = IJGVERS::OutputMessage;
+        IJGVERS::ErrorStruct jerr;
+        memset(&jerr, 0, sizeof(IJGVERS::ErrorStruct));
+        dinfo.err = jpeg_std_error(&jerr.pub);
+        jerr.pub.error_exit = IJGVERS::ErrorExit;
+        jerr.pub.output_message = IJGVERS::OutputMessage;
 
-		jpeg_create_decompress(&dinfo);
-		dinfo.src = (jpeg_source_mgr*)&src.pub;
+        jpeg_create_decompress(&dinfo);
+        dinfo.src = (jpeg_source_mgr*)&src.pub;
 
-		if (jpeg_read_header(&dinfo, TRUE) == JPEG_SUSPENDED)
-			throw gcnew DicomCodecException("Unable to decompress JPEG: Suspended");
-			
-		if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422 || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422)
-			newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
-		else
-			newPixelData->PhotometricInterpretation = oldPixelData->PhotometricInterpretation;
+        if (jpeg_read_header(&dinfo, TRUE) == JPEG_SUSPENDED)
+            throw gcnew DicomCodecException("Unable to decompress JPEG: Suspended");
+            
+        if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422 || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422)
+            newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
+        else
+            newPixelData->PhotometricInterpretation = oldPixelData->PhotometricInterpretation;
 
-		if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
-			if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
-				throw gcnew DicomCodecException("JPEG codec unable to perform colorspace conversion on signed pixel data");
-			//dinfo.jpeg_color_space = JCS_YCbCr;
-			dinfo.out_color_space = JCS_RGB;
-			newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
-			newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;
-		}
-		else {
-			dinfo.jpeg_color_space = JCS_UNKNOWN; 
-			dinfo.out_color_space = JCS_UNKNOWN;
-		}
-		
-		if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull)
-			newPixelData->PlanarConfiguration = PlanarConfiguration::Planar;
+        if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
+            if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
+                throw gcnew DicomCodecException("JPEG codec unable to perform colorspace conversion on signed pixel data");
+            //dinfo.jpeg_color_space = JCS_YCbCr;
+            dinfo.out_color_space = JCS_RGB;
+            newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
+            newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;
+        }
+        else {
+            dinfo.jpeg_color_space = JCS_UNKNOWN; 
+            dinfo.out_color_space = JCS_UNKNOWN;
+        }
+        
+        if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull)
+            newPixelData->PlanarConfiguration = PlanarConfiguration::Planar;
 
-		jpeg_calc_output_dimensions(&dinfo);
-		jpeg_start_decompress(&dinfo);
+        jpeg_calc_output_dimensions(&dinfo);
+        jpeg_start_decompress(&dinfo);
 
-		int rowSize = dinfo.output_width * dinfo.output_components * sizeof(JSAMPLE);
-		int frameSize = rowSize * dinfo.output_height;
-		if ((frameSize % 2) != 0)
-			frameSize++;
+        int rowSize = dinfo.output_width * dinfo.output_components * sizeof(JSAMPLE);
+        int frameSize = rowSize * dinfo.output_height;
+        if ((frameSize % 2) != 0)
+            frameSize++;
 
-		frameArray = gcnew PinnedByteArray(frameSize);
-		unsigned char* framePtr = (unsigned char*)(void*)frameArray->Pointer;
+        frameArray = gcnew PinnedByteArray(frameSize);
+        unsigned char* framePtr = (unsigned char*)(void*)frameArray->Pointer;
 
-		while (dinfo.output_scanline < dinfo.output_height) {
-			int rows = jpeg_read_scanlines(&dinfo, (JSAMPARRAY)&framePtr, 1);
-			framePtr += rows * rowSize;
-		}
+        while (dinfo.output_scanline < dinfo.output_height) {
+            int rows = jpeg_read_scanlines(&dinfo, (JSAMPARRAY)&framePtr, 1);
+            framePtr += rows * rowSize;
+        }
 
-		jpeg_destroy_decompress(&dinfo);
+        jpeg_destroy_decompress(&dinfo);
 
-		IByteBuffer^ buffer;
-		if (frameArray->Count >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-			buffer = gcnew TempFileBuffer(frameArray->Data);
-		else
-			buffer = gcnew MemoryByteBuffer(frameArray->Data);
-		buffer = EvenLengthBuffer::Create(buffer);
-		
-		if (newPixelData->PlanarConfiguration == PlanarConfiguration::Planar && newPixelData->SamplesPerPixel > 1) {
-			if (oldPixelData->SamplesPerPixel != 3 || oldPixelData->BitsStored > 8)
-					throw gcnew DicomCodecException("Planar reconfiguration only implemented for SamplesPerPixel=3 && BitsStores <= 8");
+        IByteBuffer^ buffer;
+        if (frameArray->Count >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+            buffer = gcnew TempFileBuffer(frameArray->Data);
+        else
+            buffer = gcnew MemoryByteBuffer(frameArray->Data);
+        buffer = EvenLengthBuffer::Create(buffer);
+        
+        if (newPixelData->PlanarConfiguration == PlanarConfiguration::Planar && newPixelData->SamplesPerPixel > 1) {
+            if (oldPixelData->SamplesPerPixel != 3 || oldPixelData->BitsStored > 8)
+                throw gcnew DicomCodecException("Planar reconfiguration only implemented for SamplesPerPixel=3 && BitsStores <= 8");
 
-			buffer = PixelDataConverter::InterleavedToPlanar24(buffer);
-		}
+            buffer = PixelDataConverter::InterleavedToPlanar24(buffer);
+        }
 
-		newPixelData->AddFrame(buffer);
-	}
-	finally{
-		if(frameArray != nullptr){
-			delete frameArray;
-			frameArray = nullptr;
-		}
-		if(jpegArray != nullptr){
-			delete jpegArray;
-			jpegArray = nullptr;
-		}
-	}
+        newPixelData->AddFrame(buffer);
+    }
+    finally{
+        if(frameArray != nullptr){
+            delete frameArray;
+            frameArray = nullptr;
+        }
+        if(jpegArray != nullptr){
+            delete jpegArray;
+            jpegArray = nullptr;
+        }
+    }
 }
 
 int JPEGCODEC::ScanHeaderForPrecision(DicomPixelData^ pixelData) {
-	PinnedByteArray^ jpegArray = gcnew PinnedByteArray(pixelData->GetFrame(0)->Data);
-	
-	jpeg_decompress_struct dinfo;
-	memset(&dinfo, 0, sizeof(dinfo));
+    PinnedByteArray^ jpegArray = gcnew PinnedByteArray(pixelData->GetFrame(0)->Data);
+    
+    jpeg_decompress_struct dinfo;
+    memset(&dinfo, 0, sizeof(dinfo));
 
-	IJGVERS::SourceManagerStruct src;
-	memset(&src, 0, sizeof(IJGVERS::SourceManagerStruct));
-	src.pub.init_source       = IJGVERS::initSource;
-	src.pub.fill_input_buffer = IJGVERS::fillInputBuffer;
-	src.pub.skip_input_data   = IJGVERS::skipInputData;
-	src.pub.resync_to_restart = jpeg_resync_to_restart;
-	src.pub.term_source       = IJGVERS::termSource;
-	src.pub.bytes_in_buffer   = 0;
-	src.pub.next_input_byte   = NULL;
-	src.skip_bytes            = 0;
-	src.next_buffer           = (unsigned char*)(void*)jpegArray->Pointer;
-	src.next_buffer_size      = (unsigned int*)jpegArray->ByteSize;
+    IJGVERS::SourceManagerStruct src;
+    memset(&src, 0, sizeof(IJGVERS::SourceManagerStruct));
+    src.pub.init_source       = IJGVERS::initSource;
+    src.pub.fill_input_buffer = IJGVERS::fillInputBuffer;
+    src.pub.skip_input_data   = IJGVERS::skipInputData;
+    src.pub.resync_to_restart = jpeg_resync_to_restart;
+    src.pub.term_source       = IJGVERS::termSource;
+    src.pub.bytes_in_buffer   = 0;
+    src.pub.next_input_byte   = NULL;
+    src.skip_bytes            = 0;
+    src.next_buffer           = (unsigned char*)(void*)jpegArray->Pointer;
+    src.next_buffer_size      = (unsigned int*)jpegArray->ByteSize;
 
     IJGVERS::ErrorStruct jerr;
-	memset(&jerr, 0, sizeof(IJGVERS::ErrorStruct));
-	dinfo.err = jpeg_std_error(&jerr.pub);
-	jerr.pub.error_exit = IJGVERS::ErrorExit;
-	jerr.pub.output_message = IJGVERS::OutputMessage;
+    memset(&jerr, 0, sizeof(IJGVERS::ErrorStruct));
+    dinfo.err = jpeg_std_error(&jerr.pub);
+    jerr.pub.error_exit = IJGVERS::ErrorExit;
+    jerr.pub.output_message = IJGVERS::OutputMessage;
 
-	jpeg_create_decompress(&dinfo);
-	dinfo.src = (jpeg_source_mgr*)&src.pub;
+    jpeg_create_decompress(&dinfo);
+    dinfo.src = (jpeg_source_mgr*)&src.pub;
 
-	if (jpeg_read_header(&dinfo, TRUE) == JPEG_SUSPENDED) {
-		jpeg_destroy_decompress(&dinfo);
-		throw gcnew DicomCodecException("Unable to read JPEG header: Suspended");
-	}
+    if (jpeg_read_header(&dinfo, TRUE) == JPEG_SUSPENDED) {
+        jpeg_destroy_decompress(&dinfo);
+        throw gcnew DicomCodecException("Unable to read JPEG header: Suspended");
+    }
 
-	jpeg_destroy_decompress(&dinfo);
+    jpeg_destroy_decompress(&dinfo);
 
-	return dinfo.data_precision;
+    return dinfo.data_precision;
 }

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg2000.cpp
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg2000.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #include "stdio.h"
 #include "string.h"
 
@@ -17,355 +20,357 @@ extern "C" {
 #include "OpenJPEG/openjpeg.h"
 #include "OpenJPEG/j2k.h"
 
-	void opj_error_callback(const char *msg, void *usr) {
-		//Dicom::Debug::Log->Error("OpenJPEG: {0}", gcnew String(msg));
-	}
+    void opj_error_callback(const char *msg, void *usr) {
+        //Dicom::Debug::Log->Error("OpenJPEG: {0}", gcnew String(msg));
+    }
 
-	void opj_warning_callback(const char *msg, void *) {
-		//Dicom::Debug::Log->Warn("OpenJPEG: {0}", gcnew String(msg));
-	}
+    void opj_warning_callback(const char *msg, void *) {
+        //Dicom::Debug::Log->Warn("OpenJPEG: {0}", gcnew String(msg));
+    }
 
-	void opj_info_callback(const char *msg, void *) {
-		//Dicom::Debug::Log->Info("OpenJPEG: {0}", gcnew String(msg));
-	}
+    void opj_info_callback(const char *msg, void *) {
+        //Dicom::Debug::Log->Info("OpenJPEG: {0}", gcnew String(msg));
+    }
 }
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
+    namespace Imaging {
+        namespace Codec {
 
-OPJ_COLOR_SPACE getOpenJpegColorSpace(PhotometricInterpretation^ photometricInterpretation) {
-	if (photometricInterpretation == PhotometricInterpretation::Rgb)
-		return CLRSPC_SRGB;
-	else if (photometricInterpretation == PhotometricInterpretation::Monochrome1 || photometricInterpretation == PhotometricInterpretation::Monochrome2)
-		return CLRSPC_GRAY;
-	else if (photometricInterpretation == PhotometricInterpretation::PaletteColor)
-		return CLRSPC_GRAY;
-	else if (photometricInterpretation == PhotometricInterpretation::YbrFull || photometricInterpretation == PhotometricInterpretation::YbrFull422 || photometricInterpretation == PhotometricInterpretation::YbrPartial422)
-		return CLRSPC_SYCC;
-	else
-		return CLRSPC_UNKNOWN;
-}
+            OPJ_COLOR_SPACE getOpenJpegColorSpace(PhotometricInterpretation^ photometricInterpretation) {
+                if (photometricInterpretation == PhotometricInterpretation::Rgb)
+                    return CLRSPC_SRGB;
+                else if (photometricInterpretation == PhotometricInterpretation::Monochrome1 || photometricInterpretation == PhotometricInterpretation::Monochrome2)
+                    return CLRSPC_GRAY;
+                else if (photometricInterpretation == PhotometricInterpretation::PaletteColor)
+                    return CLRSPC_GRAY;
+                else if (photometricInterpretation == PhotometricInterpretation::YbrFull || photometricInterpretation == PhotometricInterpretation::YbrFull422 || photometricInterpretation == PhotometricInterpretation::YbrPartial422)
+                    return CLRSPC_SYCC;
+                else
+                    return CLRSPC_UNKNOWN;
+            }
 
-void DicomJpeg2000NativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
-	if ((oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422)    ||
-		(oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422) ||
-		(oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial420))
-		throw gcnew DicomCodecException("Photometric Interpretation '{0}' not supported by JPEG 2000 encoder",
-														oldPixelData->PhotometricInterpretation);
+            void DicomJpeg2000NativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
+                if ((oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422) ||
+                    (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422) ||
+                    (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial420))
+                    throw gcnew DicomCodecException("Photometric Interpretation '{0}' not supported by JPEG 2000 encoder",
+                    oldPixelData->PhotometricInterpretation);
 
-	DicomJpeg2000Params^ jparams = (DicomJpeg2000Params^)parameters;
-	if (jparams == nullptr)
-		jparams = (DicomJpeg2000Params^)GetDefaultParameters();
+                DicomJpeg2000Params^ jparams = (DicomJpeg2000Params^)parameters;
+                if (jparams == nullptr)
+                    jparams = (DicomJpeg2000Params^)GetDefaultParameters();
 
-	int pixelCount = oldPixelData->Height * oldPixelData->Width;
+                int pixelCount = oldPixelData->Height * oldPixelData->Width;
 
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		IByteBuffer^ frameData = oldPixelData->GetFrame(frame);
-		PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData->Data);
+                for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+                    IByteBuffer^ frameData = oldPixelData->GetFrame(frame);
+                    PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData->Data);
 
-		opj_image_cmptparm_t cmptparm[3];
-		opj_cparameters_t eparams;  /* compression parameters */
-		opj_event_mgr_t event_mgr;  /* event manager */
-		opj_cinfo_t* cinfo = NULL;  /* handle to a compressor */
-		opj_image_t *image = NULL;
-		opj_cio_t *cio = NULL;
+                    opj_image_cmptparm_t cmptparm[3];
+                    opj_cparameters_t eparams;  /* compression parameters */
+                    opj_event_mgr_t event_mgr;  /* event manager */
+                    opj_cinfo_t* cinfo = NULL;  /* handle to a compressor */
+                    opj_image_t *image = NULL;
+                    opj_cio_t *cio = NULL;
 
-		memset(&event_mgr, 0, sizeof(opj_event_mgr_t));
-		event_mgr.error_handler = opj_error_callback;
-		if (jparams->IsVerbose) {
-			event_mgr.warning_handler = opj_warning_callback;
-			event_mgr.info_handler = opj_info_callback;
-		}			
+                    memset(&event_mgr, 0, sizeof(opj_event_mgr_t));
+                    event_mgr.error_handler = opj_error_callback;
+                    if (jparams->IsVerbose) {
+                        event_mgr.warning_handler = opj_warning_callback;
+                        event_mgr.info_handler = opj_info_callback;
+                    }
 
-		cinfo = opj_create_compress(CODEC_J2K);
+                    cinfo = opj_create_compress(CODEC_J2K);
 
-		opj_set_event_mgr((opj_common_ptr)cinfo, &event_mgr, NULL);
+                    opj_set_event_mgr((opj_common_ptr)cinfo, &event_mgr, NULL);
 
-		opj_set_default_encoder_parameters(&eparams);
-		eparams.cp_disto_alloc = 1;
+                    opj_set_default_encoder_parameters(&eparams);
+                    eparams.cp_disto_alloc = 1;
 
-		if (newPixelData->Syntax == DicomTransferSyntax::JPEG2000Lossy && jparams->Irreversible)
-			eparams.irreversible = 1;
+                    if (newPixelData->Syntax == DicomTransferSyntax::JPEG2000Lossy && jparams->Irreversible)
+                        eparams.irreversible = 1;
 
-		int r = 0;
-		for (; r < jparams->RateLevels->Length; r++) {
-			if (jparams->RateLevels[r] > jparams->Rate) {
-				eparams.tcp_numlayers++;
-				eparams.tcp_rates[r] = (float)jparams->RateLevels[r];
-			} else
-				break;
-		}
-		eparams.tcp_numlayers++;
-		eparams.tcp_rates[r] = (float)jparams->Rate;
+                    int r = 0;
+                    for (; r < jparams->RateLevels->Length; r++) {
+                        if (jparams->RateLevels[r] > jparams->Rate) {
+                            eparams.tcp_numlayers++;
+                            eparams.tcp_rates[r] = (float)jparams->RateLevels[r];
+                        }
+                        else
+                            break;
+                    }
+                    eparams.tcp_numlayers++;
+                    eparams.tcp_rates[r] = (float)jparams->Rate;
 
-		if (newPixelData->Syntax == DicomTransferSyntax::JPEG2000Lossless && jparams->Rate > 0)
-			eparams.tcp_rates[eparams.tcp_numlayers++] = 0;
+                    if (newPixelData->Syntax == DicomTransferSyntax::JPEG2000Lossless && jparams->Rate > 0)
+                        eparams.tcp_rates[eparams.tcp_numlayers++] = 0;
 
-		if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb && jparams->AllowMCT)
-			eparams.tcp_mct = 1;
+                    if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb && jparams->AllowMCT)
+                        eparams.tcp_mct = 1;
 
-		memset(&cmptparm[0], 0, sizeof(opj_image_cmptparm_t) * 3);
-		for (int i = 0; i < oldPixelData->SamplesPerPixel; i++) {
-			cmptparm[i].bpp = oldPixelData->BitsAllocated;
-			cmptparm[i].prec = oldPixelData->BitsStored;
-			if (!jparams->EncodeSignedPixelValuesAsUnsigned)
-				cmptparm[i].sgnd = oldPixelData->PixelRepresentation == PixelRepresentation::Signed;
-			cmptparm[i].dx = eparams.subsampling_dx;
-			cmptparm[i].dy = eparams.subsampling_dy;
-			cmptparm[i].h = oldPixelData->Height;
-			cmptparm[i].w = oldPixelData->Width;
-		}
+                    memset(&cmptparm[0], 0, sizeof(opj_image_cmptparm_t) * 3);
+                    for (int i = 0; i < oldPixelData->SamplesPerPixel; i++) {
+                        cmptparm[i].bpp = oldPixelData->BitsAllocated;
+                        cmptparm[i].prec = oldPixelData->BitsStored;
+                        if (!jparams->EncodeSignedPixelValuesAsUnsigned)
+                            cmptparm[i].sgnd = oldPixelData->PixelRepresentation == PixelRepresentation::Signed;
+                        cmptparm[i].dx = eparams.subsampling_dx;
+                        cmptparm[i].dy = eparams.subsampling_dy;
+                        cmptparm[i].h = oldPixelData->Height;
+                        cmptparm[i].w = oldPixelData->Width;
+                    }
 
-		try {
-			OPJ_COLOR_SPACE color_space = getOpenJpegColorSpace(oldPixelData->PhotometricInterpretation);
-			image = opj_image_create(oldPixelData->SamplesPerPixel, &cmptparm[0], color_space);
+                    try {
+                        OPJ_COLOR_SPACE color_space = getOpenJpegColorSpace(oldPixelData->PhotometricInterpretation);
+                        image = opj_image_create(oldPixelData->SamplesPerPixel, &cmptparm[0], color_space);
 
-			image->x0 = eparams.image_offset_x0;
-			image->y0 = eparams.image_offset_y0;
-			image->x1 =	image->x0 + ((oldPixelData->Width - 1) * eparams.subsampling_dx) + 1;
-			image->y1 =	image->y0 + ((oldPixelData->Height - 1) * eparams.subsampling_dy) + 1;
+                        image->x0 = eparams.image_offset_x0;
+                        image->y0 = eparams.image_offset_y0;
+                        image->x1 = image->x0 + ((oldPixelData->Width - 1) * eparams.subsampling_dx) + 1;
+                        image->y1 = image->y0 + ((oldPixelData->Height - 1) * eparams.subsampling_dy) + 1;
 
-			for (int c = 0; c < image->numcomps; c++) {
-				opj_image_comp_t* comp = &image->comps[c];
+                        for (int c = 0; c < image->numcomps; c++) {
+                            opj_image_comp_t* comp = &image->comps[c];
 
-				int pos = oldPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? (c * pixelCount) : c;
-				const int offset = oldPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? 1 : image->numcomps;
+                            int pos = oldPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? (c * pixelCount) : c;
+                            const int offset = oldPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? 1 : image->numcomps;
 
-				if (oldPixelData->BytesAllocated == 1) {
-					if (comp->sgnd) {
-						if (oldPixelData->BitsStored < 8) {
-							const unsigned char sign = 1 << oldPixelData->HighBit;
-							const unsigned char mask = (0xff >> (oldPixelData->BitsAllocated - oldPixelData->BitsStored));
-							for (int p = 0; p < pixelCount; p++) {
-								const unsigned char pixel = frameArray->Data[pos];
-								if (pixel & sign)
-									comp->data[p] = -(((-pixel) & mask) + 1);
-								else
-									comp->data[p] = pixel;
-								pos += offset;
-							}
-						}
-						else {
-							char* frameData8 = (char*)(void*)frameArray->Pointer;
-							for (int p = 0; p < pixelCount; p++) {
-								comp->data[p] = frameData8[pos];
-								pos += offset;
-							}
-						}
-					}
-					else {
-						for (int p = 0; p < pixelCount; p++) {
-							comp->data[p] = frameArray->Data[pos];
-							pos += offset;
-						}
-					}
-				}
-				else if (oldPixelData->BytesAllocated == 2) {
-					if (comp->sgnd) {
-						if (oldPixelData->BitsStored < 16) {
-							unsigned short* frameData16 = (unsigned short*)(void*)frameArray->Pointer;
-							const unsigned short sign = 1 << oldPixelData->HighBit;
-							const unsigned short mask = (0xffff >> (oldPixelData->BitsAllocated - oldPixelData->BitsStored));
-							for (int p = 0; p < pixelCount; p++) {
-								const unsigned short pixel = frameData16[pos];
-								if (pixel & sign)
-									comp->data[p] = -(((-pixel) & mask) + 1);
-								else
-									comp->data[p] = pixel;
-								pos += offset;
-							}
-						}
-						else {
-							short* frameData16 = (short*)(void*)frameArray->Pointer;
-							for (int p = 0; p < pixelCount; p++) {
-								comp->data[p] = frameData16[pos];
-								pos += offset;
-							}
-						}
-					}
-					else {
-						unsigned short* frameData16 = (unsigned short*)(void*)frameArray->Pointer;
-						for (int p = 0; p < pixelCount; p++) {
-							comp->data[p] = frameData16[pos];
-							pos += offset;
-						}
-					}
-				}
-				else
-					throw gcnew DicomCodecException("JPEG 2000 codec only supports Bits Allocated == 8 or 16");
-			}
+                            if (oldPixelData->BytesAllocated == 1) {
+                                if (comp->sgnd) {
+                                    if (oldPixelData->BitsStored < 8) {
+                                        const unsigned char sign = 1 << oldPixelData->HighBit;
+                                        const unsigned char mask = (0xff >> (oldPixelData->BitsAllocated - oldPixelData->BitsStored));
+                                        for (int p = 0; p < pixelCount; p++) {
+                                            const unsigned char pixel = frameArray->Data[pos];
+                                            if (pixel & sign)
+                                                comp->data[p] = -(((-pixel) & mask) + 1);
+                                            else
+                                                comp->data[p] = pixel;
+                                            pos += offset;
+                                        }
+                                    }
+                                    else {
+                                        char* frameData8 = (char*)(void*)frameArray->Pointer;
+                                        for (int p = 0; p < pixelCount; p++) {
+                                            comp->data[p] = frameData8[pos];
+                                            pos += offset;
+                                        }
+                                    }
+                                }
+                                else {
+                                    for (int p = 0; p < pixelCount; p++) {
+                                        comp->data[p] = frameArray->Data[pos];
+                                        pos += offset;
+                                    }
+                                }
+                            }
+                            else if (oldPixelData->BytesAllocated == 2) {
+                                if (comp->sgnd) {
+                                    if (oldPixelData->BitsStored < 16) {
+                                        unsigned short* frameData16 = (unsigned short*)(void*)frameArray->Pointer;
+                                        const unsigned short sign = 1 << oldPixelData->HighBit;
+                                        const unsigned short mask = (0xffff >> (oldPixelData->BitsAllocated - oldPixelData->BitsStored));
+                                        for (int p = 0; p < pixelCount; p++) {
+                                            const unsigned short pixel = frameData16[pos];
+                                            if (pixel & sign)
+                                                comp->data[p] = -(((-pixel) & mask) + 1);
+                                            else
+                                                comp->data[p] = pixel;
+                                            pos += offset;
+                                        }
+                                    }
+                                    else {
+                                        short* frameData16 = (short*)(void*)frameArray->Pointer;
+                                        for (int p = 0; p < pixelCount; p++) {
+                                            comp->data[p] = frameData16[pos];
+                                            pos += offset;
+                                        }
+                                    }
+                                }
+                                else {
+                                    unsigned short* frameData16 = (unsigned short*)(void*)frameArray->Pointer;
+                                    for (int p = 0; p < pixelCount; p++) {
+                                        comp->data[p] = frameData16[pos];
+                                        pos += offset;
+                                    }
+                                }
+                            }
+                            else
+                                throw gcnew DicomCodecException("JPEG 2000 codec only supports Bits Allocated == 8 or 16");
+                        }
 
-			opj_setup_encoder(cinfo, &eparams, image);
+                        opj_setup_encoder(cinfo, &eparams, image);
 
-			cio = opj_cio_open((opj_common_ptr)cinfo, NULL, 0);
+                        cio = opj_cio_open((opj_common_ptr)cinfo, NULL, 0);
 
-			if (opj_encode(cinfo, cio, image, eparams.index)) {
-				int clen = cio_tell(cio);
-				array<unsigned char>^ cbuf = gcnew array<unsigned char>(clen);
-				Marshal::Copy((IntPtr)cio->buffer, cbuf, 0, clen);
+                        if (opj_encode(cinfo, cio, image, eparams.index)) {
+                            int clen = cio_tell(cio);
+                            array<unsigned char>^ cbuf = gcnew array<unsigned char>(clen);
+                            Marshal::Copy((IntPtr)cio->buffer, cbuf, 0, clen);
 
-				IByteBuffer^ buffer;
-				if (clen >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-					buffer = gcnew TempFileBuffer(cbuf);
-				else
-					buffer = gcnew MemoryByteBuffer(cbuf);
-				buffer = EvenLengthBuffer::Create(buffer);
-				newPixelData->AddFrame(buffer);
-			} else
-				throw gcnew DicomCodecException("Unable to JPEG 2000 encode image");
-		}
-		finally {
-			if (cio != nullptr)
-				opj_cio_close(cio);
-			if (image != nullptr)
-				opj_image_destroy(image);
-			if (cinfo != nullptr)
-				opj_destroy_compress(cinfo);
-		}
-	}
+                            IByteBuffer^ buffer;
+                            if (clen >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+                                buffer = gcnew TempFileBuffer(cbuf);
+                            else
+                                buffer = gcnew MemoryByteBuffer(cbuf);
+                            buffer = EvenLengthBuffer::Create(buffer);
+                            newPixelData->AddFrame(buffer);
+                        }
+                        else
+                            throw gcnew DicomCodecException("Unable to JPEG 2000 encode image");
+                    }
+                    finally {
+                        if (cio != nullptr)
+                            opj_cio_close(cio);
+                        if (image != nullptr)
+                            opj_image_destroy(image);
+                        if (cinfo != nullptr)
+                            opj_destroy_compress(cinfo);
+                    }
+                }
 
-	if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb) {
-		newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;
+                if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb) {
+                    newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;
 
-		if (jparams->AllowMCT && jparams->UpdatePhotometricInterpretation) {
-			if (newPixelData->Syntax == DicomTransferSyntax::JPEG2000Lossy && jparams->Irreversible)
-				newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrIct;
-			else
-				newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrRct;
-		}
-	}
-}
+                    if (jparams->AllowMCT && jparams->UpdatePhotometricInterpretation) {
+                        if (newPixelData->Syntax == DicomTransferSyntax::JPEG2000Lossy && jparams->Irreversible)
+                            newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrIct;
+                        else
+                            newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrRct;
+                    }
+                }
+            }
 
-void DicomJpeg2000NativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
-	DicomJpeg2000Params^ jparams = (DicomJpeg2000Params^)parameters;
-	if (jparams == nullptr)
-		jparams = (DicomJpeg2000Params^)GetDefaultParameters();
+            void DicomJpeg2000NativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
+                DicomJpeg2000Params^ jparams = (DicomJpeg2000Params^)parameters;
+                if (jparams == nullptr)
+                    jparams = (DicomJpeg2000Params^)GetDefaultParameters();
 
-	const int pixelCount = oldPixelData->Height * oldPixelData->Width;
+                const int pixelCount = oldPixelData->Height * oldPixelData->Width;
 
-	if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrIct || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrRct)
-		newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
+                if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrIct || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrRct)
+                    newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
 
-	if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422 || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422)
-		newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
-	
-	if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull)
-		newPixelData->PlanarConfiguration = PlanarConfiguration::Planar;
+                if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422 || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422)
+                    newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
 
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		IByteBuffer^ jpegData = oldPixelData->GetFrame(frame);
-		PinnedByteArray^ jpegArray = gcnew PinnedByteArray(jpegData->Data);
+                if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull)
+                    newPixelData->PlanarConfiguration = PlanarConfiguration::Planar;
 
-		PinnedByteArray^ destArray = gcnew PinnedByteArray(newPixelData->UncompressedFrameSize);
+                for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+                    IByteBuffer^ jpegData = oldPixelData->GetFrame(frame);
+                    PinnedByteArray^ jpegArray = gcnew PinnedByteArray(jpegData->Data);
 
-		opj_dparameters_t dparams;
-		opj_event_mgr_t event_mgr;
-		opj_image_t *image = NULL;
-		opj_dinfo_t* dinfo = NULL;
-		opj_cio_t *cio = NULL;
+                    PinnedByteArray^ destArray = gcnew PinnedByteArray(newPixelData->UncompressedFrameSize);
 
-		memset(&event_mgr, 0, sizeof(opj_event_mgr_t));
-		event_mgr.error_handler = opj_error_callback;
-		if (jparams->IsVerbose) {
-			event_mgr.warning_handler = opj_warning_callback;
-			event_mgr.info_handler = opj_info_callback;
-		}
+                    opj_dparameters_t dparams;
+                    opj_event_mgr_t event_mgr;
+                    opj_image_t *image = NULL;
+                    opj_dinfo_t* dinfo = NULL;
+                    opj_cio_t *cio = NULL;
 
-		opj_set_default_decoder_parameters(&dparams);
-		dparams.cp_layer=0;
-		dparams.cp_reduce=0;
+                    memset(&event_mgr, 0, sizeof(opj_event_mgr_t));
+                    event_mgr.error_handler = opj_error_callback;
+                    if (jparams->IsVerbose) {
+                        event_mgr.warning_handler = opj_warning_callback;
+                        event_mgr.info_handler = opj_info_callback;
+                    }
 
-		try {
-			dinfo = opj_create_decompress(CODEC_J2K);
+                    opj_set_default_decoder_parameters(&dparams);
+                    dparams.cp_layer = 0;
+                    dparams.cp_reduce = 0;
 
-			opj_set_event_mgr((opj_common_ptr)dinfo, &event_mgr, NULL);
+                    try {
+                        dinfo = opj_create_decompress(CODEC_J2K);
 
-			opj_setup_decoder(dinfo, &dparams);
+                        opj_set_event_mgr((opj_common_ptr)dinfo, &event_mgr, NULL);
 
-			bool opj_err = false;
-			dinfo->client_data = (void*)&opj_err;
+                        opj_setup_decoder(dinfo, &dparams);
 
-			cio = opj_cio_open((opj_common_ptr)dinfo, (unsigned char*)(void*)jpegArray->Pointer, (int)jpegArray->ByteSize);
-			image = opj_decode(dinfo, cio);
+                        bool opj_err = false;
+                        dinfo->client_data = (void*)&opj_err;
 
-			if (image == nullptr)
-				throw gcnew DicomCodecException("Error in JPEG 2000 code stream!");
+                        cio = opj_cio_open((opj_common_ptr)dinfo, (unsigned char*)(void*)jpegArray->Pointer, (int)jpegArray->ByteSize);
+                        image = opj_decode(dinfo, cio);
 
-			for (int c = 0; c < image->numcomps; c++) {
-				opj_image_comp_t* comp = &image->comps[c];
+                        if (image == nullptr)
+                            throw gcnew DicomCodecException("Error in JPEG 2000 code stream!");
 
-				int pos = newPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? (c * pixelCount) : c;
-				const int offset = newPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? 1 : image->numcomps;
+                        for (int c = 0; c < image->numcomps; c++) {
+                            opj_image_comp_t* comp = &image->comps[c];
 
-				if (newPixelData->BytesAllocated == 1) {
-					if (comp->sgnd) {
-						const unsigned char sign = 1 << newPixelData->HighBit;
-                        const unsigned char mask = 0xFF ^ sign;
-						for (int p = 0; p < pixelCount; p++) {
-							const int i = comp->data[p];
-							if (i < 0)
-								//destArray->Data[pos] = (unsigned char)(-i | sign);
-                                  destArray->Data[pos] =(unsigned char)((i & mask) | sign);
-							else
-								//destArray->Data[pos] = (unsigned char)(i);
-                                destArray->Data[pos] = (unsigned char)(i & mask);
-							pos += offset;
-						}
-					}
-					else {
-						for (int p = 0; p < pixelCount; p++) {
-							destArray->Data[pos] = (unsigned char)comp->data[p];
-							pos += offset;
-						}
-					}
-				}
-				else if (newPixelData->BytesAllocated == 2) {
-					const unsigned short sign = 1 << newPixelData->HighBit;
-                    const unsigned short mask = 0xFFFF ^ sign;
-					unsigned short* destData16 = (unsigned short*)(void*)destArray->Pointer;
-					if (comp->sgnd) {
-						for (int p = 0; p < pixelCount; p++) {
-							const int i = comp->data[p];
-							if (i < 0)
-								//destData16[pos] = (unsigned short)(-i | sign);
-                                destData16[pos] = (unsigned short)((i & mask) | sign);
-							else
-								//destData16[pos] = (unsigned short)(i);
-                                destData16[pos] = (unsigned short)(i & mask);
-							pos += offset;
-						}
-					}
-					else {
-						for (int p = 0; p < pixelCount; p++) {
-							destData16[pos] = (unsigned short)comp->data[p];
-							pos += offset;
-						}
-					}
-				}
-				else
-					throw gcnew DicomCodecException("JPEG 2000 module only supports Bytes Allocated == 8 or 16!");
-			}
+                            int pos = newPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? (c * pixelCount) : c;
+                            const int offset = newPixelData->PlanarConfiguration == PlanarConfiguration::Planar ? 1 : image->numcomps;
 
-			IByteBuffer^ buffer;
-			if (destArray->Count >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-				buffer = gcnew TempFileBuffer(destArray->Data);
-			else
-				buffer = gcnew MemoryByteBuffer(destArray->Data);
-			buffer = EvenLengthBuffer::Create(buffer);
-			newPixelData->AddFrame(buffer);
-		}
-		finally {
-			if (cio != nullptr)
-				opj_cio_close(cio);
-			if (dinfo != nullptr)
-				opj_destroy_decompress(dinfo);
-			if (image != nullptr)
-				opj_image_destroy(image);
-		}
-	}
-}
+                            if (newPixelData->BytesAllocated == 1) {
+                                if (comp->sgnd) {
+                                    const unsigned char sign = 1 << newPixelData->HighBit;
+                                    const unsigned char mask = 0xFF ^ sign;
+                                    for (int p = 0; p < pixelCount; p++) {
+                                        const int i = comp->data[p];
+                                        if (i < 0)
+                                            //destArray->Data[pos] = (unsigned char)(-i | sign);
+                                            destArray->Data[pos] = (unsigned char)((i & mask) | sign);
+                                        else
+                                            //destArray->Data[pos] = (unsigned char)(i);
+                                            destArray->Data[pos] = (unsigned char)(i & mask);
+                                        pos += offset;
+                                    }
+                                }
+                                else {
+                                    for (int p = 0; p < pixelCount; p++) {
+                                        destArray->Data[pos] = (unsigned char)comp->data[p];
+                                        pos += offset;
+                                    }
+                                }
+                            }
+                            else if (newPixelData->BytesAllocated == 2) {
+                                const unsigned short sign = 1 << newPixelData->HighBit;
+                                const unsigned short mask = 0xFFFF ^ sign;
+                                unsigned short* destData16 = (unsigned short*)(void*)destArray->Pointer;
+                                if (comp->sgnd) {
+                                    for (int p = 0; p < pixelCount; p++) {
+                                        const int i = comp->data[p];
+                                        if (i < 0)
+                                            //destData16[pos] = (unsigned short)(-i | sign);
+                                            destData16[pos] = (unsigned short)((i & mask) | sign);
+                                        else
+                                            //destData16[pos] = (unsigned short)(i);
+                                            destData16[pos] = (unsigned short)(i & mask);
+                                        pos += offset;
+                                    }
+                                }
+                                else {
+                                    for (int p = 0; p < pixelCount; p++) {
+                                        destData16[pos] = (unsigned short)comp->data[p];
+                                        pos += offset;
+                                    }
+                                }
+                            }
+                            else
+                                throw gcnew DicomCodecException("JPEG 2000 module only supports Bytes Allocated == 8 or 16!");
+                        }
 
-} // Codec
-} // Imaging
+                        IByteBuffer^ buffer;
+                        if (destArray->Count >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+                            buffer = gcnew TempFileBuffer(destArray->Data);
+                        else
+                            buffer = gcnew MemoryByteBuffer(destArray->Data);
+                        buffer = EvenLengthBuffer::Create(buffer);
+                        newPixelData->AddFrame(buffer);
+                    }
+                    finally {
+                        if (cio != nullptr)
+                            opj_cio_close(cio);
+                        if (dinfo != nullptr)
+                            opj_destroy_decompress(dinfo);
+                        if (image != nullptr)
+                            opj_image_destroy(image);
+                    }
+                }
+            }
+
+        } // Codec
+    } // Imaging
 } // Dicom

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg2000.h
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg2000.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #ifndef __DICOM_IMAGING_CODEC_JPEG2000_H__
 #define __DICOM_IMAGING_CODEC_JPEG2000_H__
 
@@ -11,36 +14,36 @@ using namespace Dicom::Imaging;
 using namespace Dicom::Imaging::Codec;
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
+	namespace Imaging {
+		namespace Codec {
 
-	public ref class DicomJpeg2000NativeCodec abstract : public DicomJpeg2000Codec
-	{
-	public:
-		virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
-		virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
-	};
+			public ref class DicomJpeg2000NativeCodec abstract : public DicomJpeg2000Codec
+			{
+			public:
+				virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+				virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+			};
 
-	[Export(IDicomCodec::typeid)]
-	public ref class DicomJpeg2000LosslessCodec : public DicomJpeg2000NativeCodec
-	{
-	public:
-		virtual property DicomTransferSyntax^ TransferSyntax {
-			DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEG2000Lossless; }
-		}
-	};
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpeg2000LosslessCodec : public DicomJpeg2000NativeCodec
+			{
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEG2000Lossless; }
+				}
+			};
 
-	[Export(IDicomCodec::typeid)]
-	public ref class DicomJpeg2000LossyCodec : public DicomJpeg2000NativeCodec
-	{
-	public:
-		virtual property DicomTransferSyntax^ TransferSyntax {
-			DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEG2000Lossy; }
-		}
-	};
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpeg2000LossyCodec : public DicomJpeg2000NativeCodec
+			{
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEG2000Lossy; }
+				}
+			};
 
-} // Jpeg2000
-} // Codec
+		} // Jpeg2000
+	} // Codec
 } // Dicom
 
 #endif

--- a/DICOM [Native]/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM [Native]/Dicom.Imaging.Codec.JpegLS.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #include "Dicom.Imaging.Codec.JpegLs.h"
 
 #include "CharLS/interface.h"
@@ -15,119 +18,119 @@ using namespace Dicom::IO;
 using namespace Dicom::IO::Buffer;
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
+	namespace Imaging {
+		namespace Codec {
 
-public ref class DicomJpegLsCodecException : public DicomCodecException {
-public:
-	DicomJpegLsCodecException(JLS_ERROR error) : DicomCodecException(GetErrorMessage(error)) {
-	}
+			public ref class DicomJpegLsCodecException : public DicomCodecException {
+			public:
+				DicomJpegLsCodecException(JLS_ERROR error) : DicomCodecException(GetErrorMessage(error)) {
+				}
 
-private:
-	static String^ GetErrorMessage(JLS_ERROR error) {
-		switch (error) {
-		case InvalidJlsParameters:
-			return "Invalid JPEG-LS parameters";
-		case ParameterValueNotSupported:
-			return "Parameter value not supported";
-		case UncompressedBufferTooSmall:
-			return "Uncompressed buffer too small";
-		case CompressedBufferTooSmall:
-			return "Compressed buffer too small";
-		case InvalidCompressedData:
-			return "Invalid compressed data";
-		case TooMuchCompressedData:
-			return "Too much compressed data";
-		case ImageTypeNotSupported:
-			return "Image type not supported";
-		case UnsupportedBitDepthForTransform:
-			return "Unsupported bit depth for transform";
-		case UnsupportedColorTransform:
-			return "Unsupported color transform";
-		default:
-			return "Unknown error";
-		}
-	}
-};
+			private:
+				static String^ GetErrorMessage(JLS_ERROR error) {
+					switch (error) {
+					case InvalidJlsParameters:
+						return "Invalid JPEG-LS parameters";
+					case ParameterValueNotSupported:
+						return "Parameter value not supported";
+					case UncompressedBufferTooSmall:
+						return "Uncompressed buffer too small";
+					case CompressedBufferTooSmall:
+						return "Compressed buffer too small";
+					case InvalidCompressedData:
+						return "Invalid compressed data";
+					case TooMuchCompressedData:
+						return "Too much compressed data";
+					case ImageTypeNotSupported:
+						return "Image type not supported";
+					case UnsupportedBitDepthForTransform:
+						return "Unsupported bit depth for transform";
+					case UnsupportedColorTransform:
+						return "Unsupported color transform";
+					default:
+						return "Unknown error";
+					}
+				}
+			};
 
-void DicomJpegLsNativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
-	if ((oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422)    ||
-		(oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422) ||
-		(oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial420))
-		throw gcnew DicomCodecException("Photometric Interpretation '{0}' not supported by JPEG-LS encoder", oldPixelData->PhotometricInterpretation);
+			void DicomJpegLsNativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
+				if ((oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422) ||
+					(oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422) ||
+					(oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial420))
+					throw gcnew DicomCodecException("Photometric Interpretation '{0}' not supported by JPEG-LS encoder", oldPixelData->PhotometricInterpretation);
 
-	DicomJpegLsParams^ jparams = (DicomJpegLsParams^)parameters;
-	if (jparams == nullptr)
-		jparams = (DicomJpegLsParams^)GetDefaultParameters();
+				DicomJpegLsParams^ jparams = (DicomJpegLsParams^)parameters;
+				if (jparams == nullptr)
+					jparams = (DicomJpegLsParams^)GetDefaultParameters();
 
-	JlsParameters params = {0};
-	params.width = oldPixelData->Width;
-	params.height = oldPixelData->Height;
-	params.bitspersample = oldPixelData->BitsStored;
-	params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
-	params.components = oldPixelData->SamplesPerPixel;
+				JlsParameters params = { 0 };
+				params.width = oldPixelData->Width;
+				params.height = oldPixelData->Height;
+				params.bitspersample = oldPixelData->BitsStored;
+				params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
+				params.components = oldPixelData->SamplesPerPixel;
 
-	params.ilv = ILV_NONE;
-	params.colorTransform = COLORXFORM_NONE;
+				params.ilv = ILV_NONE;
+				params.colorTransform = COLORXFORM_NONE;
 
-	if (oldPixelData->SamplesPerPixel == 3) {
-		params.ilv = (interleavemode)jparams->InterleaveMode;
-		if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb)
-			params.colorTransform = (int)jparams->ColorTransform;
-	}
+				if (oldPixelData->SamplesPerPixel == 3) {
+					params.ilv = (interleavemode)jparams->InterleaveMode;
+					if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb)
+						params.colorTransform = (int)jparams->ColorTransform;
+				}
 
-	if (TransferSyntax == DicomTransferSyntax::JPEGLSNearLossless) {
-		params.allowedlossyerror = jparams->AllowedError;
-	}
+				if (TransferSyntax == DicomTransferSyntax::JPEGLSNearLossless) {
+					params.allowedlossyerror = jparams->AllowedError;
+				}
 
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		IByteBuffer^ frameData = oldPixelData->GetFrame(frame);
-		PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData->Data);
+				for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+					IByteBuffer^ frameData = oldPixelData->GetFrame(frame);
+					PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData->Data);
 
-		// assume compressed frame will be smaller than original
-		array<unsigned char>^ jpegData = gcnew array<unsigned char>(frameData->Size);
-		PinnedByteArray^ jpegArray = gcnew PinnedByteArray(jpegData);
+					// assume compressed frame will be smaller than original
+					array<unsigned char>^ jpegData = gcnew array<unsigned char>(frameData->Size);
+					PinnedByteArray^ jpegArray = gcnew PinnedByteArray(jpegData);
 
-		size_t jpegDataSize = 0;
+					size_t jpegDataSize = 0;
 
-		JLS_ERROR err = JpegLsEncode((void*)jpegArray->Pointer, jpegArray->Count, &jpegDataSize, (void*)frameArray->Pointer, frameArray->Count, &params);
-		if (err != OK) throw gcnew DicomJpegLsCodecException(err);
+					JLS_ERROR err = JpegLsEncode((void*)jpegArray->Pointer, jpegArray->Count, &jpegDataSize, (void*)frameArray->Pointer, frameArray->Count, &params);
+					if (err != OK) throw gcnew DicomJpegLsCodecException(err);
 
-		Array::Resize(jpegData, (int)jpegDataSize);
+					Array::Resize(jpegData, (int)jpegDataSize);
 
-		IByteBuffer^ buffer;
-		if (jpegDataSize >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-			buffer = gcnew TempFileBuffer(jpegData);
-		else
-			buffer = gcnew MemoryByteBuffer(jpegData);
-		buffer = EvenLengthBuffer::Create(buffer);
-		newPixelData->AddFrame(buffer);
-	}
-}
+					IByteBuffer^ buffer;
+					if (jpegDataSize >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+						buffer = gcnew TempFileBuffer(jpegData);
+					else
+						buffer = gcnew MemoryByteBuffer(jpegData);
+					buffer = EvenLengthBuffer::Create(buffer);
+					newPixelData->AddFrame(buffer);
+				}
+			}
 
-void DicomJpegLsNativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		IByteBuffer^ jpegData = oldPixelData->GetFrame(frame);
-		PinnedByteArray^ jpegArray = gcnew PinnedByteArray(jpegData->Data);
+			void DicomJpegLsNativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
+				for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+					IByteBuffer^ jpegData = oldPixelData->GetFrame(frame);
+					PinnedByteArray^ jpegArray = gcnew PinnedByteArray(jpegData->Data);
 
-		array<unsigned char>^ frameData = gcnew array<unsigned char>(newPixelData->UncompressedFrameSize);
-		PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData);
+					array<unsigned char>^ frameData = gcnew array<unsigned char>(newPixelData->UncompressedFrameSize);
+					PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData);
 
-		JlsParameters params = {0};
+					JlsParameters params = { 0 };
 
-		JLS_ERROR err = JpegLsDecode((void*)frameArray->Pointer, frameData->Length, (void*)jpegArray->Pointer, jpegData->Size, &params);
-		if (err != OK) throw gcnew DicomJpegLsCodecException(err);
+					JLS_ERROR err = JpegLsDecode((void*)frameArray->Pointer, frameData->Length, (void*)jpegArray->Pointer, jpegData->Size, &params);
+					if (err != OK) throw gcnew DicomJpegLsCodecException(err);
 
-		IByteBuffer^ buffer;
-		if (frameData->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-			buffer = gcnew TempFileBuffer(frameData);
-		else
-			buffer = gcnew MemoryByteBuffer(frameData);
-		buffer = EvenLengthBuffer::Create(buffer);
-		newPixelData->AddFrame(buffer);
-	}
-}
+					IByteBuffer^ buffer;
+					if (frameData->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+						buffer = gcnew TempFileBuffer(frameData);
+					else
+						buffer = gcnew MemoryByteBuffer(frameData);
+					buffer = EvenLengthBuffer::Create(buffer);
+					newPixelData->AddFrame(buffer);
+				}
+			}
 
-} // Codec
-} // Imaging
+		} // Codec
+	} // Imaging
 } // Dicom

--- a/DICOM [Native]/Dicom.Imaging.Codec.JpegLS.h
+++ b/DICOM [Native]/Dicom.Imaging.Codec.JpegLS.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #ifndef __DICOM_IMAGING_CODEC_JPEGLS_H__
 #define __DICOM_IMAGING_CODEC_JPEGLS_H__
 
@@ -10,34 +13,34 @@ using namespace Dicom;
 using namespace Dicom::Imaging;
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
-	public ref class DicomJpegLsNativeCodec abstract : public DicomJpegLsCodec
-	{
-	public:
-		virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
-		virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
-	};
+	namespace Imaging {
+		namespace Codec {
+			public ref class DicomJpegLsNativeCodec abstract : public DicomJpegLsCodec
+			{
+			public:
+				virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+				virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+			};
 
-	[Export(IDicomCodec::typeid)]
-	public ref class DicomJpegLsLosslessCodec : public DicomJpegLsNativeCodec
-	{
-	public:
-		virtual property DicomTransferSyntax^ TransferSyntax {
-			DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGLSLossless; }
-		}
-	};
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpegLsLosslessCodec : public DicomJpegLsNativeCodec
+			{
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGLSLossless; }
+				}
+			};
 
-	[Export(IDicomCodec::typeid)]
-	public ref class DicomJpegLsNearLosslessCodec : public DicomJpegLsNativeCodec
-	{
-	public:
-		virtual property DicomTransferSyntax^ TransferSyntax {
-			DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGLSNearLossless; }
-		}
-	};
-} // Codec
-} // Imaging
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomJpegLsNearLosslessCodec : public DicomJpegLsNativeCodec
+			{
+			public:
+				virtual property DicomTransferSyntax^ TransferSyntax {
+					DicomTransferSyntax^ get() override { return DicomTransferSyntax::JPEGLSNearLossless; }
+				}
+			};
+		} // Codec
+	} // Imaging
 } // Dicom
 
 #endif

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg_12.cpp
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg_12.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #include <vector>
 #include <vcclr.h>
 

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg_16.cpp
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg_16.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #include <vector>
 #include <vcclr.h>
 

--- a/DICOM [Native]/Dicom.Imaging.Codec.Jpeg_8.cpp
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Jpeg_8.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #include <vector>
 #include <vcclr.h>
 

--- a/DICOM [Native]/Dicom.Imaging.Codec.Rle.cpp
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Rle.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #include "Dicom.Imaging.Codec.Rle.h"
 
 using namespace System;
@@ -8,367 +11,367 @@ using namespace Dicom::IO;
 using namespace Dicom::IO::Buffer;
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
+	namespace Imaging {
+		namespace Codec {
 
-private ref class RLEEncoder {
-private:
-	int _count;
-	array<unsigned int>^ _offsets;
-	MemoryStream^ _stream;
-	BinaryWriter^ _writer;
-	array<unsigned char>^ _buffer;
+			private ref class RLEEncoder {
+			private:
+				int _count;
+				array<unsigned int>^ _offsets;
+				MemoryStream^ _stream;
+				BinaryWriter^ _writer;
+				array<unsigned char>^ _buffer;
 
-	int _prevByte;
-	int _repeatCount;
-	int _bufferPos;
+				int _prevByte;
+				int _repeatCount;
+				int _bufferPos;
 
-public:
-	RLEEncoder() {
-		_count = 0;
-		_offsets = gcnew array<unsigned int>(15);
-		_stream = gcnew MemoryStream();
-		_writer = EndianBinaryWriter::Create(_stream, Endian::Little);
-		_buffer = gcnew array<unsigned char>(132);
-		WriteHeader();
+			public:
+				RLEEncoder() {
+					_count = 0;
+					_offsets = gcnew array<unsigned int>(15);
+					_stream = gcnew MemoryStream();
+					_writer = EndianBinaryWriter::Create(_stream, Endian::Little);
+					_buffer = gcnew array<unsigned char>(132);
+					WriteHeader();
 
-		_prevByte = -1;
-		_repeatCount = 0;
-		_bufferPos = 0;
-	}
-
-	property int NumberOfSegments {
-		int get() { return _count; }
-	}
-
-	property long Length {
-		long get() { return (long)_stream->Length; }
-	}
-
-	array<unsigned char>^ GetBuffer() {
-		Flush();
-		WriteHeader();
-		return _stream->ToArray();
-	}
-
-	void NextSegment() {
-		Flush();
-		if ((Length & 1) == 1)
-			_stream->WriteByte(0x00);
-		_offsets[_count++] = (unsigned int)_stream->Length;
-	}
-
-	void Encode(unsigned char b) {
-		if (b == _prevByte) {
-			_repeatCount++;
-
-			if (_repeatCount > 2 && _bufferPos > 0) {
-				// We're starting a run, flush out the buffer
-				while (_bufferPos > 0) {
-					int count = Math::Min(128, _bufferPos);
-					_stream->WriteByte((unsigned char)(count - 1));
-					MoveBuffer(count);
+					_prevByte = -1;
+					_repeatCount = 0;
+					_bufferPos = 0;
 				}
-			}
-			else if (_repeatCount > 128) {
-				int count = Math::Min(_repeatCount, 128);
-				_stream->WriteByte((unsigned char)(257 - count));
-				_stream->WriteByte((unsigned char)_prevByte);
-				_repeatCount -= count;
-			}
-		}
-		else {
-			switch (_repeatCount) {
-				case 0:
-					break;
-				case 1: {
-						_buffer[_bufferPos++] = (unsigned char)_prevByte;
-						break;
+
+				property int NumberOfSegments {
+					int get() { return _count; }
+				}
+
+				property long Length {
+					long get() { return (long)_stream->Length; }
+				}
+
+				array<unsigned char>^ GetBuffer() {
+					Flush();
+					WriteHeader();
+					return _stream->ToArray();
+				}
+
+				void NextSegment() {
+					Flush();
+					if ((Length & 1) == 1)
+						_stream->WriteByte(0x00);
+					_offsets[_count++] = (unsigned int)_stream->Length;
+				}
+
+				void Encode(unsigned char b) {
+					if (b == _prevByte) {
+						_repeatCount++;
+
+						if (_repeatCount > 2 && _bufferPos > 0) {
+							// We're starting a run, flush out the buffer
+							while (_bufferPos > 0) {
+								int count = Math::Min(128, _bufferPos);
+								_stream->WriteByte((unsigned char)(count - 1));
+								MoveBuffer(count);
+							}
+						}
+						else if (_repeatCount > 128) {
+							int count = Math::Min(_repeatCount, 128);
+							_stream->WriteByte((unsigned char)(257 - count));
+							_stream->WriteByte((unsigned char)_prevByte);
+							_repeatCount -= count;
+						}
 					}
-				case 2: {
-						_buffer[_bufferPos++] = (unsigned char)_prevByte;
-						_buffer[_bufferPos++] = (unsigned char)_prevByte;
-						break;
+					else {
+						switch (_repeatCount) {
+						case 0:
+							break;
+						case 1: {
+							_buffer[_bufferPos++] = (unsigned char)_prevByte;
+							break;
+						}
+						case 2: {
+							_buffer[_bufferPos++] = (unsigned char)_prevByte;
+							_buffer[_bufferPos++] = (unsigned char)_prevByte;
+							break;
+						}
+						default: {
+							while (_repeatCount > 0) {
+								int count = Math::Min(_repeatCount, 128);
+								_stream->WriteByte((unsigned char)(257 - count));
+								_stream->WriteByte((unsigned char)_prevByte);
+								_repeatCount -= count;
+							}
+
+							break;
+						}
+						}
+
+						while (_bufferPos > 128) {
+							int count = Math::Min(128, _bufferPos);
+							_stream->WriteByte((unsigned char)(count - 1));
+							MoveBuffer(count);
+						}
+
+						_prevByte = b;
+						_repeatCount = 1;
 					}
-				default: {
+				}
+
+				void MakeEvenLength() {
+					// Make even length
+					if (_stream->Length % 2 == 1)
+						_stream->WriteByte(0);
+				}
+
+				void Flush() {
+					if (_repeatCount < 2) {
+						while (_repeatCount > 0) {
+							_buffer[_bufferPos++] = (unsigned char)_prevByte;
+							_repeatCount--;
+						}
+					}
+
+					while (_bufferPos > 0) {
+						int count = Math::Min(128, _bufferPos);
+						_stream->WriteByte((unsigned char)(count - 1));
+						MoveBuffer(count);
+					}
+
+					if (_repeatCount >= 2) {
 						while (_repeatCount > 0) {
 							int count = Math::Min(_repeatCount, 128);
 							_stream->WriteByte((unsigned char)(257 - count));
 							_stream->WriteByte((unsigned char)_prevByte);
 							_repeatCount -= count;
 						}
-
-						break;
 					}
-			}
 
-			while (_bufferPos > 128) {
-				int count = Math::Min(128, _bufferPos);
-				_stream->WriteByte((unsigned char)(count - 1));
-				MoveBuffer(count);
-			}
-
-			_prevByte = b;
-			_repeatCount = 1;
-		}
-	}
-
-	void MakeEvenLength() {
-		// Make even length
-		if (_stream->Length % 2 == 1)
-			_stream->WriteByte(0);
-	}
-
-	void Flush() {
-		if (_repeatCount < 2) {
-			while (_repeatCount > 0) {
-				_buffer[_bufferPos++] = (unsigned char)_prevByte;
-				_repeatCount--;
-			}
-		}
-
-		while (_bufferPos > 0) {
-			int count = Math::Min(128, _bufferPos);
-			_stream->WriteByte((unsigned char)(count - 1));
-			MoveBuffer(count);
-		}
-
-		if (_repeatCount >= 2) {
-			while (_repeatCount > 0) {
-				int count = Math::Min(_repeatCount, 128);
-				_stream->WriteByte((unsigned char)(257 - count));
-				_stream->WriteByte((unsigned char)_prevByte);
-				_repeatCount -= count;
-			}
-		}
-
-		_prevByte = -1;
-		_repeatCount = 0;
-		_bufferPos = 0;
-	}
-
-private:
-	void MoveBuffer(int count) {
-		_stream->Write(_buffer, 0, count);
-		for (int i = count, n = 0; i < _bufferPos; i++, n++) {
-			_buffer[n] = _buffer[i];
-		}
-		_bufferPos = _bufferPos - count;
-	}
-
-	void WriteHeader() {
-		_stream->Seek(0, SeekOrigin::Begin);
-		_writer->Write((unsigned int)_count);
-		for (int i = 0; i < 15; i++) {
-			_writer->Write(_offsets[i]);
-		}
-	}
-};
-
-void DicomRleNativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
-	int pixelCount = oldPixelData->Width * oldPixelData->Height;
-	int numberOfSegments = oldPixelData->BytesAllocated * oldPixelData->SamplesPerPixel;
-
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		IByteBuffer^ frameData = oldPixelData->GetFrame(frame);
-		PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData->Data);
-
-		RLEEncoder^ encoder = gcnew RLEEncoder();
-
-		for (int s = 0; s < numberOfSegments; s++) {
-			encoder->NextSegment();
-
-			int sample = s / oldPixelData->BytesAllocated;
-			int sabyte = s % oldPixelData->BytesAllocated;
-
-			int pos;
-			int offset;
-
-			if (newPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved) {
-				pos = sample * oldPixelData->BytesAllocated;
-				offset = numberOfSegments;
-			}
-			else {
-				pos = sample * oldPixelData->BytesAllocated * pixelCount;
-				offset = oldPixelData->BytesAllocated;
-			}
-
-			pos += oldPixelData->BytesAllocated - sabyte - 1;
-
-			for (int p = 0; p < pixelCount; p++) {
-				if ((unsigned int)pos >= frameData->Size)
-					throw gcnew DicomCodecException("Read position is past end of frame buffer");
-				encoder->Encode(frameArray[pos]);
-				pos += offset;
-			}
-			encoder->Flush();
-		}
-
-		encoder->MakeEvenLength();
-
-		array<unsigned char>^ data = encoder->GetBuffer();
-
-		IByteBuffer^ buffer;
-		if (data->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-			buffer = gcnew TempFileBuffer(data);
-		else
-			buffer = gcnew MemoryByteBuffer(data);
-		buffer = EvenLengthBuffer::Create(buffer);
-		newPixelData->AddFrame(buffer);
-	}
-}
-
-private ref class RLEDecoder {
-private:
-			int _count;
-			array<int>^ _offsets;
-			array<unsigned char>^ _data;
-
-public:
-	RLEDecoder(array<unsigned char>^ data) {
-		MemoryStream^ stream = gcnew MemoryStream(data);
-		BinaryReader^ reader = EndianBinaryReader::Create(stream, Endian::Little);
-		_count = (int)reader->ReadUInt32();
-		_offsets = gcnew array<int>(15);
-		for (int i = 0; i < 15; i++) {
-			_offsets[i] = reader->ReadInt32();
-		}
-		_data = data;
-	}
-
-	property int NumberOfSegments {
-		int get() { return _count; }
-	}
-
-	void DecodeSegment(int segment, array<unsigned char>^ buffer, int start, int sampleOffset) {
-		if (segment < 0 || segment >= _count)
-			throw gcnew IndexOutOfRangeException("Segment number out of range");
-
-		int offset = GetSegmentOffset(segment);
-		int length = GetSegmentLength(segment);
-
-		Decode(buffer, start, sampleOffset, _data, offset, length);
-	}
-
-private:
-	void Decode(array<unsigned char>^ buffer, int start, int sampleOffset, array<unsigned char>^ rleData, int offset, int count) {
-		int pos = start;
-		int end = offset + count;
-		int bufferLength = buffer->Length;
-
-		for (int i = offset; i < end && pos < bufferLength; ) {
-			char control = (char)rleData[i++];
-
-			if (control >= 0) {
-				int length = control + 1;
-
-				if ((end - i) < length)
-					throw gcnew DicomCodecException("RLE literal run exceeds input buffer length.");
-				if ((pos + ((length - 1) * sampleOffset)) >= bufferLength)
-					throw gcnew DicomCodecException("RLE literal run exceeds output buffer length.");
-
-				if (sampleOffset == 1) {
-					// ANTS says this is faster than Array.Copy!
-					Array::Copy(rleData, i, buffer, pos, length);
-					pos += length;
-					i += length;
+					_prevByte = -1;
+					_repeatCount = 0;
+					_bufferPos = 0;
 				}
-				else {
-					while (length-- > 0) {
-						buffer[pos] = rleData[i++];
-						pos += sampleOffset;
+
+			private:
+				void MoveBuffer(int count) {
+					_stream->Write(_buffer, 0, count);
+					for (int i = count, n = 0; i < _bufferPos; i++, n++) {
+						_buffer[n] = _buffer[i];
+					}
+					_bufferPos = _bufferPos - count;
+				}
+
+				void WriteHeader() {
+					_stream->Seek(0, SeekOrigin::Begin);
+					_writer->Write((unsigned int)_count);
+					for (int i = 0; i < 15; i++) {
+						_writer->Write(_offsets[i]);
 					}
 				}
-			}
-			else if (control >= -127) {
-				int length = -control;
+			};
 
-				//if (i >= end) // never happens due to check below
-				//    throw new DicomCodecException("RLE repeat run exceeds input buffer length.");
-				if ((pos + ((length - 1) * sampleOffset)) >= bufferLength)
-					throw gcnew DicomCodecException("RLE repeat run exceeds output buffer length.");
+			void DicomRleNativeCodec::Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
+				int pixelCount = oldPixelData->Width * oldPixelData->Height;
+				int numberOfSegments = oldPixelData->BytesAllocated * oldPixelData->SamplesPerPixel;
 
-				unsigned char b = rleData[i++];
+				for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+					IByteBuffer^ frameData = oldPixelData->GetFrame(frame);
+					PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData->Data);
 
-				if (sampleOffset == 1) {
-					while (length-- >= 0)
-						buffer[pos++] = b;
+					RLEEncoder^ encoder = gcnew RLEEncoder();
+
+					for (int s = 0; s < numberOfSegments; s++) {
+						encoder->NextSegment();
+
+						int sample = s / oldPixelData->BytesAllocated;
+						int sabyte = s % oldPixelData->BytesAllocated;
+
+						int pos;
+						int offset;
+
+						if (newPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved) {
+							pos = sample * oldPixelData->BytesAllocated;
+							offset = numberOfSegments;
+						}
+						else {
+							pos = sample * oldPixelData->BytesAllocated * pixelCount;
+							offset = oldPixelData->BytesAllocated;
+						}
+
+						pos += oldPixelData->BytesAllocated - sabyte - 1;
+
+						for (int p = 0; p < pixelCount; p++) {
+							if ((unsigned int)pos >= frameData->Size)
+								throw gcnew DicomCodecException("Read position is past end of frame buffer");
+							encoder->Encode(frameArray[pos]);
+							pos += offset;
+						}
+						encoder->Flush();
+					}
+
+					encoder->MakeEvenLength();
+
+					array<unsigned char>^ data = encoder->GetBuffer();
+
+					IByteBuffer^ buffer;
+					if (data->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+						buffer = gcnew TempFileBuffer(data);
+					else
+						buffer = gcnew MemoryByteBuffer(data);
+					buffer = EvenLengthBuffer::Create(buffer);
+					newPixelData->AddFrame(buffer);
 				}
-				else {
-					while (length-- >= 0) {
-						buffer[pos] = b;
-						pos += sampleOffset;
+			}
+
+			private ref class RLEDecoder {
+			private:
+				int _count;
+				array<int>^ _offsets;
+				array<unsigned char>^ _data;
+
+			public:
+				RLEDecoder(array<unsigned char>^ data) {
+					MemoryStream^ stream = gcnew MemoryStream(data);
+					BinaryReader^ reader = EndianBinaryReader::Create(stream, Endian::Little);
+					_count = (int)reader->ReadUInt32();
+					_offsets = gcnew array<int>(15);
+					for (int i = 0; i < 15; i++) {
+						_offsets[i] = reader->ReadInt32();
+					}
+					_data = data;
+				}
+
+				property int NumberOfSegments {
+					int get() { return _count; }
+				}
+
+				void DecodeSegment(int segment, array<unsigned char>^ buffer, int start, int sampleOffset) {
+					if (segment < 0 || segment >= _count)
+						throw gcnew IndexOutOfRangeException("Segment number out of range");
+
+					int offset = GetSegmentOffset(segment);
+					int length = GetSegmentLength(segment);
+
+					Decode(buffer, start, sampleOffset, _data, offset, length);
+				}
+
+			private:
+				void Decode(array<unsigned char>^ buffer, int start, int sampleOffset, array<unsigned char>^ rleData, int offset, int count) {
+					int pos = start;
+					int end = offset + count;
+					int bufferLength = buffer->Length;
+
+					for (int i = offset; i < end && pos < bufferLength;) {
+						char control = (char)rleData[i++];
+
+						if (control >= 0) {
+							int length = control + 1;
+
+							if ((end - i) < length)
+								throw gcnew DicomCodecException("RLE literal run exceeds input buffer length.");
+							if ((pos + ((length - 1) * sampleOffset)) >= bufferLength)
+								throw gcnew DicomCodecException("RLE literal run exceeds output buffer length.");
+
+							if (sampleOffset == 1) {
+								// ANTS says this is faster than Array.Copy!
+								Array::Copy(rleData, i, buffer, pos, length);
+								pos += length;
+								i += length;
+							}
+							else {
+								while (length-- > 0) {
+									buffer[pos] = rleData[i++];
+									pos += sampleOffset;
+								}
+							}
+						}
+						else if (control >= -127) {
+							int length = -control;
+
+							//if (i >= end) // never happens due to check below
+							//    throw new DicomCodecException("RLE repeat run exceeds input buffer length.");
+							if ((pos + ((length - 1) * sampleOffset)) >= bufferLength)
+								throw gcnew DicomCodecException("RLE repeat run exceeds output buffer length.");
+
+							unsigned char b = rleData[i++];
+
+							if (sampleOffset == 1) {
+								while (length-- >= 0)
+									buffer[pos++] = b;
+							}
+							else {
+								while (length-- >= 0) {
+									buffer[pos] = b;
+									pos += sampleOffset;
+								}
+							}
+						}
+
+						if ((i + 2) >= end)
+							break;
 					}
 				}
+
+				int GetSegmentOffset(int segment) {
+					return _offsets[segment];
+				}
+
+				int GetSegmentLength(int segment) {
+					int offset = GetSegmentOffset(segment);
+					if (segment < (_count - 1)) {
+						int next = GetSegmentOffset(segment + 1);
+						return next - offset;
+					}
+					else {
+						return _data->Length - offset;
+					}
+				}
+			};
+
+			void DicomRleNativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
+				for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
+					IByteBuffer^ rleData = oldPixelData->GetFrame(frame);
+					PinnedByteArray^ rleArray = gcnew PinnedByteArray(rleData->Data);
+
+					array<unsigned char>^ frameData = gcnew array<unsigned char>(newPixelData->UncompressedFrameSize);
+					PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData);
+
+					int pixelCount = oldPixelData->Width * oldPixelData->Height;
+					int numberOfSegments = oldPixelData->BytesAllocated * oldPixelData->SamplesPerPixel;
+
+					RLEDecoder^ decoder = gcnew RLEDecoder(rleArray->Data);
+
+					if (decoder->NumberOfSegments != numberOfSegments)
+						throw gcnew DicomCodecException("Unexpected number of RLE segments!");
+
+					for (int s = 0; s < numberOfSegments; s++) {
+						int sample = s / newPixelData->BytesAllocated;
+						int sabyte = s % newPixelData->BytesAllocated;
+
+						int pos, offset;
+
+						if (newPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved) {
+							pos = sample * newPixelData->BytesAllocated;
+							offset = newPixelData->SamplesPerPixel * newPixelData->BytesAllocated;
+						}
+						else {
+							pos = sample * newPixelData->BytesAllocated * pixelCount;
+							offset = newPixelData->BytesAllocated;
+						}
+
+						pos += newPixelData->BytesAllocated - sabyte - 1;
+
+						decoder->DecodeSegment(s, frameData, pos, offset);
+					}
+
+					IByteBuffer^ buffer;
+					if (frameData->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
+						buffer = gcnew TempFileBuffer(frameData);
+					else
+						buffer = gcnew MemoryByteBuffer(frameData);
+					buffer = EvenLengthBuffer::Create(buffer);
+					newPixelData->AddFrame(buffer);
+				}
 			}
 
-			if ((i + 2) >= end)
-				break;
-		}
-	}
-
-	int GetSegmentOffset(int segment) {
-		return _offsets[segment];
-	}
-
-	int GetSegmentLength(int segment) {
-		int offset = GetSegmentOffset(segment);
-		if (segment < (_count - 1)) {
-			int next = GetSegmentOffset(segment + 1);
-			return next - offset;
-		}
-		else {
-			return _data->Length - offset;
-		}
-	}
-};
-
-void DicomRleNativeCodec::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) {
-	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
-		IByteBuffer^ rleData = oldPixelData->GetFrame(frame);
-		PinnedByteArray^ rleArray = gcnew PinnedByteArray(rleData->Data);
-
-		array<unsigned char>^ frameData = gcnew array<unsigned char>(newPixelData->UncompressedFrameSize);
-		PinnedByteArray^ frameArray = gcnew PinnedByteArray(frameData);
-
-		int pixelCount = oldPixelData->Width * oldPixelData->Height;
-		int numberOfSegments = oldPixelData->BytesAllocated * oldPixelData->SamplesPerPixel;
-
-		RLEDecoder^ decoder = gcnew RLEDecoder(rleArray->Data);
-
-		if (decoder->NumberOfSegments != numberOfSegments)
-			throw gcnew DicomCodecException("Unexpected number of RLE segments!");
-
-		for (int s = 0; s < numberOfSegments; s++) {
-			int sample = s / newPixelData->BytesAllocated;
-			int sabyte = s % newPixelData->BytesAllocated;
-
-			int pos, offset;
-
-			if (newPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved) {
-				pos = sample * newPixelData->BytesAllocated;
-				offset = newPixelData->SamplesPerPixel * newPixelData->BytesAllocated;
-			}
-			else {
-				pos = sample * newPixelData->BytesAllocated * pixelCount;
-				offset = newPixelData->BytesAllocated;
-			}
-
-			pos += newPixelData->BytesAllocated - sabyte - 1;
-
-			decoder->DecodeSegment(s, frameData, pos, offset);
-		}
-
-		IByteBuffer^ buffer;
-		if (frameData->Length >= (1 * 1024 * 1024) || oldPixelData->NumberOfFrames > 1)
-			buffer = gcnew TempFileBuffer(frameData);
-		else
-			buffer = gcnew MemoryByteBuffer(frameData);
-		buffer = EvenLengthBuffer::Create(buffer);
-		newPixelData->AddFrame(buffer);
-	}
-}
-
-} // Codec
-} // Imaging
+		} // Codec
+	} // Imaging
 } // Dicom

--- a/DICOM [Native]/Dicom.Imaging.Codec.Rle.h
+++ b/DICOM [Native]/Dicom.Imaging.Codec.Rle.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #ifndef __DICOM_IMAGING_CODEC_RLE_H__
 #define __DICOM_IMAGING_CODEC_RLE_H__
 
@@ -10,17 +13,17 @@ using namespace Dicom;
 using namespace Dicom::Imaging;
 
 namespace Dicom {
-namespace Imaging {
-namespace Codec {
-	[Export(IDicomCodec::typeid)]
-	public ref class DicomRleNativeCodec : DicomRleCodec
-	{
-	public:
-		virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
-		virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
-	};
-} // Codec
-} // Imaging
+	namespace Imaging {
+		namespace Codec {
+			[Export(IDicomCodec::typeid)]
+			public ref class DicomRleNativeCodec : DicomRleCodec
+			{
+			public:
+				virtual void Encode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+				virtual void Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelData, DicomCodecParams^ parameters) override;
+			};
+		} // Codec
+	} // Imaging
 } // Dicom
 
 #endif

--- a/DICOM [Native]/DicomNativeExt.cpp
+++ b/DICOM [Native]/DicomNativeExt.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using namespace System;
 
 #include "Dicom.Imaging.Codec.Jpeg.h"

--- a/DICOM [Unit Tests]/DicomEncodingTest.cs
+++ b/DICOM [Unit Tests]/DicomEncodingTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 namespace Dicom

--- a/DICOM [Unit Tests]/DicomPersonNameTest.cs
+++ b/DICOM [Unit Tests]/DicomPersonNameTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 namespace Dicom

--- a/DICOM [Unit Tests]/DicomTagTest.cs
+++ b/DICOM [Unit Tests]/DicomTagTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 namespace Dicom

--- a/DICOM [Unit Tests]/Helpers/SerializationExtensions.cs
+++ b/DICOM [Unit Tests]/Helpers/SerializationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System.IO;

--- a/DICOM [Unit Tests]/Imaging/Mathematics/Point2Tests.cs
+++ b/DICOM [Unit Tests]/Imaging/Mathematics/Point2Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 namespace Dicom.Imaging.Mathematics

--- a/DICOM [Unit Tests]/Logging/MessageNameFormatToOrdinalFormatTests.cs
+++ b/DICOM [Unit Tests]/Logging/MessageNameFormatToOrdinalFormatTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 namespace Dicom.Logging
@@ -11,7 +11,6 @@ namespace Dicom.Logging
 
     public class MessageNameFormatToOrdinalFormatTests
     {
-
         [Fact]
         public void ComplexMessageIsCorrectlyReformatted()
         {

--- a/DICOM [Unit Tests]/Network/PDUTest.cs
+++ b/DICOM [Unit Tests]/Network/PDUTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2015 fo-dicom contributors.
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 namespace Dicom.Network

--- a/DICOM/DatabaseQueryTransformRule.cs
+++ b/DICOM/DatabaseQueryTransformRule.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Odbc;
@@ -9,80 +12,138 @@ namespace Dicom
     public enum DatabaseType
     {
         Odbc,
+
         MsSql,
+
         DB2
     }
 
     /// <summary>
     /// Updates a DICOM dataset based on a database query.
     /// </summary>
-    public class DatabaseQueryTransformRule : IDicomTransformRule {
+    public class DatabaseQueryTransformRule : IDicomTransformRule
+    {
         #region Private Members
+
         private string _connectionString;
+
         private DatabaseType _dbType;
+
         private string _query;
+
         private List<DicomTag> _output;
+
         private List<DicomTag> _params;
+
         #endregion
 
         #region Public Constructor
-        public DatabaseQueryTransformRule() {
+
+        public DatabaseQueryTransformRule()
+        {
             _dbType = DatabaseType.MsSql;
             _output = new List<DicomTag>();
             _params = new List<DicomTag>();
         }
 
-        public DatabaseQueryTransformRule(string connectionString, DatabaseType dbType, string query, DicomTag[] outputTags, DicomTag[] paramTags) {
+        public DatabaseQueryTransformRule(
+            string connectionString,
+            DatabaseType dbType,
+            string query,
+            DicomTag[] outputTags,
+            DicomTag[] paramTags)
+        {
             _connectionString = connectionString;
             _dbType = dbType;
             _query = query;
             _output = new List<DicomTag>(outputTags);
             _params = new List<DicomTag>(paramTags);
         }
+
         #endregion
 
         #region Public Properties
-        public string ConnectionString {
-            get { return _connectionString; }
-            set { _connectionString = value; }
+
+        public string ConnectionString
+        {
+            get
+            {
+                return _connectionString;
+            }
+            set
+            {
+                _connectionString = value;
+            }
         }
 
-        public DatabaseType ConnectionType {
-            get { return _dbType; }
-            set { _dbType = value; }
+        public DatabaseType ConnectionType
+        {
+            get
+            {
+                return _dbType;
+            }
+            set
+            {
+                _dbType = value;
+            }
         }
 
-        public string Query {
-            get { return _query; }
-            set { _query = value; }
+        public string Query
+        {
+            get
+            {
+                return _query;
+            }
+            set
+            {
+                _query = value;
+            }
         }
 
-        public List<DicomTag> Output {
-            get { return _output; }
-            set { _output = value; }
+        public List<DicomTag> Output
+        {
+            get
+            {
+                return _output;
+            }
+            set
+            {
+                _output = value;
+            }
         }
 
-        public List<DicomTag> Parameters {
-            get { return _params; }
-            set { _params = value; }
+        public List<DicomTag> Parameters
+        {
+            get
+            {
+                return _params;
+            }
+            set
+            {
+                _params = value;
+            }
         }
+
         #endregion
 
         #region Public Methods
-        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
             IDbConnection connection = null;
 
-            try {
-                if (_dbType == DatabaseType.Odbc)
-                    connection = new OdbcConnection(_connectionString);
-                else if (_dbType == DatabaseType.MsSql)
-                    connection = new SqlConnection(_connectionString);
+            try
+            {
+                if (_dbType == DatabaseType.Odbc) connection = new OdbcConnection(_connectionString);
+                else if (_dbType == DatabaseType.MsSql) connection = new SqlConnection(_connectionString);
 
-                using (IDbCommand command = connection.CreateCommand()) {
+                using (IDbCommand command = connection.CreateCommand())
+                {
                     command.Connection = connection;
                     command.CommandText = _query;
 
-                    for (int i = 0; i < _params.Count; i++) {
+                    for (int i = 0; i < _params.Count; i++)
+                    {
                         var str = dataset.Get<string>(_params[i], -1, String.Empty);
                         SqlParameter prm = new SqlParameter(String.Format("@{0}", i), str);
                         command.Parameters.Add(prm);
@@ -90,12 +151,18 @@ namespace Dicom
 
                     connection.Open();
 
-                    if (_output.Count == 0) {
+                    if (_output.Count == 0)
+                    {
                         command.ExecuteNonQuery();
-                    } else {
-                        using (IDataReader reader = command.ExecuteReader()) {
-                            if (reader.Read()) {
-                                for (int i = 0; i < _output.Count; i++) {
+                    }
+                    else
+                    {
+                        using (IDataReader reader = command.ExecuteReader())
+                        {
+                            if (reader.Read())
+                            {
+                                for (int i = 0; i < _output.Count; i++)
+                                {
                                     dataset.CopyTo(modifiedAttributesSequenceItem, _output[i]);
                                     string str = reader.GetString(i);
                                     dataset.Add(_output[i], str);
@@ -108,18 +175,22 @@ namespace Dicom
 
                     connection = null;
                 }
-            } finally {
-                if (connection != null) {
-                    if (connection.State == ConnectionState.Closed || connection.State == ConnectionState.Broken)
-                        connection.Close();
+            }
+            finally
+            {
+                if (connection != null)
+                {
+                    if (connection.State == ConnectionState.Closed || connection.State == ConnectionState.Broken) connection.Close();
                     connection.Dispose();
                 }
             }
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             return base.ToString();
         }
+
         #endregion
     }
 }

--- a/DICOM/DicomDataException.cs
+++ b/DICOM/DicomDataException.cs
@@ -1,17 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public class DicomDataException : DicomException {
-		public DicomDataException(string message) : base(message) {
-		}
+using System;
 
-		public DicomDataException(string format, params object[] args) : base(format, args) {
-		}
+namespace Dicom
+{
+    public class DicomDataException : DicomException
+    {
+        public DicomDataException(string message)
+            : base(message)
+        {
+        }
 
-		public DicomDataException(string message, Exception innerException) : base(message, innerException) {
-		}
-	}
+        public DicomDataException(string format, params object[] args)
+            : base(format, args)
+        {
+        }
+
+        public DicomDataException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -1,512 +1,507 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dicom.IO.Buffer;
 
 using Dicom.StructuredReport;
 
-namespace Dicom {
-	public class DicomDataset : IEnumerable<DicomItem> {
-		private IDictionary<DicomTag, DicomItem> _items;
-		private DicomTransferSyntax _syntax;
-
-		public DicomDataset() {
-			_items = new SortedList<DicomTag, DicomItem>();
-			InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
-		}
-
-		public DicomDataset(params DicomItem[] items) : this() {
-			if (items != null) {
-				foreach (DicomItem item in items)
-					if (item != null)
-						_items[item.Tag] = item;
-			}
-		}
-
-		public DicomDataset(IEnumerable<DicomItem> items) : this() {
-			if (items != null) {
-				foreach (DicomItem item in items)
-					if (item != null)
-						_items[item.Tag] = item;
-			}
-		}
-
-		/// <summary>DICOM transfer syntax of this dataset.</summary>
-		public DicomTransferSyntax InternalTransferSyntax {
-			get { return _syntax; }
-			internal set {
-				_syntax = value;
-
-				// update transfer syntax for sequence items
-				foreach (var sq in this.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>()) {
-					foreach (var item in sq.Items) {
-						item.InternalTransferSyntax = _syntax;
-					}
-				}
-			}
-		}
-
-
-		public T Get<T>(DicomTag tag, int n=0) {
-			return Get<T>(tag, n, default(T));
-		}
-
-		public T Get<T>(DicomTag tag, T defaultValue) {
-			return Get<T>(tag, 0, defaultValue);
-		}
-
-		public T Get<T>(DicomTag tag, int n, T defaultValue) {
-			DicomItem item = null;
-			if (!_items.TryGetValue(tag, out item))
-				return defaultValue;
-
-			if (typeof(T) == typeof(DicomItem))
-				return (T)(object)item;
-
-			if (typeof(T).IsSubclassOf(typeof(DicomItem)))
-				return (T)(object)item;
-
-			if (typeof(T) == typeof(DicomVR))
-				return (T)(object)item.ValueRepresentation;
-
-			if (item.GetType().IsSubclassOf(typeof(DicomElement))) {
-				DicomElement element = (DicomElement)item;
-
-				if (typeof(IByteBuffer).IsAssignableFrom(typeof(T)))
-					return (T)(object)element.Buffer;
-
-				if (typeof(T) == typeof(byte[]))
-					return (T)(object)element.Buffer.Data;
-
-				if (n >= element.Count || element.Count == 0)
-					return defaultValue;
-
-				return (T)(object)element.Get<T>(n);
-			}
-
-			if (item.GetType() == typeof(DicomSequence)) {
-				if (typeof(T) == typeof(DicomCodeItem))
-					return (T)(object)new DicomCodeItem((DicomSequence)item);
-
-				if (typeof(T) == typeof(DicomMeasuredValue))
-					return (T)(object)new DicomMeasuredValue((DicomSequence)item);
-
-				if (typeof(T) == typeof(DicomReferencedSOP))
-					return (T)(object)new DicomReferencedSOP((DicomSequence)item);
-			}
-
-			throw new DicomDataException("Unable to get a value type of {0} from DICOM item of type {1}", typeof(T), item.GetType());
-		}
-
-		/// <summary>
-		/// Converts a dictionary tag to a valid private tag. Creates the private creator tag if needed.
-		/// </summary>
-		/// <param name="tag">Dictionary DICOM tag</param>
-		/// <returns>Private DICOM tag</returns>
-		public DicomTag GetPrivateTag(DicomTag tag) {
-			// not a private tag
-			if (!tag.IsPrivate)
-				return tag;
-
-			// group length
-			if (tag.Element == 0x0000)
-				return tag;
-
-			// private creator?
-			if (tag.PrivateCreator == null)
-				return tag;
-
-			// already a valid private tag
-			if (tag.Element >= 0xff)
-				return tag;
-
-			ushort group = 0x0010;
-			for (; ; group++) {
-				var creator = new DicomTag(tag.Group, group);
-				if (!Contains(creator)) {
-					Add(new DicomLongString(creator, tag.PrivateCreator.Creator));
-					break;
-				}
-
-				var value = Get<string>(creator, String.Empty);
-				if (tag.PrivateCreator.Creator == value)
-					return new DicomTag(tag.Group, (ushort)((group << 8) + (tag.Element & 0xff)), tag.PrivateCreator);
-			}
-
-			return new DicomTag(tag.Group, (ushort)((group << 8) + (tag.Element & 0xff)), tag.PrivateCreator);
-		}
-
-		public DicomDataset Add(params DicomItem[] items) {
-			if (items != null) {
-				foreach (DicomItem item in items) {
-					if (item != null) {
-						if (item.Tag.IsPrivate)
-							_items[GetPrivateTag(item.Tag)] = item;
-						else
-							_items[item.Tag] = item;
-					}
-				}
-			}
-			return this;
-		}
-
-		public DicomDataset Add(IEnumerable<DicomItem> items) {
-			if (items != null) {
-				foreach (DicomItem item in items) {
-					if (item != null) {
-						if (item.Tag.IsPrivate)
-							_items[GetPrivateTag(item.Tag)] = item;
-						else
-							_items[item.Tag] = item;
-					}
-				}
-			}
-			return this;
-		}
-
-		public DicomDataset Add<T>(DicomTag tag, params T[] values) {
-			var entry = DicomDictionary.Default[tag];
-			if (entry == null)
-				throw new DicomDataException("Tag {0} not found in DICOM dictionary. Only dictionary tags may be added implicitly to the dataset.", tag);
-
-			DicomVR vr = null;
-			if (values != null)
-				vr = entry.ValueRepresentations.FirstOrDefault(x => x.ValueType == typeof(T));
-			if (vr == null)
-				vr = entry.ValueRepresentations.First();
-
-			if (vr == DicomVR.AE) {
-				if (values == null)
-					return Add(new DicomApplicationEntity(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomApplicationEntity(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.AS) {
-				if (values == null)
-					return Add(new DicomAgeString(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomAgeString(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.AT) {
-				if (values == null)
-					return Add(new DicomAttributeTag(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(DicomTag))
-					return Add(new DicomAttributeTag(tag, values.Cast<DicomTag>().ToArray()));
-			}
-
-			if (vr == DicomVR.CS) {
-				if (values == null)
-					return Add(new DicomCodeString(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomCodeString(tag, values.Cast<string>().ToArray()));
-				if (typeof(T).IsEnum)
-					return Add(new DicomCodeString(tag, values.Select(x => x.ToString()).ToArray()));
-			}
-
-			if (vr == DicomVR.DA) {
-				if (values == null)
-					return Add(new DicomDate(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(DateTime))
-					return Add(new DicomDate(tag, values.Cast<DateTime>().ToArray()));
-				if (typeof(T) == typeof(DicomDateRange))
-					return Add(new DicomDate(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomDate(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.DS) {
-				if (values == null)
-					return Add(new DicomDecimalString(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(decimal))
-					return Add(new DicomDecimalString(tag, values.Cast<decimal>().ToArray()));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomDecimalString(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.DT) {
-				if (values == null)
-					return Add(new DicomDateTime(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(DateTime))
-					return Add(new DicomDateTime(tag, values.Cast<DateTime>().ToArray()));
-				if (typeof(T) == typeof(DicomDateRange))
-					return Add(new DicomDateTime(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomDateTime(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.FD) {
-				if (values == null)
-					return Add(new DicomFloatingPointDouble(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(double))
-					return Add(new DicomFloatingPointDouble(tag, values.Cast<double>().ToArray()));
-			}
-
-			if (vr == DicomVR.FL) {
-				if (values == null)
-					return Add(new DicomFloatingPointSingle(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(float))
-					return Add(new DicomFloatingPointSingle(tag, values.Cast<float>().ToArray()));
-			}
-
-			if (vr == DicomVR.IS) {
-				if (values == null)
-					return Add(new DicomIntegerString(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(int))
-					return Add(new DicomIntegerString(tag, values.Cast<int>().ToArray()));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomIntegerString(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.LO) {
-				if (values == null)
-					return Add(new DicomLongString(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomLongString(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.LT) {
-				if (values == null)
-					return Add(new DicomLongText(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomLongText(tag, values.Cast<string>().First()));
-			}
-
-			if (vr == DicomVR.OB) {
-				if (values == null)
-					return Add(new DicomOtherByte(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(byte))
-					return Add(new DicomOtherByte(tag, values.Cast<byte>().ToArray()));
-			}
-
-			if (vr == DicomVR.OD) {
-				if (values == null)
-					return Add(new DicomOtherDouble(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(double))
-					return Add(new DicomOtherDouble(tag, values.Cast<double>().ToArray()));
-			}
-
-			if (vr == DicomVR.OF) {
-				if (values == null)
-					return Add(new DicomOtherFloat(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(float))
-					return Add(new DicomOtherFloat(tag, values.Cast<float>().ToArray()));
-			}
-
-			if (vr == DicomVR.OW) {
-				if (values == null)
-					return Add(new DicomOtherWord(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(ushort))
-					return Add(new DicomOtherWord(tag, values.Cast<ushort>().ToArray()));
-			}
-
-			if (vr == DicomVR.PN) {
-				if (values == null)
-					return Add(new DicomPersonName(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomPersonName(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.SH) {
-				if (values == null)
-					return Add(new DicomShortString(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomShortString(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.SL) {
-				if (values == null)
-					return Add(new DicomSignedLong(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(int))
-					return Add(new DicomSignedLong(tag, values.Cast<int>().ToArray()));
-			}
-
-			if (vr == DicomVR.SQ) {
-				if (values == null)
-					return Add(new DicomSequence(tag));
-				if (typeof(T) == typeof(DicomContentItem))
-					return Add(new DicomSequence(tag, values.Cast<DicomContentItem>().Select(x => x.Dataset).ToArray()));
-				if (typeof(T) == typeof(DicomDataset) || typeof(T) == typeof(DicomCodeItem) || typeof(T) == typeof(DicomMeasuredValue) || typeof(T) == typeof(DicomReferencedSOP))
-					return Add(new DicomSequence(tag, values.Cast<DicomDataset>().ToArray()));
-			}
-
-			if (vr == DicomVR.SS) {
-				if (values == null)
-					return Add(new DicomSignedShort(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(short))
-					return Add(new DicomSignedShort(tag, values.Cast<short>().ToArray()));
-			}
-
-			if (vr == DicomVR.ST) {
-				if (values == null)
-					return Add(new DicomShortText(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomShortText(tag, values.Cast<string>().First()));
-			}
-
-			if (vr == DicomVR.TM) {
-				if (values == null)
-					return Add(new DicomTime(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(DateTime))
-					return Add(new DicomTime(tag, values.Cast<DateTime>().ToArray()));
-				if (typeof(T) == typeof(DicomDateRange))
-					return Add(new DicomTime(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomTime(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.UC) {
-				if (values == null)
-					return Add(new DicomUnlimitedCharacters(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomUnlimitedCharacters(tag, values.Cast<string>().ToArray()));
-			}
-
-			if (vr == DicomVR.UI) {
-				if (values == null)
-					return Add(new DicomUniqueIdentifier(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomUniqueIdentifier(tag, values.Cast<string>().ToArray()));
-				if (typeof(T) == typeof(DicomUID))
-					return Add(new DicomUniqueIdentifier(tag, values.Cast<DicomUID>().ToArray()));
-				if (typeof(T) == typeof(DicomTransferSyntax))
-					return Add(new DicomUniqueIdentifier(tag, values.Cast<DicomTransferSyntax>().ToArray()));
-			}
-
-			if (vr == DicomVR.UL) {
-				if (values == null)
-					return Add(new DicomUnsignedLong(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(uint))
-					return Add(new DicomUnsignedLong(tag, values.Cast<uint>().ToArray()));
-			}
-
-			if (vr == DicomVR.UN) {
-				if (values == null)
-					return Add(new DicomUnknown(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(byte))
-					return Add(new DicomUnknown(tag, values.Cast<byte>().ToArray()));
-			}
-
-			if (vr == DicomVR.UR) {
-				if (values == null)
-					return Add(new DicomUniversalResource(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomUniversalResource(tag, values.Cast<string>().First()));
-			}
-
-			if (vr == DicomVR.US) {
-				if (values == null)
-					return Add(new DicomUnsignedShort(tag, EmptyBuffer.Value));
-				if (typeof(T) == typeof(ushort))
-					return Add(new DicomUnsignedShort(tag, values.Cast<ushort>().ToArray()));
-			}
-
-			if (vr == DicomVR.UT) {
-				if (values == null)
-					return Add(new DicomUnlimitedText(tag, DicomEncoding.Default, EmptyBuffer.Value));
-				if (typeof(T) == typeof(string))
-					return Add(new DicomUnlimitedText(tag, values.Cast<string>().First()));
-			}
-
-			throw new InvalidOperationException(String.Format("Unable to create DICOM element of type {0} with values of type {1}", vr.Code, typeof(T).ToString()));
-		}
-
-		/// <summary>
-		/// Checks the DICOM dataset to determine if the dataset already contains an item with the specified tag.
-		/// </summary>
-		/// <param name="tag">DICOM tag to test</param>
-		/// <returns><c>True</c> if a DICOM item with the specified tag already exists.</returns>
-		public bool Contains(DicomTag tag) {
-			return _items.ContainsKey(tag);
-		}
-
-		/// <summary>
-		/// Removes items for specified tags.
-		/// </summary>
-		/// <param name="tags">DICOM tags to remove</param>
-		/// <returns>Current Dataset</returns>
-		public DicomDataset Remove(params DicomTag[] tags) {
-			foreach (DicomTag tag in tags)
-				_items.Remove(tag);
-			return this;
-		}
-
-		/// <summary>
-		/// Removes items where the selector function returns true.
-		/// </summary>
-		/// <param name="selector">Selector function</param>
-		/// <returns>Current Dataset</returns>
-		public DicomDataset Remove(Func<DicomItem, bool> selector) {
-			foreach (DicomItem item in _items.Values.Where(selector).ToArray())
-				_items.Remove(item.Tag);
-			return this;
-		}
-
-		/// <summary>
-		/// Removes all items from the dataset.
-		/// </summary>
-		/// <returns>Current Dataset</returns>
-		public DicomDataset Clear() {
-			_items.Clear();
-			return this;
-		}
-
-		/// <summary>
-		/// Copies all items to the destination dataset.
-		/// </summary>
-		/// <param name="destination">Destination Dataset</param>
-		/// <returns>Current Dataset</returns>
-		public DicomDataset CopyTo(DicomDataset destination) {
-			if (destination != null)
-				destination.Add(this);
-			return this;
-		}
-
-		/// <summary>
-		/// Copies tags to the destination dataset.
-		/// </summary>
-		/// <param name="destination">Destination Dataset</param>
-		/// <param name="tags">Tags to copy</param>
-		/// <returns>Current Dataset</returns>
-		public DicomDataset CopyTo(DicomDataset destination, params DicomTag[] tags) {
-			if (destination != null) {
-				foreach (var tag in tags)
-					destination.Add(Get<DicomItem>(tag));
-			}
-			return this;
-		}
-
-		/// <summary>
-		/// Copies tags matching mask to the destination dataset.
-		/// </summary>
-		/// <param name="destination">Destination Dataset</param>
-		/// <param name="mask">Tags to copy</param>
-		/// <returns>Current Dataset</returns>
-		public DicomDataset CopyTo(DicomDataset destination, DicomMaskedTag mask) {
-			if (destination != null)
-				destination.Add(_items.Values.Where(x => mask.IsMatch(x.Tag)));
-			return this;
-		}
-
-		/// <summary>
-		/// Enumerates all DICOM items.
-		/// </summary>
-		/// <returns>Enumeration of DICOM items</returns>
-		public IEnumerator<DicomItem> GetEnumerator() {
-			return _items.Values.GetEnumerator();
-		}
-
-		/// <summary>
-		/// Enumerates all DICOM items.
-		/// </summary>
-		/// <returns>Enumeration of DICOM items</returns>
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-			return _items.Values.GetEnumerator();
-		}
-
-		public override string ToString() {
-			return String.Format("DICOM Dataset [{0} items]", _items.Count);
-		}
-	}
+namespace Dicom
+{
+    public class DicomDataset : IEnumerable<DicomItem>
+    {
+        private IDictionary<DicomTag, DicomItem> _items;
+
+        private DicomTransferSyntax _syntax;
+
+        public DicomDataset()
+        {
+            _items = new SortedList<DicomTag, DicomItem>();
+            InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
+        }
+
+        public DicomDataset(params DicomItem[] items)
+            : this()
+        {
+            if (items != null)
+            {
+                foreach (DicomItem item in items) if (item != null) _items[item.Tag] = item;
+            }
+        }
+
+        public DicomDataset(IEnumerable<DicomItem> items)
+            : this()
+        {
+            if (items != null)
+            {
+                foreach (DicomItem item in items) if (item != null) _items[item.Tag] = item;
+            }
+        }
+
+        /// <summary>DICOM transfer syntax of this dataset.</summary>
+        public DicomTransferSyntax InternalTransferSyntax
+        {
+            get
+            {
+                return _syntax;
+            }
+            internal set
+            {
+                _syntax = value;
+
+                // update transfer syntax for sequence items
+                foreach (var sq in this.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>())
+                {
+                    foreach (var item in sq.Items)
+                    {
+                        item.InternalTransferSyntax = _syntax;
+                    }
+                }
+            }
+        }
+
+
+        public T Get<T>(DicomTag tag, int n = 0)
+        {
+            return Get<T>(tag, n, default(T));
+        }
+
+        public T Get<T>(DicomTag tag, T defaultValue)
+        {
+            return Get<T>(tag, 0, defaultValue);
+        }
+
+        public T Get<T>(DicomTag tag, int n, T defaultValue)
+        {
+            DicomItem item = null;
+            if (!_items.TryGetValue(tag, out item)) return defaultValue;
+
+            if (typeof(T) == typeof(DicomItem)) return (T)(object)item;
+
+            if (typeof(T).IsSubclassOf(typeof(DicomItem))) return (T)(object)item;
+
+            if (typeof(T) == typeof(DicomVR)) return (T)(object)item.ValueRepresentation;
+
+            if (item.GetType().IsSubclassOf(typeof(DicomElement)))
+            {
+                DicomElement element = (DicomElement)item;
+
+                if (typeof(IByteBuffer).IsAssignableFrom(typeof(T))) return (T)(object)element.Buffer;
+
+                if (typeof(T) == typeof(byte[])) return (T)(object)element.Buffer.Data;
+
+                if (n >= element.Count || element.Count == 0) return defaultValue;
+
+                return (T)(object)element.Get<T>(n);
+            }
+
+            if (item.GetType() == typeof(DicomSequence))
+            {
+                if (typeof(T) == typeof(DicomCodeItem)) return (T)(object)new DicomCodeItem((DicomSequence)item);
+
+                if (typeof(T) == typeof(DicomMeasuredValue)) return (T)(object)new DicomMeasuredValue((DicomSequence)item);
+
+                if (typeof(T) == typeof(DicomReferencedSOP)) return (T)(object)new DicomReferencedSOP((DicomSequence)item);
+            }
+
+            throw new DicomDataException(
+                "Unable to get a value type of {0} from DICOM item of type {1}",
+                typeof(T),
+                item.GetType());
+        }
+
+        /// <summary>
+        /// Converts a dictionary tag to a valid private tag. Creates the private creator tag if needed.
+        /// </summary>
+        /// <param name="tag">Dictionary DICOM tag</param>
+        /// <returns>Private DICOM tag</returns>
+        public DicomTag GetPrivateTag(DicomTag tag)
+        {
+            // not a private tag
+            if (!tag.IsPrivate) return tag;
+
+            // group length
+            if (tag.Element == 0x0000) return tag;
+
+            // private creator?
+            if (tag.PrivateCreator == null) return tag;
+
+            // already a valid private tag
+            if (tag.Element >= 0xff) return tag;
+
+            ushort group = 0x0010;
+            for (;; group++)
+            {
+                var creator = new DicomTag(tag.Group, group);
+                if (!Contains(creator))
+                {
+                    Add(new DicomLongString(creator, tag.PrivateCreator.Creator));
+                    break;
+                }
+
+                var value = Get<string>(creator, String.Empty);
+                if (tag.PrivateCreator.Creator == value) return new DicomTag(tag.Group, (ushort)((group << 8) + (tag.Element & 0xff)), tag.PrivateCreator);
+            }
+
+            return new DicomTag(tag.Group, (ushort)((group << 8) + (tag.Element & 0xff)), tag.PrivateCreator);
+        }
+
+        public DicomDataset Add(params DicomItem[] items)
+        {
+            if (items != null)
+            {
+                foreach (DicomItem item in items)
+                {
+                    if (item != null)
+                    {
+                        if (item.Tag.IsPrivate) _items[GetPrivateTag(item.Tag)] = item;
+                        else _items[item.Tag] = item;
+                    }
+                }
+            }
+            return this;
+        }
+
+        public DicomDataset Add(IEnumerable<DicomItem> items)
+        {
+            if (items != null)
+            {
+                foreach (DicomItem item in items)
+                {
+                    if (item != null)
+                    {
+                        if (item.Tag.IsPrivate) _items[GetPrivateTag(item.Tag)] = item;
+                        else _items[item.Tag] = item;
+                    }
+                }
+            }
+            return this;
+        }
+
+        public DicomDataset Add<T>(DicomTag tag, params T[] values)
+        {
+            var entry = DicomDictionary.Default[tag];
+            if (entry == null)
+                throw new DicomDataException(
+                    "Tag {0} not found in DICOM dictionary. Only dictionary tags may be added implicitly to the dataset.",
+                    tag);
+
+            DicomVR vr = null;
+            if (values != null) vr = entry.ValueRepresentations.FirstOrDefault(x => x.ValueType == typeof(T));
+            if (vr == null) vr = entry.ValueRepresentations.First();
+
+            if (vr == DicomVR.AE)
+            {
+                if (values == null) return Add(new DicomApplicationEntity(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomApplicationEntity(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.AS)
+            {
+                if (values == null) return Add(new DicomAgeString(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomAgeString(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.AT)
+            {
+                if (values == null) return Add(new DicomAttributeTag(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(DicomTag)) return Add(new DicomAttributeTag(tag, values.Cast<DicomTag>().ToArray()));
+            }
+
+            if (vr == DicomVR.CS)
+            {
+                if (values == null) return Add(new DicomCodeString(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomCodeString(tag, values.Cast<string>().ToArray()));
+                if (typeof(T).IsEnum) return Add(new DicomCodeString(tag, values.Select(x => x.ToString()).ToArray()));
+            }
+
+            if (vr == DicomVR.DA)
+            {
+                if (values == null) return Add(new DicomDate(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(DateTime)) return Add(new DicomDate(tag, values.Cast<DateTime>().ToArray()));
+                if (typeof(T) == typeof(DicomDateRange))
+                    return
+                        Add(new DicomDate(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
+                if (typeof(T) == typeof(string)) return Add(new DicomDate(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.DS)
+            {
+                if (values == null) return Add(new DicomDecimalString(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(decimal)) return Add(new DicomDecimalString(tag, values.Cast<decimal>().ToArray()));
+                if (typeof(T) == typeof(string)) return Add(new DicomDecimalString(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.DT)
+            {
+                if (values == null) return Add(new DicomDateTime(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(DateTime)) return Add(new DicomDateTime(tag, values.Cast<DateTime>().ToArray()));
+                if (typeof(T) == typeof(DicomDateRange))
+                    return
+                        Add(
+                            new DicomDateTime(
+                                tag,
+                                values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
+                if (typeof(T) == typeof(string)) return Add(new DicomDateTime(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.FD)
+            {
+                if (values == null) return Add(new DicomFloatingPointDouble(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(double)) return Add(new DicomFloatingPointDouble(tag, values.Cast<double>().ToArray()));
+            }
+
+            if (vr == DicomVR.FL)
+            {
+                if (values == null) return Add(new DicomFloatingPointSingle(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(float)) return Add(new DicomFloatingPointSingle(tag, values.Cast<float>().ToArray()));
+            }
+
+            if (vr == DicomVR.IS)
+            {
+                if (values == null) return Add(new DicomIntegerString(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(int)) return Add(new DicomIntegerString(tag, values.Cast<int>().ToArray()));
+                if (typeof(T) == typeof(string)) return Add(new DicomIntegerString(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.LO)
+            {
+                if (values == null) return Add(new DicomLongString(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomLongString(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.LT)
+            {
+                if (values == null) return Add(new DicomLongText(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomLongText(tag, values.Cast<string>().First()));
+            }
+
+            if (vr == DicomVR.OB)
+            {
+                if (values == null) return Add(new DicomOtherByte(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(byte)) return Add(new DicomOtherByte(tag, values.Cast<byte>().ToArray()));
+            }
+
+            if (vr == DicomVR.OD)
+            {
+                if (values == null) return Add(new DicomOtherDouble(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(double)) return Add(new DicomOtherDouble(tag, values.Cast<double>().ToArray()));
+            }
+
+            if (vr == DicomVR.OF)
+            {
+                if (values == null) return Add(new DicomOtherFloat(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(float)) return Add(new DicomOtherFloat(tag, values.Cast<float>().ToArray()));
+            }
+
+            if (vr == DicomVR.OW)
+            {
+                if (values == null) return Add(new DicomOtherWord(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(ushort)) return Add(new DicomOtherWord(tag, values.Cast<ushort>().ToArray()));
+            }
+
+            if (vr == DicomVR.PN)
+            {
+                if (values == null) return Add(new DicomPersonName(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomPersonName(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.SH)
+            {
+                if (values == null) return Add(new DicomShortString(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomShortString(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.SL)
+            {
+                if (values == null) return Add(new DicomSignedLong(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(int)) return Add(new DicomSignedLong(tag, values.Cast<int>().ToArray()));
+            }
+
+            if (vr == DicomVR.SQ)
+            {
+                if (values == null) return Add(new DicomSequence(tag));
+                if (typeof(T) == typeof(DicomContentItem)) return Add(new DicomSequence(tag, values.Cast<DicomContentItem>().Select(x => x.Dataset).ToArray()));
+                if (typeof(T) == typeof(DicomDataset) || typeof(T) == typeof(DicomCodeItem)
+                    || typeof(T) == typeof(DicomMeasuredValue) || typeof(T) == typeof(DicomReferencedSOP)) return Add(new DicomSequence(tag, values.Cast<DicomDataset>().ToArray()));
+            }
+
+            if (vr == DicomVR.SS)
+            {
+                if (values == null) return Add(new DicomSignedShort(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(short)) return Add(new DicomSignedShort(tag, values.Cast<short>().ToArray()));
+            }
+
+            if (vr == DicomVR.ST)
+            {
+                if (values == null) return Add(new DicomShortText(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomShortText(tag, values.Cast<string>().First()));
+            }
+
+            if (vr == DicomVR.TM)
+            {
+                if (values == null) return Add(new DicomTime(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(DateTime)) return Add(new DicomTime(tag, values.Cast<DateTime>().ToArray()));
+                if (typeof(T) == typeof(DicomDateRange))
+                    return
+                        Add(new DicomTime(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
+                if (typeof(T) == typeof(string)) return Add(new DicomTime(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.UC)
+            {
+                if (values == null) return Add(new DicomUnlimitedCharacters(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomUnlimitedCharacters(tag, values.Cast<string>().ToArray()));
+            }
+
+            if (vr == DicomVR.UI)
+            {
+                if (values == null) return Add(new DicomUniqueIdentifier(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomUniqueIdentifier(tag, values.Cast<string>().ToArray()));
+                if (typeof(T) == typeof(DicomUID)) return Add(new DicomUniqueIdentifier(tag, values.Cast<DicomUID>().ToArray()));
+                if (typeof(T) == typeof(DicomTransferSyntax)) return Add(new DicomUniqueIdentifier(tag, values.Cast<DicomTransferSyntax>().ToArray()));
+            }
+
+            if (vr == DicomVR.UL)
+            {
+                if (values == null) return Add(new DicomUnsignedLong(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(uint)) return Add(new DicomUnsignedLong(tag, values.Cast<uint>().ToArray()));
+            }
+
+            if (vr == DicomVR.UN)
+            {
+                if (values == null) return Add(new DicomUnknown(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(byte)) return Add(new DicomUnknown(tag, values.Cast<byte>().ToArray()));
+            }
+
+            if (vr == DicomVR.UR)
+            {
+                if (values == null) return Add(new DicomUniversalResource(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomUniversalResource(tag, values.Cast<string>().First()));
+            }
+
+            if (vr == DicomVR.US)
+            {
+                if (values == null) return Add(new DicomUnsignedShort(tag, EmptyBuffer.Value));
+                if (typeof(T) == typeof(ushort)) return Add(new DicomUnsignedShort(tag, values.Cast<ushort>().ToArray()));
+            }
+
+            if (vr == DicomVR.UT)
+            {
+                if (values == null) return Add(new DicomUnlimitedText(tag, DicomEncoding.Default, EmptyBuffer.Value));
+                if (typeof(T) == typeof(string)) return Add(new DicomUnlimitedText(tag, values.Cast<string>().First()));
+            }
+
+            throw new InvalidOperationException(
+                String.Format(
+                    "Unable to create DICOM element of type {0} with values of type {1}",
+                    vr.Code,
+                    typeof(T).ToString()));
+        }
+
+        /// <summary>
+        /// Checks the DICOM dataset to determine if the dataset already contains an item with the specified tag.
+        /// </summary>
+        /// <param name="tag">DICOM tag to test</param>
+        /// <returns><c>True</c> if a DICOM item with the specified tag already exists.</returns>
+        public bool Contains(DicomTag tag)
+        {
+            return _items.ContainsKey(tag);
+        }
+
+        /// <summary>
+        /// Removes items for specified tags.
+        /// </summary>
+        /// <param name="tags">DICOM tags to remove</param>
+        /// <returns>Current Dataset</returns>
+        public DicomDataset Remove(params DicomTag[] tags)
+        {
+            foreach (DicomTag tag in tags) _items.Remove(tag);
+            return this;
+        }
+
+        /// <summary>
+        /// Removes items where the selector function returns true.
+        /// </summary>
+        /// <param name="selector">Selector function</param>
+        /// <returns>Current Dataset</returns>
+        public DicomDataset Remove(Func<DicomItem, bool> selector)
+        {
+            foreach (DicomItem item in _items.Values.Where(selector).ToArray()) _items.Remove(item.Tag);
+            return this;
+        }
+
+        /// <summary>
+        /// Removes all items from the dataset.
+        /// </summary>
+        /// <returns>Current Dataset</returns>
+        public DicomDataset Clear()
+        {
+            _items.Clear();
+            return this;
+        }
+
+        /// <summary>
+        /// Copies all items to the destination dataset.
+        /// </summary>
+        /// <param name="destination">Destination Dataset</param>
+        /// <returns>Current Dataset</returns>
+        public DicomDataset CopyTo(DicomDataset destination)
+        {
+            if (destination != null) destination.Add(this);
+            return this;
+        }
+
+        /// <summary>
+        /// Copies tags to the destination dataset.
+        /// </summary>
+        /// <param name="destination">Destination Dataset</param>
+        /// <param name="tags">Tags to copy</param>
+        /// <returns>Current Dataset</returns>
+        public DicomDataset CopyTo(DicomDataset destination, params DicomTag[] tags)
+        {
+            if (destination != null)
+            {
+                foreach (var tag in tags) destination.Add(Get<DicomItem>(tag));
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Copies tags matching mask to the destination dataset.
+        /// </summary>
+        /// <param name="destination">Destination Dataset</param>
+        /// <param name="mask">Tags to copy</param>
+        /// <returns>Current Dataset</returns>
+        public DicomDataset CopyTo(DicomDataset destination, DicomMaskedTag mask)
+        {
+            if (destination != null) destination.Add(_items.Values.Where(x => mask.IsMatch(x.Tag)));
+            return this;
+        }
+
+        /// <summary>
+        /// Enumerates all DICOM items.
+        /// </summary>
+        /// <returns>Enumeration of DICOM items</returns>
+        public IEnumerator<DicomItem> GetEnumerator()
+        {
+            return _items.Values.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Enumerates all DICOM items.
+        /// </summary>
+        /// <returns>Enumeration of DICOM items</returns>
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return _items.Values.GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            return String.Format("DICOM Dataset [{0} items]", _items.Count);
+        }
+    }
 }

--- a/DICOM/DicomDatasetExtensions.cs
+++ b/DICOM/DicomDatasetExtensions.cs
@@ -1,46 +1,53 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Dicom {
-	public static class DicomDatasetExtensions {
-		public static DicomDataset Clone(this DicomDataset dataset) {
-			var ds = new DicomDataset(dataset);
-			ds.InternalTransferSyntax = dataset.InternalTransferSyntax;
-			return ds;
-		}
+namespace Dicom
+{
+    public static class DicomDatasetExtensions
+    {
+        public static DicomDataset Clone(this DicomDataset dataset)
+        {
+            var ds = new DicomDataset(dataset);
+            ds.InternalTransferSyntax = dataset.InternalTransferSyntax;
+            return ds;
+        }
 
-		public static DateTime GetDateTime(this DicomDataset dataset, DicomTag date, DicomTag time) {
-			DicomDate dd = dataset.Get<DicomDate>(date);
-			DicomTime dt = dataset.Get<DicomTime>(time);
+        public static DateTime GetDateTime(this DicomDataset dataset, DicomTag date, DicomTag time)
+        {
+            DicomDate dd = dataset.Get<DicomDate>(date);
+            DicomTime dt = dataset.Get<DicomTime>(time);
 
-			DateTime da = DateTime.Today;
-			if (dd != null && dd.Count > 0)
-				da = dd.Get<DateTime>(0);
+            DateTime da = DateTime.Today;
+            if (dd != null && dd.Count > 0) da = dd.Get<DateTime>(0);
 
-			DateTime tm = DateTime.Today;
-			if (dt != null && dt.Count > 0)
-				tm = dt.Get<DateTime>(0);
+            DateTime tm = DateTime.Today;
+            if (dt != null && dt.Count > 0) tm = dt.Get<DateTime>(0);
 
-			return new DateTime(da.Year, da.Month, da.Day, tm.Hour, tm.Minute, tm.Second);
-		}
+            return new DateTime(da.Year, da.Month, da.Day, tm.Hour, tm.Minute, tm.Second);
+        }
 
-		/// <summary>
-		/// Enumerates DICOM items matching mask.
-		/// </summary>
-		/// <param name="mask">Mask</param>
-		/// <returns>Enumeration of DICOM items</returns>
-		public static IEnumerable<DicomItem> EnumerateMasked(this DicomDataset dataset, DicomMaskedTag mask) {
-			return dataset.Where(x => mask.IsMatch(x.Tag));
-		}
+        /// <summary>
+        /// Enumerates DICOM items matching mask.
+        /// </summary>
+        /// <param name="mask">Mask</param>
+        /// <returns>Enumeration of DICOM items</returns>
+        public static IEnumerable<DicomItem> EnumerateMasked(this DicomDataset dataset, DicomMaskedTag mask)
+        {
+            return dataset.Where(x => mask.IsMatch(x.Tag));
+        }
 
-		/// <summary>
-		/// Enumerates DICOM items for specified group.
-		/// </summary>
-		/// <param name="group">Group</param>
-		/// <returns>Enumeration of DICOM items</returns>
-		public static IEnumerable<DicomItem> EnumerateGroup(this DicomDataset dataset, ushort group) {
-			return dataset.Where(x => x.Tag.Group == group && x.Tag.Element != 0x0000);
-		}
-	}
+        /// <summary>
+        /// Enumerates DICOM items for specified group.
+        /// </summary>
+        /// <param name="group">Group</param>
+        /// <returns>Enumeration of DICOM items</returns>
+        public static IEnumerable<DicomItem> EnumerateGroup(this DicomDataset dataset, ushort group)
+        {
+            return dataset.Where(x => x.Tag.Group == group && x.Tag.Element != 0x0000);
+        }
+    }
 }

--- a/DICOM/DicomDatasetWalker.cs
+++ b/DICOM/DicomDatasetWalker.cs
@@ -1,195 +1,274 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 
 using Dicom.IO.Buffer;
 
-namespace Dicom {
+namespace Dicom
+{
     public delegate void DicomDatasetWalkerCallback();
 
-    public interface IDicomDatasetWalker {
-		void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback);
+    public interface IDicomDatasetWalker
+    {
+        void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback);
+
         bool OnElement(DicomElement element);
+
         bool OnBeginSequence(DicomSequence sequence);
+
         bool OnBeginSequenceItem(DicomDataset dataset);
+
         bool OnEndSequenceItem();
+
         bool OnEndSequence();
+
         bool OnBeginFragment(DicomFragmentSequence fragment);
+
         bool OnFragmentItem(IByteBuffer item);
+
         bool OnEndFragment();
-		void OnEndWalk();
+
+        void OnEndWalk();
     }
 
-    public class DicomDatasetWalker {
-		#region State Items
-		private class BeginDicomSequenceItem : DicomItem {
-			public BeginDicomSequenceItem(DicomDataset item) : base(DicomTag.Unknown) {
-				Dataset = item;
-			}
+    public class DicomDatasetWalker
+    {
+        #region State Items
 
-			public DicomDataset Dataset {
-				get;
-				private set;
-			}
+        private class BeginDicomSequenceItem : DicomItem
+        {
+            public BeginDicomSequenceItem(DicomDataset item)
+                : base(DicomTag.Unknown)
+            {
+                Dataset = item;
+            }
 
-			public override DicomVR ValueRepresentation {
-				get { return DicomVR.NONE; }
-			}
-		}
+            public DicomDataset Dataset { get; private set; }
 
-		private class EndDicomSequenceItem : DicomItem {
-			public EndDicomSequenceItem() : base(DicomTag.Unknown) { }
+            public override DicomVR ValueRepresentation
+            {
+                get
+                {
+                    return DicomVR.NONE;
+                }
+            }
+        }
 
-			public override DicomVR ValueRepresentation {
-				get { return DicomVR.NONE; }
-			}
-		}
+        private class EndDicomSequenceItem : DicomItem
+        {
+            public EndDicomSequenceItem()
+                : base(DicomTag.Unknown)
+            {
+            }
 
-		private class EndDicomSequence : DicomItem {
-			public EndDicomSequence() : base(DicomTag.Unknown) { }
+            public override DicomVR ValueRepresentation
+            {
+                get
+                {
+                    return DicomVR.NONE;
+                }
+            }
+        }
 
-			public override DicomVR ValueRepresentation {
-				get { return DicomVR.NONE; }
-			}
-		}
+        private class EndDicomSequence : DicomItem
+        {
+            public EndDicomSequence()
+                : base(DicomTag.Unknown)
+            {
+            }
 
-		private class DicomFragmentItem : DicomItem {
-			public DicomFragmentItem(IByteBuffer buffer) : base(DicomTag.Unknown) {
-				Buffer = buffer;
-			}
+            public override DicomVR ValueRepresentation
+            {
+                get
+                {
+                    return DicomVR.NONE;
+                }
+            }
+        }
 
-			public IByteBuffer Buffer {
-				get;
-				private set;
-			}
+        private class DicomFragmentItem : DicomItem
+        {
+            public DicomFragmentItem(IByteBuffer buffer)
+                : base(DicomTag.Unknown)
+            {
+                Buffer = buffer;
+            }
 
-			public override DicomVR ValueRepresentation {
-				get { return DicomVR.NONE; }
-			}
-		}
+            public IByteBuffer Buffer { get; private set; }
 
-		private class EndDicomFragment : DicomItem {
-			public EndDicomFragment() : base(DicomTag.Unknown) { }
+            public override DicomVR ValueRepresentation
+            {
+                get
+                {
+                    return DicomVR.NONE;
+                }
+            }
+        }
 
-			public override DicomVR ValueRepresentation {
-				get { return DicomVR.NONE; }
-			}
-		}
-		#endregion
+        private class EndDicomFragment : DicomItem
+        {
+            public EndDicomFragment()
+                : base(DicomTag.Unknown)
+            {
+            }
 
-		private IEnumerable<DicomItem> _dataset;
+            public override DicomVR ValueRepresentation
+            {
+                get
+                {
+                    return DicomVR.NONE;
+                }
+            }
+        }
+
+        #endregion
+
+        private IEnumerable<DicomItem> _dataset;
+
         private Queue<DicomItem> _items;
+
         private IDicomDatasetWalker _walker;
 
         private EventAsyncResult _async;
+
         private Exception _exception;
 
-        public DicomDatasetWalker(IEnumerable<DicomItem> dataset) {
-			_dataset = dataset;
+        public DicomDatasetWalker(IEnumerable<DicomItem> dataset)
+        {
+            _dataset = dataset;
         }
 
-        public void Walk(IDicomDatasetWalker walker) {
-			EndWalk(BeginWalk(walker, null, null));
+        public void Walk(IDicomDatasetWalker walker)
+        {
+            EndWalk(BeginWalk(walker, null, null));
         }
 
-        public IAsyncResult BeginWalk(IDicomDatasetWalker walker, AsyncCallback callback, object state) {
-			_walker = walker;
-			_exception = null;
-			_async = new EventAsyncResult(callback, state);
-			ThreadPool.QueueUserWorkItem(Walk, null);
-			return _async;
+        public IAsyncResult BeginWalk(IDicomDatasetWalker walker, AsyncCallback callback, object state)
+        {
+            _walker = walker;
+            _exception = null;
+            _async = new EventAsyncResult(callback, state);
+            ThreadPool.QueueUserWorkItem(Walk, null);
+            return _async;
         }
 
-        public void EndWalk(IAsyncResult result) {
+        public void EndWalk(IAsyncResult result)
+        {
             result.AsyncWaitHandle.WaitOne();
 
-            if (_exception != null)
-                throw _exception;
+            if (_exception != null) throw _exception;
         }
 
-        private void NextWalkItem() {
-			_items.Dequeue();
-			ThreadPool.QueueUserWorkItem(Walk, null);
+        private void NextWalkItem()
+        {
+            _items.Dequeue();
+            ThreadPool.QueueUserWorkItem(Walk, null);
         }
 
-		private void BuildWalkQueue(IEnumerable<DicomItem> dataset) {
-			foreach (DicomItem item in dataset) {
-				if (item is DicomElement) {
-					_items.Enqueue(item);
-				} else if (item is DicomFragmentSequence) {
-					DicomFragmentSequence sq = item as DicomFragmentSequence;
-					_items.Enqueue(item);
-					foreach (IByteBuffer fragment in sq) {
-						_items.Enqueue(new DicomFragmentItem(fragment));
-					}
-					_items.Enqueue(new EndDicomFragment());
-				} else if (item is DicomSequence) {
-					DicomSequence sq = item as DicomSequence;
-					_items.Enqueue(item);
-					foreach (DicomDataset sqi in sq) {
-						_items.Enqueue(new BeginDicomSequenceItem(sqi));
-						BuildWalkQueue(sqi);
-						_items.Enqueue(new EndDicomSequenceItem());
-					}
-					_items.Enqueue(new EndDicomSequence());
-				}
-			}
-		}
+        private void BuildWalkQueue(IEnumerable<DicomItem> dataset)
+        {
+            foreach (DicomItem item in dataset)
+            {
+                if (item is DicomElement)
+                {
+                    _items.Enqueue(item);
+                }
+                else if (item is DicomFragmentSequence)
+                {
+                    DicomFragmentSequence sq = item as DicomFragmentSequence;
+                    _items.Enqueue(item);
+                    foreach (IByteBuffer fragment in sq)
+                    {
+                        _items.Enqueue(new DicomFragmentItem(fragment));
+                    }
+                    _items.Enqueue(new EndDicomFragment());
+                }
+                else if (item is DicomSequence)
+                {
+                    DicomSequence sq = item as DicomSequence;
+                    _items.Enqueue(item);
+                    foreach (DicomDataset sqi in sq)
+                    {
+                        _items.Enqueue(new BeginDicomSequenceItem(sqi));
+                        BuildWalkQueue(sqi);
+                        _items.Enqueue(new EndDicomSequenceItem());
+                    }
+                    _items.Enqueue(new EndDicomSequence());
+                }
+            }
+        }
 
-        private void Walk(object state) {
-            try {
-                if (_items == null) {
+        private void Walk(object state)
+        {
+            try
+            {
+                if (_items == null)
+                {
                     _items = new Queue<DicomItem>();
-					BuildWalkQueue(_dataset);
-					_walker.OnBeginWalk(this, NextWalkItem);
+                    BuildWalkQueue(_dataset);
+                    _walker.OnBeginWalk(this, NextWalkItem);
                 }
 
-				DicomItem item = null;
-				while (_items.Count > 0) {
-					item = _items.Peek();
+                DicomItem item = null;
+                while (_items.Count > 0)
+                {
+                    item = _items.Peek();
 
-					if (item is DicomElement) {
-						if (!_walker.OnElement(item as DicomElement))
-							return;
-					} else if (item is DicomFragmentSequence) {
-						if (!_walker.OnBeginFragment(item as DicomFragmentSequence))
-							return;
-					} else if (item is DicomFragmentItem) {
-						if (!_walker.OnFragmentItem((item as DicomFragmentItem).Buffer))
-							return;
-					} else if (item is EndDicomFragment) {
-						if (!_walker.OnEndFragment())
-							return;
-					} else if (item is DicomSequence) {
-						if (!_walker.OnBeginSequence(item as DicomSequence))
-							return;
-					} else if (item is BeginDicomSequenceItem) {
-						if (!_walker.OnBeginSequenceItem((item as BeginDicomSequenceItem).Dataset))
-							return;
-					} else if (item is EndDicomSequenceItem) {
-						if (!_walker.OnEndSequenceItem())
-							return;
-					} else if (item is EndDicomSequence) {
-						if (!_walker.OnEndSequence())
-							return;
-					}
+                    if (item is DicomElement)
+                    {
+                        if (!_walker.OnElement(item as DicomElement)) return;
+                    }
+                    else if (item is DicomFragmentSequence)
+                    {
+                        if (!_walker.OnBeginFragment(item as DicomFragmentSequence)) return;
+                    }
+                    else if (item is DicomFragmentItem)
+                    {
+                        if (!_walker.OnFragmentItem((item as DicomFragmentItem).Buffer)) return;
+                    }
+                    else if (item is EndDicomFragment)
+                    {
+                        if (!_walker.OnEndFragment()) return;
+                    }
+                    else if (item is DicomSequence)
+                    {
+                        if (!_walker.OnBeginSequence(item as DicomSequence)) return;
+                    }
+                    else if (item is BeginDicomSequenceItem)
+                    {
+                        if (!_walker.OnBeginSequenceItem((item as BeginDicomSequenceItem).Dataset)) return;
+                    }
+                    else if (item is EndDicomSequenceItem)
+                    {
+                        if (!_walker.OnEndSequenceItem()) return;
+                    }
+                    else if (item is EndDicomSequence)
+                    {
+                        if (!_walker.OnEndSequence()) return;
+                    }
 
-					_items.Dequeue();
-				}
+                    _items.Dequeue();
+                }
 
-				_walker.OnEndWalk();
+                _walker.OnEndWalk();
 
-				_items = null;
+                _items = null;
                 _async.Set();
-            } catch (Exception e) {
-				try {
-					_walker.OnEndWalk();
-				} catch {
-				}
+            }
+            catch (Exception e)
+            {
+                try
+                {
+                    _walker.OnEndWalk();
+                }
+                catch
+                {
+                }
                 _exception = e;
-				_items = null;
+                _items = null;
                 _async.Set();
             }
         }

--- a/DICOM/DicomDateRange.cs
+++ b/DICOM/DicomDateRange.cs
@@ -1,25 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public class DicomDateRange : DicomRange<DateTime> {
-		public DicomDateRange() : base(DateTime.MinValue, DateTime.MaxValue) {
-		}
+using System;
 
-		public DicomDateRange(DateTime min, DateTime max) : base(min, max) {
-		}
+namespace Dicom
+{
+    public class DicomDateRange : DicomRange<DateTime>
+    {
+        public DicomDateRange()
+            : base(DateTime.MinValue, DateTime.MaxValue)
+        {
+        }
 
-		public override string ToString() {
-			return ToString("yyyyMMddHHmmss");
-		}
+        public DicomDateRange(DateTime min, DateTime max)
+            : base(min, max)
+        {
+        }
 
-		public string ToString(string format) {
-			var value = (Minimum == DateTime.MinValue ? String.Empty : Minimum.ToString(format)) + "-" + (Maximum == DateTime.MaxValue ? String.Empty : Maximum.ToString(format));
-			if (value == "-")
-				return String.Empty;
-			return value;
-		}
-	}
+        public override string ToString()
+        {
+            return ToString("yyyyMMddHHmmss");
+        }
+
+        public string ToString(string format)
+        {
+            var value = (Minimum == DateTime.MinValue ? String.Empty : Minimum.ToString(format)) + "-"
+                        + (Maximum == DateTime.MaxValue ? String.Empty : Maximum.ToString(format));
+            if (value == "-") return String.Empty;
+            return value;
+        }
+    }
 }

--- a/DICOM/DicomDictionary.cs
+++ b/DICOM/DicomDictionary.cs
@@ -1,189 +1,286 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Concurrent;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 
-namespace Dicom {
-	public partial class DicomDictionary : IEnumerable<DicomDictionaryEntry> {
-		#region Private Members
-		public readonly static DicomDictionaryEntry UnknownTag = new DicomDictionaryEntry(DicomMaskedTag.Parse("xxxx","xxxx"), "Unknown", "Unknown", DicomVM.VM_1_n, false, 
-			DicomVR.UN, DicomVR.AE, DicomVR.AS, DicomVR.AT, DicomVR.CS, DicomVR.DA, DicomVR.DS, DicomVR.DT, DicomVR.FD, DicomVR.FL, DicomVR.IS, DicomVR.LO, DicomVR.LT, DicomVR.OB, 
-			DicomVR.OF, DicomVR.OW, DicomVR.PN, DicomVR.SH, DicomVR.SL, DicomVR.SQ, DicomVR.SS, DicomVR.ST, DicomVR.TM, DicomVR.UI, DicomVR.UL, DicomVR.US, DicomVR.UT);
+namespace Dicom
+{
+    public partial class DicomDictionary : IEnumerable<DicomDictionaryEntry>
+    {
+        #region Private Members
 
-		public readonly static DicomDictionaryEntry PrivateCreatorTag = new DicomDictionaryEntry(DicomMaskedTag.Parse("xxxx", "00xx"), "Private Creator", "PrivateCreator", DicomVM.VM_1, false, DicomVR.LO);
+        public static readonly DicomDictionaryEntry UnknownTag =
+            new DicomDictionaryEntry(
+                DicomMaskedTag.Parse("xxxx", "xxxx"),
+                "Unknown",
+                "Unknown",
+                DicomVM.VM_1_n,
+                false,
+                DicomVR.UN,
+                DicomVR.AE,
+                DicomVR.AS,
+                DicomVR.AT,
+                DicomVR.CS,
+                DicomVR.DA,
+                DicomVR.DS,
+                DicomVR.DT,
+                DicomVR.FD,
+                DicomVR.FL,
+                DicomVR.IS,
+                DicomVR.LO,
+                DicomVR.LT,
+                DicomVR.OB,
+                DicomVR.OF,
+                DicomVR.OW,
+                DicomVR.PN,
+                DicomVR.SH,
+                DicomVR.SL,
+                DicomVR.SQ,
+                DicomVR.SS,
+                DicomVR.ST,
+                DicomVR.TM,
+                DicomVR.UI,
+                DicomVR.UL,
+                DicomVR.US,
+                DicomVR.UT);
 
-		private DicomPrivateCreator _privateCreator;
-		private IDictionary<string, DicomPrivateCreator> _creators;
-		private IDictionary<DicomPrivateCreator, DicomDictionary> _private;
-		private IDictionary<DicomTag, DicomDictionaryEntry> _entries;
-		private List<DicomDictionaryEntry> _masked;
-		private bool _sortMasked;
-		#endregion
+        public static readonly DicomDictionaryEntry PrivateCreatorTag =
+            new DicomDictionaryEntry(
+                DicomMaskedTag.Parse("xxxx", "00xx"),
+                "Private Creator",
+                "PrivateCreator",
+                DicomVM.VM_1,
+                false,
+                DicomVR.LO);
 
-		#region Constructors
-		public DicomDictionary() {
-			_creators = new Dictionary<string, DicomPrivateCreator>();
-			_private = new Dictionary<DicomPrivateCreator, DicomDictionary>();
-			_entries = new Dictionary<DicomTag, DicomDictionaryEntry>();
-			_masked = new List<DicomDictionaryEntry>();
-		}
+        private DicomPrivateCreator _privateCreator;
 
-		private DicomDictionary(DicomPrivateCreator creator) {
-			_privateCreator = creator;
-			_entries = new Dictionary<DicomTag, DicomDictionaryEntry>();
-			_masked = new List<DicomDictionaryEntry>();
-		}
-		#endregion
+        private IDictionary<string, DicomPrivateCreator> _creators;
 
-		#region Properties
-		private static object _lock = new object();
-		private static DicomDictionary _default;
+        private IDictionary<DicomPrivateCreator, DicomDictionary> _private;
 
-		private static void LoadInternalDictionaries() {
-			lock (_lock) {
-				if (_default == null) {
-					_default = new DicomDictionary();
-					_default.Add(new DicomDictionaryEntry(DicomMaskedTag.Parse("xxxx", "0000"), "Group Length", "GroupLength", DicomVM.VM_1, false, DicomVR.UL));
-					try {
-						var assembly = Assembly.GetExecutingAssembly();
-						var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.DICOM Dictionary.xml.gz");
-						var gzip = new GZipStream(stream, CompressionMode.Decompress);
-						var reader = new DicomDictionaryReader(_default, DicomDictionaryFormat.XML, gzip);
-						reader.Process();
-					} catch (Exception e) {
-						throw new DicomDataException("Unable to load DICOM dictionary from resources.\n\n" + e.Message, e);
-					}
-					try {
-						var assembly = Assembly.GetExecutingAssembly();
-						var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml.gz");
-						var gzip = new GZipStream(stream, CompressionMode.Decompress);
-						var reader = new DicomDictionaryReader(_default, DicomDictionaryFormat.XML, gzip);
-						reader.Process();
-					} catch (Exception e) {
-						throw new DicomDataException("Unable to load private dictionary from resources.\n\n" + e.Message, e);
-					}
-				}
-			}
-		}
+        private IDictionary<DicomTag, DicomDictionaryEntry> _entries;
 
-		public static DicomDictionary Default {
-			get {
-				if (_default == null)
-					LoadInternalDictionaries();
-				return _default;
-			}
-			set {
-				lock (_lock)
-					_default = value;
-			}
-		}
+        private List<DicomDictionaryEntry> _masked;
 
-		public DicomPrivateCreator PrivateCreator {
-			get { return _privateCreator; }
-			internal set { _privateCreator = value; }
-		}
+        private bool _sortMasked;
 
-		public DicomDictionaryEntry this[DicomTag tag] {
-			get {
-				if (_private != null && tag.PrivateCreator != null) {
-					DicomDictionary pvt = null;
-					if (_private.TryGetValue(tag.PrivateCreator, out pvt))
-						return pvt[tag];
-				}
+        #endregion
 
-				// special case for private creator tag
-				if (tag.IsPrivate && tag.Element != 0x0000 && tag.Element <= 0x00ff)
-					return PrivateCreatorTag;
+        #region Constructors
 
-				DicomDictionaryEntry entry = null;
-				if (_entries.TryGetValue(tag, out entry))
-					return entry;
+        public DicomDictionary()
+        {
+            _creators = new Dictionary<string, DicomPrivateCreator>();
+            _private = new Dictionary<DicomPrivateCreator, DicomDictionary>();
+            _entries = new Dictionary<DicomTag, DicomDictionaryEntry>();
+            _masked = new List<DicomDictionaryEntry>();
+        }
 
-				// this is faster than LINQ query
-				foreach (var x in _masked) {
-					if (x.MaskTag.IsMatch(tag))
-						return x;
-				}
+        private DicomDictionary(DicomPrivateCreator creator)
+        {
+            _privateCreator = creator;
+            _entries = new Dictionary<DicomTag, DicomDictionaryEntry>();
+            _masked = new List<DicomDictionaryEntry>();
+        }
 
-				return UnknownTag;
-			}
-		}
+        #endregion
 
-		public DicomDictionary this[DicomPrivateCreator creator] {
-			get {
-				DicomDictionary pvt = null;
-				if (!_private.TryGetValue(creator, out pvt)) {
-					pvt = new DicomDictionary(creator);
-					_private.Add(creator, pvt);
-				}
-				return pvt;
-			}
-		}
-		#endregion
+        #region Properties
 
-		#region Public Methods
-		public void Add(DicomDictionaryEntry entry) {
-			if (_privateCreator != null) {
-				entry.Tag = new DicomTag(entry.Tag.Group, entry.Tag.Element, _privateCreator);
-				if (entry.MaskTag != null)
-					entry.MaskTag.Tag = entry.Tag;
-			}
+        private static object _lock = new object();
 
-			if (entry.MaskTag == null) {
-				// allow overwriting of existing entries
-				_entries[entry.Tag] = entry;
-			} else {
-				_masked.Add(entry);
-				_sortMasked = true;
-			}
-		}
+        private static DicomDictionary _default;
 
-		public DicomPrivateCreator GetPrivateCreator(string creator) {
-			DicomPrivateCreator pvt = null;
-			if (!_creators.TryGetValue(creator, out pvt)) {
-				pvt = new DicomPrivateCreator(creator);
-				_creators.Add(creator, pvt);
-			}
-			return pvt;
-		}
+        private static void LoadInternalDictionaries()
+        {
+            lock (_lock)
+            {
+                if (_default == null)
+                {
+                    _default = new DicomDictionary();
+                    _default.Add(
+                        new DicomDictionaryEntry(
+                            DicomMaskedTag.Parse("xxxx", "0000"),
+                            "Group Length",
+                            "GroupLength",
+                            DicomVM.VM_1,
+                            false,
+                            DicomVR.UL));
+                    try
+                    {
+                        var assembly = Assembly.GetExecutingAssembly();
+                        var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.DICOM Dictionary.xml.gz");
+                        var gzip = new GZipStream(stream, CompressionMode.Decompress);
+                        var reader = new DicomDictionaryReader(_default, DicomDictionaryFormat.XML, gzip);
+                        reader.Process();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new DicomDataException(
+                            "Unable to load DICOM dictionary from resources.\n\n" + e.Message,
+                            e);
+                    }
+                    try
+                    {
+                        var assembly = Assembly.GetExecutingAssembly();
+                        var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml.gz");
+                        var gzip = new GZipStream(stream, CompressionMode.Decompress);
+                        var reader = new DicomDictionaryReader(_default, DicomDictionaryFormat.XML, gzip);
+                        reader.Process();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new DicomDataException(
+                            "Unable to load private dictionary from resources.\n\n" + e.Message,
+                            e);
+                    }
+                }
+            }
+        }
 
-		public void Load(string file, DicomDictionaryFormat format) {
-			using (var fs = File.OpenRead(file)) {
-				Stream s = fs;
+        public static DicomDictionary Default
+        {
+            get
+            {
+                if (_default == null) LoadInternalDictionaries();
+                return _default;
+            }
+            set
+            {
+                lock (_lock) _default = value;
+            }
+        }
 
-				if (file.EndsWith(".gz"))
-					s = new GZipStream(s, CompressionMode.Decompress);
+        public DicomPrivateCreator PrivateCreator
+        {
+            get
+            {
+                return _privateCreator;
+            }
+            internal set
+            {
+                _privateCreator = value;
+            }
+        }
 
-				DicomDictionaryReader reader = new DicomDictionaryReader(this, format, s);
-				reader.Process();
-			}
-		}
-		#endregion
+        public DicomDictionaryEntry this[DicomTag tag]
+        {
+            get
+            {
+                if (_private != null && tag.PrivateCreator != null)
+                {
+                    DicomDictionary pvt = null;
+                    if (_private.TryGetValue(tag.PrivateCreator, out pvt)) return pvt[tag];
+                }
 
-		#region IEnumerable Members
+                // special case for private creator tag
+                if (tag.IsPrivate && tag.Element != 0x0000 && tag.Element <= 0x00ff) return PrivateCreatorTag;
 
-		public IEnumerator<DicomDictionaryEntry> GetEnumerator() {
-			List<DicomDictionaryEntry> items = new List<DicomDictionaryEntry>();
-			items.AddRange(_entries.Values.OrderBy(x => x.Tag));
+                DicomDictionaryEntry entry = null;
+                if (_entries.TryGetValue(tag, out entry)) return entry;
 
-			if (_sortMasked) {
-				_masked.Sort((a, b) => { return a.MaskTag.Mask.CompareTo(b.MaskTag.Mask); });
-				_sortMasked = false;
-			}
-			items.AddRange(_masked);
+                // this is faster than LINQ query
+                foreach (var x in _masked)
+                {
+                    if (x.MaskTag.IsMatch(tag)) return x;
+                }
 
-			return items.GetEnumerator();
-		}
+                return UnknownTag;
+            }
+        }
 
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
+        public DicomDictionary this[DicomPrivateCreator creator]
+        {
+            get
+            {
+                DicomDictionary pvt = null;
+                if (!_private.TryGetValue(creator, out pvt))
+                {
+                    pvt = new DicomDictionary(creator);
+                    _private.Add(creator, pvt);
+                }
+                return pvt;
+            }
+        }
 
-		#endregion
-	}
+        #endregion
+
+        #region Public Methods
+
+        public void Add(DicomDictionaryEntry entry)
+        {
+            if (_privateCreator != null)
+            {
+                entry.Tag = new DicomTag(entry.Tag.Group, entry.Tag.Element, _privateCreator);
+                if (entry.MaskTag != null) entry.MaskTag.Tag = entry.Tag;
+            }
+
+            if (entry.MaskTag == null)
+            {
+                // allow overwriting of existing entries
+                _entries[entry.Tag] = entry;
+            }
+            else
+            {
+                _masked.Add(entry);
+                _sortMasked = true;
+            }
+        }
+
+        public DicomPrivateCreator GetPrivateCreator(string creator)
+        {
+            DicomPrivateCreator pvt = null;
+            if (!_creators.TryGetValue(creator, out pvt))
+            {
+                pvt = new DicomPrivateCreator(creator);
+                _creators.Add(creator, pvt);
+            }
+            return pvt;
+        }
+
+        public void Load(string file, DicomDictionaryFormat format)
+        {
+            using (var fs = File.OpenRead(file))
+            {
+                Stream s = fs;
+
+                if (file.EndsWith(".gz")) s = new GZipStream(s, CompressionMode.Decompress);
+
+                DicomDictionaryReader reader = new DicomDictionaryReader(this, format, s);
+                reader.Process();
+            }
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        public IEnumerator<DicomDictionaryEntry> GetEnumerator()
+        {
+            List<DicomDictionaryEntry> items = new List<DicomDictionaryEntry>();
+            items.AddRange(_entries.Values.OrderBy(x => x.Tag));
+
+            if (_sortMasked)
+            {
+                _masked.Sort((a, b) => { return a.MaskTag.Mask.CompareTo(b.MaskTag.Mask); });
+                _sortMasked = false;
+            }
+            items.AddRange(_masked);
+
+            return items.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/DicomDictionaryEntry.cs
+++ b/DICOM/DicomDictionaryEntry.cs
@@ -1,80 +1,67 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public sealed class DicomDictionaryEntry {
-		public DicomDictionaryEntry(DicomTag tag, string name, string keyword, DicomVM vm, bool retired, params DicomVR[] vrs) {
-			Tag = tag;
+using System;
 
-			if (String.IsNullOrWhiteSpace(name))
-				Name = Tag.ToString();
-			else
-				Name = name;
+namespace Dicom
+{
+    public sealed class DicomDictionaryEntry
+    {
+        public DicomDictionaryEntry(
+            DicomTag tag,
+            string name,
+            string keyword,
+            DicomVM vm,
+            bool retired,
+            params DicomVR[] vrs)
+        {
+            Tag = tag;
 
-			if (String.IsNullOrWhiteSpace(keyword))
-				Keyword = Name;
-			else
-				Keyword = keyword;
+            if (String.IsNullOrWhiteSpace(name)) Name = Tag.ToString();
+            else Name = name;
 
-			ValueMultiplicity = vm;
-			ValueRepresentations = vrs;
-			IsRetired = retired;
-		}
+            if (String.IsNullOrWhiteSpace(keyword)) Keyword = Name;
+            else Keyword = keyword;
 
-		public DicomDictionaryEntry(DicomMaskedTag tag, string name, string keyword, DicomVM vm, bool retired, params DicomVR[] vrs) {
-			Tag = tag.Tag;
-			MaskTag = tag;
+            ValueMultiplicity = vm;
+            ValueRepresentations = vrs;
+            IsRetired = retired;
+        }
 
-			if (String.IsNullOrWhiteSpace(name))
-				Name = Tag.ToString();
-			else
-				Name = name;
+        public DicomDictionaryEntry(
+            DicomMaskedTag tag,
+            string name,
+            string keyword,
+            DicomVM vm,
+            bool retired,
+            params DicomVR[] vrs)
+        {
+            Tag = tag.Tag;
+            MaskTag = tag;
 
-			if (String.IsNullOrWhiteSpace(keyword))
-				Keyword = Name;
-			else
-				Keyword = keyword;
+            if (String.IsNullOrWhiteSpace(name)) Name = Tag.ToString();
+            else Name = name;
 
-			ValueMultiplicity = vm;
-			ValueRepresentations = vrs;
-			IsRetired = retired;
-		}
+            if (String.IsNullOrWhiteSpace(keyword)) Keyword = Name;
+            else Keyword = keyword;
 
-		public DicomTag Tag {
-			get;
-			set;
-		}
+            ValueMultiplicity = vm;
+            ValueRepresentations = vrs;
+            IsRetired = retired;
+        }
 
-		public DicomMaskedTag MaskTag {
-			get;
-			private set;
-		}
+        public DicomTag Tag { get; set; }
 
-		public string Name {
-			get;
-			private set;
-		}
+        public DicomMaskedTag MaskTag { get; private set; }
 
-		public string Keyword {
-			get;
-			private set;
-		}
+        public string Name { get; private set; }
 
-		public DicomVR[] ValueRepresentations {
-			get;
-			private set;
-		}
+        public string Keyword { get; private set; }
 
-		public DicomVM ValueMultiplicity {
-			get;
-			private set;
-		}
+        public DicomVR[] ValueRepresentations { get; private set; }
 
-		public bool IsRetired {
-			get;
-			private set;
-		}
-	}
+        public DicomVM ValueMultiplicity { get; private set; }
+
+        public bool IsRetired { get; private set; }
+    }
 }

--- a/DICOM/DicomDictionaryReader.cs
+++ b/DICOM/DicomDictionaryReader.cs
@@ -1,95 +1,110 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Xml;
 using System.Xml.Linq;
 
-namespace Dicom {
-	public enum DicomDictionaryFormat {
-		XML
-	}
+namespace Dicom
+{
+    public enum DicomDictionaryFormat
+    {
+        XML
+    }
 
-	public class DicomDictionaryReader {
-		private DicomDictionary _dict;
-		private DicomDictionaryFormat _format;
-		private Stream _stream;
+    public class DicomDictionaryReader
+    {
+        private DicomDictionary _dict;
 
-		public DicomDictionaryReader(DicomDictionary dict, DicomDictionaryFormat format, Stream stream) {
-			_dict = dict;
-			_format = format;
-			_stream = stream;
-		}
+        private DicomDictionaryFormat _format;
 
-		public void Process() {
-			if (_format == DicomDictionaryFormat.XML)
-				ReadDictionaryXML();
-		}
+        private Stream _stream;
 
-		private void ReadDictionaryXML() {
-			DicomDictionary dict = _dict;
+        public DicomDictionaryReader(DicomDictionary dict, DicomDictionaryFormat format, Stream stream)
+        {
+            _dict = dict;
+            _format = format;
+            _stream = stream;
+        }
 
-			XDocument xdoc = XDocument.Load(_stream);
+        public void Process()
+        {
+            if (_format == DicomDictionaryFormat.XML) ReadDictionaryXML();
+        }
 
-			IEnumerable<XElement> xdicts;
+        private void ReadDictionaryXML()
+        {
+            DicomDictionary dict = _dict;
 
-			if (xdoc.Root.Name == "dictionaries") {
-				xdicts = xdoc.Root.Elements("dictionary");
-			} else {
-				XElement xdict = xdoc.Element("dictionary");
-				if (xdict == null)
-					throw new DicomDataException("Expected <dictionary> root node in DICOM dictionary.");
+            XDocument xdoc = XDocument.Load(_stream);
 
-				List<XElement> dicts = new List<XElement>();
-				dicts.Add(xdict);
-				xdicts = dicts;
-			}
+            IEnumerable<XElement> xdicts;
 
-			foreach (var xdict in xdicts) {
-				XAttribute creator = xdict.Attribute("creator");
-				if (creator != null && !String.IsNullOrEmpty(creator.Value)) {
-					dict = _dict[_dict.GetPrivateCreator(creator.Value)];
-				} else {
-					dict = _dict;
-				}
+            if (xdoc.Root.Name == "dictionaries")
+            {
+                xdicts = xdoc.Root.Elements("dictionary");
+            }
+            else
+            {
+                XElement xdict = xdoc.Element("dictionary");
+                if (xdict == null) throw new DicomDataException("Expected <dictionary> root node in DICOM dictionary.");
 
-				foreach (XElement xentry in xdict.Elements("tag")) {
-					string name = xentry.Value ?? "Unknown";
+                List<XElement> dicts = new List<XElement>();
+                dicts.Add(xdict);
+                xdicts = dicts;
+            }
 
-					string keyword = String.Empty;
-					if (xentry.Attribute("keyword") != null)
-						keyword = xentry.Attribute("keyword").Value;
+            foreach (var xdict in xdicts)
+            {
+                XAttribute creator = xdict.Attribute("creator");
+                if (creator != null && !String.IsNullOrEmpty(creator.Value))
+                {
+                    dict = _dict[_dict.GetPrivateCreator(creator.Value)];
+                }
+                else
+                {
+                    dict = _dict;
+                }
 
-					List<DicomVR> vrs = new List<DicomVR>();
-					XAttribute xvr = xentry.Attribute("vr");
-					if (xvr != null && !String.IsNullOrEmpty(xvr.Value)) {
-						string[] vra = xvr.Value.Split('_', '/', '\\', ',', '|');
-						foreach (string vr in vra)
-							vrs.Add(DicomVR.Parse(vr));
-					} else
-						vrs.Add(DicomVR.NONE);
+                foreach (XElement xentry in xdict.Elements("tag"))
+                {
+                    string name = xentry.Value ?? "Unknown";
 
-					DicomVM vm = DicomVM.Parse(xentry.Attribute("vm").Value);
+                    string keyword = String.Empty;
+                    if (xentry.Attribute("keyword") != null) keyword = xentry.Attribute("keyword").Value;
 
-					bool retired = false;
-					XAttribute xretired = xentry.Attribute("retired");
-					if (xretired != null && !String.IsNullOrEmpty(xretired.Value) && Boolean.Parse(xretired.Value))
-						retired = true;
+                    List<DicomVR> vrs = new List<DicomVR>();
+                    XAttribute xvr = xentry.Attribute("vr");
+                    if (xvr != null && !String.IsNullOrEmpty(xvr.Value))
+                    {
+                        string[] vra = xvr.Value.Split('_', '/', '\\', ',', '|');
+                        foreach (string vr in vra) vrs.Add(DicomVR.Parse(vr));
+                    }
+                    else vrs.Add(DicomVR.NONE);
 
-					string group = xentry.Attribute("group").Value;
-					string element = xentry.Attribute("element").Value;
-					if (group.ToLower().Contains("x") || element.ToLower().Contains("x")) {
-						DicomMaskedTag tag = DicomMaskedTag.Parse(group, element);
-						tag.Tag.PrivateCreator = dict.PrivateCreator;
-						dict.Add(new DicomDictionaryEntry(tag, name, keyword, vm, retired, vrs.ToArray()));
-					} else {
-						DicomTag tag = DicomTag.Parse(group + "," + element);
-						tag.PrivateCreator = dict.PrivateCreator;
-						dict.Add(new DicomDictionaryEntry(tag, name, keyword, vm, retired, vrs.ToArray()));
-					}
-				}
-			}
-		}
-	}
+                    DicomVM vm = DicomVM.Parse(xentry.Attribute("vm").Value);
+
+                    bool retired = false;
+                    XAttribute xretired = xentry.Attribute("retired");
+                    if (xretired != null && !String.IsNullOrEmpty(xretired.Value) && Boolean.Parse(xretired.Value)) retired = true;
+
+                    string group = xentry.Attribute("group").Value;
+                    string element = xentry.Attribute("element").Value;
+                    if (group.ToLower().Contains("x") || element.ToLower().Contains("x"))
+                    {
+                        DicomMaskedTag tag = DicomMaskedTag.Parse(group, element);
+                        tag.Tag.PrivateCreator = dict.PrivateCreator;
+                        dict.Add(new DicomDictionaryEntry(tag, name, keyword, vm, retired, vrs.ToArray()));
+                    }
+                    else
+                    {
+                        DicomTag tag = DicomTag.Parse(group + "," + element);
+                        tag.PrivateCreator = dict.PrivateCreator;
+                        dict.Add(new DicomDictionaryEntry(tag, name, keyword, vm, retired, vrs.ToArray()));
+                    }
+                }
+            }
+        }
+    }
 }

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -1,810 +1,1149 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text;
 
 using Dicom.IO;
 using Dicom.IO.Buffer;
 
-using Dicom.Imaging.Mathematics;
+namespace Dicom
+{
+    public abstract class DicomElement : DicomItem
+    {
+        protected DicomElement(DicomTag tag, IByteBuffer data)
+            : base(tag)
+        {
+            this.Buffer = data;
+        }
 
-namespace Dicom {
-	public abstract class DicomElement : DicomItem {
-		protected DicomElement(DicomTag tag, IByteBuffer data) : base(tag) {
-			this.Buffer = data;
-		}
+        /// <summary>Gets the number of values that the DICOM element contains.</summary>
+        /// <value>Number of value items</value>
+        public abstract int Count { get; }
 
-		/// <summary>Gets the number of values that the DICOM element contains.</summary>
-		/// <value>Number of value items</value>
-		public abstract int Count {
-			get;
-		}
+        public IByteBuffer Buffer { get; protected set; }
 
-		public IByteBuffer Buffer {
-			get;
-			protected set;
-		}
+        public uint Length
+        {
+            get
+            {
+                if (Buffer != null) return Buffer.Size;
+                return 0;
+            }
+        }
 
-		public uint Length {
-			get {
-				if (Buffer != null)
-					return Buffer.Size;
-				return 0;
-			}
-		}
+        public abstract T Get<T>(int item = -1);
+    }
 
-		public abstract T Get<T>(int item = -1);
-	}
+    /// <summary>
+    /// Base class for a DICOM string element.
+    /// </summary>
+    /// <seealso cref="DicomPersonName"/>
+    public abstract class DicomStringElement : DicomElement
+    {
+        protected DicomStringElement(DicomTag tag, string value)
+            : this(tag, DicomEncoding.Default, value)
+        {
+        }
 
-	/// <summary>
-	/// Base class for a DICOM string element.
-	/// </summary>
-	/// <seealso cref="DicomPersonName"/>
-	public abstract class DicomStringElement : DicomElement {
-		protected DicomStringElement(DicomTag tag, string value) : this(tag, DicomEncoding.Default, value) {
-		}
+        protected DicomStringElement(DicomTag tag, Encoding encoding, string value)
+            : base(tag, EmptyBuffer.Value)
+        {
+            Encoding = encoding;
+            Buffer = ByteConverter.ToByteBuffer(value ?? String.Empty, encoding, ValueRepresentation.PaddingValue);
+        }
 
-		protected DicomStringElement(DicomTag tag, Encoding encoding, string value) : base(tag, EmptyBuffer.Value) {
-			Encoding = encoding;
-			Buffer = ByteConverter.ToByteBuffer(value ?? String.Empty, encoding, ValueRepresentation.PaddingValue);
-		}
+        protected DicomStringElement(DicomTag tag, Encoding encoding, IByteBuffer buffer)
+            : base(tag, buffer)
+        {
+            Encoding = encoding;
+        }
 
-		protected DicomStringElement(DicomTag tag, Encoding encoding, IByteBuffer buffer) : base(tag, buffer) {
-			Encoding = encoding;
-		}
+        public Encoding Encoding { get; protected set; }
 
-		public Encoding Encoding {
-			get;
-			protected set;
-		}
+        /// <summary>Gets the number of values that the DICOM element contains.</summary>
+        /// <value>Number of value items</value>
+        public override int Count
+        {
+            get
+            {
+                return 1;
+            }
+        }
 
-		/// <summary>Gets the number of values that the DICOM element contains.</summary>
-		/// <value>Number of value items</value>
-		public override int Count {
-			get { return 1; }
-		}
+        private string _value = null;
 
-		private string _value = null;
-		protected string StringValue {
-			get {
-				if (_value == null && Buffer != null)
-					_value = Encoding.GetString(Buffer.Data, 0, (int)Buffer.Size).TrimEnd((char)ValueRepresentation.PaddingValue);
-				return _value;
-			}
-		}
+        protected string StringValue
+        {
+            get
+            {
+                if (_value == null && Buffer != null)
+                    _value =
+                        Encoding.GetString(Buffer.Data, 0, (int)Buffer.Size)
+                            .TrimEnd((char)ValueRepresentation.PaddingValue);
+                return _value;
+            }
+        }
 
-		public override T Get<T>(int item = -1) {
-			if (typeof(T) == typeof(string) || typeof(T) == typeof(object))
-				return (T)((object)StringValue);
+        public override T Get<T>(int item = -1)
+        {
+            if (typeof(T) == typeof(string) || typeof(T) == typeof(object)) return (T)((object)StringValue);
 
-			if (typeof(T) == typeof(string[]) || typeof(T) == typeof(object[]))
-				return (T)(object)(new string[] { StringValue });
+            if (typeof(T) == typeof(string[]) || typeof(T) == typeof(object[])) return (T)(object)(new string[] { StringValue });
 
-			if (typeof(T).IsSubclassOf(typeof(DicomParseable)))
-				return (T)DicomParseable.Parse<T>(StringValue);
+            if (typeof(T).IsSubclassOf(typeof(DicomParseable))) return (T)DicomParseable.Parse<T>(StringValue);
 
-			if (typeof(T).IsEnum)
-				return (T)Enum.Parse(typeof(T), StringValue, true);
+            if (typeof(T).IsEnum) return (T)Enum.Parse(typeof(T), StringValue, true);
 
-			throw new InvalidCastException("Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
-		}
-	}
+            throw new InvalidCastException(
+                "Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
+        }
+    }
 
-	public abstract class DicomMultiStringElement : DicomStringElement {
-		protected DicomMultiStringElement(DicomTag tag, params string[] values) : base(tag, DicomEncoding.Default, String.Join("\\", values)) {
-		}
+    public abstract class DicomMultiStringElement : DicomStringElement
+    {
+        protected DicomMultiStringElement(DicomTag tag, params string[] values)
+            : base(tag, DicomEncoding.Default, String.Join("\\", values))
+        {
+        }
 
-		protected DicomMultiStringElement(DicomTag tag, Encoding encoding, params string[] values) : base(tag, encoding, String.Join("\\", values)) {
-		}
+        protected DicomMultiStringElement(DicomTag tag, Encoding encoding, params string[] values)
+            : base(tag, encoding, String.Join("\\", values))
+        {
+        }
 
-		protected DicomMultiStringElement(DicomTag tag, Encoding encoding, IByteBuffer buffer) : base(tag, encoding, buffer) {
-		}
+        protected DicomMultiStringElement(DicomTag tag, Encoding encoding, IByteBuffer buffer)
+            : base(tag, encoding, buffer)
+        {
+        }
 
-		private int _count = -1;
-		public override int Count {
-			get {
-				if (_count == -1) {
-					if (String.IsNullOrEmpty(StringValue))
-						_count = 0;
-					else
-						_count = StringValue.Split('\\').Count();
-				}
-				return _count;
-			}
-		}
+        private int _count = -1;
 
-		private string[] _values = null;
-		public override T Get<T>(int item = -1) {
-			if (_values == null) {
-				if (String.IsNullOrEmpty(StringValue))
-					_values = new string[0];
-				else
-					_values = StringValue.Split('\\');
-				_count = _values.Length;
-			}
+        public override int Count
+        {
+            get
+            {
+                if (_count == -1)
+                {
+                    if (String.IsNullOrEmpty(StringValue)) _count = 0;
+                    else _count = StringValue.Split('\\').Count();
+                }
+                return _count;
+            }
+        }
 
-			if (typeof(T) == typeof(string) || typeof(T) == typeof(object)) {
-				if (item == -1)
-					return (T)((object)StringValue);
+        private string[] _values = null;
 
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+        public override T Get<T>(int item = -1)
+        {
+            if (_values == null)
+            {
+                if (String.IsNullOrEmpty(StringValue)) _values = new string[0];
+                else _values = StringValue.Split('\\');
+                _count = _values.Length;
+            }
 
-				return (T)((object)_values[item]);
-			}
+            if (typeof(T) == typeof(string) || typeof(T) == typeof(object))
+            {
+                if (item == -1) return (T)((object)StringValue);
 
-			if (typeof(T) == typeof(string[]) || typeof(T) == typeof(object[]))
-				return (T)(object)_values;
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-			if (typeof(T).IsSubclassOf(typeof(DicomParseable)))
-				return (T)DicomParseable.Parse<T>(_values[item]);
+                return (T)((object)_values[item]);
+            }
 
-			if (typeof(T).IsEnum)
-				return (T)Enum.Parse(typeof(T), _values[item], true);
+            if (typeof(T) == typeof(string[]) || typeof(T) == typeof(object[])) return (T)(object)_values;
 
-			throw new InvalidCastException("Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
-		}
-	}
+            if (typeof(T).IsSubclassOf(typeof(DicomParseable))) return (T)DicomParseable.Parse<T>(_values[item]);
 
-	public abstract class DicomDateElement : DicomMultiStringElement {
-		protected DicomDateElement(DicomTag tag, string[] dateFormats, params DateTime[] values) : base(tag, DicomEncoding.Default, values.Select(x => x.ToString(dateFormats[0])).ToArray()) {
-			DateFormats = dateFormats;
-		}
+            if (typeof(T).IsEnum) return (T)Enum.Parse(typeof(T), _values[item], true);
 
-		protected DicomDateElement(DicomTag tag, string[] dateFormats, DicomDateRange range) : base(tag, DicomEncoding.Default, range.ToString(dateFormats[0])) {
-			DateFormats = dateFormats;
-		}
+            throw new InvalidCastException(
+                "Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
+        }
+    }
 
-		protected DicomDateElement(DicomTag tag, string[] dateFormats, params string[] values) : base(tag, DicomEncoding.Default, String.Join("\\", values)) {
-			DateFormats = dateFormats;
-		}
+    public abstract class DicomDateElement : DicomMultiStringElement
+    {
+        protected DicomDateElement(DicomTag tag, string[] dateFormats, params DateTime[] values)
+            : base(tag, DicomEncoding.Default, values.Select(x => x.ToString(dateFormats[0])).ToArray())
+        {
+            DateFormats = dateFormats;
+        }
 
-		protected DicomDateElement(DicomTag tag, string[] dateFormats, IByteBuffer buffer) : base(tag, DicomEncoding.Default, buffer) {
-			DateFormats = dateFormats;
-		}
+        protected DicomDateElement(DicomTag tag, string[] dateFormats, DicomDateRange range)
+            : base(tag, DicomEncoding.Default, range.ToString(dateFormats[0]))
+        {
+            DateFormats = dateFormats;
+        }
 
-		protected string[] DateFormats {
-			get;
-			private set;
-		}
+        protected DicomDateElement(DicomTag tag, string[] dateFormats, params string[] values)
+            : base(tag, DicomEncoding.Default, String.Join("\\", values))
+        {
+            DateFormats = dateFormats;
+        }
 
-		private DateTime[] _values = null;
-		public override T Get<T>(int item = -1) {
-			// no need to parse DateTime values if returning string(s)
-			if (typeof(T) == typeof(string) || typeof(T) == typeof(string[]))
-				return base.Get<T>(item);
+        protected DicomDateElement(DicomTag tag, string[] dateFormats, IByteBuffer buffer)
+            : base(tag, DicomEncoding.Default, buffer)
+        {
+            DateFormats = dateFormats;
+        }
 
-			if (typeof(T) == typeof(DicomDateRange)) {
-				string[] vals = base.Get<string>(item).Split('-');
-				var range = new DicomDateRange();
-				if (vals.Length >= 2) {
-					if (!String.IsNullOrEmpty(vals[0]))
-						range.Minimum = DateTime.ParseExact(vals[0], DateFormats, CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault);
-					if (!String.IsNullOrEmpty(vals[1]))
-						range.Maximum = DateTime.ParseExact(vals[1], DateFormats, CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault);
-				} else if (vals.Length == 1) {
-					range.Minimum = DateTime.ParseExact(vals[0], DateFormats, CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault);
-					range.Maximum = range.Minimum.AddDays(1).AddMilliseconds(-1);
-				}
-				return (T)(object)range;
-			}
+        protected string[] DateFormats { get; private set; }
 
-			if (_values == null) {
-				string[] vals = base.Get<string[]>();
-				if (vals.Length == 1 && String.IsNullOrEmpty(vals[0]))
-					_values = new DateTime[0];
-				else {
-					_values = new DateTime[vals.Length];
-					for (int i = 0; i < vals.Length; i++)
-						_values[i] = DateTime.ParseExact(vals[i], DateFormats, CultureInfo.CurrentCulture, DateTimeStyles.NoCurrentDateDefault);
-				}
-			}
+        private DateTime[] _values = null;
 
-			if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(object)) {
-                if (item == -1)
-                    return (T)((object) _values[0]);
+        public override T Get<T>(int item = -1)
+        {
+            // no need to parse DateTime values if returning string(s)
+            if (typeof(T) == typeof(string) || typeof(T) == typeof(string[])) return base.Get<T>(item);
 
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+            if (typeof(T) == typeof(DicomDateRange))
+            {
+                string[] vals = base.Get<string>(item).Split('-');
+                var range = new DicomDateRange();
+                if (vals.Length >= 2)
+                {
+                    if (!String.IsNullOrEmpty(vals[0]))
+                        range.Minimum = DateTime.ParseExact(
+                            vals[0],
+                            DateFormats,
+                            CultureInfo.CurrentCulture,
+                            DateTimeStyles.NoCurrentDateDefault);
+                    if (!String.IsNullOrEmpty(vals[1]))
+                        range.Maximum = DateTime.ParseExact(
+                            vals[1],
+                            DateFormats,
+                            CultureInfo.CurrentCulture,
+                            DateTimeStyles.NoCurrentDateDefault);
+                }
+                else if (vals.Length == 1)
+                {
+                    range.Minimum = DateTime.ParseExact(
+                        vals[0],
+                        DateFormats,
+                        CultureInfo.CurrentCulture,
+                        DateTimeStyles.NoCurrentDateDefault);
+                    range.Maximum = range.Minimum.AddDays(1).AddMilliseconds(-1);
+                }
+                return (T)(object)range;
+            }
 
-				return (T)((object)_values[item]);
-			}
+            if (_values == null)
+            {
+                string[] vals = base.Get<string[]>();
+                if (vals.Length == 1 && String.IsNullOrEmpty(vals[0])) _values = new DateTime[0];
+                else
+                {
+                    _values = new DateTime[vals.Length];
+                    for (int i = 0; i < vals.Length; i++)
+                        _values[i] = DateTime.ParseExact(
+                            vals[i],
+                            DateFormats,
+                            CultureInfo.CurrentCulture,
+                            DateTimeStyles.NoCurrentDateDefault);
+                }
+            }
 
-			if (typeof(T) == typeof(DateTime[]) || typeof(T) == typeof(object[])) {
-				return (T)(object)_values;
-			}
+            if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(object))
+            {
+                if (item == -1) return (T)((object)_values[0]);
 
-			return base.Get<T>(item);
-		}
-	}
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-	public abstract class DicomValueElement<Tv> : DicomElement where Tv: struct {
-		protected DicomValueElement(DicomTag tag, params Tv[] values) : this(tag, ByteConverter.ToByteBuffer<Tv>(values)) {
-		}
+                return (T)((object)_values[item]);
+            }
 
-		protected DicomValueElement(DicomTag tag, IByteBuffer data) : base(tag, data) {
-		}
+            if (typeof(T) == typeof(DateTime[]) || typeof(T) == typeof(object[]))
+            {
+                return (T)(object)_values;
+            }
 
-		public override int Count {
-			get { return (int)Buffer.Size / ValueRepresentation.UnitSize; }
-		}
+            return base.Get<T>(item);
+        }
+    }
 
-		#region Public Members
-		public override T Get<T>(int item = -1) {
+    public abstract class DicomValueElement<Tv> : DicomElement
+        where Tv : struct
+    {
+        protected DicomValueElement(DicomTag tag, params Tv[] values)
+            : this(tag, ByteConverter.ToByteBuffer<Tv>(values))
+        {
+        }
+
+        protected DicomValueElement(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        public override int Count
+        {
+            get
+            {
+                return (int)Buffer.Size / ValueRepresentation.UnitSize;
+            }
+        }
+
+        #region Public Members
+
+        public override T Get<T>(int item = -1)
+        {
             if (item == -1) item = 0;
 
-			if (typeof(T) == typeof(Tv)) {
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+            if (typeof(T) == typeof(Tv))
+            {
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-				return ByteConverter.Get<T>(Buffer, item);
-			}
+                return ByteConverter.Get<T>(Buffer, item);
+            }
 
-			if (typeof(T) == typeof(Tv[])) {
-				// Is there a way to avoid this cast?
-				return (T)(object)ByteConverter.ToArray<Tv>(Buffer);
-			}
+            if (typeof(T) == typeof(Tv[]))
+            {
+                // Is there a way to avoid this cast?
+                return (T)(object)ByteConverter.ToArray<Tv>(Buffer);
+            }
 
-			if (typeof(T) == typeof(string)) {
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+            if (typeof(T) == typeof(string))
+            {
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-				return (T)(object)ByteConverter.Get<Tv>(Buffer, item).ToString();
-			}
+                return (T)(object)ByteConverter.Get<Tv>(Buffer, item).ToString();
+            }
 
-			if (typeof(T) == typeof(string[])) {
-				return (T)(object)ByteConverter.ToArray<Tv>(Buffer).Select(x => x.ToString()).ToArray();
-			}
+            if (typeof(T) == typeof(string[]))
+            {
+                return (T)(object)ByteConverter.ToArray<Tv>(Buffer).Select(x => x.ToString()).ToArray();
+            }
 
-			if (typeof(T).IsEnum) {
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+            if (typeof(T).IsEnum)
+            {
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-				var s = ByteConverter.Get<Tv>(Buffer, item).ToString();
-				return (T)Enum.Parse(typeof(T), s, true);
-			}
+                var s = ByteConverter.Get<Tv>(Buffer, item).ToString();
+                return (T)Enum.Parse(typeof(T), s, true);
+            }
 
-			if (typeof(T).IsValueType) {
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+            if (typeof(T).IsValueType)
+            {
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-				return (T)Convert.ChangeType(ByteConverter.Get<Tv>(Buffer, item), typeof(T));
-			}
+                return (T)Convert.ChangeType(ByteConverter.Get<Tv>(Buffer, item), typeof(T));
+            }
 
-			throw new InvalidCastException("Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
-		}
-		#endregion
-	}
+            throw new InvalidCastException(
+                "Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
+        }
 
-	/// <summary>Application Entity (AE)</summary>
-	public class DicomApplicationEntity : DicomMultiStringElement {
-		#region Public Constructors
-		public DicomApplicationEntity(DicomTag tag, params string[] values) : base(tag, DicomEncoding.Default, values) {
-		}
+        #endregion
+    }
 
-		public DicomApplicationEntity(DicomTag tag, IByteBuffer data) : base(tag, DicomEncoding.Default, data) {
-		}
-		#endregion
+    /// <summary>Application Entity (AE)</summary>
+    public class DicomApplicationEntity : DicomMultiStringElement
+    {
+        #region Public Constructors
 
-		#region Public Properties
-		public override DicomVR  ValueRepresentation {
-			get { return DicomVR.AE; }
-		}
-		#endregion
-	}
+        public DicomApplicationEntity(DicomTag tag, params string[] values)
+            : base(tag, DicomEncoding.Default, values)
+        {
+        }
 
-	/// <summary>Age String (AS)</summary>
-	public class DicomAgeString : DicomMultiStringElement {
-		#region Public Constructors
-		public DicomAgeString(DicomTag tag, params string[] values) : base(tag, DicomEncoding.Default, values) {
-		}
+        public DicomApplicationEntity(DicomTag tag, IByteBuffer data)
+            : base(tag, DicomEncoding.Default, data)
+        {
+        }
 
-		public DicomAgeString(DicomTag tag, IByteBuffer data) : base(tag, DicomEncoding.Default, data) {
-		}
-		#endregion
+        #endregion
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.AS; }
-		}
-		#endregion
-	}
+        #region Public Properties
 
-	/// <summary>Attribute Tag (AT)</summary>
-	public class DicomAttributeTag : DicomElement {
-		#region Public Constructors
-		public DicomAttributeTag(DicomTag tag, params DicomTag[] values) : base(tag, EmptyBuffer.Value) {
-			Values = values;
-		}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.AE;
+            }
+        }
 
-		public DicomAttributeTag(DicomTag tag, IByteBuffer data) : base(tag, data) {
-		}
-		#endregion
+        #endregion
+    }
 
-		#region Public Properties
-		public override int Count {
-			get { return (int)Buffer.Size / 4; }
-		}
+    /// <summary>Age String (AS)</summary>
+    public class DicomAgeString : DicomMultiStringElement
+    {
+        #region Public Constructors
 
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.AT; }
-		}
+        public DicomAgeString(DicomTag tag, params string[] values)
+            : base(tag, DicomEncoding.Default, values)
+        {
+        }
 
-		private DicomTag[] _values;
-		public IEnumerable<DicomTag> Values {
-			get {
-				if (_values == null) {
-					var values = new List<DicomTag>();
-					var parts = ByteBufferEnumerator<ushort>.Create(Buffer).ToArray();
-					for (int i = 0; i < parts.Length; i += 2) {
-						var group = parts[i + 0];
-						var element = parts[i + 1];
-						values.Add(new DicomTag(group, element));
-					}
-					_values = values.ToArray();
-				}
-				return _values;
-			}
-			private set {
-				_values = value.ToArray();
-				int length = _values.Length * 4;
-				byte[] buffer = new byte[length];
-				for (int i = 0; i < _values.Length; i++) {
-					var bytes = BitConverter.GetBytes(_values[i].Group);
-					Array.Copy(bytes, 0, buffer, i * 4, 2);
-					bytes = BitConverter.GetBytes(_values[i].Element);
-					Array.Copy(bytes, 0, buffer, i * 4 + 2, 2);
-				}
-				Buffer = new MemoryByteBuffer(buffer);
-			}
-		}
-		#endregion
+        public DicomAgeString(DicomTag tag, IByteBuffer data)
+            : base(tag, DicomEncoding.Default, data)
+        {
+        }
 
-		#region Public Members
-		public override T Get<T>(int item = -1) {
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.AS;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Attribute Tag (AT)</summary>
+    public class DicomAttributeTag : DicomElement
+    {
+        #region Public Constructors
+
+        public DicomAttributeTag(DicomTag tag, params DicomTag[] values)
+            : base(tag, EmptyBuffer.Value)
+        {
+            Values = values;
+        }
+
+        public DicomAttributeTag(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override int Count
+        {
+            get
+            {
+                return (int)Buffer.Size / 4;
+            }
+        }
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.AT;
+            }
+        }
+
+        private DicomTag[] _values;
+
+        public IEnumerable<DicomTag> Values
+        {
+            get
+            {
+                if (_values == null)
+                {
+                    var values = new List<DicomTag>();
+                    var parts = ByteBufferEnumerator<ushort>.Create(Buffer).ToArray();
+                    for (int i = 0; i < parts.Length; i += 2)
+                    {
+                        var group = parts[i + 0];
+                        var element = parts[i + 1];
+                        values.Add(new DicomTag(group, element));
+                    }
+                    _values = values.ToArray();
+                }
+                return _values;
+            }
+            private set
+            {
+                _values = value.ToArray();
+                int length = _values.Length * 4;
+                byte[] buffer = new byte[length];
+                for (int i = 0; i < _values.Length; i++)
+                {
+                    var bytes = BitConverter.GetBytes(_values[i].Group);
+                    Array.Copy(bytes, 0, buffer, i * 4, 2);
+                    bytes = BitConverter.GetBytes(_values[i].Element);
+                    Array.Copy(bytes, 0, buffer, i * 4 + 2, 2);
+                }
+                Buffer = new MemoryByteBuffer(buffer);
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        public override T Get<T>(int item = -1)
+        {
             if (item == -1) item = 0;
-			var tags = Values.ToArray();
+            var tags = Values.ToArray();
 
-			if (typeof(T) == typeof(DicomTag))
-				return (T)(object)tags[item];
+            if (typeof(T) == typeof(DicomTag)) return (T)(object)tags[item];
 
-			if (typeof(T) == typeof(DicomTag[]))
-				return (T)(object)tags;
+            if (typeof(T) == typeof(DicomTag[])) return (T)(object)tags;
 
-			if (typeof(T) == typeof(string))
-				return (T)(object)tags[item].ToString();
+            if (typeof(T) == typeof(string)) return (T)(object)tags[item].ToString();
 
-			if (typeof(T) == typeof(string[]))
-				return (T)(object)tags.Select(x => x.ToString()).ToArray();
+            if (typeof(T) == typeof(string[])) return (T)(object)tags.Select(x => x.ToString()).ToArray();
 
-			throw new InvalidCastException("Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
-		}
-		#endregion
-	}
+            throw new InvalidCastException(
+                "Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");
+        }
 
-	/// <summary>Code String (CS)</summary>
-	public class DicomCodeString : DicomMultiStringElement {
-		#region Public Constructors
-		public DicomCodeString(DicomTag tag, params string[] values) : base(tag, DicomEncoding.Default, values) {
-		}
+        #endregion
+    }
 
-		public DicomCodeString(DicomTag tag, IByteBuffer data) : base (tag, DicomEncoding.Default, data) {
-		}
-		#endregion
+    /// <summary>Code String (CS)</summary>
+    public class DicomCodeString : DicomMultiStringElement
+    {
+        #region Public Constructors
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.CS; }
-		}
-		#endregion
-	}
+        public DicomCodeString(DicomTag tag, params string[] values)
+            : base(tag, DicomEncoding.Default, values)
+        {
+        }
 
-	/// <summary>Date (DA)</summary>
-	public class DicomDate : DicomDateElement {
-		#region Public Constructors
-		public DicomDate(DicomTag tag, params DateTime[] values) : base(tag, PrivateDateFormats, values) {
-		}
+        public DicomCodeString(DicomTag tag, IByteBuffer data)
+            : base(tag, DicomEncoding.Default, data)
+        {
+        }
 
-		public DicomDate(DicomTag tag, DicomDateRange range) : base(tag, PrivateDateFormats, range) {
-		}
+        #endregion
 
-		public DicomDate(DicomTag tag, params string[] values) : base(tag, PrivateDateFormats, values) {
-		}
+        #region Public Properties
 
-		public DicomDate(DicomTag tag, IByteBuffer data) : base (tag, PrivateDateFormats, data) {
-		}
-		#endregion
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.CS;
+            }
+        }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.DA; }
-		}
+        #endregion
+    }
 
-		private static string[] _formats;
-		private static string[] PrivateDateFormats {
-			get {
-				if (_formats == null) {
-					_formats = new string[6];
-					_formats[0] = "yyyyMMdd";
-					_formats[1] = "yyyy.MM.dd";
-					_formats[2] = "yyyy/MM/dd";
-					_formats[3] = "yyyy";
-					_formats[4] = "yyyyMM";
-					_formats[5] = "yyyy.MM";
-				}
-				return _formats;
-			}
-		}
-		#endregion
-	}
+    /// <summary>Date (DA)</summary>
+    public class DicomDate : DicomDateElement
+    {
+        #region Public Constructors
 
-	/// <summary>Decimal String (DS)</summary>
-	public class DicomDecimalString : DicomMultiStringElement {
-		#region Public Constructors
-		public DicomDecimalString(DicomTag tag, params decimal[] values) : base(tag, DicomEncoding.Default, values.Select(x => x.ToString()).ToArray()) {
-		}
+        public DicomDate(DicomTag tag, params DateTime[] values)
+            : base(tag, PrivateDateFormats, values)
+        {
+        }
 
-		public DicomDecimalString(DicomTag tag, params string[] values) : base(tag, DicomEncoding.Default, values) {
-		}
+        public DicomDate(DicomTag tag, DicomDateRange range)
+            : base(tag, PrivateDateFormats, range)
+        {
+        }
 
-		public DicomDecimalString(DicomTag tag, IByteBuffer data) : base (tag, DicomEncoding.Default, data) {
-		}
-		#endregion
+        public DicomDate(DicomTag tag, params string[] values)
+            : base(tag, PrivateDateFormats, values)
+        {
+        }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.DS; }
-		}
-		#endregion
+        public DicomDate(DicomTag tag, IByteBuffer data)
+            : base(tag, PrivateDateFormats, data)
+        {
+        }
 
-		#region Public Members
-		private decimal[] _values;
-		public override T Get<T>(int item = -1) {
-			// no need to parse values if returning string(s)
-			if (typeof(T) == typeof(string) || typeof(T) == typeof(string[]))
-				return base.Get<T>(item);
+        #endregion
 
-			if (_values == null) {
-				_values = base.Get<string[]>().Select(x => decimal.Parse(x, NumberStyles.Any, CultureInfo.InvariantCulture)).ToArray();
-			}
+        #region Public Properties
 
-			if (typeof(T) == typeof(decimal) || typeof(T) == typeof(object)) {
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.DA;
+            }
+        }
+
+        private static string[] _formats;
+
+        private static string[] PrivateDateFormats
+        {
+            get
+            {
+                if (_formats == null)
+                {
+                    _formats = new string[6];
+                    _formats[0] = "yyyyMMdd";
+                    _formats[1] = "yyyy.MM.dd";
+                    _formats[2] = "yyyy/MM/dd";
+                    _formats[3] = "yyyy";
+                    _formats[4] = "yyyyMM";
+                    _formats[5] = "yyyy.MM";
+                }
+                return _formats;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Decimal String (DS)</summary>
+    public class DicomDecimalString : DicomMultiStringElement
+    {
+        #region Public Constructors
+
+        public DicomDecimalString(DicomTag tag, params decimal[] values)
+            : base(tag, DicomEncoding.Default, values.Select(x => x.ToString()).ToArray())
+        {
+        }
+
+        public DicomDecimalString(DicomTag tag, params string[] values)
+            : base(tag, DicomEncoding.Default, values)
+        {
+        }
+
+        public DicomDecimalString(DicomTag tag, IByteBuffer data)
+            : base(tag, DicomEncoding.Default, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.DS;
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        private decimal[] _values;
+
+        public override T Get<T>(int item = -1)
+        {
+            // no need to parse values if returning string(s)
+            if (typeof(T) == typeof(string) || typeof(T) == typeof(string[])) return base.Get<T>(item);
+
+            if (_values == null)
+            {
+                _values =
+                    base.Get<string[]>()
+                        .Select(x => decimal.Parse(x, NumberStyles.Any, CultureInfo.InvariantCulture))
+                        .ToArray();
+            }
+
+            if (typeof(T) == typeof(decimal) || typeof(T) == typeof(object))
+            {
                 return (T)(object)_values[Math.Max(item, 0)];
-			}
+            }
 
-			if (typeof(T) == typeof(decimal[]) || typeof(T) == typeof(object[])) {
-				return (T)(object)_values;
-			}
+            if (typeof(T) == typeof(decimal[]) || typeof(T) == typeof(object[]))
+            {
+                return (T)(object)_values;
+            }
 
-			if (typeof(T) == typeof(double))
-                return (T)(object)Convert.ToDouble(_values[Math.Max(item, 0)]);
+            if (typeof(T) == typeof(double)) return (T)(object)Convert.ToDouble(_values[Math.Max(item, 0)]);
 
-			if (typeof(T) == typeof(double[]))
-				return (T)(object)_values.Select(x => Convert.ToDouble(x)).ToArray();
+            if (typeof(T) == typeof(double[])) return (T)(object)_values.Select(x => Convert.ToDouble(x)).ToArray();
 
-			return base.Get<T>(item);
-		}
-		#endregion
-	}
+            return base.Get<T>(item);
+        }
 
-	/// <summary>Date Time (DT)</summary>
-	public class DicomDateTime : DicomDateElement {
-		#region Public Constructors
-		public DicomDateTime(DicomTag tag, params DateTime[] values) : base(tag, PrivateDateFormats, values) {
-		}
+        #endregion
+    }
 
-		public DicomDateTime(DicomTag tag, DicomDateRange range) : base(tag, PrivateDateFormats, range) {
-		}
+    /// <summary>Date Time (DT)</summary>
+    public class DicomDateTime : DicomDateElement
+    {
+        #region Public Constructors
 
-		public DicomDateTime(DicomTag tag, params string[] values) : base(tag, PrivateDateFormats, values) {
-		}
+        public DicomDateTime(DicomTag tag, params DateTime[] values)
+            : base(tag, PrivateDateFormats, values)
+        {
+        }
 
-		public DicomDateTime(DicomTag tag, IByteBuffer data) : base (tag, PrivateDateFormats, data) {
-		}
-		#endregion
+        public DicomDateTime(DicomTag tag, DicomDateRange range)
+            : base(tag, PrivateDateFormats, range)
+        {
+        }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.DT; }
-		}
+        public DicomDateTime(DicomTag tag, params string[] values)
+            : base(tag, PrivateDateFormats, values)
+        {
+        }
 
-		private static string[] _formats;
-		private static string[] PrivateDateFormats {
-			get {
-				if (_formats == null) {
-				    _formats = new string[11];
-					_formats[0] = "yyyyMMddHHmmsszzz";
-					_formats[1] = "yyyyMMddHHmmsszz";
-					_formats[2] = "yyyyMMddHHmmssz";
-					_formats[3] = "yyyyMMddHHmmss.fff";
-					_formats[4] = "yyyyMMddHHmmss.ff";
-					_formats[5] = "yyyyMMddHHmmss.f";
-					_formats[6] = "yyyyMMddHHmmss";
-					_formats[7] = "yyyyMMddHHmm";
-					_formats[8] = "yyyyMMdd";
-					_formats[9] = "yyyy.MM.dd";
-					_formats[10] = "yyyy/MM/dd";
-				}
-				return _formats;
-			}
-		}
-		#endregion
-	}
+        public DicomDateTime(DicomTag tag, IByteBuffer data)
+            : base(tag, PrivateDateFormats, data)
+        {
+        }
 
-	/// <summary>Floating Point Double (FD)</summary>
-	public class DicomFloatingPointDouble : DicomValueElement<double> {
-		#region Public Constructors
-		public DicomFloatingPointDouble(DicomTag tag, params double[] values) : base(tag, values) {
-		}
+        #endregion
 
-		public DicomFloatingPointDouble(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
+        #region Public Properties
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.FD; }
-		}
-		#endregion
-	}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.DT;
+            }
+        }
 
-	/// <summary>Floating Point Single (FL)</summary>
-	public class DicomFloatingPointSingle : DicomValueElement<float> {
-		#region Public Constructors
-		public DicomFloatingPointSingle(DicomTag tag, params float[] values) : base(tag, values) {
-		}
+        private static string[] _formats;
 
-		public DicomFloatingPointSingle(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
+        private static string[] PrivateDateFormats
+        {
+            get
+            {
+                if (_formats == null)
+                {
+                    _formats = new string[11];
+                    _formats[0] = "yyyyMMddHHmmsszzz";
+                    _formats[1] = "yyyyMMddHHmmsszz";
+                    _formats[2] = "yyyyMMddHHmmssz";
+                    _formats[3] = "yyyyMMddHHmmss.fff";
+                    _formats[4] = "yyyyMMddHHmmss.ff";
+                    _formats[5] = "yyyyMMddHHmmss.f";
+                    _formats[6] = "yyyyMMddHHmmss";
+                    _formats[7] = "yyyyMMddHHmm";
+                    _formats[8] = "yyyyMMdd";
+                    _formats[9] = "yyyy.MM.dd";
+                    _formats[10] = "yyyy/MM/dd";
+                }
+                return _formats;
+            }
+        }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.FL; }
-		}
-		#endregion
-	}
+        #endregion
+    }
 
-	/// <summary>Integer String (IS)</summary>
-	public class DicomIntegerString : DicomMultiStringElement {
-		#region Public Constructors
-		public DicomIntegerString(DicomTag tag, params int[] values) : base(tag, DicomEncoding.Default, values.Select(x => x.ToString()).ToArray()) {
-		}
+    /// <summary>Floating Point Double (FD)</summary>
+    public class DicomFloatingPointDouble : DicomValueElement<double>
+    {
+        #region Public Constructors
 
-		public DicomIntegerString(DicomTag tag, params string[] values) : base(tag, DicomEncoding.Default, values) {
-		}
+        public DicomFloatingPointDouble(DicomTag tag, params double[] values)
+            : base(tag, values)
+        {
+        }
 
-		public DicomIntegerString(DicomTag tag, IByteBuffer data) : base (tag, DicomEncoding.Default, data) {
-		}
-		#endregion
+        public DicomFloatingPointDouble(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.IS; }
-		}
-		#endregion
+        #endregion
 
-		#region Public Members
-		private int[] _values;
-		public override T Get<T>(int item = -1) {
-			// no need to parse values if returning string(s)
-			if (typeof(T) == typeof(string) || typeof(T) == typeof(string[]))
-				return base.Get<T>(item);
+        #region Public Properties
 
-			if (_values == null) {
-				_values = base.Get<string[]>().Select(x => int.Parse(x, CultureInfo.InvariantCulture)).ToArray();
-			}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.FD;
+            }
+        }
 
-			if (typeof(T) == typeof(int) || typeof(T) == typeof(object)) {
+        #endregion
+    }
+
+    /// <summary>Floating Point Single (FL)</summary>
+    public class DicomFloatingPointSingle : DicomValueElement<float>
+    {
+        #region Public Constructors
+
+        public DicomFloatingPointSingle(DicomTag tag, params float[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomFloatingPointSingle(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.FL;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Integer String (IS)</summary>
+    public class DicomIntegerString : DicomMultiStringElement
+    {
+        #region Public Constructors
+
+        public DicomIntegerString(DicomTag tag, params int[] values)
+            : base(tag, DicomEncoding.Default, values.Select(x => x.ToString()).ToArray())
+        {
+        }
+
+        public DicomIntegerString(DicomTag tag, params string[] values)
+            : base(tag, DicomEncoding.Default, values)
+        {
+        }
+
+        public DicomIntegerString(DicomTag tag, IByteBuffer data)
+            : base(tag, DicomEncoding.Default, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.IS;
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        private int[] _values;
+
+        public override T Get<T>(int item = -1)
+        {
+            // no need to parse values if returning string(s)
+            if (typeof(T) == typeof(string) || typeof(T) == typeof(string[])) return base.Get<T>(item);
+
+            if (_values == null)
+            {
+                _values = base.Get<string[]>().Select(x => int.Parse(x, CultureInfo.InvariantCulture)).ToArray();
+            }
+
+            if (typeof(T) == typeof(int) || typeof(T) == typeof(object))
+            {
                 return (T)(object)_values[Math.Max(item, 0)];
-			}
+            }
 
-			if (typeof(T) == typeof(int[]) || typeof(T) == typeof(object[])) {
-				return (T)(object)_values;
-			}
+            if (typeof(T) == typeof(int[]) || typeof(T) == typeof(object[]))
+            {
+                return (T)(object)_values;
+            }
 
-			if (typeof(T).IsEnum) {
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+            if (typeof(T).IsEnum)
+            {
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-				return (T)(object)_values[item];
-			}
+                return (T)(object)_values[item];
+            }
 
-			if (typeof(T).IsValueType) {
-				if (item < 0 || item >= Count)
-					throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+            if (typeof(T).IsValueType)
+            {
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-				return (T)Convert.ChangeType(_values[item], typeof(T));
-			}
+                return (T)Convert.ChangeType(_values[item], typeof(T));
+            }
 
-			return base.Get<T>(item);
-		}
-		#endregion
-	}
-
-	/// <summary>Long String (LO)</summary>
-	public class DicomLongString : DicomMultiStringElement {
-		#region Public Constructors
-        public DicomLongString(DicomTag tag, params string[] values) : base(tag, values) {
-		}
-
-        public DicomLongString(DicomTag tag, Encoding encoding, params string[] values) : base(tag, encoding, values) {
+            return base.Get<T>(item);
         }
 
-		public DicomLongString(DicomTag tag, Encoding encoding, IByteBuffer data) : base (tag, encoding, data) {
-		}
-		#endregion
+        #endregion
+    }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.LO; }
-		}
-		#endregion
-	}
+    /// <summary>Long String (LO)</summary>
+    public class DicomLongString : DicomMultiStringElement
+    {
+        #region Public Constructors
 
-	/// <summary>Long Text (LT)</summary>
-	public class DicomLongText : DicomStringElement {
-		#region Public Constructors
-		public DicomLongText(DicomTag tag, string value) : base(tag, value) {
-		}
-
-        public DicomLongText(DicomTag tag, Encoding encoding, string value) : base(tag, encoding, value) {
+        public DicomLongString(DicomTag tag, params string[] values)
+            : base(tag, values)
+        {
         }
 
-		public DicomLongText(DicomTag tag, Encoding encoding, IByteBuffer data) : base(tag, encoding, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.LT; }
-		}
-		#endregion
-	}
-
-	/// <summary>Other Byte (OB)</summary>
-	public class DicomOtherByte : DicomValueElement<byte> {
-		#region Public Constructors
-		public DicomOtherByte(DicomTag tag, params byte[] values) : base(tag, values) {
-		}
-
-		public DicomOtherByte(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.OB; }
-		}
-		#endregion
-
-		#region Public Methods
-		public override T Get<T>(int item = -1) {
-			if (!typeof(T).IsArray && item == -1)
-				item = 0;
-
-			if (typeof(T) == typeof(short))
-				return (T)(object)ByteBufferEnumerator<short>.Create(Buffer).ToArray().GetValue(item);
-
-			if (typeof(T) == typeof(short[]))
-				return (T)(object)ByteBufferEnumerator<short>.Create(Buffer).ToArray();
-
-			if (typeof(T) == typeof(ushort))
-				return (T)(object)ByteBufferEnumerator<ushort>.Create(Buffer).ToArray().GetValue(item);
-
-			if (typeof(T) == typeof(ushort[]))
-				return (T)(object)ByteBufferEnumerator<ushort>.Create(Buffer).ToArray();
-
-			if (typeof(T) == typeof(int))
-				return (T)(object)ByteBufferEnumerator<int>.Create(Buffer).ToArray().GetValue(item);
-
-			if (typeof(T) == typeof(int[]))
-				return (T)(object)ByteBufferEnumerator<int>.Create(Buffer).ToArray();
-
-			if (typeof(T) == typeof(uint))
-				return (T)(object)ByteBufferEnumerator<uint>.Create(Buffer).ToArray().GetValue(item);
-
-			if (typeof(T) == typeof(uint[]))
-				return (T)(object)ByteBufferEnumerator<uint>.Create(Buffer).ToArray();
-
-			if (typeof(T) == typeof(float))
-				return (T)(object)ByteBufferEnumerator<float>.Create(Buffer).ToArray().GetValue(item);
-
-			if (typeof(T) == typeof(float[]))
-				return (T)(object)ByteBufferEnumerator<float>.Create(Buffer).ToArray();
-
-			if (typeof(T) == typeof(double))
-				return (T)(object)ByteBufferEnumerator<double>.Create(Buffer).ToArray().GetValue(item);
-
-			if (typeof(T) == typeof(double[]))
-				return (T)(object)ByteBufferEnumerator<double>.Create(Buffer).ToArray();
-
-			return base.Get<T>(item);
-		}
-		#endregion
-	}
-
-	/// <summary>Other Word (OW)</summary>
-	public class DicomOtherWord : DicomValueElement<ushort> {
-		#region Public Constructors
-		public DicomOtherWord(DicomTag tag, params ushort[] values) : base(tag, values) {
-		}
-
-		public DicomOtherWord(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.OW; }
-		}
-		#endregion
-	}
-
-	/// <summary>Other Double (OD)</summary>
-	public class DicomOtherDouble : DicomValueElement<double> {
-		#region Public Constructors
-		public DicomOtherDouble(DicomTag tag, params double[] values) : base(tag, values) {
-		}
-
-		public DicomOtherDouble(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.OD; }
-		}
-		#endregion
-	}
-
-	/// <summary>Other Float (OF)</summary>
-	public class DicomOtherFloat : DicomValueElement<float> {
-		#region Public Constructors
-		public DicomOtherFloat(DicomTag tag, params float[] values) : base(tag, values) {
-		}
-
-		public DicomOtherFloat(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.OF; }
-		}
-		#endregion
-	}
-
-	/// <summary>Person Name (PN)</summary>
-	public sealed class DicomPersonName : DicomMultiStringElement {
-		#region Public Constructors
-        public DicomPersonName(DicomTag tag, params string[] values) : base(tag, values) {
-		}
-
-        public DicomPersonName(DicomTag tag, Encoding encoding, params string[] values) : base(tag, encoding, values) {
+        public DicomLongString(DicomTag tag, Encoding encoding, params string[] values)
+            : base(tag, encoding, values)
+        {
         }
 
-        public DicomPersonName(DicomTag tag, string Last, string First, string Middle = null, string Prefix = null, string Suffix = null) : 
-            base(tag, ConcatName(Last, First, Middle, Prefix, Suffix)) {
-		}
-
-        public DicomPersonName(DicomTag tag, Encoding encoding,  string Last, string First, string Middle = null, string Prefix = null, string Suffix = null) : 
-            base(tag, encoding, ConcatName(Last, First, Middle, Prefix, Suffix)) {
+        public DicomLongString(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
         }
 
-		public DicomPersonName(DicomTag tag, Encoding encoding, IByteBuffer data) : base (tag, encoding, data) {
-		}
-		#endregion
+        #endregion
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.PN; }
-		}
+        #region Public Properties
 
-		public string Last {
-            get {
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.LO;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Long Text (LT)</summary>
+    public class DicomLongText : DicomStringElement
+    {
+        #region Public Constructors
+
+        public DicomLongText(DicomTag tag, string value)
+            : base(tag, value)
+        {
+        }
+
+        public DicomLongText(DicomTag tag, Encoding encoding, string value)
+            : base(tag, encoding, value)
+        {
+        }
+
+        public DicomLongText(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.LT;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Other Byte (OB)</summary>
+    public class DicomOtherByte : DicomValueElement<byte>
+    {
+        #region Public Constructors
+
+        public DicomOtherByte(DicomTag tag, params byte[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomOtherByte(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.OB;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public override T Get<T>(int item = -1)
+        {
+            if (!typeof(T).IsArray && item == -1) item = 0;
+
+            if (typeof(T) == typeof(short)) return (T)(object)ByteBufferEnumerator<short>.Create(Buffer).ToArray().GetValue(item);
+
+            if (typeof(T) == typeof(short[])) return (T)(object)ByteBufferEnumerator<short>.Create(Buffer).ToArray();
+
+            if (typeof(T) == typeof(ushort)) return (T)(object)ByteBufferEnumerator<ushort>.Create(Buffer).ToArray().GetValue(item);
+
+            if (typeof(T) == typeof(ushort[])) return (T)(object)ByteBufferEnumerator<ushort>.Create(Buffer).ToArray();
+
+            if (typeof(T) == typeof(int)) return (T)(object)ByteBufferEnumerator<int>.Create(Buffer).ToArray().GetValue(item);
+
+            if (typeof(T) == typeof(int[])) return (T)(object)ByteBufferEnumerator<int>.Create(Buffer).ToArray();
+
+            if (typeof(T) == typeof(uint)) return (T)(object)ByteBufferEnumerator<uint>.Create(Buffer).ToArray().GetValue(item);
+
+            if (typeof(T) == typeof(uint[])) return (T)(object)ByteBufferEnumerator<uint>.Create(Buffer).ToArray();
+
+            if (typeof(T) == typeof(float)) return (T)(object)ByteBufferEnumerator<float>.Create(Buffer).ToArray().GetValue(item);
+
+            if (typeof(T) == typeof(float[])) return (T)(object)ByteBufferEnumerator<float>.Create(Buffer).ToArray();
+
+            if (typeof(T) == typeof(double)) return (T)(object)ByteBufferEnumerator<double>.Create(Buffer).ToArray().GetValue(item);
+
+            if (typeof(T) == typeof(double[])) return (T)(object)ByteBufferEnumerator<double>.Create(Buffer).ToArray();
+
+            return base.Get<T>(item);
+        }
+
+        #endregion
+    }
+
+    /// <summary>Other Word (OW)</summary>
+    public class DicomOtherWord : DicomValueElement<ushort>
+    {
+        #region Public Constructors
+
+        public DicomOtherWord(DicomTag tag, params ushort[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomOtherWord(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.OW;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Other Double (OD)</summary>
+    public class DicomOtherDouble : DicomValueElement<double>
+    {
+        #region Public Constructors
+
+        public DicomOtherDouble(DicomTag tag, params double[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomOtherDouble(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.OD;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Other Float (OF)</summary>
+    public class DicomOtherFloat : DicomValueElement<float>
+    {
+        #region Public Constructors
+
+        public DicomOtherFloat(DicomTag tag, params float[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomOtherFloat(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.OF;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Person Name (PN)</summary>
+    public sealed class DicomPersonName : DicomMultiStringElement
+    {
+        #region Public Constructors
+
+        public DicomPersonName(DicomTag tag, params string[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomPersonName(DicomTag tag, Encoding encoding, params string[] values)
+            : base(tag, encoding, values)
+        {
+        }
+
+        public DicomPersonName(
+            DicomTag tag,
+            string Last,
+            string First,
+            string Middle = null,
+            string Prefix = null,
+            string Suffix = null)
+            : base(tag, ConcatName(Last, First, Middle, Prefix, Suffix))
+        {
+        }
+
+        public DicomPersonName(
+            DicomTag tag,
+            Encoding encoding,
+            string Last,
+            string First,
+            string Middle = null,
+            string Prefix = null,
+            string Suffix = null)
+            : base(tag, encoding, ConcatName(Last, First, Middle, Prefix, Suffix))
+        {
+        }
+
+        public DicomPersonName(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.PN;
+            }
+        }
+
+        public string Last
+        {
+            get
+            {
                 string[] s = Get<string>().Split('\\');
                 if (s.Count() < 1) return "";
                 s = s[0].Split('=');
@@ -813,7 +1152,7 @@ namespace Dicom {
                 if (s.Count() < 1) return "";
                 return s[0];
             }
-		}
+        }
 
         public string First
         {
@@ -828,10 +1167,11 @@ namespace Dicom {
                 return s[1];
             }
         }
-        
+
         public string Middle
         {
-            get {
+            get
+            {
                 string[] s = Get<string>().Split('\\');
                 if (s.Count() < 1) return "";
                 s = s[0].Split('=');
@@ -840,12 +1180,13 @@ namespace Dicom {
                 if (s.Count() < 3) return "";
                 return s[2];
             }
-		}
+        }
 
 
         public string Prefix
         {
-            get {
+            get
+            {
                 string[] s = Get<string>().Split('\\');
                 if (s.Count() < 1) return "";
                 s = s[0].Split('=');
@@ -858,7 +1199,8 @@ namespace Dicom {
 
         public string Suffix
         {
-            get {
+            get
+            {
                 string[] s = Get<string>().Split('\\');
                 if (s.Count() < 1) return "";
                 s = s[0].Split('=');
@@ -868,339 +1210,539 @@ namespace Dicom {
                 return s[4];
             }
         }
+
         #endregion
+
         #region Private Functions
-        private static string ConcatName(string Last, string First, string Middle = null, string Prefix = null, string Suffix = null)
+
+        private static string ConcatName(
+            string Last,
+            string First,
+            string Middle = null,
+            string Prefix = null,
+            string Suffix = null)
         {
             if (!String.IsNullOrEmpty(Suffix)) return Last + "^" + First + "^" + Middle + "^" + Prefix + "^" + Suffix;
             if (!String.IsNullOrEmpty(Prefix)) return Last + "^" + First + "^" + Middle + "^" + Prefix;
             if (!String.IsNullOrEmpty(Middle)) return Last + "^" + First + "^" + Middle;
-            if (!String.IsNullOrEmpty(First))  return Last + "^" + First;
+            if (!String.IsNullOrEmpty(First)) return Last + "^" + First;
             return Last;
         }
+
         #endregion
     }
 
-	/// <summary>Short String (SH)</summary>
-	public class DicomShortString : DicomMultiStringElement {
-		#region Public Constructors
-        public DicomShortString(DicomTag tag, params string[] values) : base(tag, values) {
-		}
+    /// <summary>Short String (SH)</summary>
+    public class DicomShortString : DicomMultiStringElement
+    {
+        #region Public Constructors
 
-        public DicomShortString(DicomTag tag, Encoding encoding, params string[] values) : base(tag, encoding, values) {
+        public DicomShortString(DicomTag tag, params string[] values)
+            : base(tag, values)
+        {
         }
 
-		public DicomShortString(DicomTag tag, Encoding encoding, IByteBuffer data) : base (tag, encoding, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.SH; }
-		}
-		#endregion
-	}
-
-	/// <summary>Signed Long (SL)</summary>
-	public class DicomSignedLong : DicomValueElement<int> {
-		#region Public Constructors
-		public DicomSignedLong(DicomTag tag, params int[] values) : base(tag, values) {
-		}
-
-		public DicomSignedLong(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.SL; }
-		}
-		#endregion
-	}
-
-	/// <summary>Signed Short (SS)</summary>
-	public class DicomSignedShort : DicomValueElement<short> {
-		#region Public Constructors
-		public DicomSignedShort(DicomTag tag, params short[] values) : base(tag, values) {
-		}
-
-		public DicomSignedShort(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.SS; }
-		}
-		#endregion
-
-		#region Public Members
-		public override T Get<T>(int item = -1) {
-			if (typeof(T) == typeof(int) || typeof(T) == typeof(int[]))
-				return (T)(object)base.Get<T>(item);
-
-			return base.Get<T>(item);
-		}
-		#endregion
-	}
-
-	/// <summary>Short Text (ST)</summary>
-	public class DicomShortText : DicomStringElement {
-		#region Public Constructors
-		public DicomShortText(DicomTag tag, string value) : base(tag, value) {
-		}
-
-        public DicomShortText(DicomTag tag, Encoding encoding, string value) : base(tag, encoding, value) {
+        public DicomShortString(DicomTag tag, Encoding encoding, params string[] values)
+            : base(tag, encoding, values)
+        {
         }
 
-		public DicomShortText(DicomTag tag, Encoding encoding, IByteBuffer data) : base(tag, encoding, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.ST; }
-		}
-		#endregion
-	}
-
-	/// <summary>Time (TM)</summary>
-	public class DicomTime : DicomDateElement {
-		#region Public Constructors
-		public DicomTime(DicomTag tag, params DateTime[] values) : base(tag, PrivateDateFormats, values) {
-		}
-
-		public DicomTime(DicomTag tag, DicomDateRange range) : base(tag, PrivateDateFormats, range) {
-		}
-
-		public DicomTime(DicomTag tag, params string[] values) : base(tag, PrivateDateFormats, values) {
-		}
-
-		public DicomTime(DicomTag tag, IByteBuffer data) : base (tag, PrivateDateFormats, data) {
-		}
-		#endregion
-
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.TM; }
-		}
-
-		private static string[] _formats;
-		private static string[] PrivateDateFormats {
-			get {
-				if (_formats == null) {
-					_formats = new string[31];
-					_formats[0] = "HHmmss";
-					_formats[1] = "HH";
-					_formats[2] = "HHmm";
-					_formats[3] = "HHmmssf";
-					_formats[4] = "HHmmssff";
-					_formats[5] = "HHmmssfff";
-					_formats[6] = "HHmmssffff";
-					_formats[7] = "HHmmssfffff";
-					_formats[8] = "HHmmssffffff";
-					_formats[9] = "HHmmss.f";
-					_formats[10] = "HHmmss.ff";
-					_formats[11] = "HHmmss.fff";
-					_formats[12] = "HHmmss.ffff";
-					_formats[13] = "HHmmss.fffff";
-					_formats[14] = "HHmmss.ffffff";
-					_formats[15] = "HH.mm";
-					_formats[16] = "HH.mm.ss";
-					_formats[17] = "HH.mm.ss.f";
-					_formats[18] = "HH.mm.ss.ff";
-					_formats[19] = "HH.mm.ss.fff";
-					_formats[20] = "HH.mm.ss.ffff";
-					_formats[21] = "HH.mm.ss.fffff";
-					_formats[22] = "HH.mm.ss.ffffff";
-					_formats[23] = "HH:mm";
-					_formats[24] = "HH:mm:ss";
-					_formats[25] = "HH:mm:ss:f";
-					_formats[26] = "HH:mm:ss:ff";
-					_formats[27] = "HH:mm:ss:fff";
-					_formats[28] = "HH:mm:ss:ffff";
-					_formats[29] = "HH:mm:ss:fffff";
-					_formats[30] = "HH:mm:ss:ffffff";
-					_formats[25] = "HH:mm:ss.f";
-					_formats[26] = "HH:mm:ss.ff";
-					_formats[27] = "HH:mm:ss.fff";
-					_formats[28] = "HH:mm:ss.ffff";
-					_formats[29] = "HH:mm:ss.fffff";
-					_formats[30] = "HH:mm:ss.ffffff";
-				}
-				return _formats;
-			}
-		}
-		#endregion
-	}
-
-	/// <summary>Unlimited Characters (UC)</summary>
-	public class DicomUnlimitedCharacters : DicomMultiStringElement {
-		#region Public Constructors
-        public DicomUnlimitedCharacters(DicomTag tag, params string[] values) : base(tag, values) {
-		}
-
-        public DicomUnlimitedCharacters(DicomTag tag, Encoding encoding, params string[] values) : base(tag, encoding, values) {
+        public DicomShortString(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
         }
 
-		public DicomUnlimitedCharacters(DicomTag tag, Encoding encoding, IByteBuffer data) : base (tag, encoding, data) {
-		}
-		#endregion
+        #endregion
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.UC; }
-		}
-		#endregion
-	}
+        #region Public Properties
 
-	/// <summary>Unique Identifier (UI)</summary>
-	public class DicomUniqueIdentifier : DicomMultiStringElement {
-		#region Public Constructors
-		public DicomUniqueIdentifier(DicomTag tag, params string[] values) : base(tag, values) {
-		}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.SH;
+            }
+        }
 
-		public DicomUniqueIdentifier(DicomTag tag, params DicomUID[] values) : base(tag, values.Select(x => x.UID).ToArray()) {
-		}
+        #endregion
+    }
 
-		public DicomUniqueIdentifier(DicomTag tag, params DicomTransferSyntax[] values) : base(tag, values.Select(x => x.UID.UID).ToArray()) {
-		}
+    /// <summary>Signed Long (SL)</summary>
+    public class DicomSignedLong : DicomValueElement<int>
+    {
+        #region Public Constructors
 
-		public DicomUniqueIdentifier(DicomTag tag, IByteBuffer data) : base(tag, DicomEncoding.Default, data) {
-		}
-		#endregion
+        public DicomSignedLong(DicomTag tag, params int[] values)
+            : base(tag, values)
+        {
+        }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.UI; }
-		}
-		#endregion
+        public DicomSignedLong(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
 
-		#region Public Members
-		private DicomUID[] _values;
-		public override T Get<T>(int item = -1) {
-			if (_values == null) {
-				_values = base.Get<string[]>().Select(x => DicomUID.Parse(x)).ToArray();
-			}
+        #endregion
 
-			if (typeof(T) == typeof(DicomTransferSyntax)) {
-				return (T)(object)DicomTransferSyntax.Lookup(_values[item]);
-			}
+        #region Public Properties
 
-			if (typeof(T) == typeof(DicomTransferSyntax[])) {
-				return (T)(object)_values.Select(x => DicomTransferSyntax.Lookup(x)).ToArray();
-			}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.SL;
+            }
+        }
 
-			if (typeof(T) == typeof(DicomUID) || typeof(T) == typeof(object)) {
-				return (T)(object)_values[item];
-			}
+        #endregion
+    }
 
-			if (typeof(T) == typeof(DicomUID[]) || typeof(T) == typeof(object[])) {
-				return (T)(object)_values;
-			}
+    /// <summary>Signed Short (SS)</summary>
+    public class DicomSignedShort : DicomValueElement<short>
+    {
+        #region Public Constructors
 
-			return base.Get<T>(item);
-		}
-		#endregion
-	}
+        public DicomSignedShort(DicomTag tag, params short[] values)
+            : base(tag, values)
+        {
+        }
 
-	/// <summary>Unsigned Long (UL)</summary>
-	public class DicomUnsignedLong : DicomValueElement<uint> {
-		#region Public Constructors
-		public DicomUnsignedLong(DicomTag tag, params uint[] values) : base(tag, values) {
-		}
+        public DicomSignedShort(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
 
-		public DicomUnsignedLong(DicomTag tag, IByteBuffer data) : base(tag, data) {
-		}
-		#endregion
+        #endregion
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.UL; }
-		}
-		#endregion
-	}
+        #region Public Properties
 
-	/// <summary>Unknown (UN)</summary>
-	public class DicomUnknown : DicomOtherByte {
-		#region Public Constructors
-		public DicomUnknown(DicomTag tag, params byte[] values) : base(tag, values) {
-		}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.SS;
+            }
+        }
 
-		public DicomUnknown(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
+        #endregion
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.UN; }
-		}
-		#endregion
-	}
+        #region Public Members
 
-	/// <summary>Universal Resource Identifier or Universal Resource Locator (UR)</summary>
-	public class DicomUniversalResource : DicomStringElement {
-		#region Public Constructors
-		public DicomUniversalResource(DicomTag tag, string value) : base(tag, value) {
-		}
+        public override T Get<T>(int item = -1)
+        {
+            if (typeof(T) == typeof(int) || typeof(T) == typeof(int[])) return (T)(object)base.Get<T>(item);
 
-		public DicomUniversalResource(DicomTag tag, Encoding encoding, string value) : base(tag, encoding, value) {
-		}
+            return base.Get<T>(item);
+        }
 
-		public DicomUniversalResource(DicomTag tag, Encoding encoding, IByteBuffer data) : base(tag, encoding, data) {
-		}
-		#endregion
+        #endregion
+    }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.UR; }
-		}
-		#endregion
-	}
+    /// <summary>Short Text (ST)</summary>
+    public class DicomShortText : DicomStringElement
+    {
+        #region Public Constructors
 
-	/// <summary>Unsigned Short (US)</summary>
-	public class DicomUnsignedShort : DicomValueElement<ushort> {
-		#region Public Constructors
-		public DicomUnsignedShort(DicomTag tag, params ushort[] values) : base(tag, values) {
-		}
+        public DicomShortText(DicomTag tag, string value)
+            : base(tag, value)
+        {
+        }
 
-		public DicomUnsignedShort(DicomTag tag, IByteBuffer data) : base (tag, data) {
-		}
-		#endregion
+        public DicomShortText(DicomTag tag, Encoding encoding, string value)
+            : base(tag, encoding, value)
+        {
+        }
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.US; }
-		}
-		#endregion
+        public DicomShortText(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
+        }
 
-		#region Public Members
-		public override T Get<T>(int item = -1) {
-			if (typeof(T) == typeof(int) || typeof(T) == typeof(int[]))
-				return (T)(object)base.Get<T>(item);
+        #endregion
 
-			return base.Get<T>(item);
-		}
-		#endregion
-	}
+        #region Public Properties
 
-	/// <summary>Unlimited Text (UT)</summary>
-	public class DicomUnlimitedText : DicomStringElement {
-		#region Public Constructors
-		public DicomUnlimitedText(DicomTag tag, string value) : base(tag, value) {
-		}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.ST;
+            }
+        }
 
-		public DicomUnlimitedText(DicomTag tag, Encoding encoding, string value) : base(tag, encoding, value) {
-		}
+        #endregion
+    }
 
-		public DicomUnlimitedText(DicomTag tag, Encoding encoding, IByteBuffer data) : base(tag, encoding, data) {
-		}
-		#endregion
+    /// <summary>Time (TM)</summary>
+    public class DicomTime : DicomDateElement
+    {
+        #region Public Constructors
 
-		#region Public Properties
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.UT; }
-		}
-		#endregion
-	}
+        public DicomTime(DicomTag tag, params DateTime[] values)
+            : base(tag, PrivateDateFormats, values)
+        {
+        }
+
+        public DicomTime(DicomTag tag, DicomDateRange range)
+            : base(tag, PrivateDateFormats, range)
+        {
+        }
+
+        public DicomTime(DicomTag tag, params string[] values)
+            : base(tag, PrivateDateFormats, values)
+        {
+        }
+
+        public DicomTime(DicomTag tag, IByteBuffer data)
+            : base(tag, PrivateDateFormats, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.TM;
+            }
+        }
+
+        private static string[] _formats;
+
+        private static string[] PrivateDateFormats
+        {
+            get
+            {
+                if (_formats == null)
+                {
+                    _formats = new string[31];
+                    _formats[0] = "HHmmss";
+                    _formats[1] = "HH";
+                    _formats[2] = "HHmm";
+                    _formats[3] = "HHmmssf";
+                    _formats[4] = "HHmmssff";
+                    _formats[5] = "HHmmssfff";
+                    _formats[6] = "HHmmssffff";
+                    _formats[7] = "HHmmssfffff";
+                    _formats[8] = "HHmmssffffff";
+                    _formats[9] = "HHmmss.f";
+                    _formats[10] = "HHmmss.ff";
+                    _formats[11] = "HHmmss.fff";
+                    _formats[12] = "HHmmss.ffff";
+                    _formats[13] = "HHmmss.fffff";
+                    _formats[14] = "HHmmss.ffffff";
+                    _formats[15] = "HH.mm";
+                    _formats[16] = "HH.mm.ss";
+                    _formats[17] = "HH.mm.ss.f";
+                    _formats[18] = "HH.mm.ss.ff";
+                    _formats[19] = "HH.mm.ss.fff";
+                    _formats[20] = "HH.mm.ss.ffff";
+                    _formats[21] = "HH.mm.ss.fffff";
+                    _formats[22] = "HH.mm.ss.ffffff";
+                    _formats[23] = "HH:mm";
+                    _formats[24] = "HH:mm:ss";
+                    _formats[25] = "HH:mm:ss:f";
+                    _formats[26] = "HH:mm:ss:ff";
+                    _formats[27] = "HH:mm:ss:fff";
+                    _formats[28] = "HH:mm:ss:ffff";
+                    _formats[29] = "HH:mm:ss:fffff";
+                    _formats[30] = "HH:mm:ss:ffffff";
+                    _formats[25] = "HH:mm:ss.f";
+                    _formats[26] = "HH:mm:ss.ff";
+                    _formats[27] = "HH:mm:ss.fff";
+                    _formats[28] = "HH:mm:ss.ffff";
+                    _formats[29] = "HH:mm:ss.fffff";
+                    _formats[30] = "HH:mm:ss.ffffff";
+                }
+                return _formats;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Unlimited Characters (UC)</summary>
+    public class DicomUnlimitedCharacters : DicomMultiStringElement
+    {
+        #region Public Constructors
+
+        public DicomUnlimitedCharacters(DicomTag tag, params string[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomUnlimitedCharacters(DicomTag tag, Encoding encoding, params string[] values)
+            : base(tag, encoding, values)
+        {
+        }
+
+        public DicomUnlimitedCharacters(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.UC;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Unique Identifier (UI)</summary>
+    public class DicomUniqueIdentifier : DicomMultiStringElement
+    {
+        #region Public Constructors
+
+        public DicomUniqueIdentifier(DicomTag tag, params string[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomUniqueIdentifier(DicomTag tag, params DicomUID[] values)
+            : base(tag, values.Select(x => x.UID).ToArray())
+        {
+        }
+
+        public DicomUniqueIdentifier(DicomTag tag, params DicomTransferSyntax[] values)
+            : base(tag, values.Select(x => x.UID.UID).ToArray())
+        {
+        }
+
+        public DicomUniqueIdentifier(DicomTag tag, IByteBuffer data)
+            : base(tag, DicomEncoding.Default, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.UI;
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        private DicomUID[] _values;
+
+        public override T Get<T>(int item = -1)
+        {
+            if (_values == null)
+            {
+                _values = base.Get<string[]>().Select(x => DicomUID.Parse(x)).ToArray();
+            }
+
+            if (typeof(T) == typeof(DicomTransferSyntax))
+            {
+                return (T)(object)DicomTransferSyntax.Lookup(_values[item]);
+            }
+
+            if (typeof(T) == typeof(DicomTransferSyntax[]))
+            {
+                return (T)(object)_values.Select(x => DicomTransferSyntax.Lookup(x)).ToArray();
+            }
+
+            if (typeof(T) == typeof(DicomUID) || typeof(T) == typeof(object))
+            {
+                return (T)(object)_values[item];
+            }
+
+            if (typeof(T) == typeof(DicomUID[]) || typeof(T) == typeof(object[]))
+            {
+                return (T)(object)_values;
+            }
+
+            return base.Get<T>(item);
+        }
+
+        #endregion
+    }
+
+    /// <summary>Unsigned Long (UL)</summary>
+    public class DicomUnsignedLong : DicomValueElement<uint>
+    {
+        #region Public Constructors
+
+        public DicomUnsignedLong(DicomTag tag, params uint[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomUnsignedLong(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.UL;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Unknown (UN)</summary>
+    public class DicomUnknown : DicomOtherByte
+    {
+        #region Public Constructors
+
+        public DicomUnknown(DicomTag tag, params byte[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomUnknown(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.UN;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Universal Resource Identifier or Universal Resource Locator (UR)</summary>
+    public class DicomUniversalResource : DicomStringElement
+    {
+        #region Public Constructors
+
+        public DicomUniversalResource(DicomTag tag, string value)
+            : base(tag, value)
+        {
+        }
+
+        public DicomUniversalResource(DicomTag tag, Encoding encoding, string value)
+            : base(tag, encoding, value)
+        {
+        }
+
+        public DicomUniversalResource(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.UR;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>Unsigned Short (US)</summary>
+    public class DicomUnsignedShort : DicomValueElement<ushort>
+    {
+        #region Public Constructors
+
+        public DicomUnsignedShort(DicomTag tag, params ushort[] values)
+            : base(tag, values)
+        {
+        }
+
+        public DicomUnsignedShort(DicomTag tag, IByteBuffer data)
+            : base(tag, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.US;
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        public override T Get<T>(int item = -1)
+        {
+            if (typeof(T) == typeof(int) || typeof(T) == typeof(int[])) return (T)(object)base.Get<T>(item);
+
+            return base.Get<T>(item);
+        }
+
+        #endregion
+    }
+
+    /// <summary>Unlimited Text (UT)</summary>
+    public class DicomUnlimitedText : DicomStringElement
+    {
+        #region Public Constructors
+
+        public DicomUnlimitedText(DicomTag tag, string value)
+            : base(tag, value)
+        {
+        }
+
+        public DicomUnlimitedText(DicomTag tag, Encoding encoding, string value)
+            : base(tag, encoding, value)
+        {
+        }
+
+        public DicomUnlimitedText(DicomTag tag, Encoding encoding, IByteBuffer data)
+            : base(tag, encoding, data)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.UT;
+            }
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/DicomEncoding.cs
+++ b/DICOM/DicomEncoding.cs
@@ -1,88 +1,149 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom {
-	public static class DicomEncoding {
-		public readonly static Encoding Default = Encoding.ASCII;
+namespace Dicom
+{
+    public static class DicomEncoding
+    {
+        public static readonly Encoding Default = Encoding.ASCII;
 
-		public static Encoding GetEncoding(string charset) {
-			if (String.IsNullOrWhiteSpace(charset))
-				return Default;
+        public static Encoding GetEncoding(string charset)
+        {
+            if (String.IsNullOrWhiteSpace(charset)) return Default;
 
-			switch (charset.Trim()) {
-			case "ISO IR 13":  case "ISO_IR 13":  return Encoding.GetEncoding("shift_jis");   // JIS X 0201 (Shift JIS) Unextended
-			case "ISO IR 100": case "ISO_IR 100": return Encoding.GetEncoding("iso-8859-1"); // Latin Alphabet No. 1 Unextended
-			case "ISO IR 101": case "ISO_IR 101": return Encoding.GetEncoding("iso-8859-2"); // Latin Alphabet No. 2 Unextended
-			case "ISO IR 109": case "ISO_IR 109": return Encoding.GetEncoding("iso-8859-3"); // Latin Alphabet No. 3 Unextended
-			case "ISO IR 110": case "ISO_IR 110": return Encoding.GetEncoding("iso-8859-4"); // Latin Alphabet No. 4 Unextended
-			case "ISO IR 126": case "ISO_IR 126": return Encoding.GetEncoding("iso-8859-7"); // Greek Unextended
-			case "ISO IR 127": case "ISO_IR 127": return Encoding.GetEncoding("iso-8859-6"); // Arabic Unextended
-			case "ISO IR 138": case "ISO_IR 138": return Encoding.GetEncoding("iso-8859-8"); // Hebrew Unextended
-			case "ISO IR 144": case "ISO_IR 144": return Encoding.GetEncoding("iso-8859-5"); // Cyrillic Unextended
-			case "ISO IR 148": case "ISO_IR 148": return Encoding.GetEncoding("iso-8859-9"); // Latin Alphabet No. 5 (Turkish) Unextended
-			case "ISO IR 166": case "ISO_IR 166": return Encoding.GetEncoding("windows-874");   // TIS 620-2533 (Thai) Unextended
-			case "ISO IR 192": case "ISO_IR 192": return Encoding.GetEncoding("utf-8"); // Unicode in UTF-8
-            case "ISO 2022 IR 6": return Encoding.GetEncoding("us-ascii"); // ASCII
-            case "ISO 2022 IR 13": return Encoding.GetEncoding("iso-2022-jp"); // JIS X 0201 (Shift JIS) Extended
-            case "ISO 2022 IR 87": return Encoding.GetEncoding("iso-2022-jp"); // JIS X 0208 (Kanji) Extended
-            case "ISO 2022 IR 100": return Encoding.GetEncoding("iso-8859-1"); // Latin Alphabet No. 1 Extended
-            case "ISO 2022 IR 101": return Encoding.GetEncoding("iso-8859-2"); // Latin Alphabet No. 2 Extended
-            case "ISO 2022 IR 109": return Encoding.GetEncoding("iso-8859-3"); // Latin Alphabet No. 3 Extended
-            case "ISO 2022 IR 110": return Encoding.GetEncoding("iso-8859-4"); // Latin Alphabet No. 4 Extended
-            case "ISO 2022 IR 127": return Encoding.GetEncoding("iso-8859-6"); // Arabic Extended
-            case "ISO 2022 IR 126": return Encoding.GetEncoding("iso-8859-7"); // Greek Extended
-            case "ISO 2022 IR 138": return Encoding.GetEncoding("iso-8859-8"); // Hebrew Extended
-            case "ISO 2022 IR 144": return Encoding.GetEncoding("iso-8859-5"); // Cyrillic Extended
-            case "ISO 2022 IR 148": return Encoding.GetEncoding("iso-8859-9"); // Latin Alphabet No. 5 (Turkish) Extended
-            case "ISO 2022 IR 149": return Encoding.GetEncoding("x-cp20949"); // KS X 1001 (Hangul and Hanja) Extended
-            case "ISO 2022 IR 159": return Encoding.GetEncoding("iso-2022-jp"); // JIS X 0212 (Kanji) Extended
-            case "ISO 2022 IR 166": return Encoding.GetEncoding("windows-874");   // TIS 620-2533 (Thai) Extended
-            case "GB18030": return Encoding.GetEncoding("GB18030"); // Chinese (Simplified) Extended
-			default: // unknown encoding... return ASCII instead of throwing exception
-				//throw new ArgumentException("No codepage found for requested DICOM charset.", "charset");
-				return Default;
-			}
-		}
+            switch (charset.Trim())
+            {
+                case "ISO IR 13":
+                case "ISO_IR 13":
+                    return Encoding.GetEncoding("shift_jis"); // JIS X 0201 (Shift JIS) Unextended
+                case "ISO IR 100":
+                case "ISO_IR 100":
+                    return Encoding.GetEncoding("iso-8859-1"); // Latin Alphabet No. 1 Unextended
+                case "ISO IR 101":
+                case "ISO_IR 101":
+                    return Encoding.GetEncoding("iso-8859-2"); // Latin Alphabet No. 2 Unextended
+                case "ISO IR 109":
+                case "ISO_IR 109":
+                    return Encoding.GetEncoding("iso-8859-3"); // Latin Alphabet No. 3 Unextended
+                case "ISO IR 110":
+                case "ISO_IR 110":
+                    return Encoding.GetEncoding("iso-8859-4"); // Latin Alphabet No. 4 Unextended
+                case "ISO IR 126":
+                case "ISO_IR 126":
+                    return Encoding.GetEncoding("iso-8859-7"); // Greek Unextended
+                case "ISO IR 127":
+                case "ISO_IR 127":
+                    return Encoding.GetEncoding("iso-8859-6"); // Arabic Unextended
+                case "ISO IR 138":
+                case "ISO_IR 138":
+                    return Encoding.GetEncoding("iso-8859-8"); // Hebrew Unextended
+                case "ISO IR 144":
+                case "ISO_IR 144":
+                    return Encoding.GetEncoding("iso-8859-5"); // Cyrillic Unextended
+                case "ISO IR 148":
+                case "ISO_IR 148":
+                    return Encoding.GetEncoding("iso-8859-9"); // Latin Alphabet No. 5 (Turkish) Unextended
+                case "ISO IR 166":
+                case "ISO_IR 166":
+                    return Encoding.GetEncoding("windows-874"); // TIS 620-2533 (Thai) Unextended
+                case "ISO IR 192":
+                case "ISO_IR 192":
+                    return Encoding.GetEncoding("utf-8"); // Unicode in UTF-8
+                case "ISO 2022 IR 6":
+                    return Encoding.GetEncoding("us-ascii"); // ASCII
+                case "ISO 2022 IR 13":
+                    return Encoding.GetEncoding("iso-2022-jp"); // JIS X 0201 (Shift JIS) Extended
+                case "ISO 2022 IR 87":
+                    return Encoding.GetEncoding("iso-2022-jp"); // JIS X 0208 (Kanji) Extended
+                case "ISO 2022 IR 100":
+                    return Encoding.GetEncoding("iso-8859-1"); // Latin Alphabet No. 1 Extended
+                case "ISO 2022 IR 101":
+                    return Encoding.GetEncoding("iso-8859-2"); // Latin Alphabet No. 2 Extended
+                case "ISO 2022 IR 109":
+                    return Encoding.GetEncoding("iso-8859-3"); // Latin Alphabet No. 3 Extended
+                case "ISO 2022 IR 110":
+                    return Encoding.GetEncoding("iso-8859-4"); // Latin Alphabet No. 4 Extended
+                case "ISO 2022 IR 127":
+                    return Encoding.GetEncoding("iso-8859-6"); // Arabic Extended
+                case "ISO 2022 IR 126":
+                    return Encoding.GetEncoding("iso-8859-7"); // Greek Extended
+                case "ISO 2022 IR 138":
+                    return Encoding.GetEncoding("iso-8859-8"); // Hebrew Extended
+                case "ISO 2022 IR 144":
+                    return Encoding.GetEncoding("iso-8859-5"); // Cyrillic Extended
+                case "ISO 2022 IR 148":
+                    return Encoding.GetEncoding("iso-8859-9"); // Latin Alphabet No. 5 (Turkish) Extended
+                case "ISO 2022 IR 149":
+                    return Encoding.GetEncoding("x-cp20949"); // KS X 1001 (Hangul and Hanja) Extended
+                case "ISO 2022 IR 159":
+                    return Encoding.GetEncoding("iso-2022-jp"); // JIS X 0212 (Kanji) Extended
+                case "ISO 2022 IR 166":
+                    return Encoding.GetEncoding("windows-874"); // TIS 620-2533 (Thai) Extended
+                case "GB18030":
+                    return Encoding.GetEncoding("GB18030"); // Chinese (Simplified) Extended
+                default: // unknown encoding... return ASCII instead of throwing exception
+                    //throw new ArgumentException("No codepage found for requested DICOM charset.", "charset");
+                    return Default;
+            }
+        }
 
-		public static string GetCharset(Encoding encoding) {
-			if (encoding == null)
-				return "ISO 2022 IR 6";
+        public static string GetCharset(Encoding encoding)
+        {
+            if (encoding == null) return "ISO 2022 IR 6";
 
-			// Do we always want the extended charsets?
-			switch (encoding.WebName) {
-				//case 874:   return "ISO_IR 166";		// TIS 620-2533 (Thai) Unextended
-                case "windows-874": return "ISO 2022 IR 166";	// TIS 620-2533 (Thai) Extended
-				case "shift_jis":   return "ISO_IR 13";			// JIS X 0201 (Shift JIS) Unextended
-				case "us-ascii": return "ISO 2022 IR 6";		// ASCII
-				case "x-cp20949": return "ISO 2022 IR 149";	// KS X 1001 (Hangul and Hanja) Extended
-				//case 28591: return "ISO_IR 100";		// Latin Alphabet No. 1 Unextended
-				case "iso-8859-1": return "ISO 2022 IR 100";	// Latin Alphabet No. 1 Extended
-				//case 28592: return "ISO_IR 101";		// Latin Alphabet No. 2 Unextended
-                case "iso-8859-2": return "ISO 2022 IR 101";	// Latin Alphabet No. 2 Extended
-				//case 28593: return "ISO_IR 109";		// Latin Alphabet No. 3 Unextended
-                case "iso-8859-3": return "ISO 2022 IR 109";	// Latin Alphabet No. 3 Extended
-				//case 28594: return "ISO_IR 110";		// Latin Alphabet No. 4 Unextended
-                case "iso-8859-4": return "ISO 2022 IR 110";	// Latin Alphabet No. 4 Extended
-				//case 28595: return "ISO_IR 144";		// Cyrillic Unextended
-                case "iso-8859-5": return "ISO 2022 IR 144";	// Cyrillic Extended
-				//case 28596: return "ISO_IR 127";		// Arabic Unextended
-                case "iso-8859-6": return "ISO 2022 IR 127";	// Arabic Extended
-				//case 28597: return "ISO_IR 126";		// Greek Unextended
-                case "iso-8859-7": return "ISO 2022 IR 126";	// Greek Extended
-				//case 28598: return "ISO_IR 138";		// Hebrew Unextended
-                case "iso-8859-8": return "ISO 2022 IR 138";	// Hebrew Extended
-				//case 28599: return "ISO_IR 148";		// Latin Alphabet No. 5 (Turkish) Unextended
-                case "iso-8859-9": return "ISO 2022 IR 148";	// Latin Alphabet No. 5 (Turkish) Extended
-				//case 50222: return "ISO 2022 IR 13";	// JIS X 0201 (Shift JIS) Extended
-				//case 50222: return "ISO 2022 IR 87";	// JIS X 0208 (Kanji) Extended
-				case "iso-2022-jp": return "ISO 2022 IR 159";	// JIS X 0212 (Kanji) Extended
-				case "GB18030": return "GB18030";			// Chinese (Simplified) Extended
-				case "utf-8": return "ISO_IR 192";		// Unicode in UTF-8
-				default:
-					throw new ArgumentException("No DICOM charset found for requested encoding.", "encoding");
-			}
-		}
-	}
+            // Do we always want the extended charsets?
+            switch (encoding.WebName)
+            {
+                //case 874:   return "ISO_IR 166";		// TIS 620-2533 (Thai) Unextended
+                case "windows-874":
+                    return "ISO 2022 IR 166"; // TIS 620-2533 (Thai) Extended
+                case "shift_jis":
+                    return "ISO_IR 13"; // JIS X 0201 (Shift JIS) Unextended
+                case "us-ascii":
+                    return "ISO 2022 IR 6"; // ASCII
+                case "x-cp20949":
+                    return "ISO 2022 IR 149"; // KS X 1001 (Hangul and Hanja) Extended
+                //case 28591: return "ISO_IR 100";		// Latin Alphabet No. 1 Unextended
+                case "iso-8859-1":
+                    return "ISO 2022 IR 100"; // Latin Alphabet No. 1 Extended
+                //case 28592: return "ISO_IR 101";		// Latin Alphabet No. 2 Unextended
+                case "iso-8859-2":
+                    return "ISO 2022 IR 101"; // Latin Alphabet No. 2 Extended
+                //case 28593: return "ISO_IR 109";		// Latin Alphabet No. 3 Unextended
+                case "iso-8859-3":
+                    return "ISO 2022 IR 109"; // Latin Alphabet No. 3 Extended
+                //case 28594: return "ISO_IR 110";		// Latin Alphabet No. 4 Unextended
+                case "iso-8859-4":
+                    return "ISO 2022 IR 110"; // Latin Alphabet No. 4 Extended
+                //case 28595: return "ISO_IR 144";		// Cyrillic Unextended
+                case "iso-8859-5":
+                    return "ISO 2022 IR 144"; // Cyrillic Extended
+                //case 28596: return "ISO_IR 127";		// Arabic Unextended
+                case "iso-8859-6":
+                    return "ISO 2022 IR 127"; // Arabic Extended
+                //case 28597: return "ISO_IR 126";		// Greek Unextended
+                case "iso-8859-7":
+                    return "ISO 2022 IR 126"; // Greek Extended
+                //case 28598: return "ISO_IR 138";		// Hebrew Unextended
+                case "iso-8859-8":
+                    return "ISO 2022 IR 138"; // Hebrew Extended
+                //case 28599: return "ISO_IR 148";		// Latin Alphabet No. 5 (Turkish) Unextended
+                case "iso-8859-9":
+                    return "ISO 2022 IR 148"; // Latin Alphabet No. 5 (Turkish) Extended
+                //case 50222: return "ISO 2022 IR 13";	// JIS X 0201 (Shift JIS) Extended
+                //case 50222: return "ISO 2022 IR 87";	// JIS X 0208 (Kanji) Extended
+                case "iso-2022-jp":
+                    return "ISO 2022 IR 159"; // JIS X 0212 (Kanji) Extended
+                case "GB18030":
+                    return "GB18030"; // Chinese (Simplified) Extended
+                case "utf-8":
+                    return "ISO_IR 192"; // Unicode in UTF-8
+                default:
+                    throw new ArgumentException("No DICOM charset found for requested encoding.", "encoding");
+            }
+        }
+    }
 }

--- a/DICOM/DicomException.cs
+++ b/DICOM/DicomException.cs
@@ -1,36 +1,54 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public class DicomExceptionEventArgs : EventArgs {
-		public readonly DicomException Exception;
+using System;
 
-		public DicomExceptionEventArgs(DicomException ex) {
-			Exception = ex;
-		}
-	}
+namespace Dicom
+{
+    public class DicomExceptionEventArgs : EventArgs
+    {
+        public readonly DicomException Exception;
 
-	/// <summary>Base type for all DICOM library exceptions.</summary>
-	public abstract class DicomException : Exception {
-		protected DicomException(string message) : base(message) {
-			DicomExceptionConstructed(this);
-		}
+        public DicomExceptionEventArgs(DicomException ex)
+        {
+            Exception = ex;
+        }
+    }
 
-		protected DicomException(string format, params object[] args) : this(String.Format(format, args)) {
-		}
+    /// <summary>Base type for all DICOM library exceptions.</summary>
+    public abstract class DicomException : Exception
+    {
+        protected DicomException(string message)
+            : base(message)
+        {
+            DicomExceptionConstructed(this);
+        }
 
-		protected DicomException(string message, Exception innerException) : base(message, innerException) {
-			DicomExceptionConstructed(this);
-		}
+        protected DicomException(string format, params object[] args)
+            : this(String.Format(format, args))
+        {
+        }
 
-		internal static void DicomExceptionConstructed(DicomException ex) {
-			if (OnException != null) {
-				try {
-					OnException(ex, new DicomExceptionEventArgs(ex));
-				} catch {
-				}
-			}
-		}
+        protected DicomException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            DicomExceptionConstructed(this);
+        }
 
-		public static EventHandler<DicomExceptionEventArgs> OnException;
-	}
+        internal static void DicomExceptionConstructed(DicomException ex)
+        {
+            if (OnException != null)
+            {
+                try
+                {
+                    OnException(ex, new DicomExceptionEventArgs(ex));
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public static EventHandler<DicomExceptionEventArgs> OnException;
+    }
 }

--- a/DICOM/DicomFile.cs
+++ b/DICOM/DicomFile.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 using System.Text;
 using Dicom.IO;
@@ -6,136 +9,145 @@ using Dicom.IO;
 using Dicom.IO.Reader;
 using Dicom.IO.Writer;
 
-namespace Dicom {
-    public class DicomFile {
-		public DicomFile() {
-			FileMetaInfo = new DicomFileMetaInformation();
-			Dataset = new DicomDataset();
-			Format = DicomFileFormat.DICOM3;
-		}
+namespace Dicom
+{
+    public class DicomFile
+    {
+        public DicomFile()
+        {
+            FileMetaInfo = new DicomFileMetaInformation();
+            Dataset = new DicomDataset();
+            Format = DicomFileFormat.DICOM3;
+        }
 
-		public DicomFile(DicomDataset dataset) {
-			Dataset = dataset;
-			FileMetaInfo = new DicomFileMetaInformation(Dataset);
-			Format = DicomFileFormat.DICOM3;
-		}
+        public DicomFile(DicomDataset dataset)
+        {
+            Dataset = dataset;
+            FileMetaInfo = new DicomFileMetaInformation(Dataset);
+            Format = DicomFileFormat.DICOM3;
+        }
 
-		public FileReference File {
-			get;
-			protected set;
-		}
+        public FileReference File { get; protected set; }
 
-		public DicomFileFormat Format {
-			get;
-			protected set;
-		}
+        public DicomFileFormat Format { get; protected set; }
 
-		public DicomFileMetaInformation FileMetaInfo {
-			get;
-			protected set;
-		}
+        public DicomFileMetaInformation FileMetaInfo { get; protected set; }
 
-		public DicomDataset Dataset {
-			get;
-			protected set;
-		}
+        public DicomDataset Dataset { get; protected set; }
 
-		protected virtual void OnSave() {
-		}
+        protected virtual void OnSave()
+        {
+        }
 
-		public void Save(string fileName) {
-			if (Format == DicomFileFormat.ACRNEMA1 || Format == DicomFileFormat.ACRNEMA2)
-				throw new DicomFileException(this, "Unable to save ACR-NEMA file");
+        public void Save(string fileName)
+        {
+            if (Format == DicomFileFormat.ACRNEMA1 || Format == DicomFileFormat.ACRNEMA2) throw new DicomFileException(this, "Unable to save ACR-NEMA file");
 
-			if (Format == DicomFileFormat.DICOM3NoFileMetaInfo) {
-				// create file meta information from dataset
-				FileMetaInfo = new DicomFileMetaInformation(Dataset);
-			}
+            if (Format == DicomFileFormat.DICOM3NoFileMetaInfo)
+            {
+                // create file meta information from dataset
+                FileMetaInfo = new DicomFileMetaInformation(Dataset);
+            }
 
-			File = new FileReference(fileName);
-			File.Delete();
+            File = new FileReference(fileName);
+            File.Delete();
 
-			OnSave();
+            OnSave();
 
-			using (var target = new FileByteTarget(File)) {
-				DicomFileWriter writer = new DicomFileWriter(DicomWriteOptions.Default);
-				writer.Write(target, FileMetaInfo, Dataset);
-			}
-		}
+            using (var target = new FileByteTarget(File))
+            {
+                DicomFileWriter writer = new DicomFileWriter(DicomWriteOptions.Default);
+                writer.Write(target, FileMetaInfo, Dataset);
+            }
+        }
 
-		public void Save(Stream stream) {
-			if (Format == DicomFileFormat.ACRNEMA1 || Format == DicomFileFormat.ACRNEMA2)
-				throw new DicomFileException(this, "Unable to save ACR-NEMA file");
+        public void Save(Stream stream)
+        {
+            if (Format == DicomFileFormat.ACRNEMA1 || Format == DicomFileFormat.ACRNEMA2) throw new DicomFileException(this, "Unable to save ACR-NEMA file");
 
-			if (Format == DicomFileFormat.DICOM3NoFileMetaInfo) {
-				// create file meta information from dataset
-				FileMetaInfo = new DicomFileMetaInformation(Dataset);
-			}
+            if (Format == DicomFileFormat.DICOM3NoFileMetaInfo)
+            {
+                // create file meta information from dataset
+                FileMetaInfo = new DicomFileMetaInformation(Dataset);
+            }
 
-			OnSave();
+            OnSave();
 
-			using (var target = new StreamByteTarget(stream)) {
-				DicomFileWriter writer = new DicomFileWriter(DicomWriteOptions.Default);
-				writer.Write(target, FileMetaInfo, Dataset);
-			}
-		}
+            using (var target = new StreamByteTarget(stream))
+            {
+                DicomFileWriter writer = new DicomFileWriter(DicomWriteOptions.Default);
+                writer.Write(target, FileMetaInfo, Dataset);
+            }
+        }
 
-		public void BeginSave(string fileName, AsyncCallback callback, object state) {
-			if (Format == DicomFileFormat.ACRNEMA1 || Format == DicomFileFormat.ACRNEMA2)
-				throw new DicomFileException(this, "Unable to save ACR-NEMA file");
+        public void BeginSave(string fileName, AsyncCallback callback, object state)
+        {
+            if (Format == DicomFileFormat.ACRNEMA1 || Format == DicomFileFormat.ACRNEMA2) throw new DicomFileException(this, "Unable to save ACR-NEMA file");
 
-			if (Format == DicomFileFormat.DICOM3NoFileMetaInfo) {
-				// create file meta information from dataset
-				FileMetaInfo = new DicomFileMetaInformation(Dataset);
-			}
+            if (Format == DicomFileFormat.DICOM3NoFileMetaInfo)
+            {
+                // create file meta information from dataset
+                FileMetaInfo = new DicomFileMetaInformation(Dataset);
+            }
 
-			File = new FileReference(fileName);
-			File.Delete();
+            File = new FileReference(fileName);
+            File.Delete();
 
-			OnSave();
+            OnSave();
 
-			FileByteTarget target = new FileByteTarget(File);
+            FileByteTarget target = new FileByteTarget(File);
 
-			EventAsyncResult result = new EventAsyncResult(callback, state);
+            EventAsyncResult result = new EventAsyncResult(callback, state);
 
-			DicomFileWriter writer = new DicomFileWriter(DicomWriteOptions.Default);
-			writer.BeginWrite(target, FileMetaInfo, Dataset, OnWriteComplete, new Tuple<DicomFileWriter, EventAsyncResult>(writer, result));
-		}
-		private static void OnWriteComplete(IAsyncResult result) {
-			var state = result.AsyncState as Tuple<DicomFileWriter, EventAsyncResult>;
+            DicomFileWriter writer = new DicomFileWriter(DicomWriteOptions.Default);
+            writer.BeginWrite(
+                target,
+                FileMetaInfo,
+                Dataset,
+                OnWriteComplete,
+                new Tuple<DicomFileWriter, EventAsyncResult>(writer, result));
+        }
 
-			try {
-				state.Item1.EndWrite(result);
+        private static void OnWriteComplete(IAsyncResult result)
+        {
+            var state = result.AsyncState as Tuple<DicomFileWriter, EventAsyncResult>;
 
-				// ensure that file handles are closed
-				var target = (FileByteTarget)state.Item1.Target;
-				target.Dispose();
-			} catch (Exception ex) {
-				state.Item2.InternalState = ex;
-			}
+            try
+            {
+                state.Item1.EndWrite(result);
 
-			state.Item2.Set();
-		}
+                // ensure that file handles are closed
+                var target = (FileByteTarget)state.Item1.Target;
+                target.Dispose();
+            }
+            catch (Exception ex)
+            {
+                state.Item2.InternalState = ex;
+            }
 
-		public void EndSave(IAsyncResult result) {
-			EventAsyncResult eventResult = result as EventAsyncResult;
+            state.Item2.Set();
+        }
 
-			result.AsyncWaitHandle.WaitOne();
+        public void EndSave(IAsyncResult result)
+        {
+            EventAsyncResult eventResult = result as EventAsyncResult;
 
-			if (eventResult.InternalState != null)
-				throw eventResult.InternalState as Exception;
-		}
+            result.AsyncWaitHandle.WaitOne();
 
-	    /// <summary>
-	    /// Reads the specified filename and returns a DicomFile object.  Note that the values for large
-	    /// DICOM elements (e.g. PixelData) are read in "on demand" to conserve memory.  Large DICOM elements
-	    /// are determined by their size in bytes - see the default value for this in the FileByteSource._largeObjectSize
-	    /// </summary>
-	    /// <param name="fileName">The filename of the DICOM file</param>
-	    /// <returns>DicomFile instance</returns>
-	    public static DicomFile Open(string fileName) {
-	        return Open(fileName, DicomEncoding.Default);
-	    }
+            if (eventResult.InternalState != null) throw eventResult.InternalState as Exception;
+        }
+
+        /// <summary>
+        /// Reads the specified filename and returns a DicomFile object.  Note that the values for large
+        /// DICOM elements (e.g. PixelData) are read in "on demand" to conserve memory.  Large DICOM elements
+        /// are determined by their size in bytes - see the default value for this in the FileByteSource._largeObjectSize
+        /// </summary>
+        /// <param name="fileName">The filename of the DICOM file</param>
+        /// <returns>DicomFile instance</returns>
+        public static DicomFile Open(string fileName)
+        {
+            return Open(fileName, DicomEncoding.Default);
+        }
 
         /// <summary>
         /// Reads the specified filename and returns a DicomFile object.  Note that the values for large
@@ -145,32 +157,38 @@ namespace Dicom {
         /// <param name="fileName">The filename of the DICOM file</param>
         /// <param name="fallbackEncoding">Encoding to apply when attribute Specific Character Set is not available.</param>
         /// <returns>DicomFile instance</returns>
-        public static DicomFile Open(string fileName, Encoding fallbackEncoding) {
-	        if (fallbackEncoding == null)
-	        {
-	            throw new ArgumentNullException("fallbackEncoding");
-	        }
-	        DicomFile df = new DicomFile();
+        public static DicomFile Open(string fileName, Encoding fallbackEncoding)
+        {
+            if (fallbackEncoding == null)
+            {
+                throw new ArgumentNullException("fallbackEncoding");
+            }
+            DicomFile df = new DicomFile();
 
-			try {
-				df.File = new FileReference(fileName);
+            try
+            {
+                df.File = new FileReference(fileName);
 
-				using (var source = new FileByteSource(df.File)) {
-					DicomFileReader reader = new DicomFileReader();
-					reader.Read(source,
-						new DicomDatasetReaderObserver(df.FileMetaInfo),
-						new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding));
+                using (var source = new FileByteSource(df.File))
+                {
+                    DicomFileReader reader = new DicomFileReader();
+                    reader.Read(
+                        source,
+                        new DicomDatasetReaderObserver(df.FileMetaInfo),
+                        new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding));
 
-					df.Format = reader.FileFormat;
+                    df.Format = reader.FileFormat;
 
-					df.Dataset.InternalTransferSyntax = reader.Syntax;
+                    df.Dataset.InternalTransferSyntax = reader.Syntax;
 
-					return df;
-				}
-			} catch (Exception e) {
-				throw new DicomFileException(df, e.Message, e);
-			}
-		}
+                    return df;
+                }
+            }
+            catch (Exception e)
+            {
+                throw new DicomFileException(df, e.Message, e);
+            }
+        }
 
         public static DicomFile Open(Stream stream)
         {
@@ -185,22 +203,26 @@ namespace Dicom {
             }
             var df = new DicomFile();
 
-			try {
-				var source = new StreamByteSource(stream);
+            try
+            {
+                var source = new StreamByteSource(stream);
 
-				var reader = new DicomFileReader();
-				reader.Read(source,
-					new DicomDatasetReaderObserver(df.FileMetaInfo),
-					new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding));
+                var reader = new DicomFileReader();
+                reader.Read(
+                    source,
+                    new DicomDatasetReaderObserver(df.FileMetaInfo),
+                    new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding));
 
-				df.Format = reader.FileFormat;
+                df.Format = reader.FileFormat;
 
-				df.Dataset.InternalTransferSyntax = reader.Syntax;
+                df.Dataset.InternalTransferSyntax = reader.Syntax;
 
-				return df;
-			} catch (Exception e) {
-				throw new DicomFileException(df, e.Message, e);
-			}
+                return df;
+            }
+            catch (Exception e)
+            {
+                throw new DicomFileException(df, e.Message, e);
+            }
         }
 
         public static IAsyncResult BeginOpen(string fileName, AsyncCallback callback, object state)
@@ -208,85 +230,98 @@ namespace Dicom {
             return BeginOpen(fileName, DicomEncoding.Default, callback, state);
         }
 
-        public static IAsyncResult BeginOpen(string fileName, Encoding fallbackEncoding, AsyncCallback callback, object state)
+        public static IAsyncResult BeginOpen(
+            string fileName,
+            Encoding fallbackEncoding,
+            AsyncCallback callback,
+            object state)
         {
-			DicomFile df = new DicomFile();
-			df.File = new FileReference(fileName);
+            DicomFile df = new DicomFile();
+            df.File = new FileReference(fileName);
 
-			FileByteSource source = new FileByteSource(df.File);
+            FileByteSource source = new FileByteSource(df.File);
 
-			EventAsyncResult result = new EventAsyncResult(callback, state);
+            EventAsyncResult result = new EventAsyncResult(callback, state);
 
-			DicomFileReader reader = new DicomFileReader();
-			reader.BeginRead(source,
-				new DicomDatasetReaderObserver(df.FileMetaInfo),
-				new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding),
-				OnReadComplete, new Tuple<DicomFileReader, DicomFile, EventAsyncResult>(reader, df, result));
+            DicomFileReader reader = new DicomFileReader();
+            reader.BeginRead(
+                source,
+                new DicomDatasetReaderObserver(df.FileMetaInfo),
+                new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding),
+                OnReadComplete,
+                new Tuple<DicomFileReader, DicomFile, EventAsyncResult>(reader, df, result));
 
-			return result;
-		}
-		private static void OnReadComplete(IAsyncResult result) {
-			var state = result.AsyncState as Tuple<DicomFileReader, DicomFile, EventAsyncResult>;
+            return result;
+        }
 
-			Exception e = null;
-			try {
-				state.Item1.EndRead(result);
+        private static void OnReadComplete(IAsyncResult result)
+        {
+            var state = result.AsyncState as Tuple<DicomFileReader, DicomFile, EventAsyncResult>;
 
-				// ensure that file handles are closed
-				var source = (FileByteSource)state.Item1.Source;
-				source.Dispose();
+            Exception e = null;
+            try
+            {
+                state.Item1.EndRead(result);
 
-				state.Item2.Format = state.Item1.FileFormat;
-				state.Item2.Dataset.InternalTransferSyntax = state.Item1.Syntax;
-			} catch (Exception ex) {
-				state.Item2.Format = state.Item1.FileFormat;
-				e = ex;
-			}
+                // ensure that file handles are closed
+                var source = (FileByteSource)state.Item1.Source;
+                source.Dispose();
 
-			state.Item3.InternalState = new Tuple<DicomFile, Exception>(state.Item2, e);
-			state.Item3.Set();
-		}
+                state.Item2.Format = state.Item1.FileFormat;
+                state.Item2.Dataset.InternalTransferSyntax = state.Item1.Syntax;
+            }
+            catch (Exception ex)
+            {
+                state.Item2.Format = state.Item1.FileFormat;
+                e = ex;
+            }
 
-		public static DicomFile EndOpen(IAsyncResult result) {
-			result.AsyncWaitHandle.WaitOne();
+            state.Item3.InternalState = new Tuple<DicomFile, Exception>(state.Item2, e);
+            state.Item3.Set();
+        }
 
-			EventAsyncResult eventResult = result as EventAsyncResult;
-			var state = eventResult.InternalState as Tuple<DicomFile, Exception>;
+        public static DicomFile EndOpen(IAsyncResult result)
+        {
+            result.AsyncWaitHandle.WaitOne();
 
-			if (state.Item2 != null)
-				throw new DicomFileException(state.Item1, state.Item2.Message, state.Item2);
+            EventAsyncResult eventResult = result as EventAsyncResult;
+            var state = eventResult.InternalState as Tuple<DicomFile, Exception>;
 
-			return state.Item1;
-		}
+            if (state.Item2 != null) throw new DicomFileException(state.Item1, state.Item2.Message, state.Item2);
 
-		public override string ToString() {
-			return String.Format("DICOM File [{0}]", Format);
-		}
+            return state.Item1;
+        }
 
-		/// <summary>
-		/// Test if file has a valid preamble and DICOM 3.0 header.
-		/// </summary>
-		/// <param name="path">Path to file</param>
-		/// <returns>True if valid DICOM 3.0 file header is detected.</returns>
-		public static bool HasValidHeader(string path) {
-			try {
-				using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read)) {
-					fs.Seek(128, SeekOrigin.Begin);
+        public override string ToString()
+        {
+            return String.Format("DICOM File [{0}]", Format);
+        }
 
-					bool magic = false;
-					if (fs.ReadByte() == 'D' &&
-						fs.ReadByte() == 'I' &&
-						fs.ReadByte() == 'C' &&
-						fs.ReadByte() == 'M')
-						magic = true;
+        /// <summary>
+        /// Test if file has a valid preamble and DICOM 3.0 header.
+        /// </summary>
+        /// <param name="path">Path to file</param>
+        /// <returns>True if valid DICOM 3.0 file header is detected.</returns>
+        public static bool HasValidHeader(string path)
+        {
+            try
+            {
+                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+                {
+                    fs.Seek(128, SeekOrigin.Begin);
 
-					fs.Close();
+                    bool magic = false;
+                    if (fs.ReadByte() == 'D' && fs.ReadByte() == 'I' && fs.ReadByte() == 'C' && fs.ReadByte() == 'M') magic = true;
 
-					return magic;
-				}
-			} catch {
-				return false;
-			}
-		}
-	}
+                    fs.Close();
+
+                    return magic;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
 }

--- a/DICOM/DicomFileException.cs
+++ b/DICOM/DicomFileException.cs
@@ -1,25 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public class DicomFileException : DicomDataException {
-		public DicomFileException(DicomFile file, string message) : base(message) {
-			File = file;
-		}
+using System;
 
-		public DicomFileException(DicomFile file, string format, params object[] args) : base(format, args) {
-			File = file;
-		}
+namespace Dicom
+{
+    public class DicomFileException : DicomDataException
+    {
+        public DicomFileException(DicomFile file, string message)
+            : base(message)
+        {
+            File = file;
+        }
 
-		public DicomFileException(DicomFile file, string message, Exception innerException) : base(message, innerException) {
-			File = file;
-		}
+        public DicomFileException(DicomFile file, string format, params object[] args)
+            : base(format, args)
+        {
+            File = file;
+        }
 
-		public DicomFile File {
-			get;
-			private set;
-		}
-	}
+        public DicomFileException(DicomFile file, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            File = file;
+        }
+
+        public DicomFile File { get; private set; }
+    }
 }

--- a/DICOM/DicomFileExtensions.cs
+++ b/DICOM/DicomFileExtensions.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public static class DicomFileExtensions {
-		public static DicomFile Clone(this DicomFile original) {
-			var df = new DicomFile();
-			df.FileMetaInfo.Add(original.FileMetaInfo);
-			df.Dataset.Add(original.Dataset);
-			df.Dataset.InternalTransferSyntax = original.Dataset.InternalTransferSyntax;
-			return df;
-		}
-	}
+namespace Dicom
+{
+    public static class DicomFileExtensions
+    {
+        public static DicomFile Clone(this DicomFile original)
+        {
+            var df = new DicomFile();
+            df.FileMetaInfo.Add(original.FileMetaInfo);
+            df.Dataset.Add(original.Dataset);
+            df.Dataset.InternalTransferSyntax = original.Dataset.InternalTransferSyntax;
+            return df;
+        }
+    }
 }

--- a/DICOM/DicomFileFormat.cs
+++ b/DICOM/DicomFileFormat.cs
@@ -1,24 +1,29 @@
-﻿namespace Dicom {
-	/// <summary>
-	/// Structure of DICOM file
-	/// </summary>
-	public enum DicomFileFormat {
-		/// <summary>Parser was unable to determine structure of file. Possibly not DICOM.</summary>
-		Unknown,
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-		/// <summary>Valid DICOM file containing preamble and file meta info.</summary>
-		DICOM3,
+namespace Dicom
+{
+    /// <summary>
+    /// Structure of DICOM file
+    /// </summary>
+    public enum DicomFileFormat
+    {
+        /// <summary>Parser was unable to determine structure of file. Possibly not DICOM.</summary>
+        Unknown,
 
-		/// <summary>DICOM file that does not contain preamble but does contain file meta info.</summary>
-		DICOM3NoPreamble,
+        /// <summary>Valid DICOM file containing preamble and file meta info.</summary>
+        DICOM3,
 
-		/// <summary>DICOM file that does not contain preamble or file meta info.</summary>
-		DICOM3NoFileMetaInfo,
+        /// <summary>DICOM file that does not contain preamble but does contain file meta info.</summary>
+        DICOM3NoPreamble,
 
-		/// <summary>ACR-NEMA 1.0</summary>
-		ACRNEMA1,
+        /// <summary>DICOM file that does not contain preamble or file meta info.</summary>
+        DICOM3NoFileMetaInfo,
 
-		/// <summary>ACR-NEMA 2.0</summary>
-		ACRNEMA2
-	}
+        /// <summary>ACR-NEMA 1.0</summary>
+        ACRNEMA1,
+
+        /// <summary>ACR-NEMA 2.0</summary>
+        ACRNEMA2
+    }
 }

--- a/DICOM/DicomFileMetaInformation.cs
+++ b/DICOM/DicomFileMetaInformation.cs
@@ -1,64 +1,119 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public class DicomFileMetaInformation : DicomDataset {
-		public DicomFileMetaInformation() : base() {
-			Version = new byte[] { 0x00, 0x01 };
-			ImplementationClassUID = DicomImplementation.ClassUID;
-			ImplementationVersionName = DicomImplementation.Version;
+using System;
 
-			var machine = Environment.MachineName;
-			if (machine.Length > 16)
-				machine = machine.Substring(0, 16);
-			SourceApplicationEntityTitle = machine;
-		}
+namespace Dicom
+{
+    public class DicomFileMetaInformation : DicomDataset
+    {
+        public DicomFileMetaInformation()
+            : base()
+        {
+            Version = new byte[] { 0x00, 0x01 };
+            ImplementationClassUID = DicomImplementation.ClassUID;
+            ImplementationVersionName = DicomImplementation.Version;
 
-		public DicomFileMetaInformation(DicomDataset dataset) : this() {
-			MediaStorageSOPClassUID = dataset.Get<DicomUID>(DicomTag.SOPClassUID);
-			MediaStorageSOPInstanceUID = dataset.Get<DicomUID>(DicomTag.SOPInstanceUID);
-			TransferSyntax = dataset.InternalTransferSyntax;
-		}
+            var machine = Environment.MachineName;
+            if (machine.Length > 16) machine = machine.Substring(0, 16);
+            SourceApplicationEntityTitle = machine;
+        }
 
-		public byte[] Version {
-			get { return Get<byte[]>(DicomTag.FileMetaInformationVersion); }
-			set { Add(DicomTag.FileMetaInformationVersion, value); }
-		}
+        public DicomFileMetaInformation(DicomDataset dataset)
+            : this()
+        {
+            MediaStorageSOPClassUID = dataset.Get<DicomUID>(DicomTag.SOPClassUID);
+            MediaStorageSOPInstanceUID = dataset.Get<DicomUID>(DicomTag.SOPInstanceUID);
+            TransferSyntax = dataset.InternalTransferSyntax;
+        }
 
-		public DicomUID MediaStorageSOPClassUID {
-			get { return Get<DicomUID>(DicomTag.MediaStorageSOPClassUID); }
-			set { Add(DicomTag.MediaStorageSOPClassUID, value); }
-		}
+        public byte[] Version
+        {
+            get
+            {
+                return Get<byte[]>(DicomTag.FileMetaInformationVersion);
+            }
+            set
+            {
+                Add(DicomTag.FileMetaInformationVersion, value);
+            }
+        }
 
-		public DicomUID MediaStorageSOPInstanceUID {
-			get { return Get<DicomUID>(DicomTag.MediaStorageSOPInstanceUID); }
-			set { Add(DicomTag.MediaStorageSOPInstanceUID, value); }
-		}
+        public DicomUID MediaStorageSOPClassUID
+        {
+            get
+            {
+                return Get<DicomUID>(DicomTag.MediaStorageSOPClassUID);
+            }
+            set
+            {
+                Add(DicomTag.MediaStorageSOPClassUID, value);
+            }
+        }
 
-		public DicomTransferSyntax TransferSyntax {
-			get { return Get<DicomTransferSyntax>(DicomTag.TransferSyntaxUID); }
-			set { Add(DicomTag.TransferSyntaxUID, value.UID); }
-		}
+        public DicomUID MediaStorageSOPInstanceUID
+        {
+            get
+            {
+                return Get<DicomUID>(DicomTag.MediaStorageSOPInstanceUID);
+            }
+            set
+            {
+                Add(DicomTag.MediaStorageSOPInstanceUID, value);
+            }
+        }
 
-		public DicomUID ImplementationClassUID {
-			get { return Get<DicomUID>(DicomTag.ImplementationClassUID); }
-			set { Add(DicomTag.ImplementationClassUID, value); }
-		}
+        public DicomTransferSyntax TransferSyntax
+        {
+            get
+            {
+                return Get<DicomTransferSyntax>(DicomTag.TransferSyntaxUID);
+            }
+            set
+            {
+                Add(DicomTag.TransferSyntaxUID, value.UID);
+            }
+        }
 
-		public string ImplementationVersionName {
-			get { return Get<string>(DicomTag.ImplementationVersionName); }
-			set { Add(DicomTag.ImplementationVersionName, value); }
-		}
+        public DicomUID ImplementationClassUID
+        {
+            get
+            {
+                return Get<DicomUID>(DicomTag.ImplementationClassUID);
+            }
+            set
+            {
+                Add(DicomTag.ImplementationClassUID, value);
+            }
+        }
 
-		public string SourceApplicationEntityTitle {
-			get { return Get<string>(DicomTag.SourceApplicationEntityTitle); }
-			set { Add(DicomTag.SourceApplicationEntityTitle, value); }
-		}
+        public string ImplementationVersionName
+        {
+            get
+            {
+                return Get<string>(DicomTag.ImplementationVersionName);
+            }
+            set
+            {
+                Add(DicomTag.ImplementationVersionName, value);
+            }
+        }
 
-		public override string ToString() {
-			return "DICOM File Meta Info";
-		}
-	}
+        public string SourceApplicationEntityTitle
+        {
+            get
+            {
+                return Get<string>(DicomTag.SourceApplicationEntityTitle);
+            }
+            set
+            {
+                Add(DicomTag.SourceApplicationEntityTitle, value);
+            }
+        }
+
+        public override string ToString()
+        {
+            return "DICOM File Meta Info";
+        }
+    }
 }

--- a/DICOM/DicomFragmentSequence.cs
+++ b/DICOM/DicomFragmentSequence.cs
@@ -1,70 +1,100 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
+using System.Collections.Generic;
+
 using Dicom.IO.Buffer;
 
-namespace Dicom {
-	public abstract class DicomFragmentSequence : DicomItem, IEnumerable<IByteBuffer> {
-		private IList<uint> _offsetTable;
-		private IList<IByteBuffer> _fragments;
+namespace Dicom
+{
+    public abstract class DicomFragmentSequence : DicomItem, IEnumerable<IByteBuffer>
+    {
+        private IList<uint> _offsetTable;
 
-		protected DicomFragmentSequence(DicomTag tag) : base(tag) {
-			_fragments = new List<IByteBuffer>();
-		}
+        private IList<IByteBuffer> _fragments;
 
-		public IList<uint> OffsetTable {
-			get {
-				if (_offsetTable == null)
-					_offsetTable = new List<uint>();
-				return _offsetTable;
-			}
-		}
+        protected DicomFragmentSequence(DicomTag tag)
+            : base(tag)
+        {
+            _fragments = new List<IByteBuffer>();
+        }
 
-		public IList<IByteBuffer> Fragments {
-			get { return _fragments; }
-		}
+        public IList<uint> OffsetTable
+        {
+            get
+            {
+                if (_offsetTable == null) _offsetTable = new List<uint>();
+                return _offsetTable;
+            }
+        }
 
-		internal void Add(IByteBuffer fragment) {
-			if (_offsetTable == null) {
-				var en = ByteBufferEnumerator<uint>.Create(fragment);
-				_offsetTable = new List<uint>(en);
-				return;
-			}
-			_fragments.Add(fragment);
-		}
+        public IList<IByteBuffer> Fragments
+        {
+            get
+            {
+                return _fragments;
+            }
+        }
 
-		public IEnumerator<IByteBuffer> GetEnumerator() {
-			return _fragments.GetEnumerator();
-		}
+        internal void Add(IByteBuffer fragment)
+        {
+            if (_offsetTable == null)
+            {
+                var en = ByteBufferEnumerator<uint>.Create(fragment);
+                _offsetTable = new List<uint>(en);
+                return;
+            }
+            _fragments.Add(fragment);
+        }
 
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-			return _fragments.GetEnumerator();
-		}
-	}
+        public IEnumerator<IByteBuffer> GetEnumerator()
+        {
+            return _fragments.GetEnumerator();
+        }
 
-	public abstract class DicomFragmentSequenceT<T> : DicomFragmentSequence {
-		protected DicomFragmentSequenceT(DicomTag tag) : base(tag) {
-		}
-	}
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return _fragments.GetEnumerator();
+        }
+    }
 
-	public class DicomOtherByteFragment : DicomFragmentSequenceT<byte> {
-		public DicomOtherByteFragment(DicomTag tag) : base(tag) {
-		}
+    public abstract class DicomFragmentSequenceT<T> : DicomFragmentSequence
+    {
+        protected DicomFragmentSequenceT(DicomTag tag)
+            : base(tag)
+        {
+        }
+    }
 
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.OB; }
-		}
-	}
+    public class DicomOtherByteFragment : DicomFragmentSequenceT<byte>
+    {
+        public DicomOtherByteFragment(DicomTag tag)
+            : base(tag)
+        {
+        }
 
-	public class DicomOtherWordFragment : DicomFragmentSequenceT<ushort> {
-		public DicomOtherWordFragment(DicomTag tag) : base(tag) {
-		}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.OB;
+            }
+        }
+    }
 
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.OW; }
-		}
-	}
+    public class DicomOtherWordFragment : DicomFragmentSequenceT<ushort>
+    {
+        public DicomOtherWordFragment(DicomTag tag)
+            : base(tag)
+        {
+        }
+
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.OW;
+            }
+        }
+    }
 }

--- a/DICOM/DicomImplementation.cs
+++ b/DICOM/DicomImplementation.cs
@@ -1,17 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Reflection;
-using System.Text;
 
-namespace Dicom {
-	public static class DicomImplementation {
-		public static DicomUID ClassUID = new DicomUID("1.3.6.1.4.1.30071.8", "Implementation Class UID", DicomUidType.Unknown);
-		public static string Version = GetImplementationVersion();
+namespace Dicom
+{
+    public static class DicomImplementation
+    {
+        public static DicomUID ClassUID = new DicomUID(
+            "1.3.6.1.4.1.30071.8",
+            "Implementation Class UID",
+            DicomUidType.Unknown);
 
-		private static string GetImplementationVersion() {
-			var version = Assembly.GetExecutingAssembly().GetName().Version;
-			return String.Format("fo-dicom {0}.{1}.{2}", version.Major, version.Minor, version.Build);
-		}
-	}
+        public static string Version = GetImplementationVersion();
+
+        private static string GetImplementationVersion()
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            return String.Format("fo-dicom {0}.{1}.{2}", version.Major, version.Minor, version.Build);
+        }
+    }
 }

--- a/DICOM/DicomItem.cs
+++ b/DICOM/DicomItem.cs
@@ -1,45 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
+using System;
 
-namespace Dicom {
-	public abstract class DicomItem : IComparable<DicomItem>, IComparable {
-		protected DicomItem(DicomTag tag) {
-			Tag = tag;
+namespace Dicom
+{
+    public abstract class DicomItem : IComparable<DicomItem>, IComparable
+    {
+        protected DicomItem(DicomTag tag)
+        {
+            Tag = tag;
 
-			//DicomDictionaryEntry entry = DicomDictionary.Default[Tag];
-			//if (entry != null && !entry.ValueRepresentations.Contains(ValueRepresentation))
-			//	throw new DicomDataException("{0} is not a valid value representation for {1}", ValueRepresentation, Tag);
-		}
+            //DicomDictionaryEntry entry = DicomDictionary.Default[Tag];
+            //if (entry != null && !entry.ValueRepresentations.Contains(ValueRepresentation))
+            //	throw new DicomDataException("{0} is not a valid value representation for {1}", ValueRepresentation, Tag);
+        }
 
-		public DicomTag Tag {
-			get;
-			protected set;
-		}
+        public DicomTag Tag { get; protected set; }
 
-		public abstract DicomVR ValueRepresentation {
-			get;
-		}
+        public abstract DicomVR ValueRepresentation { get; }
 
-		public int CompareTo(DicomItem other) {
-			return Tag.CompareTo(other.Tag);
-		}
+        public int CompareTo(DicomItem other)
+        {
+            return Tag.CompareTo(other.Tag);
+        }
 
-		public int CompareTo(object obj) {
-			if (obj == null)
-				throw new ArgumentNullException("obj");
-			if (!(obj is DicomItem))
-				throw new ArgumentException("Passed non-DicomItem to comparer", "obj");
-			return CompareTo(obj as DicomItem);
-		}
+        public int CompareTo(object obj)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            if (!(obj is DicomItem)) throw new ArgumentException("Passed non-DicomItem to comparer", "obj");
+            return CompareTo(obj as DicomItem);
+        }
 
-		public override string ToString() {
-			if (Tag.DictionaryEntry != null)
-				return String.Format("{0} {1} {2}", Tag, ValueRepresentation, Tag.DictionaryEntry.Name);
-			return String.Format("{0} {1} Unknown", Tag, ValueRepresentation);
-		}
-	}
+        public override string ToString()
+        {
+            if (Tag.DictionaryEntry != null) return String.Format("{0} {1} {2}", Tag, ValueRepresentation, Tag.DictionaryEntry.Name);
+            return String.Format("{0} {1} Unknown", Tag, ValueRepresentation);
+        }
+    }
 }

--- a/DICOM/DicomMaskedTag.cs
+++ b/DICOM/DicomMaskedTag.cs
@@ -1,146 +1,177 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 
-namespace Dicom {
-	public sealed class DicomMaskedTag : IFormattable {
-		public const uint FullMask = 0xffffffff;
+namespace Dicom
+{
+    public sealed class DicomMaskedTag : IFormattable
+    {
+        public const uint FullMask = 0xffffffff;
 
-		public DicomMaskedTag(DicomTag tag) {
-			Tag = tag;
-			Mask = FullMask;
-		}
+        public DicomMaskedTag(DicomTag tag)
+        {
+            Tag = tag;
+            Mask = FullMask;
+        }
 
-		private DicomMaskedTag() {
-		}
+        private DicomMaskedTag()
+        {
+        }
 
-		private DicomTag _tag = null;
-		public DicomTag Tag {
-			get {
-				if (_tag == null)
-					_tag = new DicomTag(Group, Element);
-				return _tag;
-			}
-			set {
-				_tag = value;
-				Card = ((uint)Group << 16) | (uint)Element;
-			}
-		}
+        private DicomTag _tag = null;
 
-		public ushort Group {
-			get { return Tag.Group; }
-		}
+        public DicomTag Tag
+        {
+            get
+            {
+                if (_tag == null) _tag = new DicomTag(Group, Element);
+                return _tag;
+            }
+            set
+            {
+                _tag = value;
+                Card = ((uint)Group << 16) | (uint)Element;
+            }
+        }
 
-		public ushort Element {
-			get { return Tag.Element; }
-		}
+        public ushort Group
+        {
+            get
+            {
+                return Tag.Group;
+            }
+        }
 
-		public uint Card {
-			get;
-			private set;
-		}
+        public ushort Element
+        {
+            get
+            {
+                return Tag.Element;
+            }
+        }
 
-		public uint Mask {
-			get;
-			private set;
-		}
+        public uint Card { get; private set; }
 
-		public override string ToString() {
-			return ToString("G", null);
-		}
+        public uint Mask { get; private set; }
 
-		public string ToString(string format, IFormatProvider formatProvider) {
-			if (formatProvider != null) {
-				ICustomFormatter fmt = formatProvider.GetFormat(this.GetType()) as ICustomFormatter;
-				if (fmt != null)
-					return fmt.Format(format, this, formatProvider);
-			}
+        public override string ToString()
+        {
+            return ToString("G", null);
+        }
 
-			switch (format) {
-				case "g": {
-						string s = Group.ToString("x4");
-						string x = String.Empty;
-						x += ((Mask & 0xf0000000) != 0) ? s[0] : 'x';
-						x += ((Mask & 0x0f000000) != 0) ? s[1] : 'x';
-						x += ((Mask & 0x00f00000) != 0) ? s[2] : 'x';
-						x += ((Mask & 0x000f0000) != 0) ? s[3] : 'x';
-						return x;
-					}
-				case "e": {
-						string s = Element.ToString("x4");
-						string x = String.Empty;
-						x += ((Mask & 0x0000f000) != 0) ? s[0] : 'x';
-						x += ((Mask & 0x00000f00) != 0) ? s[1] : 'x';
-						x += ((Mask & 0x000000f0) != 0) ? s[2] : 'x';
-						x += ((Mask & 0x0000000f) != 0) ? s[3] : 'x';
-						return x;
-					}
-				case "G":
-				default: {
-						return String.Format("({0},{1})", this.ToString("g", null), this.ToString("e", null));
-					}
-			}
-		}
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (formatProvider != null)
+            {
+                ICustomFormatter fmt = formatProvider.GetFormat(this.GetType()) as ICustomFormatter;
+                if (fmt != null) return fmt.Format(format, this, formatProvider);
+            }
 
-		public bool IsMatch(DicomTag tag) {
-			return Card == ((((uint)tag.Group << 16) | (uint)tag.Element) & Mask);
-		}
+            switch (format)
+            {
+                case "g":
+                    {
+                        string s = Group.ToString("x4");
+                        string x = String.Empty;
+                        x += ((Mask & 0xf0000000) != 0) ? s[0] : 'x';
+                        x += ((Mask & 0x0f000000) != 0) ? s[1] : 'x';
+                        x += ((Mask & 0x00f00000) != 0) ? s[2] : 'x';
+                        x += ((Mask & 0x000f0000) != 0) ? s[3] : 'x';
+                        return x;
+                    }
+                case "e":
+                    {
+                        string s = Element.ToString("x4");
+                        string x = String.Empty;
+                        x += ((Mask & 0x0000f000) != 0) ? s[0] : 'x';
+                        x += ((Mask & 0x00000f00) != 0) ? s[1] : 'x';
+                        x += ((Mask & 0x000000f0) != 0) ? s[2] : 'x';
+                        x += ((Mask & 0x0000000f) != 0) ? s[3] : 'x';
+                        return x;
+                    }
+                case "G":
+                default:
+                    {
+                        return String.Format("({0},{1})", this.ToString("g", null), this.ToString("e", null));
+                    }
+            }
+        }
 
-		public static DicomMaskedTag Parse(string s) {
-			try {
-				if (s.Length < 8)
-					throw new ArgumentOutOfRangeException("s", "Expected a string of 8 or more characters");
+        public bool IsMatch(DicomTag tag)
+        {
+            return Card == ((((uint)tag.Group << 16) | (uint)tag.Element) & Mask);
+        }
 
-				int pos = 0;
-				if (s[pos] == '(')
-					pos++;
+        public static DicomMaskedTag Parse(string s)
+        {
+            try
+            {
+                if (s.Length < 8) throw new ArgumentOutOfRangeException("s", "Expected a string of 8 or more characters");
 
-				int idx = s.IndexOf(',');
-				if (idx == -1)
-					idx = pos + 4;
+                int pos = 0;
+                if (s[pos] == '(') pos++;
 
-				string group = s.Substring(pos, idx - pos);
+                int idx = s.IndexOf(',');
+                if (idx == -1) idx = pos + 4;
 
-				pos = idx + 1;
+                string group = s.Substring(pos, idx - pos);
 
-				string element = null;
-				if (s[s.Length - 1] == ')')
-					element = s.Substring(pos, s.Length - pos - 1);
-				else
-					element = s.Substring(pos);
+                pos = idx + 1;
 
-				return Parse(group, element);
-			} catch (Exception e) {
-				if (e is DicomDataException)
-					throw;
-				else
-					throw new DicomDataException("Error parsing masked DICOM tag ['" + s + "']", e);
-			}
-		}
+                string element = null;
+                if (s[s.Length - 1] == ')') element = s.Substring(pos, s.Length - pos - 1);
+                else element = s.Substring(pos);
 
-		public static DicomMaskedTag Parse(string group, string element) {
-			try {
-				DicomMaskedTag tag = new DicomMaskedTag();
+                return Parse(group, element);
+            }
+            catch (Exception e)
+            {
+                if (e is DicomDataException) throw;
+                else throw new DicomDataException("Error parsing masked DICOM tag ['" + s + "']", e);
+            }
+        }
 
-				ushort g = ushort.Parse(group.ToLower().Replace('x', '0'), NumberStyles.HexNumber);
-				ushort e = ushort.Parse(element.ToLower().Replace('x', '0'), NumberStyles.HexNumber);
-				tag.Tag = new DicomTag(g, e);
+        public static DicomMaskedTag Parse(string group, string element)
+        {
+            try
+            {
+                DicomMaskedTag tag = new DicomMaskedTag();
 
-				string mask = group + element;
-				mask = mask.Replace('0', 'f').Replace('1', 'f').Replace('2', 'f')
-							.Replace('3', 'f').Replace('4', 'f').Replace('5', 'f')
-							.Replace('6', 'f').Replace('7', 'f').Replace('8', 'f')
-							.Replace('9', 'f').Replace('a', 'f').Replace('b', 'f')
-							.Replace('c', 'f').Replace('d', 'f').Replace('e', 'f')
-							.Replace('f', 'f').Replace('x', '0');
-				tag.Mask = uint.Parse(mask, NumberStyles.HexNumber);
+                ushort g = ushort.Parse(group.ToLower().Replace('x', '0'), NumberStyles.HexNumber);
+                ushort e = ushort.Parse(element.ToLower().Replace('x', '0'), NumberStyles.HexNumber);
+                tag.Tag = new DicomTag(g, e);
 
-				return tag;
-			} catch (Exception e) {
-				throw new DicomDataException("Error parsing masked DICOM tag [group:'" + group + "', element:'" + element +"']", e);
-			}
-		}
-	}
+                string mask = group + element;
+                mask =
+                    mask.Replace('0', 'f')
+                        .Replace('1', 'f')
+                        .Replace('2', 'f')
+                        .Replace('3', 'f')
+                        .Replace('4', 'f')
+                        .Replace('5', 'f')
+                        .Replace('6', 'f')
+                        .Replace('7', 'f')
+                        .Replace('8', 'f')
+                        .Replace('9', 'f')
+                        .Replace('a', 'f')
+                        .Replace('b', 'f')
+                        .Replace('c', 'f')
+                        .Replace('d', 'f')
+                        .Replace('e', 'f')
+                        .Replace('f', 'f')
+                        .Replace('x', '0');
+                tag.Mask = uint.Parse(mask, NumberStyles.HexNumber);
+
+                return tag;
+            }
+            catch (Exception e)
+            {
+                throw new DicomDataException(
+                    "Error parsing masked DICOM tag [group:'" + group + "', element:'" + element + "']",
+                    e);
+            }
+        }
+    }
 }

--- a/DICOM/DicomMatchRules.cs
+++ b/DICOM/DicomMatchRules.cs
@@ -1,405 +1,548 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Dicom {
-	public interface IDicomMatchRule {
-		bool Match(DicomDataset dataset);
-	}
+namespace Dicom
+{
+    public interface IDicomMatchRule
+    {
+        bool Match(DicomDataset dataset);
+    }
 
-	public enum DicomMatchOperator : byte {
-		/// <summary>All rules match</summary>
-		And,
+    public enum DicomMatchOperator : byte
+    {
+        /// <summary>All rules match</summary>
+        And,
 
-		/// <summary>Any rule matches</summary>
-		Or
-	}
+        /// <summary>Any rule matches</summary>
+        Or
+    }
 
-	public class DicomMatchRuleSet : IDicomMatchRule {
-		#region Private Members
-		private DicomMatchOperator _operator;
-		private IList<IDicomMatchRule> _rules;
-		#endregion
+    public class DicomMatchRuleSet : IDicomMatchRule
+    {
+        #region Private Members
 
-		#region Public Constructor
-		public DicomMatchRuleSet() {
-			_rules = new List<IDicomMatchRule>();
-			_operator = DicomMatchOperator.And;
-		}
+        private DicomMatchOperator _operator;
 
-		public DicomMatchRuleSet(DicomMatchOperator op) {
-			_rules = new List<IDicomMatchRule>();
-			_operator = op;
-		}
+        private IList<IDicomMatchRule> _rules;
 
-		public DicomMatchRuleSet(params IDicomMatchRule[] rules) {
-			_rules = new List<IDicomMatchRule>(rules);
-			_operator = DicomMatchOperator.And;
-		}
+        #endregion
 
-		public DicomMatchRuleSet(DicomMatchOperator op, params IDicomMatchRule[] rules) {
-			_rules = new List<IDicomMatchRule>(rules);
-			_operator = op;
-		}
-		#endregion
+        #region Public Constructor
 
-		#region Public Properties
-		public DicomMatchOperator Operator {
-			get { return _operator; }
-			set { _operator = value; }
-		}
-		#endregion
+        public DicomMatchRuleSet()
+        {
+            _rules = new List<IDicomMatchRule>();
+            _operator = DicomMatchOperator.And;
+        }
 
-		#region Public Methods
-		public void Add(IDicomMatchRule rule) {
-			_rules.Add(rule);
-		}
+        public DicomMatchRuleSet(DicomMatchOperator op)
+        {
+            _rules = new List<IDicomMatchRule>();
+            _operator = op;
+        }
 
-		public bool Match(DicomDataset dataset) {
-			if (_rules.Count == 0)
-				return true;
+        public DicomMatchRuleSet(params IDicomMatchRule[] rules)
+        {
+            _rules = new List<IDicomMatchRule>(rules);
+            _operator = DicomMatchOperator.And;
+        }
 
-			if (_operator == DicomMatchOperator.Or) {
-				foreach (var rule in _rules)
-					if (rule.Match(dataset))
-						return true;
+        public DicomMatchRuleSet(DicomMatchOperator op, params IDicomMatchRule[] rules)
+        {
+            _rules = new List<IDicomMatchRule>(rules);
+            _operator = op;
+        }
 
-				return false;
-			} else {
-				foreach (var rule in _rules)
-					if (!rule.Match(dataset))
-						return false;
+        #endregion
 
-				return true;
-			}
-		}
+        #region Public Properties
 
-		public override string ToString() {
-			var sb = new StringBuilder();
-			foreach (IDicomMatchRule rule in _rules) {
-				if (sb.Length > 0)
-					sb.Append("  ").Append(Operator.ToString().ToUpper()).Append(" ");
-				if (rule is DicomMatchRuleSet)
-					sb.Append("(").AppendLine(rule.ToString()).AppendLine(")");
-				else
-					sb.Append(rule.ToString());
-			}
-			return sb.ToString();
-		}
-		#endregion
-	}
+        public DicomMatchOperator Operator
+        {
+            get
+            {
+                return _operator;
+            }
+            set
+            {
+                _operator = value;
+            }
+        }
 
-	/// <summary>
-	/// Negates the return value of a match rule.
-	/// </summary>
-	public class NegateDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private IDicomMatchRule _rule;
-		#endregion
+        #endregion
 
-		#region Public Constructor
-		public NegateDicomMatchRule(IDicomMatchRule rule) {
-			_rule = rule;
-		}
-		#endregion
+        #region Public Methods
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			return !_rule.Match(dataset);
-		}
+        public void Add(IDicomMatchRule rule)
+        {
+            _rules.Add(rule);
+        }
 
-		public override string ToString() {
-			return String.Format("not {0}", _rule);
-		}
-		#endregion
-	}
+        public bool Match(DicomDataset dataset)
+        {
+            if (_rules.Count == 0) return true;
 
-	/// <summary>
-	/// Checks that a DICOM element exists.
-	/// </summary>
-	public class ExistsDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		#endregion
+            if (_operator == DicomMatchOperator.Or)
+            {
+                foreach (var rule in _rules) if (rule.Match(dataset)) return true;
 
-		#region Public Constructor
-		public ExistsDicomMatchRule(DicomTag tag) {
-			_tag = tag;
-		}
-		#endregion
+                return false;
+            }
+            else
+            {
+                foreach (var rule in _rules) if (!rule.Match(dataset)) return false;
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			return dataset.Contains(_tag);
-		}
+                return true;
+            }
+        }
 
-		public override string ToString() {
-			return String.Format("{0} exists", _tag);
-		}
-		#endregion
-	}
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            foreach (IDicomMatchRule rule in _rules)
+            {
+                if (sb.Length > 0) sb.Append("  ").Append(Operator.ToString().ToUpper()).Append(" ");
+                if (rule is DicomMatchRuleSet) sb.Append("(").AppendLine(rule.ToString()).AppendLine(")");
+                else sb.Append(rule.ToString());
+            }
+            return sb.ToString();
+        }
 
-	/// <summary>
-	/// Checks if a DICOM element exists and has a value.
-	/// </summary>
-	public class IsEmptyDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		#endregion
+        #endregion
+    }
 
-		#region Public Constructor
-		public IsEmptyDicomMatchRule(DicomTag tag) {
-			_tag = tag;
-		}
-		#endregion
+    /// <summary>
+    /// Negates the return value of a match rule.
+    /// </summary>
+    public class NegateDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			if (dataset.Contains(_tag)) {
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				return String.IsNullOrEmpty(value);
-			}
-			return true;
-		}
+        private IDicomMatchRule _rule;
 
-		public override string ToString() {
-			return String.Format("{0} is empty", _tag);
-		}
-		#endregion
-	}
+        #endregion
 
-	/// <summary>
-	/// Compares a DICOM element value against a string.
-	/// </summary>
-	public class EqualsDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _value;
-		#endregion
+        #region Public Constructor
 
-		#region Public Constructor
-		public EqualsDicomMatchRule(DicomTag tag, string value) {
-			_tag = tag;
-			_value = value;
-		}
-		#endregion
+        public NegateDicomMatchRule(IDicomMatchRule rule)
+        {
+            _rule = rule;
+        }
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			var value = dataset.Get<string>(_tag, -1, String.Empty);
-			return _value == value;
-		}
+        #endregion
 
-		public override string ToString() {
-			return String.Format("{0} equals '{1}'", _tag, _value);
-		}
-		#endregion
-	}
+        #region Public Methods
 
-	/// <summary>
-	/// Checks if a DICOM element value starts with a string.
-	/// </summary>
-	public class StartsWithDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _value;
-		#endregion
+        public bool Match(DicomDataset dataset)
+        {
+            return !_rule.Match(dataset);
+        }
 
-		#region Public Constructor
-		public StartsWithDicomMatchRule(DicomTag tag, string value) {
-			_tag = tag;
-			_value = value;
-		}
-		#endregion
+        public override string ToString()
+        {
+            return String.Format("not {0}", _rule);
+        }
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			var value = dataset.Get<string>(_tag, -1, String.Empty);
-			return value.StartsWith(_value);
-		}
+        #endregion
+    }
 
-		public override string ToString() {
-			return String.Format("{0} starts with '{1}'", _tag, _value);
-		}
-		#endregion
-	}
+    /// <summary>
+    /// Checks that a DICOM element exists.
+    /// </summary>
+    public class ExistsDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
 
-	/// <summary>
-	/// Checks if a DICOM element value ends with a string.
-	/// </summary>
-	public class EndsWithDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _value;
-		#endregion
+        private DicomTag _tag;
 
-		#region Public Constructor
-		public EndsWithDicomMatchRule(DicomTag tag, string value) {
-			_tag = tag;
-			_value = value;
-		}
-		#endregion
+        #endregion
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			var value = dataset.Get<string>(_tag, -1, String.Empty);
-			return value.EndsWith(_value);
-		}
+        #region Public Constructor
 
-		public override string ToString() {
-			return String.Format("{0} ends with '{1}'", _tag, _value);
-		}
-		#endregion
-	}
+        public ExistsDicomMatchRule(DicomTag tag)
+        {
+            _tag = tag;
+        }
 
-	/// <summary>
-	/// Checks if a DICOM element value contains a string.
-	/// </summary>
-	public class ContainsDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _value;
-		#endregion
+        #endregion
 
-		#region Public Constructor
-		public ContainsDicomMatchRule(DicomTag tag, string value) {
-			_tag = tag;
-			_value = value;
-		}
-		#endregion
+        #region Public Methods
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			var value = dataset.Get<string>(_tag, -1, String.Empty);
-			return value.Contains(_value);
-		}
+        public bool Match(DicomDataset dataset)
+        {
+            return dataset.Contains(_tag);
+        }
 
-		public override string ToString() {
-			return String.Format("{0} contains '{1}'", _tag, _value);
-		}
-		#endregion
-	}
+        public override string ToString()
+        {
+            return String.Format("{0} exists", _tag);
+        }
 
-	/// <summary>
-	/// Matches a wildcard pattern against a DICOM element value.
-	/// </summary>
-	public class WildcardDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _pattern;
-		#endregion
+        #endregion
+    }
 
-		#region Public Constructor
-		public WildcardDicomMatchRule(DicomTag tag, string pattern) {
-			_tag = tag;
-			_pattern = pattern;
-		}
-		#endregion
+    /// <summary>
+    /// Checks if a DICOM element exists and has a value.
+    /// </summary>
+    public class IsEmptyDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			var value = dataset.Get<string>(_tag, -1, String.Empty);
-			return value.Wildcard(_pattern);
-		}
+        private DicomTag _tag;
 
-		public override string ToString() {
-			return String.Format("{0} wildcard match '{1}'", _tag, _pattern);
-		}
-		#endregion
-	}
+        #endregion
 
-	/// <summary>
-	/// Matches regular expression pattern against a DICOM element value.
-	/// </summary>
-	public class RegexDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _pattern;
-		private Regex _regex;
-		#endregion
+        #region Public Constructor
 
-		#region Public Constructor
-		public RegexDicomMatchRule(DicomTag tag, string pattern) {
-			_tag = tag;
-			_pattern = pattern;
-			_regex = new Regex(_pattern, RegexOptions.Compiled);
-		}
-		#endregion
+        public IsEmptyDicomMatchRule(DicomTag tag)
+        {
+            _tag = tag;
+        }
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			var value = dataset.Get<string>(_tag, -1, String.Empty);
-			return _regex.IsMatch(value);
-		}
+        #endregion
 
-		public override string ToString() {
-			return String.Format("{0} regex match '{1}'", _tag, _pattern);
-		}
-		#endregion
-	}
+        #region Public Methods
 
-	/// <summary>
-	/// Matches a DICOM element value against a set of strings.
-	/// </summary>
-	public class OneOfDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string[] _values;
-		#endregion
+        public bool Match(DicomDataset dataset)
+        {
+            if (dataset.Contains(_tag))
+            {
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                return String.IsNullOrEmpty(value);
+            }
+            return true;
+        }
 
-		#region Public Constructor
-		public OneOfDicomMatchRule(DicomTag tag, params string[] values) {
-			_tag = tag;
-			_values = values;
-		}
-		#endregion
+        public override string ToString()
+        {
+            return String.Format("{0} is empty", _tag);
+        }
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			var value = dataset.Get<string>(_tag, -1, String.Empty);
-			foreach (string v in _values)
-				if (v == value)
-					return true;
-			return false;
-		}
+        #endregion
+    }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} is one of ['", _tag);
-			for (int i = 0; i < _values.Length; i++) {
-				if (i > 0)
-					sb.Append("', '");
-				sb.Append(_values[i]);
-			}
-			sb.Append("']");
-			return sb.ToString();
-		}
-		#endregion
-	}
+    /// <summary>
+    /// Compares a DICOM element value against a string.
+    /// </summary>
+    public class EqualsDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
 
-	/// <summary>
-	/// Rule that always returns true or false.
-	/// </summary>
-	public class BoolDicomMatchRule : IDicomMatchRule {
-		#region Private Members
-		private bool _value;
-		#endregion
+        private DicomTag _tag;
 
-		#region Public Constructor
-		public BoolDicomMatchRule(bool value) {
-			_value = value;
-		}
-		#endregion
+        private string _value;
 
-		#region Public Methods
-		public bool Match(DicomDataset dataset) {
-			return _value;
-		}
+        #endregion
 
-		public override string ToString() {
-			return _value.ToString();
-		}
-		#endregion
-	}
+        #region Public Constructor
+
+        public EqualsDicomMatchRule(DicomTag tag, string value)
+        {
+            _tag = tag;
+            _value = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            var value = dataset.Get<string>(_tag, -1, String.Empty);
+            return _value == value;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} equals '{1}'", _tag, _value);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Checks if a DICOM element value starts with a string.
+    /// </summary>
+    public class StartsWithDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _value;
+
+        #endregion
+
+        #region Public Constructor
+
+        public StartsWithDicomMatchRule(DicomTag tag, string value)
+        {
+            _tag = tag;
+            _value = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            var value = dataset.Get<string>(_tag, -1, String.Empty);
+            return value.StartsWith(_value);
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} starts with '{1}'", _tag, _value);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Checks if a DICOM element value ends with a string.
+    /// </summary>
+    public class EndsWithDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _value;
+
+        #endregion
+
+        #region Public Constructor
+
+        public EndsWithDicomMatchRule(DicomTag tag, string value)
+        {
+            _tag = tag;
+            _value = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            var value = dataset.Get<string>(_tag, -1, String.Empty);
+            return value.EndsWith(_value);
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} ends with '{1}'", _tag, _value);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Checks if a DICOM element value contains a string.
+    /// </summary>
+    public class ContainsDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _value;
+
+        #endregion
+
+        #region Public Constructor
+
+        public ContainsDicomMatchRule(DicomTag tag, string value)
+        {
+            _tag = tag;
+            _value = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            var value = dataset.Get<string>(_tag, -1, String.Empty);
+            return value.Contains(_value);
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} contains '{1}'", _tag, _value);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Matches a wildcard pattern against a DICOM element value.
+    /// </summary>
+    public class WildcardDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _pattern;
+
+        #endregion
+
+        #region Public Constructor
+
+        public WildcardDicomMatchRule(DicomTag tag, string pattern)
+        {
+            _tag = tag;
+            _pattern = pattern;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            var value = dataset.Get<string>(_tag, -1, String.Empty);
+            return value.Wildcard(_pattern);
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} wildcard match '{1}'", _tag, _pattern);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Matches regular expression pattern against a DICOM element value.
+    /// </summary>
+    public class RegexDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _pattern;
+
+        private Regex _regex;
+
+        #endregion
+
+        #region Public Constructor
+
+        public RegexDicomMatchRule(DicomTag tag, string pattern)
+        {
+            _tag = tag;
+            _pattern = pattern;
+            _regex = new Regex(_pattern, RegexOptions.Compiled);
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            var value = dataset.Get<string>(_tag, -1, String.Empty);
+            return _regex.IsMatch(value);
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} regex match '{1}'", _tag, _pattern);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Matches a DICOM element value against a set of strings.
+    /// </summary>
+    public class OneOfDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string[] _values;
+
+        #endregion
+
+        #region Public Constructor
+
+        public OneOfDicomMatchRule(DicomTag tag, params string[] values)
+        {
+            _tag = tag;
+            _values = values;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            var value = dataset.Get<string>(_tag, -1, String.Empty);
+            foreach (string v in _values) if (v == value) return true;
+            return false;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} is one of ['", _tag);
+            for (int i = 0; i < _values.Length; i++)
+            {
+                if (i > 0) sb.Append("', '");
+                sb.Append(_values[i]);
+            }
+            sb.Append("']");
+            return sb.ToString();
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Rule that always returns true or false.
+    /// </summary>
+    public class BoolDicomMatchRule : IDicomMatchRule
+    {
+        #region Private Members
+
+        private bool _value;
+
+        #endregion
+
+        #region Public Constructor
+
+        public BoolDicomMatchRule(bool value)
+        {
+            _value = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public bool Match(DicomDataset dataset)
+        {
+            return _value;
+        }
+
+        public override string ToString()
+        {
+            return _value.ToString();
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/DicomParseable.cs
+++ b/DICOM/DicomParseable.cs
@@ -1,16 +1,20 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
-namespace Dicom {
-	public abstract class DicomParseable {
-		public static T Parse<T>(string value) {
-			if (!typeof(T).IsSubclassOf(typeof(DicomParseable)))
-				throw new DicomDataException("DicomParseable.Parse expects a class derived from DicomParseable");
+namespace Dicom
+{
+    public abstract class DicomParseable
+    {
+        public static T Parse<T>(string value)
+        {
+            if (!typeof(T).IsSubclassOf(typeof(DicomParseable))) throw new DicomDataException("DicomParseable.Parse expects a class derived from DicomParseable");
 
-			Type t = typeof(T);
-			MethodInfo m = typeof(T).GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
-			return (T)m.Invoke(null, new object[] { value });
-		}
-	}
+            Type t = typeof(T);
+            MethodInfo m = typeof(T).GetMethod("Parse", BindingFlags.Public | BindingFlags.Static);
+            return (T)m.Invoke(null, new object[] { value });
+        }
+    }
 }

--- a/DICOM/DicomPrivateCreator.cs
+++ b/DICOM/DicomPrivateCreator.cs
@@ -1,54 +1,57 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
+using System;
+using System.Runtime.Serialization;
+
+namespace Dicom
+{
     [DataContract]
-	public sealed class DicomPrivateCreator : IEquatable<DicomPrivateCreator>, IComparable<DicomPrivateCreator>, IComparable {
-		internal DicomPrivateCreator(string creator) {
-			this.Creator = creator;
-		}
+    public sealed class DicomPrivateCreator : IEquatable<DicomPrivateCreator>,
+                                              IComparable<DicomPrivateCreator>,
+                                              IComparable
+    {
+        internal DicomPrivateCreator(string creator)
+        {
+            this.Creator = creator;
+        }
 
         [DataMember]
-		public string Creator {
-			get;
-			private set;
-		}
+        public string Creator { get; private set; }
 
-		public int CompareTo(DicomPrivateCreator other) {
-			return Creator.CompareTo(other.Creator);
-		}
+        public int CompareTo(DicomPrivateCreator other)
+        {
+            return Creator.CompareTo(other.Creator);
+        }
 
-		public int CompareTo(object obj) {
-			if (obj == null)
-				throw new ArgumentNullException("obj");
-			if (!(obj is DicomPrivateCreator))
-				throw new ArgumentException("Passed non-DicomPrivateCreator to comparer", "obj");
-			return CompareTo(obj as DicomPrivateCreator);
-		}
+        public int CompareTo(object obj)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            if (!(obj is DicomPrivateCreator)) throw new ArgumentException("Passed non-DicomPrivateCreator to comparer", "obj");
+            return CompareTo(obj as DicomPrivateCreator);
+        }
 
-		public override bool Equals(object obj) {
-			if (Object.ReferenceEquals(obj, null))
-				return false;
-			if (Object.ReferenceEquals(this, obj))
-				return true;
-			if (this.GetType() != obj.GetType())
-				return false;
-			return Equals(obj as DicomPrivateCreator);
-		}
+        public override bool Equals(object obj)
+        {
+            if (Object.ReferenceEquals(obj, null)) return false;
+            if (Object.ReferenceEquals(this, obj)) return true;
+            if (this.GetType() != obj.GetType()) return false;
+            return Equals(obj as DicomPrivateCreator);
+        }
 
-		public bool Equals(DicomPrivateCreator other) {
-			return CompareTo(other) == 0;
-		}
+        public bool Equals(DicomPrivateCreator other)
+        {
+            return CompareTo(other) == 0;
+        }
 
-		public override int GetHashCode() {
-			return Creator.GetHashCode();
-		}
+        public override int GetHashCode()
+        {
+            return Creator.GetHashCode();
+        }
 
-		public override string ToString() {
-			return Creator;
-		}
-	}
+        public override string ToString()
+        {
+            return Creator;
+        }
+    }
 }

--- a/DICOM/DicomRange.cs
+++ b/DICOM/DicomRange.cs
@@ -1,27 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public class DicomRange<T> where T : IComparable<T> {
-		public DicomRange(T min, T max) {
-			Minimum = min;
-			Maximum = max;
-		}
+using System;
 
-		public T Minimum {
-			get;
-			set;
-		}
+namespace Dicom
+{
+    public class DicomRange<T>
+        where T : IComparable<T>
+    {
+        public DicomRange(T min, T max)
+        {
+            Minimum = min;
+            Maximum = max;
+        }
 
-		public T Maximum {
-			get;
-			set;
-		}
+        public T Minimum { get; set; }
 
-		public bool Contains(T value) {
-			return Minimum.CompareTo(value) <= 0 && Maximum.CompareTo(value) >= 0;
-		}
-	}
+        public T Maximum { get; set; }
+
+        public bool Contains(T value)
+        {
+            return Minimum.CompareTo(value) <= 0 && Maximum.CompareTo(value) >= 0;
+        }
+    }
 }

--- a/DICOM/DicomSequence.cs
+++ b/DICOM/DicomSequence.cs
@@ -1,28 +1,44 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 
-namespace Dicom {
-	public class DicomSequence : DicomItem, IEnumerable<DicomDataset> {
-		private IList<DicomDataset> _items;
+namespace Dicom
+{
+    public class DicomSequence : DicomItem, IEnumerable<DicomDataset>
+    {
+        private IList<DicomDataset> _items;
 
-		public DicomSequence(DicomTag tag, params DicomDataset[] items) : base(tag) {
-			_items = new List<DicomDataset>(items);
-		}
+        public DicomSequence(DicomTag tag, params DicomDataset[] items)
+            : base(tag)
+        {
+            _items = new List<DicomDataset>(items);
+        }
 
-		public override DicomVR ValueRepresentation {
-			get { return DicomVR.SQ; }
-		}
+        public override DicomVR ValueRepresentation
+        {
+            get
+            {
+                return DicomVR.SQ;
+            }
+        }
 
-		public IList<DicomDataset> Items {
-			get { return _items; }
-		}
+        public IList<DicomDataset> Items
+        {
+            get
+            {
+                return _items;
+            }
+        }
 
-		public IEnumerator<DicomDataset> GetEnumerator() {
-			return _items.GetEnumerator();
-		}
+        public IEnumerator<DicomDataset> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
 
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-			return _items.GetEnumerator();
-		}
-	}
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+    }
 }

--- a/DICOM/DicomTag.cs
+++ b/DICOM/DicomTag.cs
@@ -1,207 +1,207 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Globalization;
 
 using Dicom.Imaging.Mathematics;
 
-namespace Dicom {
-	/// <summary>
-	/// DICOM Tag
-	/// </summary>
-	public sealed partial class DicomTag : IFormattable, IEquatable<DicomTag>, IComparable<DicomTag>, IComparable {
-		public readonly static DicomTag Unknown = new DicomTag(0xffff, 0xffff);
+namespace Dicom
+{
+    /// <summary>
+    /// DICOM Tag
+    /// </summary>
+    public sealed partial class DicomTag : IFormattable, IEquatable<DicomTag>, IComparable<DicomTag>, IComparable
+    {
+        public static readonly DicomTag Unknown = new DicomTag(0xffff, 0xffff);
 
-		public DicomTag(ushort group, ushort element) {
-			Group = group;
-			Element = element;
-		}
+        public DicomTag(ushort group, ushort element)
+        {
+            Group = group;
+            Element = element;
+        }
 
-		public DicomTag(ushort group, ushort element, string privateCreator) : this(group, element, DicomDictionary.Default.GetPrivateCreator(privateCreator)) {
-		}
+        public DicomTag(ushort group, ushort element, string privateCreator)
+            : this(group, element, DicomDictionary.Default.GetPrivateCreator(privateCreator))
+        {
+        }
 
-		public DicomTag(ushort group, ushort element, DicomPrivateCreator privateCreator) {
-			Group = group;
-			Element = element;
-			PrivateCreator = privateCreator;
-		}
+        public DicomTag(ushort group, ushort element, DicomPrivateCreator privateCreator)
+        {
+            Group = group;
+            Element = element;
+            PrivateCreator = privateCreator;
+        }
 
-		public ushort Group {
-			get;
-			private set;
-		}
+        public ushort Group { get; private set; }
 
-		public ushort Element {
-			get;
-			private set;
-		}
+        public ushort Element { get; private set; }
 
-		public bool IsPrivate {
-			get { return Group.IsOdd(); }
-		}
+        public bool IsPrivate
+        {
+            get
+            {
+                return Group.IsOdd();
+            }
+        }
 
-		public DicomPrivateCreator PrivateCreator {
-			get;
-			internal set;
-		}
+        public DicomPrivateCreator PrivateCreator { get; internal set; }
 
-		public DicomDictionaryEntry DictionaryEntry {
-			get {
-				return DicomDictionary.Default[this];
-			}
-		}
+        public DicomDictionaryEntry DictionaryEntry
+        {
+            get
+            {
+                return DicomDictionary.Default[this];
+            }
+        }
 
-		public override string ToString() {
-			return ToString("G", null);
-		}
+        public override string ToString()
+        {
+            return ToString("G", null);
+        }
 
-		public string ToString(string format, IFormatProvider formatProvider) {
-			if (formatProvider != null) {
-				ICustomFormatter fmt = formatProvider.GetFormat(this.GetType()) as ICustomFormatter;
-				if (fmt != null)
-					return fmt.Format(format, this, formatProvider);
-			}
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (formatProvider != null)
+            {
+                ICustomFormatter fmt = formatProvider.GetFormat(this.GetType()) as ICustomFormatter;
+                if (fmt != null) return fmt.Format(format, this, formatProvider);
+            }
 
-			switch (format) {
-			case "X": {
-				if (PrivateCreator != null)
-					return String.Format("({0:x4},xx{1:x2}:{2})", Group, Element & 0xff, PrivateCreator.Creator);
-				else
-					return String.Format("({0:x4},{1:x4})", Group, Element);
-			}
-			case "g": {
-					if (PrivateCreator != null)
-						return String.Format("{0:x4},{1:x4}:{2}", Group, Element, PrivateCreator.Creator);
-					else
-						return String.Format("{0:x4},{1:x4}", Group, Element);
-				}
-            case "J": {
+            switch (format)
+            {
+                case "X":
+                    {
+                        if (PrivateCreator != null) return String.Format("({0:x4},xx{1:x2}:{2})", Group, Element & 0xff, PrivateCreator.Creator);
+                        else return String.Format("({0:x4},{1:x4})", Group, Element);
+                    }
+                case "g":
+                    {
+                        if (PrivateCreator != null) return String.Format("{0:x4},{1:x4}:{2}", Group, Element, PrivateCreator.Creator);
+                        else return String.Format("{0:x4},{1:x4}", Group, Element);
+                    }
+                case "J":
+                    {
                         return String.Format("{0:X4}{1:X4}", Group, Element);
+                    }
+                case "G":
+                default:
+                    {
+                        if (PrivateCreator != null) return String.Format("({0:x4},{1:x4}:{2})", Group, Element, PrivateCreator.Creator);
+                        else return String.Format("({0:x4},{1:x4})", Group, Element);
+                    }
+            }
+        }
+
+        public int CompareTo(DicomTag other)
+        {
+            if (Group != other.Group) return Group.CompareTo(other.Group);
+
+            if (Element != other.Element) return Element.CompareTo(other.Element);
+
+            // sort by private creator only if element values are equal
+            if (PrivateCreator != null || other.PrivateCreator != null)
+            {
+                if (PrivateCreator == null) return -1;
+                if (other.PrivateCreator == null) return 1;
+
+                if (PrivateCreator != other.PrivateCreator) return PrivateCreator.CompareTo(other.PrivateCreator);
+            }
+
+            return 0;
+        }
+
+        public int CompareTo(object obj)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            if (!(obj is DicomTag)) throw new ArgumentException("Passed non-DicomTag to comparer", "obj");
+            return CompareTo(obj as DicomTag);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(obj, null)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (GetType() != obj.GetType()) return false;
+            return Equals(obj as DicomTag);
+        }
+
+        public bool Equals(DicomTag other)
+        {
+            if (ReferenceEquals(other, null)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            if (Group != other.Group) return false;
+
+            if (PrivateCreator != null || other.PrivateCreator != null)
+            {
+                if (PrivateCreator == null || other.PrivateCreator == null) return false;
+
+                if (PrivateCreator.Creator != other.PrivateCreator.Creator) return false;
+
+                return (Element & 0xff) == (other.Element & 0xff);
+            }
+
+            return Element == other.Element;
+        }
+
+        public static bool operator ==(DicomTag a, DicomTag b)
+        {
+            if (((object)a == null) && ((object)b == null)) return true;
+            if (((object)a == null) || ((object)b == null)) return false;
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(DicomTag a, DicomTag b)
+        {
+            return !(a == b);
+        }
+
+        private int _hash = 0;
+
+        public override int GetHashCode()
+        {
+            if (_hash == 0) _hash = ToString("X", null).GetHashCode();
+            return _hash;
+        }
+
+        public static DicomTag Parse(string s)
+        {
+            try
+            {
+                if (s.Length < 8) throw new ArgumentOutOfRangeException("s", "Expected a string of 8 or more characters");
+
+                int pos = 0;
+                if (s[pos] == '(') pos++;
+
+                ushort group = ushort.Parse(s.Substring(pos, 4), NumberStyles.HexNumber);
+                pos += 4;
+
+                if (s[pos] == ',') pos++;
+
+                ushort element = ushort.Parse(s.Substring(pos, 4), NumberStyles.HexNumber);
+                pos += 4;
+
+                DicomPrivateCreator creator = null;
+                if (s.Length > pos && s[pos] == ':')
+                {
+                    pos++;
+
+                    string c = null;
+                    if (s[s.Length - 1] == ')') c = s.Substring(pos, s.Length - pos - 1);
+                    else c = s.Substring(pos);
+
+                    creator = DicomDictionary.Default.GetPrivateCreator(c);
                 }
-			case "G":
-			default: {
-				if (PrivateCreator != null)
-					return String.Format("({0:x4},{1:x4}:{2})", Group, Element, PrivateCreator.Creator);
-				else
-					return String.Format("({0:x4},{1:x4})", Group, Element);
-				}
-			}
-		}
 
-		public int CompareTo(DicomTag other) {
-			if (Group != other.Group)
-				return Group.CompareTo(other.Group);
+                //TODO: get value from related DicomDictionaryEntry
 
-			if (Element != other.Element)
-				return Element.CompareTo(other.Element);
-
-			// sort by private creator only if element values are equal
-			if (PrivateCreator != null || other.PrivateCreator != null) {
-			    if (PrivateCreator == null)
-			        return -1;
-			    if (other.PrivateCreator == null)
-			        return 1;
-
-				if (PrivateCreator != other.PrivateCreator)
-					return PrivateCreator.CompareTo(other.PrivateCreator);
-			}
-
-			return 0;
-		}
-
-		public int CompareTo(object obj) {
-			if (obj == null)
-				throw new ArgumentNullException("obj");
-			if (!(obj is DicomTag))
-				throw new ArgumentException("Passed non-DicomTag to comparer", "obj");
-			return CompareTo(obj as DicomTag);
-		}
-
-		public override bool Equals(object obj) {
-			if (ReferenceEquals(obj, null))
-				return false;
-			if (ReferenceEquals(this, obj))
-				return true;
-			if (GetType() != obj.GetType())
-				return false;
-			return Equals(obj as DicomTag);
-		}
-
-		public bool Equals(DicomTag other) {
-			if (ReferenceEquals(other, null))
-				return false;
-			if (ReferenceEquals(this, other))
-				return true;
-
-			if (Group != other.Group)
-				return false;
-
-			if (PrivateCreator != null || other.PrivateCreator != null) {
-				if (PrivateCreator == null || other.PrivateCreator == null)
-					return false;
-
-				if (PrivateCreator.Creator != other.PrivateCreator.Creator)
-					return false;
-
-				return (Element & 0xff) == (other.Element & 0xff);
-			}
-
-			return Element == other.Element;
-		}
-
-		public static bool operator ==(DicomTag a, DicomTag b) {
-			if (((object)a == null) && ((object)b == null))
-				return true;
-			if (((object)a == null) || ((object)b == null))
-				return false;
-			return a.Equals(b);
-		}
-
-		public static bool operator !=(DicomTag a, DicomTag b) {
-			return !(a == b);
-		}
-
-		private int _hash = 0;
-
-		public override int GetHashCode() {
-			if (_hash == 0)
-				_hash = ToString("X", null).GetHashCode();
-			return _hash;
-		}
-
-		public static DicomTag Parse(string s) {
-			try {
-				if (s.Length < 8)
-					throw new ArgumentOutOfRangeException("s", "Expected a string of 8 or more characters");
-
-				int pos = 0;
-				if (s[pos] == '(')
-					pos++;
-
-				ushort group = ushort.Parse(s.Substring(pos, 4), NumberStyles.HexNumber); pos += 4;
-
-				if (s[pos] == ',')
-					pos++;
-
-				ushort element = ushort.Parse(s.Substring(pos, 4), NumberStyles.HexNumber); pos += 4;
-
-				DicomPrivateCreator creator = null;
-				if (s.Length > pos && s[pos] == ':') {
-					pos++;
-
-					string c = null;
-					if (s[s.Length - 1] == ')')
-						c = s.Substring(pos, s.Length - pos - 1);
-					else
-						c = s.Substring(pos);
-
-					creator = DicomDictionary.Default.GetPrivateCreator(c);
-				}
-
-				//TODO: get value from related DicomDictionaryEntry
-
-				return new DicomTag(group, element, creator);
-			} catch (Exception e) {
-				throw new DicomDataException("Error parsing DICOM tag ['" + s + "']", e);
-			}
-		}
-	}
+                return new DicomTag(group, element, creator);
+            }
+            catch (Exception e)
+            {
+                throw new DicomDataException("Error parsing DICOM tag ['" + s + "']", e);
+            }
+        }
+    }
 }

--- a/DICOM/DicomTransferSyntax.cs
+++ b/DICOM/DicomTransferSyntax.cs
@@ -1,426 +1,522 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using Dicom.IO;
 
-namespace Dicom {
-	public class DicomTransferSyntax : DicomParseable {
-		private DicomTransferSyntax() {
-		}
+namespace Dicom
+{
+    public class DicomTransferSyntax : DicomParseable
+    {
+        private DicomTransferSyntax()
+        {
+        }
 
-		public DicomUID UID {
-			get;
-			private set;
-		}
+        public DicomUID UID { get; private set; }
 
-		public bool IsRetired {
-			get;
-			private set;
-		}
+        public bool IsRetired { get; private set; }
 
-		public bool IsExplicitVR {
-			get;
-			private set;
-		}
+        public bool IsExplicitVR { get; private set; }
 
-		public bool IsEncapsulated {
-			get;
-			private set;
-		}
+        public bool IsEncapsulated { get; private set; }
 
-		public bool IsLossy {
-			get;
-			private set;
-		}
+        public bool IsLossy { get; private set; }
 
-		public string LossyCompressionMethod {
-			get;
-			private set;
-		}
+        public string LossyCompressionMethod { get; private set; }
 
-		public bool IsDeflate {
-			get;
-			private set;
-		}
+        public bool IsDeflate { get; private set; }
 
-		public Endian Endian {
-			get;
-			private set;
-		}
+        public Endian Endian { get; private set; }
 
-		public bool SwapPixelData {
-			get;
-			private set;
-		}
+        public bool SwapPixelData { get; private set; }
 
-		public override string ToString() {
-			return UID.Name;
-		}
+        public override string ToString()
+        {
+            return UID.Name;
+        }
 
-		public override bool Equals(object obj) {
-			if (obj is DicomTransferSyntax)
-				return ((DicomTransferSyntax)obj).UID.Equals(UID);
-			if (obj is DicomUID)
-				return ((DicomUID)obj).Equals(UID);
-			if (obj is String)
-				return UID.Equals((String)obj);
-			return false;
-		}
+        public override bool Equals(object obj)
+        {
+            if (obj is DicomTransferSyntax) return ((DicomTransferSyntax)obj).UID.Equals(UID);
+            if (obj is DicomUID) return ((DicomUID)obj).Equals(UID);
+            if (obj is String) return UID.Equals((String)obj);
+            return false;
+        }
 
-		public override int GetHashCode() {
-			return base.GetHashCode();
-		}
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
 
-		public static bool operator ==(DicomTransferSyntax a, DicomTransferSyntax b) {
-			if (((object)a == null) && ((object)b == null))
-				return true;
-			if (((object)a == null) || ((object)b == null))
-				return false;
-			return a.UID == b.UID;
-		}
-		public static bool operator !=(DicomTransferSyntax a, DicomTransferSyntax b) {
-			return !(a == b);
-		}
+        public static bool operator ==(DicomTransferSyntax a, DicomTransferSyntax b)
+        {
+            if (((object)a == null) && ((object)b == null)) return true;
+            if (((object)a == null) || ((object)b == null)) return false;
+            return a.UID == b.UID;
+        }
 
-		#region Dicom Transfer Syntax
-		/// <summary>Virtual transfer syntax for reading datasets improperly encoded in Big Endian format with implicit VR.</summary>
-		public static DicomTransferSyntax ImplicitVRBigEndian = new DicomTransferSyntax {
-			UID = new DicomUID(DicomUID.ExplicitVRBigEndianRETIRED.UID + ".123456", "Implicit VR Big Endian", DicomUidType.TransferSyntax),
-			IsExplicitVR = false,
-			Endian = Endian.Big
-		};
+        public static bool operator !=(DicomTransferSyntax a, DicomTransferSyntax b)
+        {
+            return !(a == b);
+        }
 
-		/// <summary>GE Private Implicit VR Big Endian</summary>
-		/// <remarks>Same as Implicit VR Little Endian except for big endian pixel data.</remarks>
-		public static DicomTransferSyntax GEPrivateImplicitVRBigEndian = new DicomTransferSyntax {
-			UID = new DicomUID("1.2.840.113619.5.2", "GE Private Implicit VR Big Endian", DicomUidType.TransferSyntax),
-			IsExplicitVR = false,
-			Endian = Endian.Little,
-			SwapPixelData = true
-		};
+        #region Dicom Transfer Syntax
 
-		/// <summary>Implicit VR Little Endian</summary>
-		public static DicomTransferSyntax ImplicitVRLittleEndian = new DicomTransferSyntax {
-			UID = DicomUID.ImplicitVRLittleEndian,
-			Endian = Endian.Little
-		};
+        /// <summary>Virtual transfer syntax for reading datasets improperly encoded in Big Endian format with implicit VR.</summary>
+        public static DicomTransferSyntax ImplicitVRBigEndian = new DicomTransferSyntax
+                                                                    {
+                                                                        UID =
+                                                                            new DicomUID(
+                                                                            DicomUID
+                                                                                .ExplicitVRBigEndianRETIRED
+                                                                                .UID + ".123456",
+                                                                            "Implicit VR Big Endian",
+                                                                            DicomUidType
+                                                                            .TransferSyntax),
+                                                                        IsExplicitVR = false,
+                                                                        Endian = Endian.Big
+                                                                    };
 
-		/// <summary>Explicit VR Little Endian</summary>
-		public static DicomTransferSyntax ExplicitVRLittleEndian = new DicomTransferSyntax {
-			UID = DicomUID.ExplicitVRLittleEndian,
-			IsExplicitVR = true,
-			Endian = Endian.Little
-		};
+        /// <summary>GE Private Implicit VR Big Endian</summary>
+        /// <remarks>Same as Implicit VR Little Endian except for big endian pixel data.</remarks>
+        public static DicomTransferSyntax GEPrivateImplicitVRBigEndian = new DicomTransferSyntax
+                                                                             {
+                                                                                 UID =
+                                                                                     new DicomUID(
+                                                                                     "1.2.840.113619.5.2",
+                                                                                     "GE Private Implicit VR Big Endian",
+                                                                                     DicomUidType
+                                                                                     .TransferSyntax),
+                                                                                 IsExplicitVR =
+                                                                                     false,
+                                                                                 Endian =
+                                                                                     Endian.Little,
+                                                                                 SwapPixelData =
+                                                                                     true
+                                                                             };
 
-		/// <summary>Explicit VR Big Endian</summary>
-		public static DicomTransferSyntax ExplicitVRBigEndian = new DicomTransferSyntax {
-			UID = DicomUID.ExplicitVRBigEndianRETIRED,
-			IsExplicitVR = true,
-			Endian = Endian.Big
-		};
+        /// <summary>Implicit VR Little Endian</summary>
+        public static DicomTransferSyntax ImplicitVRLittleEndian = new DicomTransferSyntax
+                                                                       {
+                                                                           UID =
+                                                                               DicomUID
+                                                                               .ImplicitVRLittleEndian,
+                                                                           Endian = Endian.Little
+                                                                       };
 
-		/// <summary>Deflated Explicit VR Little Endian</summary>
-		public static DicomTransferSyntax DeflatedExplicitVRLittleEndian = new DicomTransferSyntax {
-			UID = DicomUID.DeflatedExplicitVRLittleEndian,
-			IsExplicitVR = true,
-			IsDeflate = true,
-			Endian = Endian.Little
-		};
+        /// <summary>Explicit VR Little Endian</summary>
+        public static DicomTransferSyntax ExplicitVRLittleEndian = new DicomTransferSyntax
+                                                                       {
+                                                                           UID =
+                                                                               DicomUID
+                                                                               .ExplicitVRLittleEndian,
+                                                                           IsExplicitVR = true,
+                                                                           Endian = Endian.Little
+                                                                       };
 
-		/// <summary>JPEG Baseline (Process 1)</summary>
-		public static DicomTransferSyntax JPEGProcess1 = new DicomTransferSyntax {
-			UID = DicomUID.JPEGBaseline1,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>Explicit VR Big Endian</summary>
+        public static DicomTransferSyntax ExplicitVRBigEndian = new DicomTransferSyntax
+                                                                    {
+                                                                        UID =
+                                                                            DicomUID
+                                                                            .ExplicitVRBigEndianRETIRED,
+                                                                        IsExplicitVR = true,
+                                                                        Endian = Endian.Big
+                                                                    };
 
-		/// <summary>JPEG Extended (Process 2 &amp; 4)</summary>
-		public static DicomTransferSyntax JPEGProcess2_4 = new DicomTransferSyntax {
-			UID = DicomUID.JPEGExtended24,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>Deflated Explicit VR Little Endian</summary>
+        public static DicomTransferSyntax DeflatedExplicitVRLittleEndian = new DicomTransferSyntax
+                                                                               {
+                                                                                   UID =
+                                                                                       DicomUID
+                                                                                       .DeflatedExplicitVRLittleEndian,
+                                                                                   IsExplicitVR =
+                                                                                       true,
+                                                                                   IsDeflate = true,
+                                                                                   Endian =
+                                                                                       Endian.Little
+                                                                               };
 
-		/// <summary>JPEG Extended (Process 3 &amp; 5) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess3_5Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGExtended35RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Baseline (Process 1)</summary>
+        public static DicomTransferSyntax JPEGProcess1 = new DicomTransferSyntax
+                                                             {
+                                                                 UID = DicomUID.JPEGBaseline1,
+                                                                 IsExplicitVR = true,
+                                                                 IsEncapsulated = true,
+                                                                 IsLossy = true,
+                                                                 LossyCompressionMethod =
+                                                                     "ISO_10918_1",
+                                                                 Endian = Endian.Little
+                                                             };
 
-		/// <summary>JPEG Spectral Selection, Non-Hierarchical (Process 6 &amp; 8) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess6_8Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGSpectralSelectionNonHierarchical68RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Extended (Process 2 &amp; 4)</summary>
+        public static DicomTransferSyntax JPEGProcess2_4 = new DicomTransferSyntax
+                                                               {
+                                                                   UID = DicomUID.JPEGExtended24,
+                                                                   IsExplicitVR = true,
+                                                                   IsEncapsulated = true,
+                                                                   IsLossy = true,
+                                                                   LossyCompressionMethod =
+                                                                       "ISO_10918_1",
+                                                                   Endian = Endian.Little
+                                                               };
 
-		/// <summary>JPEG Spectral Selection, Non-Hierarchical (Process 7 &amp; 9) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess7_9Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGSpectralSelectionNonHierarchical79RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Extended (Process 3 &amp; 5) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess3_5Retired = new DicomTransferSyntax
+                                                                      {
+                                                                          UID =
+                                                                              DicomUID
+                                                                              .JPEGExtended35RETIRED,
+                                                                          IsRetired = true,
+                                                                          IsExplicitVR = true,
+                                                                          IsEncapsulated = true,
+                                                                          IsLossy = true,
+                                                                          LossyCompressionMethod =
+                                                                              "ISO_10918_1",
+                                                                          Endian = Endian.Little
+                                                                      };
 
-		/// <summary>JPEG Full Progression, Non-Hierarchical (Process 10 &amp; 12) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess10_12Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGFullProgressionNonHierarchical1012RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Spectral Selection, Non-Hierarchical (Process 6 &amp; 8) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess6_8Retired = new DicomTransferSyntax
+                                                                      {
+                                                                          UID =
+                                                                              DicomUID
+                                                                              .JPEGSpectralSelectionNonHierarchical68RETIRED,
+                                                                          IsRetired = true,
+                                                                          IsExplicitVR = true,
+                                                                          IsEncapsulated = true,
+                                                                          IsLossy = true,
+                                                                          LossyCompressionMethod =
+                                                                              "ISO_10918_1",
+                                                                          Endian = Endian.Little
+                                                                      };
 
-		/// <summary>JPEG Full Progression, Non-Hierarchical (Process 11 &amp; 13) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess11_13Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGFullProgressionNonHierarchical1113RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Spectral Selection, Non-Hierarchical (Process 7 &amp; 9) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess7_9Retired = new DicomTransferSyntax
+                                                                      {
+                                                                          UID =
+                                                                              DicomUID
+                                                                              .JPEGSpectralSelectionNonHierarchical79RETIRED,
+                                                                          IsRetired = true,
+                                                                          IsExplicitVR = true,
+                                                                          IsEncapsulated = true,
+                                                                          IsLossy = true,
+                                                                          LossyCompressionMethod =
+                                                                              "ISO_10918_1",
+                                                                          Endian = Endian.Little
+                                                                      };
 
-		/// <summary>JPEG Lossless, Non-Hierarchical (Process 14)</summary>
-		public static DicomTransferSyntax JPEGProcess14 = new DicomTransferSyntax {
-			UID = DicomUID.JPEGLosslessNonHierarchical14,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Full Progression, Non-Hierarchical (Process 10 &amp; 12) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess10_12Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGFullProgressionNonHierarchical1012RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Lossless, Non-Hierarchical (Process 15) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess15Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGLosslessNonHierarchical15RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Full Progression, Non-Hierarchical (Process 11 &amp; 13) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess11_13Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGFullProgressionNonHierarchical1113RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Extended, Hierarchical (Process 16 &amp; 18) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess16_18Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGExtendedHierarchical1618RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Lossless, Non-Hierarchical (Process 14)</summary>
+        public static DicomTransferSyntax JPEGProcess14 = new DicomTransferSyntax
+                                                              {
+                                                                  UID =
+                                                                      DicomUID
+                                                                      .JPEGLosslessNonHierarchical14,
+                                                                  IsExplicitVR = true,
+                                                                  IsEncapsulated = true,
+                                                                  Endian = Endian.Little
+                                                              };
 
-		/// <summary>JPEG Extended, Hierarchical (Process 17 &amp; 19) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess17_19Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGExtendedHierarchical1719RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Lossless, Non-Hierarchical (Process 15) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess15Retired = new DicomTransferSyntax
+                                                                     {
+                                                                         UID =
+                                                                             DicomUID
+                                                                             .JPEGLosslessNonHierarchical15RETIRED,
+                                                                         IsRetired = true,
+                                                                         IsExplicitVR = true,
+                                                                         IsEncapsulated = true,
+                                                                         Endian = Endian.Little
+                                                                     };
 
-		/// <summary>JPEG Spectral Selection, Hierarchical (Process 20 &amp; 22) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess20_22Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGSpectralSelectionHierarchical2022RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Extended, Hierarchical (Process 16 &amp; 18) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess16_18Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGExtendedHierarchical1618RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Spectral Selection, Hierarchical (Process 21 &amp; 23) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess21_23Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGSpectralSelectionHierarchical2123RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Extended, Hierarchical (Process 17 &amp; 19) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess17_19Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGExtendedHierarchical1719RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Full Progression, Hierarchical (Process 24 &amp; 26) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess24_26Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGFullProgressionHierarchical2426RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Spectral Selection, Hierarchical (Process 20 &amp; 22) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess20_22Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGSpectralSelectionHierarchical2022RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Full Progression, Hierarchical (Process 25 &amp; 27) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess25_27Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGFullProgressionHierarchical2527RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_10918_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Spectral Selection, Hierarchical (Process 21 &amp; 23) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess21_23Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGSpectralSelectionHierarchical2123RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Lossless, Hierarchical (Process 28) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess28Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGLosslessHierarchical28RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Full Progression, Hierarchical (Process 24 &amp; 26) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess24_26Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGFullProgressionHierarchical2426RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Lossless, Hierarchical (Process 29) (Retired)</summary>
-		public static DicomTransferSyntax JPEGProcess29Retired = new DicomTransferSyntax {
-			UID = DicomUID.JPEGLosslessHierarchical29RETIRED,
-			IsRetired = true,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Full Progression, Hierarchical (Process 25 &amp; 27) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess25_27Retired = new DicomTransferSyntax
+                                                                        {
+                                                                            UID =
+                                                                                DicomUID
+                                                                                .JPEGFullProgressionHierarchical2527RETIRED,
+                                                                            IsRetired = true,
+                                                                            IsExplicitVR = true,
+                                                                            IsEncapsulated = true,
+                                                                            IsLossy = true,
+                                                                            LossyCompressionMethod =
+                                                                                "ISO_10918_1",
+                                                                            Endian = Endian.Little
+                                                                        };
 
-		/// <summary>JPEG Lossless, Non-Hierarchical, First-Order Prediction (Process 14 [Selection Value 1])</summary>
-		public static DicomTransferSyntax JPEGProcess14SV1 = new DicomTransferSyntax {
-			UID = DicomUID.JPEGLossless,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Lossless, Hierarchical (Process 28) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess28Retired = new DicomTransferSyntax
+                                                                     {
+                                                                         UID =
+                                                                             DicomUID
+                                                                             .JPEGLosslessHierarchical28RETIRED,
+                                                                         IsRetired = true,
+                                                                         IsExplicitVR = true,
+                                                                         IsEncapsulated = true,
+                                                                         Endian = Endian.Little
+                                                                     };
 
-		/// <summary>JPEG-LS Lossless Image Compression</summary>
-		public static DicomTransferSyntax JPEGLSLossless = new DicomTransferSyntax {
-			UID = DicomUID.JPEGLSLossless,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Lossless, Hierarchical (Process 29) (Retired)</summary>
+        public static DicomTransferSyntax JPEGProcess29Retired = new DicomTransferSyntax
+                                                                     {
+                                                                         UID =
+                                                                             DicomUID
+                                                                             .JPEGLosslessHierarchical29RETIRED,
+                                                                         IsRetired = true,
+                                                                         IsExplicitVR = true,
+                                                                         IsEncapsulated = true,
+                                                                         Endian = Endian.Little
+                                                                     };
 
-		/// <summary>JPEG-LS Lossy (Near-Lossless) Image Compression</summary>
-		public static DicomTransferSyntax JPEGLSNearLossless = new DicomTransferSyntax {
-			UID = DicomUID.JPEGLSLossyNearLossless,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_14495_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG Lossless, Non-Hierarchical, First-Order Prediction (Process 14 [Selection Value 1])</summary>
+        public static DicomTransferSyntax JPEGProcess14SV1 = new DicomTransferSyntax
+                                                                 {
+                                                                     UID = DicomUID.JPEGLossless,
+                                                                     IsExplicitVR = true,
+                                                                     IsEncapsulated = true,
+                                                                     Endian = Endian.Little
+                                                                 };
 
-		/// <summary>JPEG 2000 Lossless Image Compression</summary>
-		public static DicomTransferSyntax JPEG2000Lossless = new DicomTransferSyntax {
-			UID = DicomUID.JPEG2000LosslessOnly,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG-LS Lossless Image Compression</summary>
+        public static DicomTransferSyntax JPEGLSLossless = new DicomTransferSyntax
+                                                               {
+                                                                   UID = DicomUID.JPEGLSLossless,
+                                                                   IsExplicitVR = true,
+                                                                   IsEncapsulated = true,
+                                                                   Endian = Endian.Little
+                                                               };
 
-		/// <summary>JPEG 2000 Lossy Image Compression</summary>
-		public static DicomTransferSyntax JPEG2000Lossy = new DicomTransferSyntax {
-			UID = DicomUID.JPEG2000,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_15444_1",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG-LS Lossy (Near-Lossless) Image Compression</summary>
+        public static DicomTransferSyntax JPEGLSNearLossless = new DicomTransferSyntax
+                                                                   {
+                                                                       UID =
+                                                                           DicomUID
+                                                                           .JPEGLSLossyNearLossless,
+                                                                       IsExplicitVR = true,
+                                                                       IsEncapsulated = true,
+                                                                       IsLossy = true,
+                                                                       LossyCompressionMethod =
+                                                                           "ISO_14495_1",
+                                                                       Endian = Endian.Little
+                                                                   };
 
-		/// <summary>MPEG2 Main Profile @ Main Level</summary>
-		public static DicomTransferSyntax MPEG2 = new DicomTransferSyntax {
-			UID = DicomUID.MPEG2,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			IsLossy = true,
-			LossyCompressionMethod = "ISO_13818_2",
-			Endian = Endian.Little
-		};
+        /// <summary>JPEG 2000 Lossless Image Compression</summary>
+        public static DicomTransferSyntax JPEG2000Lossless = new DicomTransferSyntax
+                                                                 {
+                                                                     UID =
+                                                                         DicomUID
+                                                                         .JPEG2000LosslessOnly,
+                                                                     IsExplicitVR = true,
+                                                                     IsEncapsulated = true,
+                                                                     Endian = Endian.Little
+                                                                 };
 
-		/// <summary>RLE Lossless</summary>
-		public static DicomTransferSyntax RLELossless = new DicomTransferSyntax {
-			UID = DicomUID.RLELossless,
-			IsExplicitVR = true,
-			IsEncapsulated = true,
-			Endian = Endian.Little
-		};
-		#endregion
+        /// <summary>JPEG 2000 Lossy Image Compression</summary>
+        public static DicomTransferSyntax JPEG2000Lossy = new DicomTransferSyntax
+                                                              {
+                                                                  UID = DicomUID.JPEG2000,
+                                                                  IsExplicitVR = true,
+                                                                  IsEncapsulated = true,
+                                                                  IsLossy = true,
+                                                                  LossyCompressionMethod =
+                                                                      "ISO_15444_1",
+                                                                  Endian = Endian.Little
+                                                              };
 
-		#region Static Methods
-		private static IDictionary<DicomUID, DicomTransferSyntax> Entries = new Dictionary<DicomUID, DicomTransferSyntax>();
+        /// <summary>MPEG2 Main Profile @ Main Level</summary>
+        public static DicomTransferSyntax MPEG2 = new DicomTransferSyntax
+                                                      {
+                                                          UID = DicomUID.MPEG2,
+                                                          IsExplicitVR = true,
+                                                          IsEncapsulated = true,
+                                                          IsLossy = true,
+                                                          LossyCompressionMethod = "ISO_13818_2",
+                                                          Endian = Endian.Little
+                                                      };
 
-		static DicomTransferSyntax() {
-			#region Load Transfer Syntax List
-			Entries.Add(DicomTransferSyntax.GEPrivateImplicitVRBigEndian.UID, DicomTransferSyntax.GEPrivateImplicitVRBigEndian);
-			Entries.Add(DicomTransferSyntax.ImplicitVRLittleEndian.UID, DicomTransferSyntax.ImplicitVRLittleEndian);
-			Entries.Add(DicomTransferSyntax.ExplicitVRLittleEndian.UID, DicomTransferSyntax.ExplicitVRLittleEndian);
-			Entries.Add(DicomTransferSyntax.ExplicitVRBigEndian.UID, DicomTransferSyntax.ExplicitVRBigEndian);
-			Entries.Add(DicomTransferSyntax.DeflatedExplicitVRLittleEndian.UID, DicomTransferSyntax.DeflatedExplicitVRLittleEndian);
-			Entries.Add(DicomTransferSyntax.JPEGProcess1.UID, DicomTransferSyntax.JPEGProcess1);
-			Entries.Add(DicomTransferSyntax.JPEGProcess2_4.UID, DicomTransferSyntax.JPEGProcess2_4);
-			Entries.Add(DicomTransferSyntax.JPEGProcess3_5Retired.UID, DicomTransferSyntax.JPEGProcess3_5Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess6_8Retired.UID, DicomTransferSyntax.JPEGProcess6_8Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess7_9Retired.UID, DicomTransferSyntax.JPEGProcess7_9Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess10_12Retired.UID, DicomTransferSyntax.JPEGProcess10_12Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess11_13Retired.UID, DicomTransferSyntax.JPEGProcess11_13Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess14.UID, DicomTransferSyntax.JPEGProcess14);
-			Entries.Add(DicomTransferSyntax.JPEGProcess15Retired.UID, DicomTransferSyntax.JPEGProcess15Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess16_18Retired.UID, DicomTransferSyntax.JPEGProcess16_18Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess17_19Retired.UID, DicomTransferSyntax.JPEGProcess17_19Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess20_22Retired.UID, DicomTransferSyntax.JPEGProcess20_22Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess21_23Retired.UID, DicomTransferSyntax.JPEGProcess21_23Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess24_26Retired.UID, DicomTransferSyntax.JPEGProcess24_26Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess25_27Retired.UID, DicomTransferSyntax.JPEGProcess25_27Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess28Retired.UID, DicomTransferSyntax.JPEGProcess28Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess29Retired.UID, DicomTransferSyntax.JPEGProcess29Retired);
-			Entries.Add(DicomTransferSyntax.JPEGProcess14SV1.UID, DicomTransferSyntax.JPEGProcess14SV1);
-			Entries.Add(DicomTransferSyntax.JPEGLSLossless.UID, DicomTransferSyntax.JPEGLSLossless);
-			Entries.Add(DicomTransferSyntax.JPEGLSNearLossless.UID, DicomTransferSyntax.JPEGLSNearLossless);
-			Entries.Add(DicomTransferSyntax.JPEG2000Lossless.UID, DicomTransferSyntax.JPEG2000Lossless);
-			Entries.Add(DicomTransferSyntax.JPEG2000Lossy.UID, DicomTransferSyntax.JPEG2000Lossy);
-			Entries.Add(DicomTransferSyntax.MPEG2.UID, DicomTransferSyntax.MPEG2);
-			Entries.Add(DicomTransferSyntax.RLELossless.UID, DicomTransferSyntax.RLELossless);
-			#endregion
-		}
+        /// <summary>RLE Lossless</summary>
+        public static DicomTransferSyntax RLELossless = new DicomTransferSyntax
+                                                            {
+                                                                UID = DicomUID.RLELossless,
+                                                                IsExplicitVR = true,
+                                                                IsEncapsulated = true,
+                                                                Endian = Endian.Little
+                                                            };
 
-		public static DicomTransferSyntax Parse(string uid) {
-			return Lookup(DicomUID.Parse(uid));
-		}
+        #endregion
 
-		public static DicomTransferSyntax Lookup(DicomUID uid) {
-			DicomTransferSyntax tx;
-			if (Entries.TryGetValue(uid, out tx))
-				return tx;
-			return new DicomTransferSyntax {
-				UID = uid,
-				IsExplicitVR = true,
-				IsEncapsulated = true,
-				Endian = Endian.Little
-			};
-			//throw new DicomDataException("Unknown transfer syntax UID: {0}", uid);
-		}
-		#endregion
-	}
+        #region Static Methods
+
+        private static IDictionary<DicomUID, DicomTransferSyntax> Entries =
+            new Dictionary<DicomUID, DicomTransferSyntax>();
+
+        static DicomTransferSyntax()
+        {
+            #region Load Transfer Syntax List
+
+            Entries.Add(
+                DicomTransferSyntax.GEPrivateImplicitVRBigEndian.UID,
+                DicomTransferSyntax.GEPrivateImplicitVRBigEndian);
+            Entries.Add(DicomTransferSyntax.ImplicitVRLittleEndian.UID, DicomTransferSyntax.ImplicitVRLittleEndian);
+            Entries.Add(DicomTransferSyntax.ExplicitVRLittleEndian.UID, DicomTransferSyntax.ExplicitVRLittleEndian);
+            Entries.Add(DicomTransferSyntax.ExplicitVRBigEndian.UID, DicomTransferSyntax.ExplicitVRBigEndian);
+            Entries.Add(
+                DicomTransferSyntax.DeflatedExplicitVRLittleEndian.UID,
+                DicomTransferSyntax.DeflatedExplicitVRLittleEndian);
+            Entries.Add(DicomTransferSyntax.JPEGProcess1.UID, DicomTransferSyntax.JPEGProcess1);
+            Entries.Add(DicomTransferSyntax.JPEGProcess2_4.UID, DicomTransferSyntax.JPEGProcess2_4);
+            Entries.Add(DicomTransferSyntax.JPEGProcess3_5Retired.UID, DicomTransferSyntax.JPEGProcess3_5Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess6_8Retired.UID, DicomTransferSyntax.JPEGProcess6_8Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess7_9Retired.UID, DicomTransferSyntax.JPEGProcess7_9Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess10_12Retired.UID, DicomTransferSyntax.JPEGProcess10_12Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess11_13Retired.UID, DicomTransferSyntax.JPEGProcess11_13Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess14.UID, DicomTransferSyntax.JPEGProcess14);
+            Entries.Add(DicomTransferSyntax.JPEGProcess15Retired.UID, DicomTransferSyntax.JPEGProcess15Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess16_18Retired.UID, DicomTransferSyntax.JPEGProcess16_18Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess17_19Retired.UID, DicomTransferSyntax.JPEGProcess17_19Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess20_22Retired.UID, DicomTransferSyntax.JPEGProcess20_22Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess21_23Retired.UID, DicomTransferSyntax.JPEGProcess21_23Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess24_26Retired.UID, DicomTransferSyntax.JPEGProcess24_26Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess25_27Retired.UID, DicomTransferSyntax.JPEGProcess25_27Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess28Retired.UID, DicomTransferSyntax.JPEGProcess28Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess29Retired.UID, DicomTransferSyntax.JPEGProcess29Retired);
+            Entries.Add(DicomTransferSyntax.JPEGProcess14SV1.UID, DicomTransferSyntax.JPEGProcess14SV1);
+            Entries.Add(DicomTransferSyntax.JPEGLSLossless.UID, DicomTransferSyntax.JPEGLSLossless);
+            Entries.Add(DicomTransferSyntax.JPEGLSNearLossless.UID, DicomTransferSyntax.JPEGLSNearLossless);
+            Entries.Add(DicomTransferSyntax.JPEG2000Lossless.UID, DicomTransferSyntax.JPEG2000Lossless);
+            Entries.Add(DicomTransferSyntax.JPEG2000Lossy.UID, DicomTransferSyntax.JPEG2000Lossy);
+            Entries.Add(DicomTransferSyntax.MPEG2.UID, DicomTransferSyntax.MPEG2);
+            Entries.Add(DicomTransferSyntax.RLELossless.UID, DicomTransferSyntax.RLELossless);
+
+            #endregion
+        }
+
+        public static DicomTransferSyntax Parse(string uid)
+        {
+            return Lookup(DicomUID.Parse(uid));
+        }
+
+        public static DicomTransferSyntax Lookup(DicomUID uid)
+        {
+            DicomTransferSyntax tx;
+            if (Entries.TryGetValue(uid, out tx)) return tx;
+            return new DicomTransferSyntax
+                       {
+                           UID = uid,
+                           IsExplicitVR = true,
+                           IsEncapsulated = true,
+                           Endian = Endian.Little
+                       };
+            //throw new DicomDataException("Unknown transfer syntax UID: {0}", uid);
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/DicomTransformRules.cs
+++ b/DICOM/DicomTransformRules.cs
@@ -1,591 +1,792 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 using Dicom.IO.Buffer;
 
-namespace Dicom {
-	public interface IDicomTransformRule {
-		void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null);
-	}
-
-	public class DicomTransformRuleSet : IDicomTransformRule {
-		#region Private Members
-		private List<IDicomTransformRule> _transformRules;
-		private DicomMatchRuleSet _conditions;
-		#endregion
-
-		#region Public Constructor
-		public DicomTransformRuleSet() {
-			_transformRules = new List<IDicomTransformRule>();
-		}
-
-		public DicomTransformRuleSet(params IDicomTransformRule[] rules) {
-			_transformRules = new List<IDicomTransformRule>(rules);
-		}
-
-		public DicomTransformRuleSet(DicomMatchRuleSet conditions, params IDicomTransformRule[] rules) {
-			_conditions = conditions;
-			_transformRules = new List<IDicomTransformRule>(rules);
-		}
-		#endregion
-
-		#region Public Properties
-		public DicomMatchRuleSet Conditions {
-			get {
-				if (_conditions == null)
-					_conditions = new DicomMatchRuleSet();
-				return _conditions;
-			}
-			set { _conditions = value; }
-		}
-		#endregion
-
-		#region Public Methods
-		public void Add(IDicomTransformRule rule) {
-			_transformRules.Add(rule);
-		}
-
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (_conditions != null)
-				if (!_conditions.Match(dataset))
-					return;
-
-			foreach (IDicomTransformRule rule in _transformRules)
-				rule.Transform(dataset);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Remove an element from a DICOM dataset.
-	/// </summary>
-	public class RemoveElementDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomMaskedTag _mask;
-		#endregion
-
-		#region Public Constructor
-		public RemoveElementDicomTransformRule(DicomMaskedTag mask) {
-			_mask = mask;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			var remove = dataset.EnumerateMasked(_mask).Select(x => x.Tag).ToList();
-			foreach (DicomTag tag in remove) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, tag);
-				dataset.Remove(tag);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("[{0}]", _mask);
-			return String.Format("'{0}' remove", name);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Sets the value of a DICOM element.
-	/// </summary>
-	public class SetValueDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _value;
-		#endregion
-
-		#region Public Constructor
-		public SetValueDicomTransformRule(DicomTag tag, string value) {
-			_tag = tag;
-			_value = value;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-			dataset.Add(_tag, _value);
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' set '{1}'", name, _value);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Maps the value of a DICOM element to a value.
-	/// </summary>
-	public class MapValueDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _match;
-		private string _value;
-		#endregion
-
-		#region Public Constructor
-		public MapValueDicomTransformRule(DicomTag tag, string match, string value) {
-			_tag = tag;
-			_match = match;
-			_value = value;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag) && dataset.Get<string>(_tag, -1, String.Empty) == _match) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				dataset.Add(_tag, _value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' map '{1}' -> '{2}'", name, _match, _value);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Copies the value of a DICOM element to another DICOM element.
-	/// </summary>
-	public class CopyValueDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _src;
-		private DicomTag _dst;
-		#endregion
-
-		#region Public Constructor
-		public CopyValueDicomTransformRule(DicomTag src, DicomTag dst) {
-			_src = src;
-			_dst = dst;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_src)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _dst);
-				dataset.Add(_dst, dataset.Get<IByteBuffer>(_src));
-			}
-		}
-
-		public override string ToString() {
-			string sname = String.Format("{0} {1}", _src, _src.DictionaryEntry.Name);
-			string dname = String.Format("{0} {1}", _dst, _dst.DictionaryEntry.Name);
-			return String.Format("'{0}' copy to '{1}'", sname, dname);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Performs a regular expression replace operation on a DICOM element value.
-	/// </summary>
-	public class RegexDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _pattern;
-		private string _replacement;
-		#endregion
-
-		#region Public Constructor
-		public RegexDicomTransformRule(DicomTag tag, string pattern, string replacement) {
-			_tag = tag;
-			_pattern = pattern;
-			_replacement = replacement;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				value = Regex.Replace(value, _pattern, _replacement);
-				dataset.Add(_tag, value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' regex '{1}' -> '{2}'", name, _pattern, _replacement);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Prefix the value of a DICOM element.
-	/// </summary>
-	public class PrefixDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _prefix;
-		#endregion
-
-		#region Public Constructor
-		public PrefixDicomTransformRule(DicomTag tag, string prefix) {
-			_tag = tag;
-			_prefix = prefix;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				dataset.Add(_tag, _prefix + value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' prefix '{1}'", name, _prefix);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Append the value of a DICOM element.
-	/// </summary>
-	public class AppendDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _append;
-		#endregion
-
-		#region Public Constructor
-		public AppendDicomTransformRule(DicomTag tag, string append) {
-			_tag = tag;
-			_append = append;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				dataset.Add(_tag, value + _append);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' append '{1}'", name, _append);
-		}
-		#endregion
-	}
-
-	public enum DicomTrimPosition {
-		Start,
-		End,
-		Both
-	}
-
-	/// <summary>
-	/// Trims a string from the beginning and end of a DICOM element value.
-	/// </summary>
-	public class TrimStringDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private string _trim;
-		private DicomTrimPosition _position;
-		#endregion
-
-		#region Public Constructor
-		public TrimStringDicomTransformRule(DicomTag tag, DicomTrimPosition position, string trim) {
-			_tag = tag;
-			_trim = trim;
-			_position = position;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				if (_position == DicomTrimPosition.Start || _position == DicomTrimPosition.Both)
-					while (value.StartsWith(_trim))
-						value = value.Substring(_trim.Length);
-				if (_position == DicomTrimPosition.End || _position == DicomTrimPosition.Both)
-					while (value.EndsWith(_trim))
-						value = value.Substring(0, value.Length - _trim.Length);
-				dataset.Add(_tag, value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' trim '{1}' from {2}", name, _trim, _position.ToString().ToLower());
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Trims whitespace or a set of characters from the beginning and end of a DICOM element value.
-	/// </summary>
-	public class TrimCharactersDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private char[] _trim;
-		private DicomTrimPosition _position;
-		#endregion
-
-		#region Public Constructor
-		public TrimCharactersDicomTransformRule(DicomTag tag, DicomTrimPosition position) {
-			_tag = tag;
-			_trim = null;
-			_position = position;
-		}
-
-		public TrimCharactersDicomTransformRule(DicomTag tag, DicomTrimPosition position, char[] trim) {
-			_tag = tag;
-			_trim = trim;
-			_position = position;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				if (_position == DicomTrimPosition.Both) {
-					if (_trim != null)
-						value = value.Trim(_trim);
-					else
-						value = value.Trim();
-				} else if (_position == DicomTrimPosition.Start) {
-					if (_trim != null)
-						value = value.TrimStart(_trim);
-					else
-						value = value.TrimStart();
-				} else {
-					if (_trim != null)
-						value = value.TrimEnd(_trim);
-					else
-						value = value.TrimEnd();
-				}
-				dataset.Add(_tag, value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			if (_trim != null)
-				return String.Format("'{0}' trim '{1}' from {2}", name, new string(_trim), _position.ToString().ToLower());
-			else
-				return String.Format("'{0}' trim whitespace from {2}", name, _position.ToString().ToLower());
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Pads a DICOM element value.
-	/// </summary>
-	public class PadStringDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private char _paddingChar;
-		private int _totalLength;
-		#endregion
-
-		#region Public Constructor
-		public PadStringDicomTransformRule(DicomTag tag, int totalLength, char paddingChar) {
-			_tag = tag;
-			_totalLength = totalLength;
-			_paddingChar = paddingChar;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				if (_totalLength < 0)
-					value = value.PadLeft(-_totalLength, _paddingChar);
-				else
-					value = value.PadRight(_totalLength, _paddingChar);
-				dataset.Add(_tag, value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' pad to {1} with '{2}'", name, _totalLength, _paddingChar);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Truncates a DICOM element value.
-	/// </summary>
-	public class TruncateDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private int _length;
-		#endregion
-
-		#region Public Constructor
-		public TruncateDicomTransformRule(DicomTag tag, int length) {
-			_tag = tag;
-			_length = length;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				string[] parts = value.Split('\\');
-				for (int i = 0; i < parts.Length; i++) {
-					if (parts[i].Length > _length)
-						parts[i] = parts[i].Substring(0, _length);
-				}
-				value = String.Join("\\", parts);
-				dataset.Add(_tag, value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' truncate to {1} characters", name, _length);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Splits a DICOM element value and then formats the a string from the resulting array.
-	/// </summary>
-	public class SplitFormatDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private char[] _seperators;
-		private string _format;
-		#endregion
-
-		#region Public Constructor
-		public SplitFormatDicomTransformRule(DicomTag tag, char[] seperators, string format) {
-			_tag = tag;
-			_seperators = seperators;
-			_format = format;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				string[] parts = value.Split(_seperators);
-				value = String.Format(_format, parts);
-				dataset.Add(_tag, value);
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' split on '{1}' and format as '{2}'", name, new string(_seperators), _format);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Changes the case of a DICOM element value to all upper case.
-	/// </summary>
-	public class ToUpperDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		#endregion
-
-		#region Public Constructor
-		public ToUpperDicomTransformRule(DicomTag tag) {
-			_tag = tag;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				dataset.Add(_tag, value.ToUpper());
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' to upper case", name);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Changes the case of a DICOM element value to all lower case.
-	/// </summary>
-	public class ToLowerDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		#endregion
-
-		#region Public Constructor
-		public ToLowerDicomTransformRule(DicomTag tag) {
-			_tag = tag;
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			if (dataset.Contains(_tag)) {
-				dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-				var value = dataset.Get<string>(_tag, -1, String.Empty);
-				dataset.Add(_tag, value.ToLower());
-			}
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' to lower case", name);
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Generates a new UID for a DICOM element.
-	/// </summary>
-	public class GenerateUidDicomTransformRule : IDicomTransformRule {
-		#region Private Members
-		private DicomTag _tag;
-		private DicomUIDGenerator _generator;
-		#endregion
-
-		#region Public Constructor
-		public GenerateUidDicomTransformRule(DicomTag tag, DicomUIDGenerator generator = null) {
-			_tag = tag;
-			_generator = generator ?? new DicomUIDGenerator();
-		}
-		#endregion
-
-		#region Public Methods
-		public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null) {
-			dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-			var uid = dataset.Get<DicomUID>(_tag);
-			dataset.Add(_tag, _generator.Generate(uid));
-		}
-
-		public override string ToString() {
-			string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
-			return String.Format("'{0}' generate UID", name);
-		}
-		#endregion
-	}
+namespace Dicom
+{
+    public interface IDicomTransformRule
+    {
+        void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null);
+    }
+
+    public class DicomTransformRuleSet : IDicomTransformRule
+    {
+        #region Private Members
+
+        private List<IDicomTransformRule> _transformRules;
+
+        private DicomMatchRuleSet _conditions;
+
+        #endregion
+
+        #region Public Constructor
+
+        public DicomTransformRuleSet()
+        {
+            _transformRules = new List<IDicomTransformRule>();
+        }
+
+        public DicomTransformRuleSet(params IDicomTransformRule[] rules)
+        {
+            _transformRules = new List<IDicomTransformRule>(rules);
+        }
+
+        public DicomTransformRuleSet(DicomMatchRuleSet conditions, params IDicomTransformRule[] rules)
+        {
+            _conditions = conditions;
+            _transformRules = new List<IDicomTransformRule>(rules);
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public DicomMatchRuleSet Conditions
+        {
+            get
+            {
+                if (_conditions == null) _conditions = new DicomMatchRuleSet();
+                return _conditions;
+            }
+            set
+            {
+                _conditions = value;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Add(IDicomTransformRule rule)
+        {
+            _transformRules.Add(rule);
+        }
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (_conditions != null) if (!_conditions.Match(dataset)) return;
+
+            foreach (IDicomTransformRule rule in _transformRules) rule.Transform(dataset);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Remove an element from a DICOM dataset.
+    /// </summary>
+    public class RemoveElementDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomMaskedTag _mask;
+
+        #endregion
+
+        #region Public Constructor
+
+        public RemoveElementDicomTransformRule(DicomMaskedTag mask)
+        {
+            _mask = mask;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            var remove = dataset.EnumerateMasked(_mask).Select(x => x.Tag).ToList();
+            foreach (DicomTag tag in remove)
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, tag);
+                dataset.Remove(tag);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("[{0}]", _mask);
+            return String.Format("'{0}' remove", name);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Sets the value of a DICOM element.
+    /// </summary>
+    public class SetValueDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _value;
+
+        #endregion
+
+        #region Public Constructor
+
+        public SetValueDicomTransformRule(DicomTag tag, string value)
+        {
+            _tag = tag;
+            _value = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+            dataset.Add(_tag, _value);
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' set '{1}'", name, _value);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Maps the value of a DICOM element to a value.
+    /// </summary>
+    public class MapValueDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _match;
+
+        private string _value;
+
+        #endregion
+
+        #region Public Constructor
+
+        public MapValueDicomTransformRule(DicomTag tag, string match, string value)
+        {
+            _tag = tag;
+            _match = match;
+            _value = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag) && dataset.Get<string>(_tag, -1, String.Empty) == _match)
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                dataset.Add(_tag, _value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' map '{1}' -> '{2}'", name, _match, _value);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Copies the value of a DICOM element to another DICOM element.
+    /// </summary>
+    public class CopyValueDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _src;
+
+        private DicomTag _dst;
+
+        #endregion
+
+        #region Public Constructor
+
+        public CopyValueDicomTransformRule(DicomTag src, DicomTag dst)
+        {
+            _src = src;
+            _dst = dst;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_src))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _dst);
+                dataset.Add(_dst, dataset.Get<IByteBuffer>(_src));
+            }
+        }
+
+        public override string ToString()
+        {
+            string sname = String.Format("{0} {1}", _src, _src.DictionaryEntry.Name);
+            string dname = String.Format("{0} {1}", _dst, _dst.DictionaryEntry.Name);
+            return String.Format("'{0}' copy to '{1}'", sname, dname);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Performs a regular expression replace operation on a DICOM element value.
+    /// </summary>
+    public class RegexDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _pattern;
+
+        private string _replacement;
+
+        #endregion
+
+        #region Public Constructor
+
+        public RegexDicomTransformRule(DicomTag tag, string pattern, string replacement)
+        {
+            _tag = tag;
+            _pattern = pattern;
+            _replacement = replacement;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                value = Regex.Replace(value, _pattern, _replacement);
+                dataset.Add(_tag, value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' regex '{1}' -> '{2}'", name, _pattern, _replacement);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Prefix the value of a DICOM element.
+    /// </summary>
+    public class PrefixDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _prefix;
+
+        #endregion
+
+        #region Public Constructor
+
+        public PrefixDicomTransformRule(DicomTag tag, string prefix)
+        {
+            _tag = tag;
+            _prefix = prefix;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                dataset.Add(_tag, _prefix + value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' prefix '{1}'", name, _prefix);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Append the value of a DICOM element.
+    /// </summary>
+    public class AppendDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _append;
+
+        #endregion
+
+        #region Public Constructor
+
+        public AppendDicomTransformRule(DicomTag tag, string append)
+        {
+            _tag = tag;
+            _append = append;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                dataset.Add(_tag, value + _append);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' append '{1}'", name, _append);
+        }
+
+        #endregion
+    }
+
+    public enum DicomTrimPosition
+    {
+        Start,
+
+        End,
+
+        Both
+    }
+
+    /// <summary>
+    /// Trims a string from the beginning and end of a DICOM element value.
+    /// </summary>
+    public class TrimStringDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private string _trim;
+
+        private DicomTrimPosition _position;
+
+        #endregion
+
+        #region Public Constructor
+
+        public TrimStringDicomTransformRule(DicomTag tag, DicomTrimPosition position, string trim)
+        {
+            _tag = tag;
+            _trim = trim;
+            _position = position;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                if (_position == DicomTrimPosition.Start || _position == DicomTrimPosition.Both) while (value.StartsWith(_trim)) value = value.Substring(_trim.Length);
+                if (_position == DicomTrimPosition.End || _position == DicomTrimPosition.Both) while (value.EndsWith(_trim)) value = value.Substring(0, value.Length - _trim.Length);
+                dataset.Add(_tag, value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' trim '{1}' from {2}", name, _trim, _position.ToString().ToLower());
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Trims whitespace or a set of characters from the beginning and end of a DICOM element value.
+    /// </summary>
+    public class TrimCharactersDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private char[] _trim;
+
+        private DicomTrimPosition _position;
+
+        #endregion
+
+        #region Public Constructor
+
+        public TrimCharactersDicomTransformRule(DicomTag tag, DicomTrimPosition position)
+        {
+            _tag = tag;
+            _trim = null;
+            _position = position;
+        }
+
+        public TrimCharactersDicomTransformRule(DicomTag tag, DicomTrimPosition position, char[] trim)
+        {
+            _tag = tag;
+            _trim = trim;
+            _position = position;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                if (_position == DicomTrimPosition.Both)
+                {
+                    if (_trim != null) value = value.Trim(_trim);
+                    else value = value.Trim();
+                }
+                else if (_position == DicomTrimPosition.Start)
+                {
+                    if (_trim != null) value = value.TrimStart(_trim);
+                    else value = value.TrimStart();
+                }
+                else
+                {
+                    if (_trim != null) value = value.TrimEnd(_trim);
+                    else value = value.TrimEnd();
+                }
+                dataset.Add(_tag, value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            if (_trim != null)
+                return String.Format(
+                    "'{0}' trim '{1}' from {2}",
+                    name,
+                    new string(_trim),
+                    _position.ToString().ToLower());
+            else return String.Format("'{0}' trim whitespace from {2}", name, _position.ToString().ToLower());
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Pads a DICOM element value.
+    /// </summary>
+    public class PadStringDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private char _paddingChar;
+
+        private int _totalLength;
+
+        #endregion
+
+        #region Public Constructor
+
+        public PadStringDicomTransformRule(DicomTag tag, int totalLength, char paddingChar)
+        {
+            _tag = tag;
+            _totalLength = totalLength;
+            _paddingChar = paddingChar;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                if (_totalLength < 0) value = value.PadLeft(-_totalLength, _paddingChar);
+                else value = value.PadRight(_totalLength, _paddingChar);
+                dataset.Add(_tag, value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' pad to {1} with '{2}'", name, _totalLength, _paddingChar);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Truncates a DICOM element value.
+    /// </summary>
+    public class TruncateDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private int _length;
+
+        #endregion
+
+        #region Public Constructor
+
+        public TruncateDicomTransformRule(DicomTag tag, int length)
+        {
+            _tag = tag;
+            _length = length;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                string[] parts = value.Split('\\');
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    if (parts[i].Length > _length) parts[i] = parts[i].Substring(0, _length);
+                }
+                value = String.Join("\\", parts);
+                dataset.Add(_tag, value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' truncate to {1} characters", name, _length);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Splits a DICOM element value and then formats the a string from the resulting array.
+    /// </summary>
+    public class SplitFormatDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private char[] _seperators;
+
+        private string _format;
+
+        #endregion
+
+        #region Public Constructor
+
+        public SplitFormatDicomTransformRule(DicomTag tag, char[] seperators, string format)
+        {
+            _tag = tag;
+            _seperators = seperators;
+            _format = format;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                string[] parts = value.Split(_seperators);
+                value = String.Format(_format, parts);
+                dataset.Add(_tag, value);
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' split on '{1}' and format as '{2}'", name, new string(_seperators), _format);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Changes the case of a DICOM element value to all upper case.
+    /// </summary>
+    public class ToUpperDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        #endregion
+
+        #region Public Constructor
+
+        public ToUpperDicomTransformRule(DicomTag tag)
+        {
+            _tag = tag;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                dataset.Add(_tag, value.ToUpper());
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' to upper case", name);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Changes the case of a DICOM element value to all lower case.
+    /// </summary>
+    public class ToLowerDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        #endregion
+
+        #region Public Constructor
+
+        public ToLowerDicomTransformRule(DicomTag tag)
+        {
+            _tag = tag;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            if (dataset.Contains(_tag))
+            {
+                dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+                var value = dataset.Get<string>(_tag, -1, String.Empty);
+                dataset.Add(_tag, value.ToLower());
+            }
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' to lower case", name);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Generates a new UID for a DICOM element.
+    /// </summary>
+    public class GenerateUidDicomTransformRule : IDicomTransformRule
+    {
+        #region Private Members
+
+        private DicomTag _tag;
+
+        private DicomUIDGenerator _generator;
+
+        #endregion
+
+        #region Public Constructor
+
+        public GenerateUidDicomTransformRule(DicomTag tag, DicomUIDGenerator generator = null)
+        {
+            _tag = tag;
+            _generator = generator ?? new DicomUIDGenerator();
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
+        {
+            dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
+            var uid = dataset.Get<DicomUID>(_tag);
+            dataset.Add(_tag, _generator.Generate(uid));
+        }
+
+        public override string ToString()
+        {
+            string name = String.Format("{0} {1}", _tag, _tag.DictionaryEntry.Name);
+            return String.Format("'{0}' generate UID", name);
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/DicomUIDGenerator.cs
+++ b/DICOM/DicomUIDGenerator.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -6,87 +9,111 @@ using System.Net.NetworkInformation;
 using System.Text;
 using System.Threading;
 
-namespace Dicom {
-	public class DicomUIDGenerator {
-		private static volatile DicomUID _instanceRootUid = null;
-		private static DicomUID InstanceRootUID {
-			get {
-				if (_instanceRootUid == null) {
-					lock (GenerateUidLock) {
-						if (_instanceRootUid == null) {
+namespace Dicom
+{
+    public class DicomUIDGenerator
+    {
+        private static volatile DicomUID _instanceRootUid = null;
+
+        private static DicomUID InstanceRootUID
+        {
+            get
+            {
+                if (_instanceRootUid == null)
+                {
+                    lock (GenerateUidLock)
+                    {
+                        if (_instanceRootUid == null)
+                        {
 #if !SILVERLIGHT
-							NetworkInterface[] interfaces = NetworkInterface.GetAllNetworkInterfaces();
-							for (int i = 0; i < interfaces.Length; i++) {
-								if (NetworkInterface.LoopbackInterfaceIndex != i && interfaces[i].OperationalStatus == OperationalStatus.Up) {
-									string hex = interfaces[i].GetPhysicalAddress().ToString();
-									if (!String.IsNullOrEmpty(hex)) {
-										try {
-											long mac = long.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-											return DicomUID.Append(DicomImplementation.ClassUID, mac);
-										} catch {
-										}
-									}
-								}
-							}
+                            NetworkInterface[] interfaces = NetworkInterface.GetAllNetworkInterfaces();
+                            for (int i = 0; i < interfaces.Length; i++)
+                            {
+                                if (NetworkInterface.LoopbackInterfaceIndex != i
+                                    && interfaces[i].OperationalStatus == OperationalStatus.Up)
+                                {
+                                    string hex = interfaces[i].GetPhysicalAddress().ToString();
+                                    if (!String.IsNullOrEmpty(hex))
+                                    {
+                                        try
+                                        {
+                                            long mac = long.Parse(
+                                                hex,
+                                                NumberStyles.HexNumber,
+                                                CultureInfo.InvariantCulture);
+                                            return DicomUID.Append(DicomImplementation.ClassUID, mac);
+                                        }
+                                        catch
+                                        {
+                                        }
+                                    }
+                                }
+                            }
 #endif
-							_instanceRootUid = DicomUID.Append(DicomImplementation.ClassUID, Environment.TickCount);
-						}
-					}
-				}
-				return _instanceRootUid;
-			}
-			set {
-				_instanceRootUid = value;
-			}
-		}
+                            _instanceRootUid = DicomUID.Append(DicomImplementation.ClassUID, Environment.TickCount);
+                        }
+                    }
+                }
+                return _instanceRootUid;
+            }
+            set
+            {
+                _instanceRootUid = value;
+            }
+        }
 
-		private static long LastTicks = 0;
-		private static object GenerateUidLock = new object();
-		private static DateTime Y2K = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static long LastTicks = 0;
 
-		private Dictionary<string, DicomUID> _uidMap = new Dictionary<string, DicomUID>();
+        private static object GenerateUidLock = new object();
 
-		public DicomUID Generate(DicomUID sourceUid = null) {
-			lock (GenerateUidLock) {
-				DicomUID destinationUid;
-				if (sourceUid != null && _uidMap.TryGetValue(sourceUid.UID, out destinationUid))
-					return destinationUid;
+        private static DateTime Y2K = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-				long ticks = DateTime.UtcNow.Subtract(Y2K).Ticks;
-				while (ticks == LastTicks) {
-					Thread.Sleep(1);
-					ticks = DateTime.UtcNow.Subtract(Y2K).Ticks;
-				}
-				LastTicks = ticks;
+        private Dictionary<string, DicomUID> _uidMap = new Dictionary<string, DicomUID>();
 
-				string str = ticks.ToString();
-				if (str.EndsWith("0000"))
-					str = str.Substring(0, str.Length - 4);
+        public DicomUID Generate(DicomUID sourceUid = null)
+        {
+            lock (GenerateUidLock)
+            {
+                DicomUID destinationUid;
+                if (sourceUid != null && _uidMap.TryGetValue(sourceUid.UID, out destinationUid)) return destinationUid;
 
-				StringBuilder uid = new StringBuilder();
-				uid.Append(InstanceRootUID.UID).Append('.').Append(str);
+                long ticks = DateTime.UtcNow.Subtract(Y2K).Ticks;
+                while (ticks == LastTicks)
+                {
+                    Thread.Sleep(1);
+                    ticks = DateTime.UtcNow.Subtract(Y2K).Ticks;
+                }
+                LastTicks = ticks;
 
-				destinationUid = new DicomUID(uid.ToString(), "SOP Instance UID", DicomUidType.SOPInstance);
+                string str = ticks.ToString();
+                if (str.EndsWith("0000")) str = str.Substring(0, str.Length - 4);
 
-				if (sourceUid != null)
-					_uidMap.Add(sourceUid.UID, destinationUid);
+                StringBuilder uid = new StringBuilder();
+                uid.Append(InstanceRootUID.UID).Append('.').Append(str);
 
-				return destinationUid;
-			}
-		}
+                destinationUid = new DicomUID(uid.ToString(), "SOP Instance UID", DicomUidType.SOPInstance);
 
-		public void RegenerateAll(DicomDataset dataset) {
-			foreach (var ui in dataset.Where(x => x.ValueRepresentation == DicomVR.UI).ToArray()) {
-				var uid = dataset.Get<DicomUID>(ui.Tag);
-				if (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown)
-					dataset.Add(ui.Tag, Generate(uid));
-			}
+                if (sourceUid != null) _uidMap.Add(sourceUid.UID, destinationUid);
 
-			foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>().ToArray()) {
-				foreach (var item in sq) {
-					RegenerateAll(item);
-				}
-			}
-		}
-	}
+                return destinationUid;
+            }
+        }
+
+        public void RegenerateAll(DicomDataset dataset)
+        {
+            foreach (var ui in dataset.Where(x => x.ValueRepresentation == DicomVR.UI).ToArray())
+            {
+                var uid = dataset.Get<DicomUID>(ui.Tag);
+                if (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown) dataset.Add(ui.Tag, Generate(uid));
+            }
+
+            foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>().ToArray())
+            {
+                foreach (var item in sq)
+                {
+                    RegenerateAll(item);
+                }
+            }
+        }
+    }
 }

--- a/DICOM/DicomUIDPrivate.cs
+++ b/DICOM/DicomUIDPrivate.cs
@@ -1,16 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public partial class DicomUID {
-		private static void LoadPrivateUIDs() {
-			_uids.Add(DicomUID.GEPrivateImplicitVRBigEndian.UID, DicomUID.GEPrivateImplicitVRBigEndian);
-		}
+namespace Dicom
+{
+    public partial class DicomUID
+    {
+        private static void LoadPrivateUIDs()
+        {
+            _uids.Add(DicomUID.GEPrivateImplicitVRBigEndian.UID, DicomUID.GEPrivateImplicitVRBigEndian);
+        }
 
-		/// <summary>GE Private Implicit VR Big Endian</summary>
-		/// <remarks>Same as Implicit VR Little Endian except for big endian pixel data.</remarks>
-		public readonly static DicomUID GEPrivateImplicitVRBigEndian = new DicomUID("1.2.840.113619.5.2", "GE Private Implicit VR Big Endian", DicomUidType.TransferSyntax);
-	}
+        /// <summary>GE Private Implicit VR Big Endian</summary>
+        /// <remarks>Same as Implicit VR Little Endian except for big endian pixel data.</remarks>
+        public static readonly DicomUID GEPrivateImplicitVRBigEndian = new DicomUID(
+            "1.2.840.113619.5.2",
+            "GE Private Implicit VR Big Endian",
+            DicomUidType.TransferSyntax);
+    }
 }

--- a/DICOM/DicomVM.cs
+++ b/DICOM/DicomVM.cs
@@ -1,93 +1,111 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 
-namespace Dicom {
-    public class DicomVM {
+namespace Dicom
+{
+    public class DicomVM
+    {
         private static IDictionary<string, DicomVM> _vm = new Dictionary<string, DicomVM>();
 
-        public readonly static DicomVM VM_1 = DicomVM.Parse("1");
-        public readonly static DicomVM VM_1_2 = DicomVM.Parse("1-2");
-        public readonly static DicomVM VM_1_3 = DicomVM.Parse("1-3");
-        public readonly static DicomVM VM_1_8 = DicomVM.Parse("1-8");
-        public readonly static DicomVM VM_1_32 = DicomVM.Parse("1-32");
-        public readonly static DicomVM VM_1_99 = DicomVM.Parse("1-99");
-        public readonly static DicomVM VM_1_n = DicomVM.Parse("1-n");
-        public readonly static DicomVM VM_2 = DicomVM.Parse("2");
-        public readonly static DicomVM VM_2_n = DicomVM.Parse("2-n");
-        public readonly static DicomVM VM_2_2n = DicomVM.Parse("2-2n");
-        public readonly static DicomVM VM_3 = DicomVM.Parse("3");
-        public readonly static DicomVM VM_3_n = DicomVM.Parse("3-n");
-        public readonly static DicomVM VM_3_3n = DicomVM.Parse("3-3n");
-        public readonly static DicomVM VM_4 = DicomVM.Parse("4");
-        public readonly static DicomVM VM_6 = DicomVM.Parse("6");
-        public readonly static DicomVM VM_16 = DicomVM.Parse("16");
+        public static readonly DicomVM VM_1 = DicomVM.Parse("1");
 
-        public DicomVM(int minimum, int maximum, int multiplicity) {
+        public static readonly DicomVM VM_1_2 = DicomVM.Parse("1-2");
+
+        public static readonly DicomVM VM_1_3 = DicomVM.Parse("1-3");
+
+        public static readonly DicomVM VM_1_8 = DicomVM.Parse("1-8");
+
+        public static readonly DicomVM VM_1_32 = DicomVM.Parse("1-32");
+
+        public static readonly DicomVM VM_1_99 = DicomVM.Parse("1-99");
+
+        public static readonly DicomVM VM_1_n = DicomVM.Parse("1-n");
+
+        public static readonly DicomVM VM_2 = DicomVM.Parse("2");
+
+        public static readonly DicomVM VM_2_n = DicomVM.Parse("2-n");
+
+        public static readonly DicomVM VM_2_2n = DicomVM.Parse("2-2n");
+
+        public static readonly DicomVM VM_3 = DicomVM.Parse("3");
+
+        public static readonly DicomVM VM_3_n = DicomVM.Parse("3-n");
+
+        public static readonly DicomVM VM_3_3n = DicomVM.Parse("3-3n");
+
+        public static readonly DicomVM VM_4 = DicomVM.Parse("4");
+
+        public static readonly DicomVM VM_6 = DicomVM.Parse("6");
+
+        public static readonly DicomVM VM_16 = DicomVM.Parse("16");
+
+        public DicomVM(int minimum, int maximum, int multiplicity)
+        {
             Minimum = minimum;
             Maximum = maximum;
             Multiplicity = multiplicity;
         }
 
-        private DicomVM() {
+        private DicomVM()
+        {
             Minimum = 1;
             Maximum = 1;
             Multiplicity = 1;
         }
 
-        public int Minimum {
-            get;
-            private set;
-        }
+        public int Minimum { get; private set; }
 
-        public int Maximum {
-            get;
-            private set;
-        }
+        public int Maximum { get; private set; }
 
-        public int Multiplicity {
-            get;
-            private set;
-        }
+        public int Multiplicity { get; private set; }
 
-        public override string ToString() {
-            if (Minimum == Maximum)
-                return Minimum.ToString();
+        public override string ToString()
+        {
+            if (Minimum == Maximum) return Minimum.ToString();
 
-            if (Maximum == int.MaxValue) {
-                if (Multiplicity > 1)
-                    return String.Format(@"{0}-{1}n", Minimum, Multiplicity);
-                else
-                    return String.Format(@"{0}-n", Minimum);
+            if (Maximum == int.MaxValue)
+            {
+                if (Multiplicity > 1) return String.Format(@"{0}-{1}n", Minimum, Multiplicity);
+                else return String.Format(@"{0}-n", Minimum);
             }
 
             return String.Format(@"{0}-{1}", Minimum, Maximum);
         }
 
-        public static DicomVM Parse(string s) {
-            try {
+        public static DicomVM Parse(string s)
+        {
+            try
+            {
                 DicomVM vm = null;
-                if (_vm.TryGetValue(s, out vm))
-                    return vm;
+                if (_vm.TryGetValue(s, out vm)) return vm;
 
                 string[] parts = s.Split(new[] { "-", " ", "or" }, StringSplitOptions.RemoveEmptyEntries);
 
-                if (parts.Length == 1) {
+                if (parts.Length == 1)
+                {
                     vm = new DicomVM();
                     vm.Minimum = int.Parse(parts[0]);
                     vm.Maximum = vm.Minimum;
                     vm.Multiplicity = vm.Minimum;
-                } else {
+                }
+                else
+                {
                     vm = new DicomVM();
                     vm.Minimum = int.Parse(parts[0]);
                     vm.Multiplicity = 1;
 
-                    if (parts[1].IndexOf("n", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    if (parts[1].IndexOf("n", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
                         vm.Maximum = int.MaxValue;
                         parts[1] = parts[1].TrimEnd('n', 'N');
 
-                        if (parts[1].Length > 0)
-                            vm.Multiplicity = int.Parse(parts[1]);
-                    } else {
+                        if (parts[1].Length > 0) vm.Multiplicity = int.Parse(parts[1]);
+                    }
+                    else
+                    {
                         vm.Maximum = int.Parse(parts[1]);
                     }
                 }
@@ -95,7 +113,9 @@ namespace Dicom {
                 _vm.Add(s, vm);
 
                 return vm;
-            } catch (Exception e) {
+            }
+            catch (Exception e)
+            {
                 throw new DicomDataException("Error parsing value multiplicty ['" + s + "']", e);
             }
         }

--- a/DICOM/DicomVR.cs
+++ b/DICOM/DicomVR.cs
@@ -1,88 +1,60 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
+using System;
+
+namespace Dicom
+{
     /// <summary>DICOM Value Representation</summary>
-    public sealed class DicomVR {
+    public sealed class DicomVR
+    {
         private const byte PadZero = 0x00;
+
         private const byte PadSpace = 0x20;
 
-        private DicomVR() {
+        private DicomVR()
+        {
         }
 
         /// <summary>Code used to represent VR.</summary>
-        public string Code {
-            get;
-            private set;
-        }
+        public string Code { get; private set; }
 
         /// <summary>Descriptive name of VR.</summary>
-        public string Name {
-            get;
-            private set;
-        }
+        public string Name { get; private set; }
 
         /// <summary>Value is a string.</summary>
-        public bool IsString {
-            get;
-            private set;
-        }
+        public bool IsString { get; private set; }
 
         /// <summary>String is encoded using the specified character set.</summary>
-        public bool IsStringEncoded {
-            get;
-            private set;
-        }
+        public bool IsStringEncoded { get; private set; }
 
         /// <summary>Length field of value is a 16-bit short integer.</summary>
-        public bool Is16bitLength {
-            get;
-            private set;
-        }
+        public bool Is16bitLength { get; private set; }
 
         /// <summary>Value can contain multiple items.</summary>
-        public bool IsMultiValue {
-            get;
-            private set;
-        }
+        public bool IsMultiValue { get; private set; }
 
         /// <summary>Byte value used to pad value to even length.</summary>
-        public byte PaddingValue {
-            get;
-            private set;
-        }
+        public byte PaddingValue { get; private set; }
 
         /// <summary>Maximum length of a single value.</summary>
-        public uint MaximumLength {
-            get;
-            private set;
-        }
+        public uint MaximumLength { get; private set; }
 
         /// <summary>Size of each individual value unit for fixed length value types.</summary>
-        public int UnitSize {
-            get;
-            private set;
-        }
+        public int UnitSize { get; private set; }
 
         /// <summary>Number of bytes to swap when changing endian representation of value. Usually equal to the <see cref="UnitSize"/>.</summary>
-        public int ByteSwap {
-            get;
-            private set;
-        }
+        public int ByteSwap { get; private set; }
 
         /// <summary>Type used to represent VR value.</summary>
-        public Type ValueType {
-            get;
-            private set;
-        }
+        public Type ValueType { get; private set; }
 
         /// <summary>
         /// Gets a string representation of this VR.
         /// </summary>
         /// <returns>VR code</returns>
-        public override string ToString() {
+        public override string ToString()
+        {
             return Code;
         }
 
@@ -91,11 +63,11 @@ namespace Dicom {
         /// </summary>
         /// <param name="vr">String representation of VR</param>
         /// <returns>VR</returns>
-        public static DicomVR Parse(string vr) {
+        public static DicomVR Parse(string vr)
+        {
             bool valid;
             DicomVR result = TryParse(vr, out valid);
-            if (!valid)
-                throw new DicomDataException(string.Format("Unknown VR: '{0}'", vr) );
+            if (!valid) throw new DicomDataException(string.Format("Unknown VR: '{0}'", vr));
             return result;
         }
 
@@ -105,525 +77,586 @@ namespace Dicom {
         /// <param name="vr">String representation of VR</param>
         /// <param name="result">VR code</param>
         /// <returns>true if VR was successfully parsed, false otherwise</returns>
-        public static bool TryParse(string vr, out DicomVR result) {
+        public static bool TryParse(string vr, out DicomVR result)
+        {
             bool valid;
             result = TryParse(vr, out valid);
             return valid;
         }
 
-        private static DicomVR TryParse(string vr, out bool valid) {
+        private static DicomVR TryParse(string vr, out bool valid)
+        {
             valid = true;
-            switch ( vr )
+            switch (vr)
             {
-            case "NONE": return DicomVR.NONE;
-            case "AE": return DicomVR.AE;
-            case "AS": return DicomVR.AS;
-            case "AT": return DicomVR.AT;
-            case "CS": return DicomVR.CS;
-            case "DA": return DicomVR.DA;
-            case "DS": return DicomVR.DS;
-            case "DT": return DicomVR.DT;
-            case "FD": return DicomVR.FD;
-            case "FL": return DicomVR.FL;
-            case "IS": return DicomVR.IS;
-            case "LO": return DicomVR.LO;
-            case "LT": return DicomVR.LT;
-            case "OB": return DicomVR.OB;
-            case "OD": return DicomVR.OD;
-            case "OF": return DicomVR.OF;
-            case "OW": return DicomVR.OW;
-            case "PN": return DicomVR.PN;
-            case "SH": return DicomVR.SH;
-            case "SL": return DicomVR.SL;
-            case "SQ": return DicomVR.SQ;
-            case "SS": return DicomVR.SS;
-            case "ST": return DicomVR.ST;
-            case "TM": return DicomVR.TM;
-            case "UC": return DicomVR.UC;
-            case "UI": return DicomVR.UI;
-            case "UL": return DicomVR.UL;
-            case "UN": return DicomVR.UN;
-            case "UR": return DicomVR.UR;
-            case "US": return DicomVR.US;
-            case "UT": return DicomVR.UT;
-            default:
-                valid = false;
-                return DicomVR.NONE;
+                case "NONE":
+                    return DicomVR.NONE;
+                case "AE":
+                    return DicomVR.AE;
+                case "AS":
+                    return DicomVR.AS;
+                case "AT":
+                    return DicomVR.AT;
+                case "CS":
+                    return DicomVR.CS;
+                case "DA":
+                    return DicomVR.DA;
+                case "DS":
+                    return DicomVR.DS;
+                case "DT":
+                    return DicomVR.DT;
+                case "FD":
+                    return DicomVR.FD;
+                case "FL":
+                    return DicomVR.FL;
+                case "IS":
+                    return DicomVR.IS;
+                case "LO":
+                    return DicomVR.LO;
+                case "LT":
+                    return DicomVR.LT;
+                case "OB":
+                    return DicomVR.OB;
+                case "OD":
+                    return DicomVR.OD;
+                case "OF":
+                    return DicomVR.OF;
+                case "OW":
+                    return DicomVR.OW;
+                case "PN":
+                    return DicomVR.PN;
+                case "SH":
+                    return DicomVR.SH;
+                case "SL":
+                    return DicomVR.SL;
+                case "SQ":
+                    return DicomVR.SQ;
+                case "SS":
+                    return DicomVR.SS;
+                case "ST":
+                    return DicomVR.ST;
+                case "TM":
+                    return DicomVR.TM;
+                case "UC":
+                    return DicomVR.UC;
+                case "UI":
+                    return DicomVR.UI;
+                case "UL":
+                    return DicomVR.UL;
+                case "UN":
+                    return DicomVR.UN;
+                case "UR":
+                    return DicomVR.UR;
+                case "US":
+                    return DicomVR.US;
+                case "UT":
+                    return DicomVR.UT;
+                default:
+                    valid = false;
+                    return DicomVR.NONE;
             }
         }
 
         /// <summary>Implicit VR in Explicit VR context</summary>
-        internal readonly static DicomVR Implicit = new DicomVR();
+        internal static readonly DicomVR Implicit = new DicomVR();
 
         /// <summary>No VR</summary>
-        public readonly static DicomVR NONE = new DicomVR {
-            Code = "NONE",
-            Name = "No Value Representation",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = false,
-            PaddingValue = PadZero,
-            MaximumLength = 0,
-            UnitSize = 0,
-            ByteSwap = 0,
-            ValueType = typeof(object)
-        };
+        public static readonly DicomVR NONE = new DicomVR
+                                                  {
+                                                      Code = "NONE",
+                                                      Name = "No Value Representation",
+                                                      IsString = false,
+                                                      IsStringEncoded = false,
+                                                      Is16bitLength = false,
+                                                      IsMultiValue = false,
+                                                      PaddingValue = PadZero,
+                                                      MaximumLength = 0,
+                                                      UnitSize = 0,
+                                                      ByteSwap = 0,
+                                                      ValueType = typeof(object)
+                                                  };
 
         /// <summary>Application Entity</summary>
-        public readonly static DicomVR AE = new DicomVR {
-            Code = "AE",
-            Name = "Application Entity",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 16,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR AE = new DicomVR
+                                                {
+                                                    Code = "AE",
+                                                    Name = "Application Entity",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 16,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Age String</summary>
-        public readonly static DicomVR AS = new DicomVR {
-            Code = "AS",
-            Name = "Age String",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 4,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR AS = new DicomVR
+                                                {
+                                                    Code = "AS",
+                                                    Name = "Age String",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 4,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Attribute Tag</summary>
-        public readonly static DicomVR AT = new DicomVR {
-            Code = "AT",
-            Name = "Attribute Tag",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 4,
-            UnitSize = 4,
-            ByteSwap = 2,
-            ValueType = typeof(DicomTag)
-        };
+        public static readonly DicomVR AT = new DicomVR
+                                                {
+                                                    Code = "AT",
+                                                    Name = "Attribute Tag",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 4,
+                                                    UnitSize = 4,
+                                                    ByteSwap = 2,
+                                                    ValueType = typeof(DicomTag)
+                                                };
 
         /// <summary>Code String</summary>
-        public readonly static DicomVR CS = new DicomVR {
-            Code = "CS",
-            Name = "Code String",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 16,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR CS = new DicomVR
+                                                {
+                                                    Code = "CS",
+                                                    Name = "Code String",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 16,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Date</summary>
-        public readonly static DicomVR DA = new DicomVR {
-            Code = "DA",
-            Name = "Date",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 8,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(DateTime)
-        };
+        public static readonly DicomVR DA = new DicomVR
+                                                {
+                                                    Code = "DA",
+                                                    Name = "Date",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 8,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(DateTime)
+                                                };
 
         /// <summary>Decimal String</summary>
-        public readonly static DicomVR DS = new DicomVR {
-            Code = "DS",
-            Name = "Decimal String",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 16,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(decimal)
-        };
+        public static readonly DicomVR DS = new DicomVR
+                                                {
+                                                    Code = "DS",
+                                                    Name = "Decimal String",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 16,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(decimal)
+                                                };
 
         /// <summary>Date Time</summary>
-        public readonly static DicomVR DT = new DicomVR {
-            Code = "DT",
-            Name = "Date Time",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 26,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(DateTime)
-        };
+        public static readonly DicomVR DT = new DicomVR
+                                                {
+                                                    Code = "DT",
+                                                    Name = "Date Time",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 26,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(DateTime)
+                                                };
 
         /// <summary>Floating Point Double</summary>
-        public readonly static DicomVR FD = new DicomVR {
-            Code = "FD",
-            Name = "Floating Point Double",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 8,
-            UnitSize = 8,
-            ByteSwap = 8,
-            ValueType = typeof(double)
-        };
+        public static readonly DicomVR FD = new DicomVR
+                                                {
+                                                    Code = "FD",
+                                                    Name = "Floating Point Double",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 8,
+                                                    UnitSize = 8,
+                                                    ByteSwap = 8,
+                                                    ValueType = typeof(double)
+                                                };
 
         /// <summary>Floating Point Single</summary>
-        public readonly static DicomVR FL = new DicomVR {
-            Code = "FL",
-            Name = "Floating Point Single",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 4,
-            UnitSize = 4,
-            ByteSwap = 4,
-            ValueType = typeof(float)
-        };
+        public static readonly DicomVR FL = new DicomVR
+                                                {
+                                                    Code = "FL",
+                                                    Name = "Floating Point Single",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 4,
+                                                    UnitSize = 4,
+                                                    ByteSwap = 4,
+                                                    ValueType = typeof(float)
+                                                };
 
         /// <summary>Integer String</summary>
-        public readonly static DicomVR IS = new DicomVR {
-            Code = "IS",
-            Name = "Integer String",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 12,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(int)
-        };
+        public static readonly DicomVR IS = new DicomVR
+                                                {
+                                                    Code = "IS",
+                                                    Name = "Integer String",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 12,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(int)
+                                                };
 
         /// <summary>Long String</summary>
-        public readonly static DicomVR LO = new DicomVR {
-            Code = "LO",
-            Name = "Long String",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = true,
-            //IsMultiValue = false,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 64,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR LO = new DicomVR
+                                                {
+                                                    Code = "LO",
+                                                    Name = "Long String",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = true,
+                                                    //IsMultiValue = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 64,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Long Text</summary>
-        public readonly static DicomVR LT = new DicomVR {
-            Code = "LT",
-            Name = "Long Text",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = true,
-            IsMultiValue = false,
-            PaddingValue = PadSpace,
-            MaximumLength = 10240,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR LT = new DicomVR
+                                                {
+                                                    Code = "LT",
+                                                    Name = "Long Text",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = false,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 10240,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Other Byte</summary>
-        public readonly static DicomVR OB = new DicomVR {
-            Code = "OB",
-            Name = "Other Byte",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 0,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(byte[])
-        };
+        public static readonly DicomVR OB = new DicomVR
+                                                {
+                                                    Code = "OB",
+                                                    Name = "Other Byte",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(byte[])
+                                                };
 
         /// <summary>Other Double</summary>
-        public readonly static DicomVR OD = new DicomVR
-        {
-            Code = "OD",
-            Name = "Other Double",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 0,
-            UnitSize = 8,
-            ByteSwap = 8,
-            ValueType = typeof(double[])
-        };
+        public static readonly DicomVR OD = new DicomVR
+                                                {
+                                                    Code = "OD",
+                                                    Name = "Other Double",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 8,
+                                                    ByteSwap = 8,
+                                                    ValueType = typeof(double[])
+                                                };
 
         /// <summary>Other Float</summary>
-        public readonly static DicomVR OF = new DicomVR {
-            Code = "OF",
-            Name = "Other Float",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 0,
-            UnitSize = 4,
-            ByteSwap = 4,
-            ValueType = typeof(float[])
-        };
+        public static readonly DicomVR OF = new DicomVR
+                                                {
+                                                    Code = "OF",
+                                                    Name = "Other Float",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 4,
+                                                    ByteSwap = 4,
+                                                    ValueType = typeof(float[])
+                                                };
 
         /// <summary>Other Word</summary>
-        public readonly static DicomVR OW = new DicomVR {
-            Code = "OW",
-            Name = "Other Word",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 0,
-            UnitSize = 2,
-            ByteSwap = 2,
-            ValueType = typeof(ushort)
-        };
+        public static readonly DicomVR OW = new DicomVR
+                                                {
+                                                    Code = "OW",
+                                                    Name = "Other Word",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 2,
+                                                    ByteSwap = 2,
+                                                    ValueType = typeof(ushort)
+                                                };
 
         /// <summary>Person Name</summary>
-        public readonly static DicomVR PN = new DicomVR {
-            Code = "PN",
-            Name = "Person Name",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = true,
-            //IsMultiValue = false,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 64,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(String)
-        };
+        public static readonly DicomVR PN = new DicomVR
+                                                {
+                                                    Code = "PN",
+                                                    Name = "Person Name",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = true,
+                                                    //IsMultiValue = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 64,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(String)
+                                                };
 
         /// <summary>Short String</summary>
-        public readonly static DicomVR SH = new DicomVR {
-            Code = "SH",
-            Name = "Short String",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = true,
-            //IsMultiValue = false,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 16,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR SH = new DicomVR
+                                                {
+                                                    Code = "SH",
+                                                    Name = "Short String",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = true,
+                                                    //IsMultiValue = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 16,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Signed Long</summary>
-        public readonly static DicomVR SL = new DicomVR {
-            Code = "SL",
-            Name = "Signed Long",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 4,
-            UnitSize = 4,
-            ByteSwap = 4,
-            ValueType = typeof(int)
-        };
+        public static readonly DicomVR SL = new DicomVR
+                                                {
+                                                    Code = "SL",
+                                                    Name = "Signed Long",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 4,
+                                                    UnitSize = 4,
+                                                    ByteSwap = 4,
+                                                    ValueType = typeof(int)
+                                                };
 
         /// <summary>Sequence of Items</summary>
-        public readonly static DicomVR SQ = new DicomVR {
-            Code = "SQ",
-            Name = "Sequence of Items",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = false,
-            PaddingValue = PadSpace,
-            MaximumLength = 0,
-            UnitSize = 0,
-            ByteSwap = 0,
-            //ValueType = typeof(IList<DicomDataset>)
-        };
+        public static readonly DicomVR SQ = new DicomVR
+                                                {
+                                                    Code = "SQ",
+                                                    Name = "Sequence of Items",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = false,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 0,
+                                                    ByteSwap = 0,
+                                                    //ValueType = typeof(IList<DicomDataset>)
+                                                };
 
         /// <summary>Signed Short</summary>
-        public readonly static DicomVR SS = new DicomVR {
-            Code = "SS",
-            Name = "Signed Short",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 2,
-            UnitSize = 2,
-            ByteSwap = 2,
-            ValueType = typeof(short)
-        };
+        public static readonly DicomVR SS = new DicomVR
+                                                {
+                                                    Code = "SS",
+                                                    Name = "Signed Short",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 2,
+                                                    UnitSize = 2,
+                                                    ByteSwap = 2,
+                                                    ValueType = typeof(short)
+                                                };
 
         /// <summary>Short Text</summary>
-        public readonly static DicomVR ST = new DicomVR {
-            Code = "ST",
-            Name = "Short Text",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = true,
-            IsMultiValue = false,
-            PaddingValue = PadSpace,
-            MaximumLength = 1024,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR ST = new DicomVR
+                                                {
+                                                    Code = "ST",
+                                                    Name = "Short Text",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = false,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 1024,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Time</summary>
-        public readonly static DicomVR TM = new DicomVR {
-            Code = "TM",
-            Name = "Time",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 16,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(DateTime)
-        };
+        public static readonly DicomVR TM = new DicomVR
+                                                {
+                                                    Code = "TM",
+                                                    Name = "Time",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 16,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(DateTime)
+                                                };
 
         /// <summary>Unlimited Characters</summary>
-        public readonly static DicomVR UC = new DicomVR
-        {
-            Code = "UC",
-            Name = "Unlimited Characters",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = false,
-            IsMultiValue = true,
-            PaddingValue = PadSpace,
-            MaximumLength = 0,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR UC = new DicomVR
+                                                {
+                                                    Code = "UC",
+                                                    Name = "Unlimited Characters",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Unique Identifier</summary>
-        public readonly static DicomVR UI = new DicomVR {
-            Code = "UI",
-            Name = "Unique Identifier",
-            IsString = true,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 64,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR UI = new DicomVR
+                                                {
+                                                    Code = "UI",
+                                                    Name = "Unique Identifier",
+                                                    IsString = true,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 64,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Unsigned Long</summary>
-        public readonly static DicomVR UL = new DicomVR {
-            Code = "UL",
-            Name = "Unsigned Long",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 4,
-            UnitSize = 4,
-            ByteSwap = 4,
-            ValueType = typeof(uint)
-        };
+        public static readonly DicomVR UL = new DicomVR
+                                                {
+                                                    Code = "UL",
+                                                    Name = "Unsigned Long",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 4,
+                                                    UnitSize = 4,
+                                                    ByteSwap = 4,
+                                                    ValueType = typeof(uint)
+                                                };
 
         /// <summary>Unknown</summary>
-        public readonly static DicomVR UN = new DicomVR {
-            Code = "UN",
-            Name = "Unknown",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = false,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 0,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(byte[])
-        };
+        public static readonly DicomVR UN = new DicomVR
+                                                {
+                                                    Code = "UN",
+                                                    Name = "Unknown",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(byte[])
+                                                };
 
         /// <summary>Universal Resource Identifier or Universal Resource Locator (URI/URL)</summary>
-        public readonly static DicomVR UR = new DicomVR
-        {
-            Code = "UR",
-            Name = "Universal Resource Identifier or Locator",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = false,
-            IsMultiValue = false,
-            PaddingValue = PadSpace,
-            MaximumLength = 0,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR UR = new DicomVR
+                                                {
+                                                    Code = "UR",
+                                                    Name = "Universal Resource Identifier or Locator",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = false,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
 
         /// <summary>Unsigned Short</summary>
-        public readonly static DicomVR US = new DicomVR {
-            Code = "US",
-            Name = "Unsigned Short",
-            IsString = false,
-            IsStringEncoded = false,
-            Is16bitLength = true,
-            IsMultiValue = true,
-            PaddingValue = PadZero,
-            MaximumLength = 2,
-            UnitSize = 2,
-            ByteSwap = 2,
-            ValueType = typeof(ushort)
-        };
+        public static readonly DicomVR US = new DicomVR
+                                                {
+                                                    Code = "US",
+                                                    Name = "Unsigned Short",
+                                                    IsString = false,
+                                                    IsStringEncoded = false,
+                                                    Is16bitLength = true,
+                                                    IsMultiValue = true,
+                                                    PaddingValue = PadZero,
+                                                    MaximumLength = 2,
+                                                    UnitSize = 2,
+                                                    ByteSwap = 2,
+                                                    ValueType = typeof(ushort)
+                                                };
 
         /// <summary>Unlimited Text</summary>
-        public readonly static DicomVR UT = new DicomVR {
-            Code = "UT",
-            Name = "Unlimited Text",
-            IsString = true,
-            IsStringEncoded = true,
-            Is16bitLength = false,
-            IsMultiValue = false,
-            PaddingValue = PadSpace,
-            MaximumLength = 0,
-            UnitSize = 1,
-            ByteSwap = 1,
-            ValueType = typeof(string)
-        };
+        public static readonly DicomVR UT = new DicomVR
+                                                {
+                                                    Code = "UT",
+                                                    Name = "Unlimited Text",
+                                                    IsString = true,
+                                                    IsStringEncoded = true,
+                                                    Is16bitLength = false,
+                                                    IsMultiValue = false,
+                                                    PaddingValue = PadSpace,
+                                                    MaximumLength = 0,
+                                                    UnitSize = 1,
+                                                    ByteSwap = 1,
+                                                    ValueType = typeof(string)
+                                                };
     }
 }

--- a/DICOM/EventAsyncResult.cs
+++ b/DICOM/EventAsyncResult.cs
@@ -1,53 +1,78 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Threading;
 
-namespace Dicom {
-	internal class EventAsyncResult : IAsyncResult {
-		private ManualResetEventSlim _event;
-		private object _state;
-		private AsyncCallback _callback;
+namespace Dicom
+{
+    internal class EventAsyncResult : IAsyncResult
+    {
+        private ManualResetEventSlim _event;
 
-		public EventAsyncResult(AsyncCallback callback=null, object state=null) {
-			_state = state;
-			_callback = callback;
-			_event = new ManualResetEventSlim(false);
-		}
+        private object _state;
 
-		public void Set() {
-			if (_event.IsSet)
-				return;
+        private AsyncCallback _callback;
 
-			_event.Set();
+        public EventAsyncResult(AsyncCallback callback = null, object state = null)
+        {
+            _state = state;
+            _callback = callback;
+            _event = new ManualResetEventSlim(false);
+        }
 
-			if (_callback != null)
-				_callback.BeginInvoke(this, OnAsyncCallbackComplete, null);
-		}
-		private void OnAsyncCallbackComplete(IAsyncResult ar) {
-			try {
-				_callback.EndInvoke(ar);
-			} catch {
-			}
-		}
+        public void Set()
+        {
+            if (_event.IsSet) return;
 
-		public object AsyncState {
-			get { return _state; }
-		}
+            _event.Set();
 
-		public object InternalState {
-			get;
-			set;
-		}
+            if (_callback != null) _callback.BeginInvoke(this, OnAsyncCallbackComplete, null);
+        }
 
-		public WaitHandle AsyncWaitHandle {
-			get { return _event.WaitHandle; }
-		}
+        private void OnAsyncCallbackComplete(IAsyncResult ar)
+        {
+            try
+            {
+                _callback.EndInvoke(ar);
+            }
+            catch
+            {
+            }
+        }
 
-		public bool CompletedSynchronously {
-			get { return false; }
-		}
+        public object AsyncState
+        {
+            get
+            {
+                return _state;
+            }
+        }
 
-		public bool IsCompleted {
-			get { return _event.IsSet; }
-		}
-	}
+        public object InternalState { get; set; }
+
+        public WaitHandle AsyncWaitHandle
+        {
+            get
+            {
+                return _event.WaitHandle;
+            }
+        }
+
+        public bool CompletedSynchronously
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public bool IsCompleted
+        {
+            get
+            {
+                return _event.IsSet;
+            }
+        }
+    }
 }

--- a/DICOM/Extensions.cs
+++ b/DICOM/Extensions.cs
@@ -1,13 +1,16 @@
-﻿using System;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Threading;
 
-namespace Dicom {
-	internal static class Extensions {
-		public static void InvokeAsync(this Delegate delegate_, params object[] args) {
-			ThreadPool.QueueUserWorkItem(delegate(object state) {
-				delegate_.DynamicInvoke(args);
-			});
-		}
-	}
+namespace Dicom
+{
+    internal static class Extensions
+    {
+        public static void InvokeAsync(this Delegate delegate_, params object[] args)
+        {
+            ThreadPool.QueueUserWorkItem(delegate(object state) { delegate_.DynamicInvoke(args); });
+        }
+    }
 }

--- a/DICOM/Extensions/DicomUID.cs
+++ b/DICOM/Extensions/DicomUID.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 
 namespace Dicom
 {

--- a/DICOM/Generators/DicomDictionaryGenerator.cs
+++ b/DICOM/Generators/DicomDictionaryGenerator.cs
@@ -1,60 +1,113 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom.Generators {
-	public class DicomDictionaryGenerator {
-		public static string Generate(string vnamespace, string vclass, string vmethod, DicomDictionary dict) {
-			StringBuilder output = new StringBuilder();
+namespace Dicom.Generators
+{
+    public class DicomDictionaryGenerator
+    {
+        public static string Generate(string vnamespace, string vclass, string vmethod, DicomDictionary dict)
+        {
+            StringBuilder output = new StringBuilder();
 
-			output.AppendFormat("namespace {0} {{", vnamespace).AppendLine();
-			output.AppendFormat("\tpublic partial class {0} {{", vclass).AppendLine();
-			output.AppendFormat("\t\tpublic static void {0}(DicomDictionary dict) {{", vmethod).AppendLine();
+            output.AppendFormat("namespace {0} {{", vnamespace).AppendLine();
+            output.AppendFormat("\tpublic partial class {0} {{", vclass).AppendLine();
+            output.AppendFormat("\t\tpublic static void {0}(DicomDictionary dict) {{", vmethod).AppendLine();
 
-			foreach (DicomDictionaryEntry entry in dict) {
-				string vm = null;
-				switch (entry.ValueMultiplicity.ToString()) {
-					case "1": vm = "DicomVM.VM_1"; break;
-					case "1-2": vm = "DicomVM.VM_1_2"; break;
-					case "1-3": vm = "DicomVM.VM_1_3"; break;
-					case "1-8": vm = "DicomVM.VM_1_8"; break;
-					case "1-32": vm = "DicomVM.VM_1_32"; break;
-					case "1-99": vm = "DicomVM.VM_1_99"; break;
-					case "1-n": vm = "DicomVM.VM_1_n"; break;
-					case "2": vm = "DicomVM.VM_2"; break;
-					case "2-n": vm = "DicomVM.VM_2_n"; break;
-					case "2-2n": vm = "DicomVM.VM_2_2n"; break;
-					case "3": vm = "DicomVM.VM_3"; break;
-					case "3-n": vm = "DicomVM.VM_3_n"; break;
-					case "3-3n": vm = "DicomVM.VM_3_3n"; break;
-					case "4": vm = "DicomVM.VM_4"; break;
-					case "6": vm = "DicomVM.VM_6"; break;
-					case "16": vm = "DicomVM.VM_16"; break;
-					default:
-						vm = String.Format("DicomVM.Parse(\"{0}\")", entry.ValueMultiplicity);
-						break;
-				}
+            foreach (DicomDictionaryEntry entry in dict)
+            {
+                string vm = null;
+                switch (entry.ValueMultiplicity.ToString())
+                {
+                    case "1":
+                        vm = "DicomVM.VM_1";
+                        break;
+                    case "1-2":
+                        vm = "DicomVM.VM_1_2";
+                        break;
+                    case "1-3":
+                        vm = "DicomVM.VM_1_3";
+                        break;
+                    case "1-8":
+                        vm = "DicomVM.VM_1_8";
+                        break;
+                    case "1-32":
+                        vm = "DicomVM.VM_1_32";
+                        break;
+                    case "1-99":
+                        vm = "DicomVM.VM_1_99";
+                        break;
+                    case "1-n":
+                        vm = "DicomVM.VM_1_n";
+                        break;
+                    case "2":
+                        vm = "DicomVM.VM_2";
+                        break;
+                    case "2-n":
+                        vm = "DicomVM.VM_2_n";
+                        break;
+                    case "2-2n":
+                        vm = "DicomVM.VM_2_2n";
+                        break;
+                    case "3":
+                        vm = "DicomVM.VM_3";
+                        break;
+                    case "3-n":
+                        vm = "DicomVM.VM_3_n";
+                        break;
+                    case "3-3n":
+                        vm = "DicomVM.VM_3_3n";
+                        break;
+                    case "4":
+                        vm = "DicomVM.VM_4";
+                        break;
+                    case "6":
+                        vm = "DicomVM.VM_6";
+                        break;
+                    case "16":
+                        vm = "DicomVM.VM_16";
+                        break;
+                    default:
+                        vm = String.Format("DicomVM.Parse(\"{0}\")", entry.ValueMultiplicity);
+                        break;
+                }
 
-				if (entry.MaskTag == null) {
-					output.AppendFormat("\t\t\tdict._entries.Add(DicomTag.{3}{6}, new DicomDictionaryEntry(DicomTag.{3}{6}, \"{2}\", \"{3}\", {4}, {5}",
-						entry.Tag.ToString("g", null), entry.Tag.ToString("e", null), entry.Name, entry.Keyword, vm, entry.IsRetired ? "true" : "false", entry.IsRetired ? "RETIRED" : "");
-				} else {
-					output.AppendFormat("\t\t\tdict.Add(new DicomDictionaryEntry(DicomMaskedTag.Parse(\"{0}\",\"{1}\"), \"{2}\", \"{3}\", {4}, {5}",
-						entry.MaskTag.ToString("g", null), entry.MaskTag.ToString("e", null), entry.Name, entry.Keyword, vm, entry.IsRetired ? "true" : "false");
-				}
+                if (entry.MaskTag == null)
+                {
+                    output.AppendFormat(
+                        "\t\t\tdict._entries.Add(DicomTag.{3}{6}, new DicomDictionaryEntry(DicomTag.{3}{6}, \"{2}\", \"{3}\", {4}, {5}",
+                        entry.Tag.ToString("g", null),
+                        entry.Tag.ToString("e", null),
+                        entry.Name,
+                        entry.Keyword,
+                        vm,
+                        entry.IsRetired ? "true" : "false",
+                        entry.IsRetired ? "RETIRED" : "");
+                }
+                else
+                {
+                    output.AppendFormat(
+                        "\t\t\tdict.Add(new DicomDictionaryEntry(DicomMaskedTag.Parse(\"{0}\",\"{1}\"), \"{2}\", \"{3}\", {4}, {5}",
+                        entry.MaskTag.ToString("g", null),
+                        entry.MaskTag.ToString("e", null),
+                        entry.Name,
+                        entry.Keyword,
+                        vm,
+                        entry.IsRetired ? "true" : "false");
+                }
 
-				foreach (DicomVR vr in entry.ValueRepresentations)
-					output.AppendFormat(", DicomVR.{0}", vr.Code);
+                foreach (DicomVR vr in entry.ValueRepresentations) output.AppendFormat(", DicomVR.{0}", vr.Code);
 
-				output.AppendLine("));");
-			}
+                output.AppendLine("));");
+            }
 
-			output.AppendLine("\t\t}");
-			output.AppendLine("\t}");
-			output.AppendLine("}");
+            output.AppendLine("\t\t}");
+            output.AppendLine("\t}");
+            output.AppendLine("}");
 
-			return output.ToString();
-		}
-	}
+            return output.ToString();
+        }
+    }
 }

--- a/DICOM/Generators/DicomTagGenerator.cs
+++ b/DICOM/Generators/DicomTagGenerator.cs
@@ -1,46 +1,61 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Linq;
 using System.Text;
 
-namespace Dicom.Generators {
-	public class DicomTagGenerator {
-		public static string Generate(string vnamespace, string vclass, DicomDictionary dict) {
-			StringBuilder output = new StringBuilder();
+namespace Dicom.Generators
+{
+    public class DicomTagGenerator
+    {
+        public static string Generate(string vnamespace, string vclass, DicomDictionary dict)
+        {
+            StringBuilder output = new StringBuilder();
 
-			output.AppendFormat("namespace {0} {{", vnamespace).AppendLine();
-			output.AppendFormat("\tpublic partial class {0} {{", vclass).AppendLine();
+            output.AppendFormat("namespace {0} {{", vnamespace).AppendLine();
+            output.AppendFormat("\tpublic partial class {0} {{", vclass).AppendLine();
 
-			foreach (DicomDictionaryEntry entry in dict) {
-				//if (entry.MaskTag != null)
-				//	continue;
+            foreach (DicomDictionaryEntry entry in dict)
+            {
+                //if (entry.MaskTag != null)
+                //	continue;
 
-				string vrs = String.Join("/", entry.ValueRepresentations.Select(x => x.ToString()));
-				string variable = "_" + Char.ToLower(entry.Keyword[0]) + entry.Keyword.Substring(1);
+                string vrs = String.Join("/", entry.ValueRepresentations.Select(x => x.ToString()));
+                string variable = "_" + Char.ToLower(entry.Keyword[0]) + entry.Keyword.Substring(1);
 
-				output.AppendFormat("\t\t///<summary>{0} VR={1} VM={2} {3}{4}</summary>",
-					entry.Tag, vrs, entry.ValueMultiplicity, entry.Name, entry.IsRetired ? " (RETIRED)" : "").AppendLine();
-				output.AppendFormat("\t\tpublic readonly static DicomTag {0}{1} = new DicomTag(0x{2:x4}, 0x{3:x4});", 
-					entry.Keyword, entry.IsRetired ? "RETIRED" : "", entry.Tag.Group, entry.Tag.Element).AppendLine();
-				output.AppendLine();
+                output.AppendFormat(
+                    "\t\t///<summary>{0} VR={1} VM={2} {3}{4}</summary>",
+                    entry.Tag,
+                    vrs,
+                    entry.ValueMultiplicity,
+                    entry.Name,
+                    entry.IsRetired ? " (RETIRED)" : "").AppendLine();
+                output.AppendFormat(
+                    "\t\tpublic readonly static DicomTag {0}{1} = new DicomTag(0x{2:x4}, 0x{3:x4});",
+                    entry.Keyword,
+                    entry.IsRetired ? "RETIRED" : "",
+                    entry.Tag.Group,
+                    entry.Tag.Element).AppendLine();
+                output.AppendLine();
 
-				//output.AppendFormat("\t\t///<summary>{0} VR={1} VM={2} {3}{4}</summary>",
-				//    entry.Tag, vrs, entry.ValueMultiplicity, entry.Name, entry.IsRetired ? " (RETIRED)" : "").AppendLine();
-				//output.AppendFormat("\t\tpublic static DicomTag {0}{1} {{", entry.Keyword, entry.IsRetired ? "RETIRED" : "").AppendLine();
-				//output.AppendLine("\t\t\tget {");
-				//output.AppendFormat("\t\t\t\tif ({0} == null)", variable).AppendLine();
-				//output.AppendFormat("\t\t\t\t\t{0} = new DicomTag(0x{1:x4}, 0x{2:x4});", variable, entry.Tag.Group, entry.Tag.Element).AppendLine();
-				//output.AppendFormat("\t\t\t\treturn {0};", variable).AppendLine();
-				//output.AppendLine("\t\t\t}");
-				//output.AppendLine("\t\t}");
-				//output.AppendFormat("\t\tprivate static DicomTag {0};", variable).AppendLine();
-				//output.AppendLine();
-			}
+                //output.AppendFormat("\t\t///<summary>{0} VR={1} VM={2} {3}{4}</summary>",
+                //    entry.Tag, vrs, entry.ValueMultiplicity, entry.Name, entry.IsRetired ? " (RETIRED)" : "").AppendLine();
+                //output.AppendFormat("\t\tpublic static DicomTag {0}{1} {{", entry.Keyword, entry.IsRetired ? "RETIRED" : "").AppendLine();
+                //output.AppendLine("\t\t\tget {");
+                //output.AppendFormat("\t\t\t\tif ({0} == null)", variable).AppendLine();
+                //output.AppendFormat("\t\t\t\t\t{0} = new DicomTag(0x{1:x4}, 0x{2:x4});", variable, entry.Tag.Group, entry.Tag.Element).AppendLine();
+                //output.AppendFormat("\t\t\t\treturn {0};", variable).AppendLine();
+                //output.AppendLine("\t\t\t}");
+                //output.AppendLine("\t\t}");
+                //output.AppendFormat("\t\tprivate static DicomTag {0};", variable).AppendLine();
+                //output.AppendLine();
+            }
 
-			output.AppendLine("\t}");
-			output.AppendLine("}");
+            output.AppendLine("\t}");
+            output.AppendLine("}");
 
-			return output.ToString();
-		}
-	}
+            return output.ToString();
+        }
+    }
 }

--- a/DICOM/Generators/DicomUIDGenerator.cs
+++ b/DICOM/Generators/DicomUIDGenerator.cs
@@ -1,118 +1,122 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
-using System.Xml;
 using System.Xml.Linq;
 
-namespace Dicom.Generators {
-	public class DicomUIDGenerator {
-		public static string Process(string file) {
-			StringBuilder list = new StringBuilder();
-			StringBuilder uids = new StringBuilder();
+namespace Dicom.Generators
+{
+    public class DicomUIDGenerator
+    {
+        public static string Process(string file)
+        {
+            StringBuilder list = new StringBuilder();
+            StringBuilder uids = new StringBuilder();
 
-			XDocument doc = XDocument.Load(file);
-			XElement xdict = doc.Element("dictionary");
-			if (xdict == null)
-				throw new DicomDataException("Expected <dictionary> root node in DICOM dictionary.");
+            XDocument doc = XDocument.Load(file);
+            XElement xdict = doc.Element("dictionary");
+            if (xdict == null) throw new DicomDataException("Expected <dictionary> root node in DICOM dictionary.");
 
-			foreach (XElement xuid in xdict.Elements("uid")) {
-				string name = xuid.Value;
+            foreach (XElement xuid in xdict.Elements("uid"))
+            {
+                string name = xuid.Value;
 
-				if (xuid.Attribute("uid") == null)
-					continue;
-				string uid = xuid.Attribute("uid").Value;
+                if (xuid.Attribute("uid") == null) continue;
+                string uid = xuid.Attribute("uid").Value;
 
-				if (xuid.Attribute("keyword") == null)
-					continue;
-				string keyword = xuid.Attribute("keyword").Value;
+                if (xuid.Attribute("keyword") == null) continue;
+                string keyword = xuid.Attribute("keyword").Value;
 
-				bool retired = false;
-				XAttribute xretired = xuid.Attribute("retired");
-				if (xretired != null && !String.IsNullOrEmpty(xretired.Value) && Boolean.Parse(xretired.Value))
-					retired = true;
+                bool retired = false;
+                XAttribute xretired = xuid.Attribute("retired");
+                if (xretired != null && !String.IsNullOrEmpty(xretired.Value) && Boolean.Parse(xretired.Value)) retired = true;
 
-				if (retired)
-					keyword += "RETIRED";
+                if (retired) keyword += "RETIRED";
 
-				if (xuid.Attribute("type") == null)
-					continue;
-				string type = xuid.Attribute("type").Value;
+                if (xuid.Attribute("type") == null) continue;
+                string type = xuid.Attribute("type").Value;
 
-				DicomUidType uidType = DicomUidType.Unknown;
-				switch (type) {
-				case "Transfer":
-				case "Transfer Syntax":
-					uidType = DicomUidType.TransferSyntax;
-					break;
-				case "SOP Class":
-				case "Query/Retrieve":
-					uidType = DicomUidType.SOPClass;
-					break;
-				case "Meta SOP Class":
-					uidType = DicomUidType.MetaSOPClass;
-					break;
-				case "Service Class":
-					uidType = DicomUidType.ServiceClass;
-					break;
-				case "Well-known frame of reference":
-				case "Synchronization Frame of Reference":
-					uidType = DicomUidType.FrameOfReference;
-					break;
-				case "Well-known SOP Instance":
-				case "Well-known Printer SOP Instance":
-				case "Well-known Print Queue SOP Instance":
-					uidType = DicomUidType.SOPInstance;
-					break;
-				case "Coding Scheme":
-				case "DICOM UIDs as a Coding Scheme":
-					uidType = DicomUidType.CodingScheme;
-					break;
-				case "Application Context Name":
-					uidType = DicomUidType.ApplicationContextName;
-					break;
-				case "LDAP":
-				case "LDAP OID":
-					uidType = DicomUidType.LDAP;
-					break;
-				case "Context Group Name":
-					uidType = DicomUidType.ContextGroupName;
-					break;
-				case "Application Hosting Model":
-					uidType = DicomUidType.ApplicationHostingModel;
-					break;
-				case "":
-					uidType = DicomUidType.Unknown;
-					break;
-				default:
-					throw new DicomDataException("Unkown UID type: {0}", type);
-				}
+                DicomUidType uidType = DicomUidType.Unknown;
+                switch (type)
+                {
+                    case "Transfer":
+                    case "Transfer Syntax":
+                        uidType = DicomUidType.TransferSyntax;
+                        break;
+                    case "SOP Class":
+                    case "Query/Retrieve":
+                        uidType = DicomUidType.SOPClass;
+                        break;
+                    case "Meta SOP Class":
+                        uidType = DicomUidType.MetaSOPClass;
+                        break;
+                    case "Service Class":
+                        uidType = DicomUidType.ServiceClass;
+                        break;
+                    case "Well-known frame of reference":
+                    case "Synchronization Frame of Reference":
+                        uidType = DicomUidType.FrameOfReference;
+                        break;
+                    case "Well-known SOP Instance":
+                    case "Well-known Printer SOP Instance":
+                    case "Well-known Print Queue SOP Instance":
+                        uidType = DicomUidType.SOPInstance;
+                        break;
+                    case "Coding Scheme":
+                    case "DICOM UIDs as a Coding Scheme":
+                        uidType = DicomUidType.CodingScheme;
+                        break;
+                    case "Application Context Name":
+                        uidType = DicomUidType.ApplicationContextName;
+                        break;
+                    case "LDAP":
+                    case "LDAP OID":
+                        uidType = DicomUidType.LDAP;
+                        break;
+                    case "Context Group Name":
+                        uidType = DicomUidType.ContextGroupName;
+                        break;
+                    case "Application Hosting Model":
+                        uidType = DicomUidType.ApplicationHostingModel;
+                        break;
+                    case "":
+                        uidType = DicomUidType.Unknown;
+                        break;
+                    default:
+                        throw new DicomDataException("Unkown UID type: {0}", type);
+                }
 
-				list.AppendFormat("\t\t\t_uids.Add(DicomUID.{0}.UID, DicomUID.{0});", keyword).AppendLine();
+                list.AppendFormat("\t\t\t_uids.Add(DicomUID.{0}.UID, DicomUID.{0});", keyword).AppendLine();
 
-				uids.AppendLine();
-				uids.AppendFormat("\t\t/// <summary>{0}: {1}</summary>", type, name).AppendLine();
-				uids.AppendFormat("\t\tpublic readonly static DicomUID {0} = new DicomUID(\"{1}\", \"{2}\", DicomUidType.{3}, {4});", keyword, uid, name, uidType, retired ? "true" : "false").AppendLine();
-			}
+                uids.AppendLine();
+                uids.AppendFormat("\t\t/// <summary>{0}: {1}</summary>", type, name).AppendLine();
+                uids.AppendFormat(
+                    "\t\tpublic readonly static DicomUID {0} = new DicomUID(\"{1}\", \"{2}\", DicomUidType.{3}, {4});",
+                    keyword,
+                    uid,
+                    name,
+                    uidType,
+                    retired ? "true" : "false").AppendLine();
+            }
 
-			string code = @"using System;
+            string code = @"using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
 namespace Dicom {
-	public partial class DicomUID {
-		private static void LoadInternalUIDs() {
+    public partial class DicomUID {
+        private static void LoadInternalUIDs() {
 ";
 
-			code += list.ToString();
-			code += "		}";
-			code += uids.ToString();
+            code += list.ToString();
+            code += "		}";
+            code += uids.ToString();
 
-			code += @"	}
+            code += @"	}
 }";
-			return code;
-		}
-	}
+            return code;
+        }
+    }
 }

--- a/DICOM/IO/Buffer/ByteBufferEnumerator.cs
+++ b/DICOM/IO/Buffer/ByteBufferEnumerator.cs
@@ -1,191 +1,233 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 
-namespace Dicom.IO.Buffer {
-	public abstract class ByteBufferEnumerator<T> : IEnumerable<T>, IEnumerator<T> {
-		protected ByteBufferEnumerator(IByteBuffer buffer) {
-			Buffer = buffer;
-			UnitSize = Marshal.SizeOf(typeof(T));
-			Position = -UnitSize;
-		}
+namespace Dicom.IO.Buffer
+{
+    public abstract class ByteBufferEnumerator<T> : IEnumerable<T>, IEnumerator<T>
+    {
+        protected ByteBufferEnumerator(IByteBuffer buffer)
+        {
+            Buffer = buffer;
+            UnitSize = Marshal.SizeOf(typeof(T));
+            Position = -UnitSize;
+        }
 
-		public IByteBuffer Buffer {
-			get;
-			protected set;
-		}
+        public IByteBuffer Buffer { get; protected set; }
 
-		private byte[] _data;
-		protected byte[] Data {
-			get {
-				if (_data == null)
-					_data = Buffer.Data;
-				return _data;
-			}
-		}
+        private byte[] _data;
 
-		protected int Position {
-			get;
-			set;
-		}
+        protected byte[] Data
+        {
+            get
+            {
+                if (_data == null) _data = Buffer.Data;
+                return _data;
+            }
+        }
 
-		protected int UnitSize {
-			get;
-			set;
-		}
+        protected int Position { get; set; }
 
-		public void Dispose() {
-			_data = null;
-		}
+        protected int UnitSize { get; set; }
 
-		public IEnumerator<T> GetEnumerator() {
-			return this;
-		}
+        public void Dispose()
+        {
+            _data = null;
+        }
 
-		IEnumerator IEnumerable.GetEnumerator() {
-			return this;
-		}
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this;
+        }
 
-		public T Current {
-			get { return CurrentItem(); }
-		}
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this;
+        }
 
-		object System.Collections.IEnumerator.Current {
-			get { return CurrentItem(); }
-		}
+        public T Current
+        {
+            get
+            {
+                return CurrentItem();
+            }
+        }
 
-		public bool MoveNext() {
-			Position += UnitSize;
-			if (Position <= (Buffer.Size - UnitSize))
-				return true;
-			return false;
-		}
+        object System.Collections.IEnumerator.Current
+        {
+            get
+            {
+                return CurrentItem();
+            }
+        }
 
-		public void Reset() {
-			Position = -UnitSize;
-		}
+        public bool MoveNext()
+        {
+            Position += UnitSize;
+            if (Position <= (Buffer.Size - UnitSize)) return true;
+            return false;
+        }
 
-		protected abstract T CurrentItem();
+        public void Reset()
+        {
+            Position = -UnitSize;
+        }
 
-		public static IEnumerable<T> Create(IByteBuffer buffer) {
-			if (typeof(T) == typeof(byte))
-				return (IEnumerable<T>)new ByteBufferByteEnumerator(buffer);
-			if (typeof(T) == typeof(sbyte))
-				return (IEnumerable<T>)new ByteBufferSByteEnumerator(buffer);
+        protected abstract T CurrentItem();
 
-			if (typeof(T) == typeof(short))
-				return (IEnumerable<T>)new ByteBufferInt16Enumerator(buffer);
-			if (typeof(T) == typeof(ushort))
-				return (IEnumerable<T>)new ByteBufferUInt16Enumerator(buffer);
+        public static IEnumerable<T> Create(IByteBuffer buffer)
+        {
+            if (typeof(T) == typeof(byte)) return (IEnumerable<T>)new ByteBufferByteEnumerator(buffer);
+            if (typeof(T) == typeof(sbyte)) return (IEnumerable<T>)new ByteBufferSByteEnumerator(buffer);
 
-			if (typeof(T) == typeof(int))
-				return (IEnumerable<T>)new ByteBufferInt32Enumerator(buffer);
-			if (typeof(T) == typeof(uint))
-				return (IEnumerable<T>)new ByteBufferUInt32Enumerator(buffer);
+            if (typeof(T) == typeof(short)) return (IEnumerable<T>)new ByteBufferInt16Enumerator(buffer);
+            if (typeof(T) == typeof(ushort)) return (IEnumerable<T>)new ByteBufferUInt16Enumerator(buffer);
 
-			if (typeof(T) == typeof(long))
-				return (IEnumerable<T>)new ByteBufferInt64Enumerator(buffer);
-			if (typeof(T) == typeof(ulong))
-				return (IEnumerable<T>)new ByteBufferUInt64Enumerator(buffer);
+            if (typeof(T) == typeof(int)) return (IEnumerable<T>)new ByteBufferInt32Enumerator(buffer);
+            if (typeof(T) == typeof(uint)) return (IEnumerable<T>)new ByteBufferUInt32Enumerator(buffer);
 
-			if (typeof(T) == typeof(float))
-				return (IEnumerable<T>)new ByteBufferSingleEnumerator(buffer);
-			if (typeof(T) == typeof(double))
-				return (IEnumerable<T>)new ByteBufferDoubleEnumerator(buffer);
+            if (typeof(T) == typeof(long)) return (IEnumerable<T>)new ByteBufferInt64Enumerator(buffer);
+            if (typeof(T) == typeof(ulong)) return (IEnumerable<T>)new ByteBufferUInt64Enumerator(buffer);
 
-			throw new NotSupportedException("ByteBufferEnumerator<T> only provides support for the base .NET numeric types.");
-		}
+            if (typeof(T) == typeof(float)) return (IEnumerable<T>)new ByteBufferSingleEnumerator(buffer);
+            if (typeof(T) == typeof(double)) return (IEnumerable<T>)new ByteBufferDoubleEnumerator(buffer);
 
-		protected class ByteBufferByteEnumerator : ByteBufferEnumerator<byte> {
-			public ByteBufferByteEnumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            throw new NotSupportedException(
+                "ByteBufferEnumerator<T> only provides support for the base .NET numeric types.");
+        }
 
-			protected override byte CurrentItem() {
-				return Data[Position];
-			}
-		}
+        protected class ByteBufferByteEnumerator : ByteBufferEnumerator<byte>
+        {
+            public ByteBufferByteEnumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferSByteEnumerator : ByteBufferEnumerator<sbyte> {
-			public ByteBufferSByteEnumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override byte CurrentItem()
+            {
+                return Data[Position];
+            }
+        }
 
-			protected override sbyte CurrentItem() {
-				return (sbyte)Data[Position];
-			}
-		}
+        protected class ByteBufferSByteEnumerator : ByteBufferEnumerator<sbyte>
+        {
+            public ByteBufferSByteEnumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferInt16Enumerator : ByteBufferEnumerator<short> {
-			public ByteBufferInt16Enumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override sbyte CurrentItem()
+            {
+                return (sbyte)Data[Position];
+            }
+        }
 
-			protected override short CurrentItem() {
-				return BitConverter.ToInt16(Data, Position);
-			}
-		}
+        protected class ByteBufferInt16Enumerator : ByteBufferEnumerator<short>
+        {
+            public ByteBufferInt16Enumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferUInt16Enumerator : ByteBufferEnumerator<ushort> {
-			public ByteBufferUInt16Enumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override short CurrentItem()
+            {
+                return BitConverter.ToInt16(Data, Position);
+            }
+        }
 
-			protected override ushort CurrentItem() {
-				return BitConverter.ToUInt16(Data, Position);
-			}
-		}
+        protected class ByteBufferUInt16Enumerator : ByteBufferEnumerator<ushort>
+        {
+            public ByteBufferUInt16Enumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferInt32Enumerator : ByteBufferEnumerator<int> {
-			public ByteBufferInt32Enumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override ushort CurrentItem()
+            {
+                return BitConverter.ToUInt16(Data, Position);
+            }
+        }
 
-			protected override int CurrentItem() {
-				return BitConverter.ToInt32(Data, Position);
-			}
-		}
+        protected class ByteBufferInt32Enumerator : ByteBufferEnumerator<int>
+        {
+            public ByteBufferInt32Enumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferUInt32Enumerator : ByteBufferEnumerator<uint> {
-			public ByteBufferUInt32Enumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override int CurrentItem()
+            {
+                return BitConverter.ToInt32(Data, Position);
+            }
+        }
 
-			protected override uint CurrentItem() {
-				return BitConverter.ToUInt32(Data, Position);
-			}
-		}
+        protected class ByteBufferUInt32Enumerator : ByteBufferEnumerator<uint>
+        {
+            public ByteBufferUInt32Enumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferInt64Enumerator : ByteBufferEnumerator<long> {
-			public ByteBufferInt64Enumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override uint CurrentItem()
+            {
+                return BitConverter.ToUInt32(Data, Position);
+            }
+        }
 
-			protected override long CurrentItem() {
-				return BitConverter.ToInt64(Data, Position);
-			}
-		}
+        protected class ByteBufferInt64Enumerator : ByteBufferEnumerator<long>
+        {
+            public ByteBufferInt64Enumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferUInt64Enumerator : ByteBufferEnumerator<ulong> {
-			public ByteBufferUInt64Enumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override long CurrentItem()
+            {
+                return BitConverter.ToInt64(Data, Position);
+            }
+        }
 
-			protected override ulong CurrentItem() {
-				return BitConverter.ToUInt64(Data, Position);
-			}
-		}
+        protected class ByteBufferUInt64Enumerator : ByteBufferEnumerator<ulong>
+        {
+            public ByteBufferUInt64Enumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferSingleEnumerator : ByteBufferEnumerator<float> {
-			public ByteBufferSingleEnumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override ulong CurrentItem()
+            {
+                return BitConverter.ToUInt64(Data, Position);
+            }
+        }
 
-			protected override float CurrentItem() {
-				return BitConverter.ToSingle(Data, Position);
-			}
-		}
+        protected class ByteBufferSingleEnumerator : ByteBufferEnumerator<float>
+        {
+            public ByteBufferSingleEnumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
 
-		protected class ByteBufferDoubleEnumerator : ByteBufferEnumerator<double> {
-			public ByteBufferDoubleEnumerator(IByteBuffer buffer) : base(buffer) {
-			}
+            protected override float CurrentItem()
+            {
+                return BitConverter.ToSingle(Data, Position);
+            }
+        }
 
-			protected override double CurrentItem() {
-				return BitConverter.ToDouble(Data, Position);
-			}
-		}
-	}
+        protected class ByteBufferDoubleEnumerator : ByteBufferEnumerator<double>
+        {
+            public ByteBufferDoubleEnumerator(IByteBuffer buffer)
+                : base(buffer)
+            {
+            }
+
+            protected override double CurrentItem()
+            {
+                return BitConverter.ToDouble(Data, Position);
+            }
+        }
+    }
 }

--- a/DICOM/IO/Buffer/ByteBufferExtensions.cs
+++ b/DICOM/IO/Buffer/ByteBufferExtensions.cs
@@ -1,10 +1,15 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 
-namespace Dicom.IO.Buffer {
-	public static class ByteBufferExtensions {
-		public static IEnumerable<T> Enumerate<T>(this IByteBuffer buffer) {
-			return ByteBufferEnumerator<T>.Create(buffer);
-		}
-	}
+namespace Dicom.IO.Buffer
+{
+    public static class ByteBufferExtensions
+    {
+        public static IEnumerable<T> Enumerate<T>(this IByteBuffer buffer)
+        {
+            return ByteBufferEnumerator<T>.Create(buffer);
+        }
+    }
 }

--- a/DICOM/IO/Buffer/CompositeByteBuffer.cs
+++ b/DICOM/IO/Buffer/CompositeByteBuffer.cs
@@ -1,73 +1,88 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Dicom.IO.Buffer {
-	public class CompositeByteBuffer : IByteBuffer {
-		public CompositeByteBuffer(params IByteBuffer[] buffers) {
-			Buffers = new List<IByteBuffer>(buffers);
-		}
+namespace Dicom.IO.Buffer
+{
+    public class CompositeByteBuffer : IByteBuffer
+    {
+        public CompositeByteBuffer(params IByteBuffer[] buffers)
+        {
+            Buffers = new List<IByteBuffer>(buffers);
+        }
 
-		public IList<IByteBuffer> Buffers {
-			get;
-			private set;
-		}
+        public IList<IByteBuffer> Buffers { get; private set; }
 
-		public bool IsMemory {
-			get { return true; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return true;
+            }
+        }
 
-		public uint Size {
-			get { return (uint)Buffers.Sum(x => x.Size); }
-		}
+        public uint Size
+        {
+            get
+            {
+                return (uint)Buffers.Sum(x => x.Size);
+            }
+        }
 
-		public byte[] Data {
-			get {
-				byte[] data = new byte[Size];
-				int offset = 0;
-				foreach (IByteBuffer buffer in Buffers) {
-					System.Buffer.BlockCopy(buffer.Data, 0, data, offset, (int)buffer.Size);
-					offset += (int)buffer.Size;
-				}
-				return data;
-			}
-		}
+        public byte[] Data
+        {
+            get
+            {
+                byte[] data = new byte[Size];
+                int offset = 0;
+                foreach (IByteBuffer buffer in Buffers)
+                {
+                    System.Buffer.BlockCopy(buffer.Data, 0, data, offset, (int)buffer.Size);
+                    offset += (int)buffer.Size;
+                }
+                return data;
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			int pos = 0;
-			for (; pos < Buffers.Count && offset > Buffers[pos].Size; pos++)
-				offset -= (int)Buffers[pos].Size;
+        public byte[] GetByteRange(int offset, int count)
+        {
+            int pos = 0;
+            for (; pos < Buffers.Count && offset > Buffers[pos].Size; pos++) offset -= (int)Buffers[pos].Size;
 
-			int offset2 = 0;
-			byte[] data = new byte[count];
-			for (; pos < Buffers.Count && count > 0; pos++) {
-				int remain = (int)Buffers[pos].Size - offset;
+            int offset2 = 0;
+            byte[] data = new byte[count];
+            for (; pos < Buffers.Count && count > 0; pos++)
+            {
+                int remain = (int)Buffers[pos].Size - offset;
 
-				if (Buffers[pos].IsMemory)
+                if (Buffers[pos].IsMemory)
                 {
                     try
                     {
-					System.Buffer.BlockCopy(Buffers[pos].Data, offset, data, offset2, remain);
+                        System.Buffer.BlockCopy(Buffers[pos].Data, offset, data, offset2, remain);
                     }
                     catch (Exception)
                     {
-                       data = Buffers[pos].Data.ToArray();
+                        data = Buffers[pos].Data.ToArray();
                     }
-                    
+
                 }
-					
-				else {
-					byte[] temp = Buffers[pos].GetByteRange(offset, remain);
-					System.Buffer.BlockCopy(temp, 0, data, offset2, remain);
-				}
 
-				count -= remain;
-				offset2 += remain;
-				if (offset > 0)
-					offset = 0;
-			}
+                else
+                {
+                    byte[] temp = Buffers[pos].GetByteRange(offset, remain);
+                    System.Buffer.BlockCopy(temp, 0, data, offset2, remain);
+                }
 
-			return data;
-		}
-	}
+                count -= remain;
+                offset2 += remain;
+                if (offset > 0) offset = 0;
+            }
+
+            return data;
+        }
+    }
 }

--- a/DICOM/IO/Buffer/EmptyBuffer.cs
+++ b/DICOM/IO/Buffer/EmptyBuffer.cs
@@ -1,33 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public sealed class EmptyBuffer : IByteBuffer {
-		public readonly static IByteBuffer Value = new EmptyBuffer();
+using System;
 
-		internal EmptyBuffer() {
-			Data = new byte[0];
-		}
+namespace Dicom.IO.Buffer
+{
+    public sealed class EmptyBuffer : IByteBuffer
+    {
+        public static readonly IByteBuffer Value = new EmptyBuffer();
 
-		public bool IsMemory {
-			get { return true; }
-		}
+        internal EmptyBuffer()
+        {
+            Data = new byte[0];
+        }
 
-		public byte[] Data {
-			get;
-			private set;
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return true;
+            }
+        }
 
-		public uint Size {
-			get { return 0; }
-		}
+        public byte[] Data { get; private set; }
 
-		public byte[] GetByteRange(int offset, int count) {
-			if (offset != 0 || count != 0)
-				throw new ArgumentOutOfRangeException("offset", "Offset and count cannot be greater than 0 in EmptyBuffer");
-			return Data;
-		}
-	}
+        public uint Size
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public byte[] GetByteRange(int offset, int count)
+        {
+            if (offset != 0 || count != 0)
+                throw new ArgumentOutOfRangeException(
+                    "offset",
+                    "Offset and count cannot be greater than 0 in EmptyBuffer");
+            return Data;
+        }
+    }
 }

--- a/DICOM/IO/Buffer/EndianByteBuffer.cs
+++ b/DICOM/IO/Buffer/EndianByteBuffer.cs
@@ -1,69 +1,73 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public class EndianByteBuffer : IByteBuffer {
-		protected EndianByteBuffer(IByteBuffer buffer, Endian endian, int unitSize) {
-			Internal = buffer;
-			Endian = endian;
-			UnitSize = unitSize;
-		}
+namespace Dicom.IO.Buffer
+{
+    public class EndianByteBuffer : IByteBuffer
+    {
+        protected EndianByteBuffer(IByteBuffer buffer, Endian endian, int unitSize)
+        {
+            Internal = buffer;
+            Endian = endian;
+            UnitSize = unitSize;
+        }
 
-		public IByteBuffer Internal {
-			get;
-			private set;
-		}
+        public IByteBuffer Internal { get; private set; }
 
-		public Endian Endian {
-			get;
-			private set;
-		}
+        public Endian Endian { get; private set; }
 
-		public int UnitSize {
-			get;
-			private set;
-		}
+        public int UnitSize { get; private set; }
 
-		public bool IsMemory {
-			get { return Internal.IsMemory; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return Internal.IsMemory;
+            }
+        }
 
-		public uint Size {
-			get { return Internal.Size; }
-		}
+        public uint Size
+        {
+            get
+            {
+                return Internal.Size;
+            }
+        }
 
-		public byte[] Data {
-			get {
-				byte[] data = null;
-				if (IsMemory) {
-					data = new byte[Size];
-					System.Buffer.BlockCopy(Internal.Data, 0, data, 0, data.Length);
-				} else {
-					data = Internal.Data;
-				}
+        public byte[] Data
+        {
+            get
+            {
+                byte[] data = null;
+                if (IsMemory)
+                {
+                    data = new byte[Size];
+                    System.Buffer.BlockCopy(Internal.Data, 0, data, 0, data.Length);
+                }
+                else
+                {
+                    data = Internal.Data;
+                }
 
-				if (Endian != Endian.LocalMachine)
-					Endian.SwapBytes(UnitSize, data);
+                if (Endian != Endian.LocalMachine) Endian.SwapBytes(UnitSize, data);
 
-				return data;
-			}
-		}
+                return data;
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			byte[] data = Internal.GetByteRange(offset, count);
+        public byte[] GetByteRange(int offset, int count)
+        {
+            byte[] data = Internal.GetByteRange(offset, count);
 
-			if (Endian != Endian.LocalMachine)
-				Endian.SwapBytes(UnitSize, data);
+            if (Endian != Endian.LocalMachine) Endian.SwapBytes(UnitSize, data);
 
-			return data;
-		}
+            return data;
+        }
 
-		public static IByteBuffer Create(IByteBuffer buffer, Endian endian, int unitSize) {
-			if (endian == Endian.LocalMachine || unitSize == 1)
-				return buffer;
-			return new EndianByteBuffer(buffer, endian, unitSize);
-		}
-	}
+        public static IByteBuffer Create(IByteBuffer buffer, Endian endian, int unitSize)
+        {
+            if (endian == Endian.LocalMachine || unitSize == 1) return buffer;
+            return new EndianByteBuffer(buffer, endian, unitSize);
+        }
+    }
 }

--- a/DICOM/IO/Buffer/EvenLengthBuffer.cs
+++ b/DICOM/IO/Buffer/EvenLengthBuffer.cs
@@ -1,45 +1,56 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public class EvenLengthBuffer : IByteBuffer {
-		private EvenLengthBuffer(IByteBuffer buffer) {
-			Buffer = buffer;
-		}
+using System;
 
-		public IByteBuffer Buffer {
-			get;
-			private set;
-		}
+namespace Dicom.IO.Buffer
+{
+    public class EvenLengthBuffer : IByteBuffer
+    {
+        private EvenLengthBuffer(IByteBuffer buffer)
+        {
+            Buffer = buffer;
+        }
 
-		public bool IsMemory {
-			get { return true; }
-		}
+        public IByteBuffer Buffer { get; private set; }
 
-		public uint Size {
-			get { return Buffer.Size + 1; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return true;
+            }
+        }
 
-		public byte[] Data {
-			get {
-				byte[] data = new byte[Size];
-				System.Buffer.BlockCopy(Buffer.Data, 0, data, 0, (int)Buffer.Size);
-				return data;
-			}
-		}
+        public uint Size
+        {
+            get
+            {
+                return Buffer.Size + 1;
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			byte[] data = new byte[count];
-			System.Buffer.BlockCopy(Buffer.Data, offset, data, 0, Math.Min((int)Buffer.Size, count));
-			return data;
-		}
+        public byte[] Data
+        {
+            get
+            {
+                byte[] data = new byte[Size];
+                System.Buffer.BlockCopy(Buffer.Data, 0, data, 0, (int)Buffer.Size);
+                return data;
+            }
+        }
 
-		public static IByteBuffer Create(IByteBuffer buffer) {
-			if ((buffer.Size & 1) == 1)
-				return new EvenLengthBuffer(buffer);
-			return buffer;
-		}
-	}
+        public byte[] GetByteRange(int offset, int count)
+        {
+            byte[] data = new byte[count];
+            System.Buffer.BlockCopy(Buffer.Data, offset, data, 0, Math.Min((int)Buffer.Size, count));
+            return data;
+        }
+
+        public static IByteBuffer Create(IByteBuffer buffer)
+        {
+            if ((buffer.Size & 1) == 1) return new EvenLengthBuffer(buffer);
+            return buffer;
+        }
+    }
 }

--- a/DICOM/IO/Buffer/FileByteBuffer.cs
+++ b/DICOM/IO/Buffer/FileByteBuffer.cs
@@ -1,38 +1,42 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public sealed class FileByteBuffer : IByteBuffer {
-		public FileByteBuffer(FileReference file, long Position, uint Length) {
-			this.File = file;
-			this.Position = Position;
-			this.Size = Length;
-		}
+namespace Dicom.IO.Buffer
+{
+    public sealed class FileByteBuffer : IByteBuffer
+    {
+        public FileByteBuffer(FileReference file, long Position, uint Length)
+        {
+            this.File = file;
+            this.Position = Position;
+            this.Size = Length;
+        }
 
-		public bool IsMemory {
-			get { return false; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-		public FileReference File {
-			get;
-			private set;
-		}
+        public FileReference File { get; private set; }
 
-		public long Position {
-			get;
-			private set;
-		}
+        public long Position { get; private set; }
 
-		public uint Size {
-			get;
-			private set;
-		}
+        public uint Size { get; private set; }
 
-		public byte[] Data {
-			get { return File.GetByteRange((int)Position, (int)Size); }
-		}
+        public byte[] Data
+        {
+            get
+            {
+                return File.GetByteRange((int)Position, (int)Size);
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			return File.GetByteRange((int)Position + offset, count);
-		}
-	}
+        public byte[] GetByteRange(int offset, int count)
+        {
+            return File.GetByteRange((int)Position + offset, count);
+        }
+    }
 }

--- a/DICOM/IO/Buffer/IByteBuffer.cs
+++ b/DICOM/IO/Buffer/IByteBuffer.cs
@@ -1,22 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public interface IByteBuffer {
-		bool IsMemory {
-			get;
-		}
+namespace Dicom.IO.Buffer
+{
+    public interface IByteBuffer
+    {
+        bool IsMemory { get; }
 
-		uint Size {
-			get;
-		}
+        uint Size { get; }
 
-		byte[] Data {
-			get;
-		}
+        byte[] Data { get; }
 
-		byte[] GetByteRange(int offset, int count);
-	}
+        byte[] GetByteRange(int offset, int count);
+    }
 }

--- a/DICOM/IO/Buffer/MappedFileBuffer.cs
+++ b/DICOM/IO/Buffer/MappedFileBuffer.cs
@@ -1,27 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 using System.IO.MemoryMappedFiles;
-using System.Linq;
-using System.Text;
 
 namespace Dicom.IO.Buffer
 {
     public sealed class MappedFileBuffer : IByteBuffer, IDisposable
     {
         private MemoryMappedFile _file;
+
         private MemoryMappedViewStream _stream;
-		private uint _size;
+
+        private uint _size;
+
         private bool _disposed = false;
+
         public MappedFileBuffer(byte[] data)
         {
             _file = MemoryMappedFile.CreateNew(Guid.NewGuid().ToString(), data.Length);
             _stream = _file.CreateViewStream();
             _stream.Write(data, 0, data.Length);
-            
-			//File.WriteAllBytes(_file.Name, data);
-			_size = (uint)data.Length;
-		}
+
+            //File.WriteAllBytes(_file.Name, data);
+            _size = (uint)data.Length;
+        }
 
         ~MappedFileBuffer()
         {
@@ -29,29 +33,39 @@ namespace Dicom.IO.Buffer
 
         }
 
-		public bool IsMemory {
-			get { return false; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-		public uint Size {
-			get { return _size; }
-		}
+        public uint Size
+        {
+            get
+            {
+                return _size;
+            }
+        }
 
-		public byte[] Data {
-			get 
+        public byte[] Data
+        {
+            get
             {
                 return GetByteRange(0, (int)_size);
             }
-		}
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			byte[] buffer = new byte[count];
+        public byte[] GetByteRange(int offset, int count)
+        {
+            byte[] buffer = new byte[count];
 
             _stream.Seek(offset, SeekOrigin.Begin);
             _stream.Read(buffer, 0, count);
 
-			return buffer;
-		}
+            return buffer;
+        }
 
         #region IDisposable Members
 

--- a/DICOM/IO/Buffer/MemoryByteBuffer.cs
+++ b/DICOM/IO/Buffer/MemoryByteBuffer.cs
@@ -1,36 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public sealed class MemoryByteBuffer : IByteBuffer {
-		public MemoryByteBuffer(byte[] Data) {
-			int len = Data.Length;
-			this.Data = new byte[len];
-			System.Buffer.BlockCopy(Data, 0, this.Data, 0, len);
-		}
+using System;
 
-		public bool IsMemory {
-			get { return true; }
-		}
+namespace Dicom.IO.Buffer
+{
+    public sealed class MemoryByteBuffer : IByteBuffer
+    {
+        public MemoryByteBuffer(byte[] Data)
+        {
+            int len = Data.Length;
+            this.Data = new byte[len];
+            System.Buffer.BlockCopy(Data, 0, this.Data, 0, len);
+        }
 
-		public byte[] Data {
-			get;
-			private set;
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return true;
+            }
+        }
 
-		public uint Size {
-			get { return (uint)Data.Length; }
-		}
+        public byte[] Data { get; private set; }
 
-		public byte[] GetByteRange(int offset, int count) {
-			if (offset == 0 && count == Size)
-				return Data;
+        public uint Size
+        {
+            get
+            {
+                return (uint)Data.Length;
+            }
+        }
 
-			byte[] buffer = new byte[count];
-			Array.Copy(Data, offset, buffer, 0, count);
-			return buffer;
-		}
-	}
+        public byte[] GetByteRange(int offset, int count)
+        {
+            if (offset == 0 && count == Size) return Data;
+
+            byte[] buffer = new byte[count];
+            Array.Copy(Data, offset, buffer, 0, count);
+            return buffer;
+        }
+    }
 }

--- a/DICOM/IO/Buffer/RangeByteBuffer.cs
+++ b/DICOM/IO/Buffer/RangeByteBuffer.cs
@@ -1,44 +1,50 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public class RangeByteBuffer : IByteBuffer {
-		public RangeByteBuffer(IByteBuffer buffer, uint offset, uint length) {
-			Internal = buffer;
-			Offset = offset;
-			Length = length;
-		}
+namespace Dicom.IO.Buffer
+{
+    public class RangeByteBuffer : IByteBuffer
+    {
+        public RangeByteBuffer(IByteBuffer buffer, uint offset, uint length)
+        {
+            Internal = buffer;
+            Offset = offset;
+            Length = length;
+        }
 
-		public IByteBuffer Internal {
-			get;
-			private set;
-		}
+        public IByteBuffer Internal { get; private set; }
 
-		public uint Offset {
-			get;
-			private set;
-		}
+        public uint Offset { get; private set; }
 
-		public uint Length {
-			get;
-			private set;
-		}
+        public uint Length { get; private set; }
 
-		public bool IsMemory {
-			get { return Internal.IsMemory; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return Internal.IsMemory;
+            }
+        }
 
-		public uint Size {
-			get { return Length; }
-		}
+        public uint Size
+        {
+            get
+            {
+                return Length;
+            }
+        }
 
-		public byte[] Data {
-			get {
-				return Internal.GetByteRange((int)Offset, (int)Length);
-			}
-		}
+        public byte[] Data
+        {
+            get
+            {
+                return Internal.GetByteRange((int)Offset, (int)Length);
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			return Internal.GetByteRange((int)Offset + offset, count);
-		}
-	}
+        public byte[] GetByteRange(int offset, int count)
+        {
+            return Internal.GetByteRange((int)Offset + offset, count);
+        }
+    }
 }

--- a/DICOM/IO/Buffer/StreamByteBuffer.cs
+++ b/DICOM/IO/Buffer/StreamByteBuffer.cs
@@ -1,50 +1,52 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.IO;
 
-namespace Dicom.IO.Buffer {
-	public sealed class StreamByteBuffer : IByteBuffer {
-		public StreamByteBuffer(Stream Stream, long Position, uint Length) {
-			this.Stream = Stream;
-			this.Position = Position;
-			this.Size = Length;
-		}
+namespace Dicom.IO.Buffer
+{
+    public sealed class StreamByteBuffer : IByteBuffer
+    {
+        public StreamByteBuffer(Stream Stream, long Position, uint Length)
+        {
+            this.Stream = Stream;
+            this.Position = Position;
+            this.Size = Length;
+        }
 
-		public bool IsMemory {
-			get { return false; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-		public Stream Stream {
-			get;
-			private set;
-		}
+        public Stream Stream { get; private set; }
 
-		public long Position {
-			get;
-			private set;
-		}
+        public long Position { get; private set; }
 
-		public uint Size {
-			get;
-			private set;
-		}
+        public uint Size { get; private set; }
 
-		public byte[] Data {
-			get {
-				byte[] data = new byte[Size];
-				Stream.Position = Position;
-				Stream.Read(data, 0, (int)Size);
-				return data;
-			}
-		}
+        public byte[] Data
+        {
+            get
+            {
+                byte[] data = new byte[Size];
+                Stream.Position = Position;
+                Stream.Read(data, 0, (int)Size);
+                return data;
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			if (offset == 0 && count == Size)
-				return Data;
+        public byte[] GetByteRange(int offset, int count)
+        {
+            if (offset == 0 && count == Size) return Data;
 
-			byte[] buffer = new byte[count];
-			Stream.Position = Position + offset;
-			Stream.Read(buffer, 0, count);
-			return buffer;
-		}
-	}
+            byte[] buffer = new byte[count];
+            Stream.Position = Position + offset;
+            Stream.Read(buffer, 0, count);
+            return buffer;
+        }
+    }
 }

--- a/DICOM/IO/Buffer/SwapByteBuffer.cs
+++ b/DICOM/IO/Buffer/SwapByteBuffer.cs
@@ -1,53 +1,62 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Buffer {
-	public class SwapByteBuffer : IByteBuffer {
-		public SwapByteBuffer(IByteBuffer buffer, int unitSize) {
-			Internal = buffer;
-			UnitSize = unitSize;
-		}
+namespace Dicom.IO.Buffer
+{
+    public class SwapByteBuffer : IByteBuffer
+    {
+        public SwapByteBuffer(IByteBuffer buffer, int unitSize)
+        {
+            Internal = buffer;
+            UnitSize = unitSize;
+        }
 
-		public IByteBuffer Internal {
-			get;
-			private set;
-		}
+        public IByteBuffer Internal { get; private set; }
 
-		public int UnitSize {
-			get;
-			private set;
-		}
+        public int UnitSize { get; private set; }
 
-		public bool IsMemory {
-			get { return Internal.IsMemory; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return Internal.IsMemory;
+            }
+        }
 
-		public uint Size {
-			get { return Internal.Size; }
-		}
+        public uint Size
+        {
+            get
+            {
+                return Internal.Size;
+            }
+        }
 
-		public byte[] Data {
-			get {
-				byte[] data = null;
-				if (IsMemory) {
-					data = new byte[Size];
-					System.Buffer.BlockCopy(Internal.Data, 0, data, 0, data.Length);
-				} else {
-					data = Internal.Data;
-				}
+        public byte[] Data
+        {
+            get
+            {
+                byte[] data = null;
+                if (IsMemory)
+                {
+                    data = new byte[Size];
+                    System.Buffer.BlockCopy(Internal.Data, 0, data, 0, data.Length);
+                }
+                else
+                {
+                    data = Internal.Data;
+                }
 
-				Endian.SwapBytes(UnitSize, data);
+                Endian.SwapBytes(UnitSize, data);
 
-				return data;
-			}
-		}
+                return data;
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			byte[] data = Internal.GetByteRange(offset, count);
-			Endian.SwapBytes(UnitSize, data);
-			return data;
-		}
-	}
+        public byte[] GetByteRange(int offset, int count)
+        {
+            byte[] data = Internal.GetByteRange(offset, count);
+            Endian.SwapBytes(UnitSize, data);
+            return data;
+        }
+    }
 }

--- a/DICOM/IO/Buffer/TempFileBuffer.cs
+++ b/DICOM/IO/Buffer/TempFileBuffer.cs
@@ -1,39 +1,59 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.IO;
 
-namespace Dicom.IO.Buffer {
-	public sealed class TempFileBuffer : IByteBuffer {
-		private TemporaryFile _file;
-		private uint _size;
+namespace Dicom.IO.Buffer
+{
+    public sealed class TempFileBuffer : IByteBuffer
+    {
+        private TemporaryFile _file;
 
-		public TempFileBuffer(byte[] data) {
-			_file = new TemporaryFile();
+        private uint _size;
 
-			File.WriteAllBytes(_file.Name, data);
-			_size = (uint)data.Length;
-		}
+        public TempFileBuffer(byte[] data)
+        {
+            _file = new TemporaryFile();
 
-		public bool IsMemory {
-			get { return false; }
-		}
+            File.WriteAllBytes(_file.Name, data);
+            _size = (uint)data.Length;
+        }
 
-		public uint Size {
-			get { return _size; }
-		}
+        public bool IsMemory
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-		public byte[] Data {
-			get { return File.ReadAllBytes(_file.Name); }
-		}
+        public uint Size
+        {
+            get
+            {
+                return _size;
+            }
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			byte[] buffer = new byte[count];
+        public byte[] Data
+        {
+            get
+            {
+                return File.ReadAllBytes(_file.Name);
+            }
+        }
 
-			using (Stream fs = File.OpenRead(_file.Name)) {
-				fs.Seek(offset, SeekOrigin.Begin);
-				fs.Read(buffer, 0, count);
-			}
+        public byte[] GetByteRange(int offset, int count)
+        {
+            byte[] buffer = new byte[count];
 
-			return buffer;
-		}
-	}
+            using (Stream fs = File.OpenRead(_file.Name))
+            {
+                fs.Seek(offset, SeekOrigin.Begin);
+                fs.Read(buffer, 0, count);
+            }
+
+            return buffer;
+        }
+    }
 }

--- a/DICOM/IO/ByteConverter.cs
+++ b/DICOM/IO/ByteConverter.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -8,75 +9,85 @@ using Dicom.IO.Buffer;
 using Dicom.Imaging.Mathematics
 ;
 
-namespace Dicom.IO {
-	public static class ByteConverter {
-		public static IByteBuffer ToByteBuffer(string value, Encoding encoding=null) {
-			if (encoding == null)
-				encoding = Encoding.UTF8;
+namespace Dicom.IO
+{
+    public static class ByteConverter
+    {
+        public static IByteBuffer ToByteBuffer(string value, Encoding encoding = null)
+        {
+            if (encoding == null) encoding = Encoding.UTF8;
 
-			byte[] bytes = encoding.GetBytes(value);
+            byte[] bytes = encoding.GetBytes(value);
 
-			return new MemoryByteBuffer(bytes);
-		}
+            return new MemoryByteBuffer(bytes);
+        }
 
-		public static IByteBuffer ToByteBuffer(string value, Encoding encoding, byte padding) {
-			if (encoding == null)
-				encoding = Encoding.UTF8;
+        public static IByteBuffer ToByteBuffer(string value, Encoding encoding, byte padding)
+        {
+            if (encoding == null) encoding = Encoding.UTF8;
 
-			byte[] bytes = encoding.GetBytes(value);
+            byte[] bytes = encoding.GetBytes(value);
 
-			if (bytes.Length.IsOdd()) {
-				Array.Resize(ref bytes, bytes.Length + 1);
-				bytes[bytes.Length - 1] = padding;
-			}
+            if (bytes.Length.IsOdd())
+            {
+                Array.Resize(ref bytes, bytes.Length + 1);
+                bytes[bytes.Length - 1] = padding;
+            }
 
-			return new MemoryByteBuffer(bytes);
-		}
+            return new MemoryByteBuffer(bytes);
+        }
 
-		public static IByteBuffer ToByteBuffer<T>(T[] values) where T: struct {
-			int size = System.Buffer.ByteLength(values);
-			byte[] data = new byte[size];
-			System.Buffer.BlockCopy(values, 0, data, 0, size);
-			return new MemoryByteBuffer(data);
-		}
+        public static IByteBuffer ToByteBuffer<T>(T[] values) where T : struct
+        {
+            int size = System.Buffer.ByteLength(values);
+            byte[] data = new byte[size];
+            System.Buffer.BlockCopy(values, 0, data, 0, size);
+            return new MemoryByteBuffer(data);
+        }
 
-		public static T[] ToArray<T>(IByteBuffer buffer) {
-			uint size = (uint)Marshal.SizeOf(typeof(T));
-			uint padding = buffer.Size % size;
-			uint count = buffer.Size / size;
-			T[] values = new T[count];
-			System.Buffer.BlockCopy(buffer.Data, 0, values, 0, (int)(buffer.Size - padding));
-			return values;
-		}
+        public static T[] ToArray<T>(IByteBuffer buffer)
+        {
+            uint size = (uint)Marshal.SizeOf(typeof(T));
+            uint padding = buffer.Size % size;
+            uint count = buffer.Size / size;
+            T[] values = new T[count];
+            System.Buffer.BlockCopy(buffer.Data, 0, values, 0, (int)(buffer.Size - padding));
+            return values;
+        }
 
-		public static T Get<T>(IByteBuffer buffer, int n) {
-			int size = Marshal.SizeOf(typeof(T));
-			T[] values = new T[1];
-			if (buffer.IsMemory)
-				System.Buffer.BlockCopy(buffer.Data, size * n, values, 0, size);
-			else {
-				byte[] temp = buffer.GetByteRange(size * n, size);
-				System.Buffer.BlockCopy(temp, 0, values, 0, size);
-			}
-			return values[0];
-		}
+        public static T Get<T>(IByteBuffer buffer, int n)
+        {
+            int size = Marshal.SizeOf(typeof(T));
+            T[] values = new T[1];
+            if (buffer.IsMemory) System.Buffer.BlockCopy(buffer.Data, size * n, values, 0, size);
+            else
+            {
+                byte[] temp = buffer.GetByteRange(size * n, size);
+                System.Buffer.BlockCopy(temp, 0, values, 0, size);
+            }
+            return values[0];
+        }
 
-		public static IByteBuffer UnpackLow16(IByteBuffer data) {
-			byte[] bytes = new byte[data.Size / 2];
-			byte[] datab = data.Data;
-			for (int i = 0; i < bytes.Length && (i * 2) < datab.Length; i++) {
-				bytes[i] = datab[i * 2];
-			}
-			return new MemoryByteBuffer(bytes);
-		}
+        public static IByteBuffer UnpackLow16(IByteBuffer data)
+        {
+            byte[] bytes = new byte[data.Size / 2];
+            byte[] datab = data.Data;
+            for (int i = 0; i < bytes.Length && (i * 2) < datab.Length; i++)
+            {
+                bytes[i] = datab[i * 2];
+            }
+            return new MemoryByteBuffer(bytes);
+        }
 
-		public static IByteBuffer UnpackHigh16(IByteBuffer data) {
-			byte[] bytes = new byte[data.Size / 2];
-			byte[] datab = data.Data;
-			for (int i = 0; i < bytes.Length && ((i * 2) + 1) < datab.Length; i++) {
-				bytes[i] = datab[(i * 2) + 1];
-			}
-			return new MemoryByteBuffer(bytes);
-		}
-	}
+        public static IByteBuffer UnpackHigh16(IByteBuffer data)
+        {
+            byte[] bytes = new byte[data.Size / 2];
+            byte[] datab = data.Data;
+            for (int i = 0; i < bytes.Length && ((i * 2) + 1) < datab.Length; i++)
+            {
+                bytes[i] = datab[(i * 2) + 1];
+            }
+            return new MemoryByteBuffer(bytes);
+        }
+    }
 }

--- a/DICOM/IO/DicomIoException.cs
+++ b/DICOM/IO/DicomIoException.cs
@@ -1,17 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO {
-	public class DicomIoException : DicomException {
-		public DicomIoException(string message) : base(message) {
-		}
+using System;
 
-		public DicomIoException(string format, params object[] args) : base(format, args) {
-		}
+namespace Dicom.IO
+{
+    public class DicomIoException : DicomException
+    {
+        public DicomIoException(string message)
+            : base(message)
+        {
+        }
 
-		public DicomIoException(string message, Exception innerException) : base(message, innerException) {
-		}
-	}
+        public DicomIoException(string format, params object[] args)
+            : base(format, args)
+        {
+        }
+
+        public DicomIoException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/DICOM/IO/Endian.cs
+++ b/DICOM/IO/Endian.cs
@@ -1,521 +1,705 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System;
 using System.IO;
-using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Dicom.IO {
-	#region Endian
-	public struct Endian {
-		public static readonly Endian Little = new Endian(false);
-		public static readonly Endian Big = new Endian(true);
-		public static readonly Endian LocalMachine = BitConverter.IsLittleEndian ? Little : Big;
-		public static readonly Endian Network = Big;
+namespace Dicom.IO
+{
 
-		private bool _isBigEndian;
-		private Endian(bool isBigEndian) {
-			_isBigEndian = isBigEndian;
-		}
+    #region Endian
 
-		public override bool Equals(object obj) {
-			if (obj == null)
-				return false;
-			if (obj is Endian)
-				return this == (Endian)obj;
-			return false;
-		}
+    public struct Endian
+    {
+        public static readonly Endian Little = new Endian(false);
 
-		public override int GetHashCode() {
-			return _isBigEndian.GetHashCode();
-		}
+        public static readonly Endian Big = new Endian(true);
 
-		public override string ToString() {
-			if (_isBigEndian)
-				return "Big Endian";
-			return "Little Endian";
-		}
+        public static readonly Endian LocalMachine = BitConverter.IsLittleEndian ? Little : Big;
 
-		public static bool operator ==(Endian e1, Endian e2) {
-			if ((object)e1 == null && (object)e2 == null)
-				return true;
-			if ((object)e1 == null || (object)e2 == null)
-				return false;
-			return e1._isBigEndian == e2._isBigEndian;
-		}
-		public static bool operator !=(Endian e1, Endian e2) {
-			return !(e1 == e2);
-		}
+        public static readonly Endian Network = Big;
 
-		public static void SwapBytes(int bytesToSwap, byte[] bytes) {
-			if (bytesToSwap == 1)
-				return;
-			if (bytesToSwap == 2) { SwapBytes2(bytes); return; }
-			if (bytesToSwap == 4) { SwapBytes4(bytes); return; }
-			//if (bytesToSwap == 8) { Swap8(); return; }
-			unchecked {
-				int l = bytes.Length - (bytes.Length % bytesToSwap);
-				for (int i = 0; i < l; i += bytesToSwap) {
-					Array.Reverse(bytes, i, bytesToSwap);
-				}
-			}
-		}
-		public static void SwapBytes2(byte[] bytes) {
-			unchecked {
-				byte b;
-				int l = bytes.Length - (bytes.Length % 2);
-				for (int i = 0; i < l; i += 2) {
-					b = bytes[i + 1];
-					bytes[i + 1] = bytes[i];
-					bytes[i] = b;
-				}
-			}
-		}
-		public static void SwapBytes4(byte[] bytes) {
-			unchecked {
-				byte b;
-				int l = bytes.Length - (bytes.Length % 4);
-				for (int i = 0; i < l; i += 4) {
-					b = bytes[i + 3];
-					bytes[i + 3] = bytes[i];
-					bytes[i] = b;
-					b = bytes[i + 2];
-					bytes[i + 2] = bytes[i + 1];
-					bytes[i + 1] = b;
-				}
-			}
-		}
-		public static void SwapBytes8(byte[] bytes) {
-			SwapBytes(8, bytes);
-		}
+        private bool _isBigEndian;
 
-		public static short Swap(short value) {
-			return (short)Swap((ushort)value);
-		}
-		public static ushort Swap(ushort value) {
-			return unchecked((ushort)((value >> 8) | (value << 8)));
-		}
+        private Endian(bool isBigEndian)
+        {
+            _isBigEndian = isBigEndian;
+        }
 
-		public static int Swap(int value) {
-			return (int)Swap((uint)value);
-		}
-		public static uint Swap(uint value) {
-			return unchecked(
-					((value & 0x000000ffU) << 24) |
-					((value & 0x0000ff00U) <<  8) |
-					((value & 0x00ff0000U) >>  8) |
-					((value & 0xff000000U) >> 24));
-		}
+        public override bool Equals(object obj)
+        {
+            if (obj == null) return false;
+            if (obj is Endian) return this == (Endian)obj;
+            return false;
+        }
 
-		public static long Swap(long value) {
-			return (long)Swap((ulong)value);
-		}
-		public static ulong Swap(ulong value) {
-			return unchecked(
-					((value & 0x00000000000000ffU) << 56) |
-					((value & 0x000000000000ff00U) << 40) |
-					((value & 0x0000000000ff0000U) << 24) |
-					((value & 0x00000000ff000000U) <<  8) |
-					((value & 0x000000ff00000000U) >>  8) |
-					((value & 0x0000ff0000000000U) >> 24) |
-					((value & 0x00ff000000000000U) >> 40) |
-					((value & 0xff00000000000000U) >> 56));
-		}
+        public override int GetHashCode()
+        {
+            return _isBigEndian.GetHashCode();
+        }
 
-		public static float Swap(float value) {
-			byte[] b = BitConverter.GetBytes(value);
-			Array.Reverse(b);
-			return BitConverter.ToSingle(b, 0);
-		}
+        public override string ToString()
+        {
+            if (_isBigEndian) return "Big Endian";
+            return "Little Endian";
+        }
 
-		public static double Swap(double value) {
-			byte[] b = BitConverter.GetBytes(value);
-			Array.Reverse(b);
-			return BitConverter.ToDouble(b, 0);
-		}
+        public static bool operator ==(Endian e1, Endian e2)
+        {
+            if ((object)e1 == null && (object)e2 == null) return true;
+            if ((object)e1 == null || (object)e2 == null) return false;
+            return e1._isBigEndian == e2._isBigEndian;
+        }
 
-		public static void Swap(short[] values) {
-			Parallel.For(0, values.Length, (i) => {
-				values[i] = Swap(values[i]);
-			});
-		}
+        public static bool operator !=(Endian e1, Endian e2)
+        {
+            return !(e1 == e2);
+        }
 
-		public static void Swap(ushort[] values) {
-			Parallel.For(0, values.Length, (i) => {
-				values[i] = Swap(values[i]);
-			});
-		}
+        public static void SwapBytes(int bytesToSwap, byte[] bytes)
+        {
+            if (bytesToSwap == 1) return;
+            if (bytesToSwap == 2)
+            {
+                SwapBytes2(bytes);
+                return;
+            }
+            if (bytesToSwap == 4)
+            {
+                SwapBytes4(bytes);
+                return;
+            }
+            //if (bytesToSwap == 8) { Swap8(); return; }
+            unchecked
+            {
+                int l = bytes.Length - (bytes.Length % bytesToSwap);
+                for (int i = 0; i < l; i += bytesToSwap)
+                {
+                    Array.Reverse(bytes, i, bytesToSwap);
+                }
+            }
+        }
 
-		public static void Swap(int[] values) {
-			Parallel.For(0, values.Length, (i) => {
-				values[i] = Swap(values[i]);
-			});
-		}
+        public static void SwapBytes2(byte[] bytes)
+        {
+            unchecked
+            {
+                byte b;
+                int l = bytes.Length - (bytes.Length % 2);
+                for (int i = 0; i < l; i += 2)
+                {
+                    b = bytes[i + 1];
+                    bytes[i + 1] = bytes[i];
+                    bytes[i] = b;
+                }
+            }
+        }
 
-		public static void Swap(uint[] values) {
-			Parallel.For(0, values.Length, (i) => {
-				values[i] = Swap(values[i]);
-			});
-		}
+        public static void SwapBytes4(byte[] bytes)
+        {
+            unchecked
+            {
+                byte b;
+                int l = bytes.Length - (bytes.Length % 4);
+                for (int i = 0; i < l; i += 4)
+                {
+                    b = bytes[i + 3];
+                    bytes[i + 3] = bytes[i];
+                    bytes[i] = b;
+                    b = bytes[i + 2];
+                    bytes[i + 2] = bytes[i + 1];
+                    bytes[i + 1] = b;
+                }
+            }
+        }
 
-		public static void Swap<T>(T[] values) {
-			if (typeof(T) == typeof(short))
-				Swap(values as short[]);
-			else if (typeof(T) == typeof(ushort))
-				Swap(values as ushort[]);
-			else if (typeof(T) == typeof(int))
-				Swap(values as int[]);
-			else if (typeof(T) == typeof(uint))
-				Swap(values as uint[]);
-			else
-				throw new InvalidOperationException("Attempted to byte swap non-specialized type: " + typeof(T).Name);
-		}
-	}
-	#endregion
+        public static void SwapBytes8(byte[] bytes)
+        {
+            SwapBytes(8, bytes);
+        }
 
-	#region EndianBinaryReader
-	public class EndianBinaryReader : BinaryReader {
-		#region Private Members
-		private bool SwapBytes = false;
-		private byte[] InternalBuffer = new byte[8];
-		#endregion
+        public static short Swap(short value)
+        {
+            return (short)Swap((ushort)value);
+        }
 
-		#region Public Constructors
-		public EndianBinaryReader(Stream input) : base(input) {
-		}
-		public EndianBinaryReader(Stream input, Encoding encoding) : base(input, encoding) {
-		}
-		public EndianBinaryReader(Stream input, Endian endian) : base(input) {
-			Endian = endian;
-		}
-		public EndianBinaryReader(Stream input, Encoding encoding, Endian endian) : base(input, encoding) {
-			Endian = endian;
-		}
+        public static ushort Swap(ushort value)
+        {
+            return unchecked((ushort)((value >> 8) | (value << 8)));
+        }
 
-		public static BinaryReader Create(Stream input, Endian endian) {
-			if (input == null)
-				throw new ArgumentNullException("input");
-			if (endian == null)
-				throw new ArgumentNullException("endian");
+        public static int Swap(int value)
+        {
+            return (int)Swap((uint)value);
+        }
 
-			if (BitConverter.IsLittleEndian) {
-				if (Endian.Little == endian) {
-					return new BinaryReader(input);
-				} else {
-					return new EndianBinaryReader(input, endian);
-				}
-			} else {
-				if (Endian.Big == endian) {
-					return new BinaryReader(input);
-				} else {
-					return new EndianBinaryReader(input, endian);
-				}
-			}
-		}
+        public static uint Swap(uint value)
+        {
+            return
+                unchecked(
+                    ((value & 0x000000ffU) << 24) | ((value & 0x0000ff00U) << 8) | ((value & 0x00ff0000U) >> 8)
+                    | ((value & 0xff000000U) >> 24));
+        }
 
-		public static BinaryReader Create(Stream input, Encoding encoding, Endian endian) {
-			if (encoding == null)
-				return Create(input, endian);
-			if (input == null)
-				throw new ArgumentNullException("input");
-			if (endian == null)
-				throw new ArgumentNullException("endian");
+        public static long Swap(long value)
+        {
+            return (long)Swap((ulong)value);
+        }
 
-			if (BitConverter.IsLittleEndian) {
-				if (Endian.Little == endian) {
-					return new BinaryReader(input, encoding);
-				}
-				else {
-					return new EndianBinaryReader(input, encoding, endian);
-				}
-			}
-			else {
-				if (Endian.Big == endian) {
-					return new BinaryReader(input, encoding);
-				}
-				else {
-					return new EndianBinaryReader(input, encoding, endian);
-				}
-			}
-		}
-		#endregion
+        public static ulong Swap(ulong value)
+        {
+            return
+                unchecked(
+                    ((value & 0x00000000000000ffU) << 56) | ((value & 0x000000000000ff00U) << 40)
+                    | ((value & 0x0000000000ff0000U) << 24) | ((value & 0x00000000ff000000U) << 8)
+                    | ((value & 0x000000ff00000000U) >> 8) | ((value & 0x0000ff0000000000U) >> 24)
+                    | ((value & 0x00ff000000000000U) >> 40) | ((value & 0xff00000000000000U) >> 56));
+        }
 
-		#region Public Properties
-		public Endian Endian {
-			get {
-				if (BitConverter.IsLittleEndian) {
-					return SwapBytes ? Endian.Big : Endian.Little;
-				} else {
-					return SwapBytes ? Endian.Little : Endian.Big;
-				}
-			}
-			set {
-				if (BitConverter.IsLittleEndian) {
-					SwapBytes = (Endian.Big == value);
-				} else {
-					SwapBytes = (Endian.Little == value);
-				}
-			}
-		}
+        public static float Swap(float value)
+        {
+            byte[] b = BitConverter.GetBytes(value);
+            Array.Reverse(b);
+            return BitConverter.ToSingle(b, 0);
+        }
 
-		public bool UseInternalBuffer {
-			get {
-				return (InternalBuffer != null);
-			}
-			set {
-				if (value && (InternalBuffer == null)) {
-					InternalBuffer = new byte[8];
-				} else {
-					InternalBuffer = null;
-				}
-			}
-		}
-		#endregion
+        public static double Swap(double value)
+        {
+            byte[] b = BitConverter.GetBytes(value);
+            Array.Reverse(b);
+            return BitConverter.ToDouble(b, 0);
+        }
 
-		#region Private Methods
-		private byte[] ReadBytesInternal(int count) {
-			byte[] Buffer = null;
-			if (InternalBuffer != null) {
-				base.Read(InternalBuffer, 0, count);
-				Buffer = InternalBuffer;
-			} else {
-				Buffer = base.ReadBytes(count);
-			}
-			if (SwapBytes) {
-				Array.Reverse(Buffer, 0, count);
-			}
-			return Buffer;
-		}
-		#endregion
+        public static void Swap(short[] values)
+        {
+            Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+        }
 
-		#region BinaryReader Overrides
-		public override short ReadInt16() {
-			if (SwapBytes) {
-				return Endian.Swap(base.ReadInt16());
-			}
-			return base.ReadInt16();
-		}
+        public static void Swap(ushort[] values)
+        {
+            Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+        }
 
-		public override int ReadInt32() {
-			if (SwapBytes) {
-				return Endian.Swap(base.ReadInt32());
-			}
-			return base.ReadInt32();
-		}
+        public static void Swap(int[] values)
+        {
+            Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+        }
 
-		public override long ReadInt64() {
-			if (SwapBytes) {
-				return Endian.Swap(base.ReadInt64());
-			}
-			return base.ReadInt64();
-		}
+        public static void Swap(uint[] values)
+        {
+            Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+        }
 
-		public override float ReadSingle() {
-			if (SwapBytes) {
-				byte[] b = ReadBytesInternal(4);
-				return BitConverter.ToSingle(b, 0);
-			}
-			return base.ReadSingle();
-		}
+        public static void Swap<T>(T[] values)
+        {
+            if (typeof(T) == typeof(short)) Swap(values as short[]);
+            else if (typeof(T) == typeof(ushort)) Swap(values as ushort[]);
+            else if (typeof(T) == typeof(int)) Swap(values as int[]);
+            else if (typeof(T) == typeof(uint)) Swap(values as uint[]);
+            else throw new InvalidOperationException("Attempted to byte swap non-specialized type: " + typeof(T).Name);
+        }
+    }
 
-		public override double ReadDouble() {
-			if (SwapBytes) {
-				byte[] b = ReadBytesInternal(8);
-				return BitConverter.ToDouble(b, 0);
-			}
-			return base.ReadDouble();
-		}
+    #endregion
 
-		public override ushort ReadUInt16() {
-			if (SwapBytes) {
-				return Endian.Swap(base.ReadUInt16());
-			}
-			return base.ReadUInt16();
-		}
+    #region EndianBinaryReader
 
-		public override uint ReadUInt32() {
-			if (SwapBytes) {
-				return Endian.Swap(base.ReadUInt32());
-			}
-			return base.ReadUInt32();
-		}
+    public class EndianBinaryReader : BinaryReader
+    {
+        #region Private Members
 
-		public override ulong ReadUInt64() {
-			if (SwapBytes) {
-				return Endian.Swap(base.ReadUInt64());
-			}
-			return base.ReadUInt64();
-		}
-		#endregion
-	}
-	#endregion
+        private bool SwapBytes = false;
 
-	#region EndianBinaryWriter
-	public class EndianBinaryWriter : BinaryWriter {
-		#region Private Members
-		private bool SwapBytes = false;
-		#endregion
+        private byte[] InternalBuffer = new byte[8];
 
-		#region Public Constructors
-		public EndianBinaryWriter(Stream output) : base(output) {
-		}
-		public EndianBinaryWriter(Stream output, Encoding encoding) : base(output, encoding) {
-		}
-		public EndianBinaryWriter(Stream output, Endian endian) : base(output) {
-			Endian = endian;
-		}
-		public EndianBinaryWriter(Stream output, Encoding encoding, Endian endian) : base(output, encoding) {
-			Endian = endian;
-		}
+        #endregion
 
-		public static BinaryWriter Create(Stream output, Endian endian) {
-			if (output == null)
-				throw new ArgumentNullException("output");
-			if (endian == null)
-				throw new ArgumentNullException("endian");
+        #region Public Constructors
 
-			if (BitConverter.IsLittleEndian) {
-				if (Endian.Little == endian) {
-					return new BinaryWriter(output);
-				} else {
-					return new EndianBinaryWriter(output, endian);
-				}
-			} else {
-				if (Endian.Big == endian) {
-					return new BinaryWriter(output);
-				} else {
-					return new EndianBinaryWriter(output, endian);
-				}
-			}
-		}
+        public EndianBinaryReader(Stream input)
+            : base(input)
+        {
+        }
 
-		public static BinaryWriter Create(Stream output, Encoding encoding, Endian endian) {
-			if (encoding == null)
-				return Create(output, endian);
-			if (output == null)
-				throw new ArgumentNullException("output");
-			if (endian == null)
-				throw new ArgumentNullException("endian");
+        public EndianBinaryReader(Stream input, Encoding encoding)
+            : base(input, encoding)
+        {
+        }
 
-			if (BitConverter.IsLittleEndian) {
-				if (Endian.Little == endian) {
-					return new BinaryWriter(output, encoding);
-				}
-				else {
-					return new EndianBinaryWriter(output, encoding, endian);
-				}
-			}
-			else {
-				if (Endian.Big == endian) {
-					return new BinaryWriter(output, encoding);
-				}
-				else {
-					return new EndianBinaryWriter(output, encoding, endian);
-				}
-			}
-		}
-		#endregion
+        public EndianBinaryReader(Stream input, Endian endian)
+            : base(input)
+        {
+            Endian = endian;
+        }
 
-		#region Public Properties
-		public Endian Endian {
-			get {
-				if (BitConverter.IsLittleEndian) {
-					return SwapBytes ? Endian.Big : Endian.Little;
-				} else {
-					return SwapBytes ? Endian.Little : Endian.Big;
-				}
-			}
-			set {
-				if (BitConverter.IsLittleEndian) {
-					SwapBytes = (Endian.Big == value);
-				} else {
-					SwapBytes = (Endian.Little == value);
-				}
-			}
-		}
-		#endregion
+        public EndianBinaryReader(Stream input, Encoding encoding, Endian endian)
+            : base(input, encoding)
+        {
+            Endian = endian;
+        }
 
-		#region Private Methods
-		private void WriteInternal(byte[] Buffer) {
-			if (SwapBytes) {
-				Array.Reverse(Buffer);
-			}
-			base.Write(Buffer);
-		}
-		#endregion
+        public static BinaryReader Create(Stream input, Endian endian)
+        {
+            if (input == null) throw new ArgumentNullException("input");
+            if (endian == null) throw new ArgumentNullException("endian");
 
-		#region BinaryWriter Overrides
-		public override void Write(double value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
+            if (BitConverter.IsLittleEndian)
+            {
+                if (Endian.Little == endian)
+                {
+                    return new BinaryReader(input);
+                }
+                else
+                {
+                    return new EndianBinaryReader(input, endian);
+                }
+            }
+            else
+            {
+                if (Endian.Big == endian)
+                {
+                    return new BinaryReader(input);
+                }
+                else
+                {
+                    return new EndianBinaryReader(input, endian);
+                }
+            }
+        }
 
-		public override void Write(float value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
+        public static BinaryReader Create(Stream input, Encoding encoding, Endian endian)
+        {
+            if (encoding == null) return Create(input, endian);
+            if (input == null) throw new ArgumentNullException("input");
+            if (endian == null) throw new ArgumentNullException("endian");
 
-		public override void Write(int value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
+            if (BitConverter.IsLittleEndian)
+            {
+                if (Endian.Little == endian)
+                {
+                    return new BinaryReader(input, encoding);
+                }
+                else
+                {
+                    return new EndianBinaryReader(input, encoding, endian);
+                }
+            }
+            else
+            {
+                if (Endian.Big == endian)
+                {
+                    return new BinaryReader(input, encoding);
+                }
+                else
+                {
+                    return new EndianBinaryReader(input, encoding, endian);
+                }
+            }
+        }
 
-		public override void Write(long value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
+        #endregion
 
-		public override void Write(short value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
+        #region Public Properties
 
-		public override void Write(uint value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
+        public Endian Endian
+        {
+            get
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return SwapBytes ? Endian.Big : Endian.Little;
+                }
+                else
+                {
+                    return SwapBytes ? Endian.Little : Endian.Big;
+                }
+            }
+            set
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    SwapBytes = (Endian.Big == value);
+                }
+                else
+                {
+                    SwapBytes = (Endian.Little == value);
+                }
+            }
+        }
 
-		public override void Write(ulong value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
+        public bool UseInternalBuffer
+        {
+            get
+            {
+                return (InternalBuffer != null);
+            }
+            set
+            {
+                if (value && (InternalBuffer == null))
+                {
+                    InternalBuffer = new byte[8];
+                }
+                else
+                {
+                    InternalBuffer = null;
+                }
+            }
+        }
 
-		public override void Write(ushort value) {
-			if (SwapBytes) {
-				byte[] b = BitConverter.GetBytes(value);
-				WriteInternal(b);
-			} else {
-				base.Write(value);
-			}
-		}
-		#endregion
-	}
-	#endregion
+        #endregion
+
+        #region Private Methods
+
+        private byte[] ReadBytesInternal(int count)
+        {
+            byte[] Buffer = null;
+            if (InternalBuffer != null)
+            {
+                base.Read(InternalBuffer, 0, count);
+                Buffer = InternalBuffer;
+            }
+            else
+            {
+                Buffer = base.ReadBytes(count);
+            }
+            if (SwapBytes)
+            {
+                Array.Reverse(Buffer, 0, count);
+            }
+            return Buffer;
+        }
+
+        #endregion
+
+        #region BinaryReader Overrides
+
+        public override short ReadInt16()
+        {
+            if (SwapBytes)
+            {
+                return Endian.Swap(base.ReadInt16());
+            }
+            return base.ReadInt16();
+        }
+
+        public override int ReadInt32()
+        {
+            if (SwapBytes)
+            {
+                return Endian.Swap(base.ReadInt32());
+            }
+            return base.ReadInt32();
+        }
+
+        public override long ReadInt64()
+        {
+            if (SwapBytes)
+            {
+                return Endian.Swap(base.ReadInt64());
+            }
+            return base.ReadInt64();
+        }
+
+        public override float ReadSingle()
+        {
+            if (SwapBytes)
+            {
+                byte[] b = ReadBytesInternal(4);
+                return BitConverter.ToSingle(b, 0);
+            }
+            return base.ReadSingle();
+        }
+
+        public override double ReadDouble()
+        {
+            if (SwapBytes)
+            {
+                byte[] b = ReadBytesInternal(8);
+                return BitConverter.ToDouble(b, 0);
+            }
+            return base.ReadDouble();
+        }
+
+        public override ushort ReadUInt16()
+        {
+            if (SwapBytes)
+            {
+                return Endian.Swap(base.ReadUInt16());
+            }
+            return base.ReadUInt16();
+        }
+
+        public override uint ReadUInt32()
+        {
+            if (SwapBytes)
+            {
+                return Endian.Swap(base.ReadUInt32());
+            }
+            return base.ReadUInt32();
+        }
+
+        public override ulong ReadUInt64()
+        {
+            if (SwapBytes)
+            {
+                return Endian.Swap(base.ReadUInt64());
+            }
+            return base.ReadUInt64();
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region EndianBinaryWriter
+
+    public class EndianBinaryWriter : BinaryWriter
+    {
+        #region Private Members
+
+        private bool SwapBytes = false;
+
+        #endregion
+
+        #region Public Constructors
+
+        public EndianBinaryWriter(Stream output)
+            : base(output)
+        {
+        }
+
+        public EndianBinaryWriter(Stream output, Encoding encoding)
+            : base(output, encoding)
+        {
+        }
+
+        public EndianBinaryWriter(Stream output, Endian endian)
+            : base(output)
+        {
+            Endian = endian;
+        }
+
+        public EndianBinaryWriter(Stream output, Encoding encoding, Endian endian)
+            : base(output, encoding)
+        {
+            Endian = endian;
+        }
+
+        public static BinaryWriter Create(Stream output, Endian endian)
+        {
+            if (output == null) throw new ArgumentNullException("output");
+            if (endian == null) throw new ArgumentNullException("endian");
+
+            if (BitConverter.IsLittleEndian)
+            {
+                if (Endian.Little == endian)
+                {
+                    return new BinaryWriter(output);
+                }
+                else
+                {
+                    return new EndianBinaryWriter(output, endian);
+                }
+            }
+            else
+            {
+                if (Endian.Big == endian)
+                {
+                    return new BinaryWriter(output);
+                }
+                else
+                {
+                    return new EndianBinaryWriter(output, endian);
+                }
+            }
+        }
+
+        public static BinaryWriter Create(Stream output, Encoding encoding, Endian endian)
+        {
+            if (encoding == null) return Create(output, endian);
+            if (output == null) throw new ArgumentNullException("output");
+            if (endian == null) throw new ArgumentNullException("endian");
+
+            if (BitConverter.IsLittleEndian)
+            {
+                if (Endian.Little == endian)
+                {
+                    return new BinaryWriter(output, encoding);
+                }
+                else
+                {
+                    return new EndianBinaryWriter(output, encoding, endian);
+                }
+            }
+            else
+            {
+                if (Endian.Big == endian)
+                {
+                    return new BinaryWriter(output, encoding);
+                }
+                else
+                {
+                    return new EndianBinaryWriter(output, encoding, endian);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public Endian Endian
+        {
+            get
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    return SwapBytes ? Endian.Big : Endian.Little;
+                }
+                else
+                {
+                    return SwapBytes ? Endian.Little : Endian.Big;
+                }
+            }
+            set
+            {
+                if (BitConverter.IsLittleEndian)
+                {
+                    SwapBytes = (Endian.Big == value);
+                }
+                else
+                {
+                    SwapBytes = (Endian.Little == value);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void WriteInternal(byte[] Buffer)
+        {
+            if (SwapBytes)
+            {
+                Array.Reverse(Buffer);
+            }
+            base.Write(Buffer);
+        }
+
+        #endregion
+
+        #region BinaryWriter Overrides
+
+        public override void Write(double value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        public override void Write(float value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        public override void Write(int value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        public override void Write(long value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        public override void Write(short value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        public override void Write(uint value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        public override void Write(ulong value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        public override void Write(ushort value)
+        {
+            if (SwapBytes)
+            {
+                byte[] b = BitConverter.GetBytes(value);
+                WriteInternal(b);
+            }
+            else
+            {
+                base.Write(value);
+            }
+        }
+
+        #endregion
+    }
+
+    #endregion
 }

--- a/DICOM/IO/FileByteSource.cs
+++ b/DICOM/IO/FileByteSource.cs
@@ -4,170 +4,229 @@ using System.IO;
 
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO {
-	public class FileByteSource : IByteSource, IDisposable {
-		private FileReference _file;
-		private Stream _stream;
-		private Endian _endian;
-		private BinaryReader _reader;
-		private long _mark;
+namespace Dicom.IO
+{
+    public class FileByteSource : IByteSource, IDisposable
+    {
+        private FileReference _file;
 
-		private int _largeObjectSize;
+        private Stream _stream;
 
-		private Stack<long> _milestones;
-		private object _lock;
+        private Endian _endian;
 
-		public FileByteSource(FileReference file) {
-			_file = file;
-			_stream = _file.OpenRead();
-			_endian = Endian.LocalMachine;
-			_reader = EndianBinaryReader.Create(_stream, _endian);
-			_mark = 0;
+        private BinaryReader _reader;
 
-			_largeObjectSize = 64 * 1024;
+        private long _mark;
 
-			_milestones = new Stack<long>();
-			_lock = new object();
-		}
+        private int _largeObjectSize;
 
-		public Endian Endian {
-			get { return _endian; }
-			set {
-				if (_endian != value) {
-					lock (_lock) {
-						_endian = value;
-						_reader = EndianBinaryReader.Create(_stream, _endian);
-					}
-				}
-			}
-		}
+        private Stack<long> _milestones;
 
-		public long Position {
-			get { return _stream.Position; }
-		}
+        private object _lock;
 
-		public long Marker {
-			get { return _mark; }
-		}
+        public FileByteSource(FileReference file)
+        {
+            _file = file;
+            _stream = _file.OpenRead();
+            _endian = Endian.LocalMachine;
+            _reader = EndianBinaryReader.Create(_stream, _endian);
+            _mark = 0;
 
-		public bool IsEOF {
-			get { return _stream.Position >= _stream.Length; }
-		}
+            _largeObjectSize = 64 * 1024;
 
-		public bool CanRewind {
-			get { return _stream.CanSeek; }
-		}
+            _milestones = new Stack<long>();
+            _lock = new object();
+        }
 
-		public int LargeObjectSize {
-			get { return _largeObjectSize; }
-			set { _largeObjectSize = value; }
-		}
+        public Endian Endian
+        {
+            get
+            {
+                return _endian;
+            }
+            set
+            {
+                if (_endian != value)
+                {
+                    lock (_lock)
+                    {
+                        _endian = value;
+                        _reader = EndianBinaryReader.Create(_stream, _endian);
+                    }
+                }
+            }
+        }
 
-		public byte GetUInt8() {
-			return _reader.ReadByte();
-		}
+        public long Position
+        {
+            get
+            {
+                return _stream.Position;
+            }
+        }
 
-		public short GetInt16() {
-			return _reader.ReadInt16();
-		}
+        public long Marker
+        {
+            get
+            {
+                return _mark;
+            }
+        }
 
-		public ushort GetUInt16() {
-			return _reader.ReadUInt16();
-		}
+        public bool IsEOF
+        {
+            get
+            {
+                return _stream.Position >= _stream.Length;
+            }
+        }
 
-		public int GetInt32() {
-			return _reader.ReadInt32();
-		}
+        public bool CanRewind
+        {
+            get
+            {
+                return _stream.CanSeek;
+            }
+        }
 
-		public uint GetUInt32() {
-			return _reader.ReadUInt32();
-		}
+        public int LargeObjectSize
+        {
+            get
+            {
+                return _largeObjectSize;
+            }
+            set
+            {
+                _largeObjectSize = value;
+            }
+        }
 
-		public long GetInt64() {
-			return _reader.ReadInt64();
-		}
+        public byte GetUInt8()
+        {
+            return _reader.ReadByte();
+        }
 
-		public ulong GetUInt64() {
-			return _reader.ReadUInt64();
-		}
+        public short GetInt16()
+        {
+            return _reader.ReadInt16();
+        }
 
-		public float GetSingle() {
-			return _reader.ReadSingle();
-		}
+        public ushort GetUInt16()
+        {
+            return _reader.ReadUInt16();
+        }
 
-		public double GetDouble() {
-			return _reader.ReadDouble();
-		}
+        public int GetInt32()
+        {
+            return _reader.ReadInt32();
+        }
 
-		public byte[] GetBytes(int count) {
-			return _reader.ReadBytes(count);
-		}
+        public uint GetUInt32()
+        {
+            return _reader.ReadUInt32();
+        }
 
-		public IByteBuffer GetBuffer(uint count) {
-			IByteBuffer buffer = null;
-			if (count == 0)
-				buffer = EmptyBuffer.Value;
-			else if (count >= _largeObjectSize) {
-				buffer = new FileByteBuffer(_file, _stream.Position, count);
-				_stream.Seek((int)count, SeekOrigin.Current);
-			} else
-				buffer = new MemoryByteBuffer(GetBytes((int)count));
-			return buffer;
-		}
+        public long GetInt64()
+        {
+            return _reader.ReadInt64();
+        }
 
-		public void Skip(int count) {
-			_stream.Seek(count, SeekOrigin.Current);
-		}
+        public ulong GetUInt64()
+        {
+            return _reader.ReadUInt64();
+        }
 
-		public void Mark() {
-			_mark = _stream.Position;
-		}
+        public float GetSingle()
+        {
+            return _reader.ReadSingle();
+        }
 
-		public void Rewind() {
-			_stream.Position = _mark;
-		}
+        public double GetDouble()
+        {
+            return _reader.ReadDouble();
+        }
 
-		public void PushMilestone(uint count) {
-			lock (_lock)
-				_milestones.Push(_stream.Position + count);
-		}
+        public byte[] GetBytes(int count)
+        {
+            return _reader.ReadBytes(count);
+        }
 
-		public void PopMilestone() {
-			lock (_lock)
-				_milestones.Pop();
-		}
+        public IByteBuffer GetBuffer(uint count)
+        {
+            IByteBuffer buffer = null;
+            if (count == 0) buffer = EmptyBuffer.Value;
+            else if (count >= _largeObjectSize)
+            {
+                buffer = new FileByteBuffer(_file, _stream.Position, count);
+                _stream.Seek((int)count, SeekOrigin.Current);
+            }
+            else buffer = new MemoryByteBuffer(GetBytes((int)count));
+            return buffer;
+        }
 
-		public bool HasReachedMilestone() {
-			lock (_lock) {
-				if (_milestones.Count > 0 && _stream.Position >= _milestones.Peek())
-					return true;
-				return false;
-			}
-		}
+        public void Skip(int count)
+        {
+            _stream.Seek(count, SeekOrigin.Current);
+        }
 
-		public bool Require(uint count) {
-			return Require(count, null, null);
-		}
+        public void Mark()
+        {
+            _mark = _stream.Position;
+        }
 
-		public bool Require(uint count, ByteSourceCallback callback, object state) {
-			lock (_lock) {
-				if ((_stream.Length - _stream.Position) >= count)
-					return true;
+        public void Rewind()
+        {
+            _stream.Position = _mark;
+        }
 
-				throw new DicomIoException("Requested {0} bytes past end of file.", count);
-			}
-		}
+        public void PushMilestone(uint count)
+        {
+            lock (_lock) _milestones.Push(_stream.Position + count);
+        }
 
-		public void Dispose() {
-			try {
-				_reader.Close();
+        public void PopMilestone()
+        {
+            lock (_lock) _milestones.Pop();
+        }
 
-				// closing binary reader should close this
-				_stream.Close();
-			} catch {
-			}
+        public bool HasReachedMilestone()
+        {
+            lock (_lock)
+            {
+                if (_milestones.Count > 0 && _stream.Position >= _milestones.Peek()) return true;
+                return false;
+            }
+        }
 
-			GC.SuppressFinalize(this);
-		}
-	}
+        public bool Require(uint count)
+        {
+            return Require(count, null, null);
+        }
+
+        public bool Require(uint count, ByteSourceCallback callback, object state)
+        {
+            lock (_lock)
+            {
+                if ((_stream.Length - _stream.Position) >= count) return true;
+
+                throw new DicomIoException("Requested {0} bytes past end of file.", count);
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _reader.Close();
+
+                // closing binary reader should close this
+                _stream.Close();
+            }
+            catch
+            {
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
 }

--- a/DICOM/IO/FileByteTarget.cs
+++ b/DICOM/IO/FileByteTarget.cs
@@ -1,107 +1,157 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 
-using Dicom.IO.Buffer;
+namespace Dicom.IO
+{
+    public class FileByteTarget : IDisposable, IByteTarget
+    {
+        private FileReference _file;
 
-namespace Dicom.IO {
-	public class FileByteTarget : IDisposable, IByteTarget {
-		private FileReference _file;
-		private Stream _stream;
-		private Endian _endian;
-		private BinaryWriter _writer;
-		private object _lock;
+        private Stream _stream;
 
-		public FileByteTarget(FileReference file) {
-			_file = file;
-			_stream = _file.OpenWrite();
-			_endian = Endian.LocalMachine;
-			_writer = EndianBinaryWriter.Create(_stream, _endian);
-			_lock = new object();
-		}
+        private Endian _endian;
 
-		public Endian Endian {
-			get { return _endian; }
-			set {
-				if (_endian != value) {
-					lock (_lock) {
-						_endian = value;
-						_writer = EndianBinaryWriter.Create(_stream, _endian);
-					}
-				}
-			}
-		}
+        private BinaryWriter _writer;
 
-		public long Position {
-			get { return _stream.Position; }
-		}
+        private object _lock;
 
-		public void Write(byte v) {
-			_writer.Write(v);
-		}
+        public FileByteTarget(FileReference file)
+        {
+            _file = file;
+            _stream = _file.OpenWrite();
+            _endian = Endian.LocalMachine;
+            _writer = EndianBinaryWriter.Create(_stream, _endian);
+            _lock = new object();
+        }
 
-		public void Write(short v) {
-			_writer.Write(v);
-		}
+        public Endian Endian
+        {
+            get
+            {
+                return _endian;
+            }
+            set
+            {
+                if (_endian != value)
+                {
+                    lock (_lock)
+                    {
+                        _endian = value;
+                        _writer = EndianBinaryWriter.Create(_stream, _endian);
+                    }
+                }
+            }
+        }
 
-		public void Write(ushort v) {
-			_writer.Write(v);
-		}
+        public long Position
+        {
+            get
+            {
+                return _stream.Position;
+            }
+        }
 
-		public void Write(int v) {
-			_writer.Write(v);
-		}
+        public void Write(byte v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(uint v) {
-			_writer.Write(v);
-		}
+        public void Write(short v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(long v) {
-			_writer.Write(v);
-		}
+        public void Write(ushort v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(ulong v) {
-			_writer.Write(v);
-		}
+        public void Write(int v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(float v) {
-			_writer.Write(v);
-		}
+        public void Write(uint v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(double v) {
-			_writer.Write(v);
-		}
+        public void Write(long v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(byte[] buffer, uint offset = 0, uint count = uint.MaxValue, ByteTargetCallback callback = null, object state = null) {
-			if (count == uint.MaxValue)
-				count = (uint)buffer.Length - offset;
+        public void Write(ulong v)
+        {
+            _writer.Write(v);
+        }
 
-			if (callback != null)
-				_stream.BeginWrite(buffer, (int)offset, (int)count, OnEndWrite, new Tuple<ByteTargetCallback, object>(callback, state));
-			else
-				_stream.Write(buffer, (int)offset, (int)count);
-		}
-		private void OnEndWrite(IAsyncResult result) {
-			try {
-				_stream.EndWrite(result);
-			} catch {
-			} finally {
-				if (result.AsyncState != null) {
-					Tuple<ByteTargetCallback, object> state = result.AsyncState as Tuple<ByteTargetCallback, object>;
-					state.Item1(this, state.Item2);
-				}
-			}
-		}
+        public void Write(float v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Close() {
-			try {
-				_stream.Close();
-				_stream = null;
-			} catch {
-			}
-		}
+        public void Write(double v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Dispose() {
-			Close();
-		}
-	}
+        public void Write(
+            byte[] buffer,
+            uint offset = 0,
+            uint count = uint.MaxValue,
+            ByteTargetCallback callback = null,
+            object state = null)
+        {
+            if (count == uint.MaxValue) count = (uint)buffer.Length - offset;
+
+            if (callback != null)
+                _stream.BeginWrite(
+                    buffer,
+                    (int)offset,
+                    (int)count,
+                    OnEndWrite,
+                    new Tuple<ByteTargetCallback, object>(callback, state));
+            else _stream.Write(buffer, (int)offset, (int)count);
+        }
+
+        private void OnEndWrite(IAsyncResult result)
+        {
+            try
+            {
+                _stream.EndWrite(result);
+            }
+            catch
+            {
+            }
+            finally
+            {
+                if (result.AsyncState != null)
+                {
+                    Tuple<ByteTargetCallback, object> state = result.AsyncState as Tuple<ByteTargetCallback, object>;
+                    state.Item1(this, state.Item2);
+                }
+            }
+        }
+
+        public void Close()
+        {
+            try
+            {
+                _stream.Close();
+                _stream = null;
+            }
+            catch
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+    }
 }

--- a/DICOM/IO/FileReference.cs
+++ b/DICOM/IO/FileReference.cs
@@ -1,79 +1,87 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 
-namespace Dicom.IO {
-	public sealed class FileReference {
-		public FileReference(string fileName, bool isTempFile = false) {
-			Name = fileName;
-			IsTempFile = isTempFile;
-		}
+namespace Dicom.IO
+{
+    public sealed class FileReference
+    {
+        public FileReference(string fileName, bool isTempFile = false)
+        {
+            Name = fileName;
+            IsTempFile = isTempFile;
+        }
 
-		~FileReference() {
-			if (IsTempFile) {
-				try {
-					Delete();
-				} catch {
-				}
-			}
-		}
+        ~FileReference()
+        {
+            if (IsTempFile)
+            {
+                try
+                {
+                    Delete();
+                }
+                catch
+                {
+                }
+            }
+        }
 
-		public string Name {
-			get;
-			private set;
-		}
+        public string Name { get; private set; }
 
-		/// <summary>File will be deleted when object is <c>Disposed</c>.</summary>
-		public bool IsTempFile {
-			get;
-			internal set;
-		}
+        /// <summary>File will be deleted when object is <c>Disposed</c>.</summary>
+        public bool IsTempFile { get; internal set; }
 
-		public Stream OpenRead() {
-			return File.OpenRead(Name);
-		}
+        public Stream OpenRead()
+        {
+            return File.OpenRead(Name);
+        }
 
-		public Stream OpenWrite() {
-			return File.OpenWrite(Name);
-		}
+        public Stream OpenWrite()
+        {
+            return File.OpenWrite(Name);
+        }
 
-		public void Delete() {
-			if (IsTempFile)
-				TemporaryFileRemover.Delete(Name);
-			else if (File.Exists(Name))
-				File.Delete(Name);
-		}
+        public void Delete()
+        {
+            if (IsTempFile) TemporaryFileRemover.Delete(Name);
+            else if (File.Exists(Name)) File.Delete(Name);
+        }
 
-		/// <summary>
-		/// Moves file and updates internal reference.
-		/// 
-		/// Calling this method will also remove set the <see cref="IsTempFile"/> property to <c>False</c>.
-		/// </summary>
-		/// <param name="dstFileName"></param>
-		public void Move(string dstFileName, bool overwrite = false) {
-			// delete if overwriting; let File.Move thow IOException if not
-			if (File.Exists(dstFileName) && overwrite)
-				File.Delete(dstFileName);
+        /// <summary>
+        /// Moves file and updates internal reference.
+        /// 
+        /// Calling this method will also remove set the <see cref="IsTempFile"/> property to <c>False</c>.
+        /// </summary>
+        /// <param name="dstFileName"></param>
+        public void Move(string dstFileName, bool overwrite = false)
+        {
+            // delete if overwriting; let File.Move thow IOException if not
+            if (File.Exists(dstFileName) && overwrite) File.Delete(dstFileName);
 
-			File.Move(Name, dstFileName);
-			Name = Path.GetFullPath(dstFileName);
-			IsTempFile = false;
-		}
+            File.Move(Name, dstFileName);
+            Name = Path.GetFullPath(dstFileName);
+            IsTempFile = false;
+        }
 
-		public byte[] GetByteRange(int offset, int count) {
-			byte[] buffer = new byte[count];
+        public byte[] GetByteRange(int offset, int count)
+        {
+            byte[] buffer = new byte[count];
 
-			using (Stream fs = OpenRead()) {
-				fs.Seek(offset, SeekOrigin.Begin);
-				fs.Read(buffer, 0, count);
-			}
+            using (Stream fs = OpenRead())
+            {
+                fs.Seek(offset, SeekOrigin.Begin);
+                fs.Read(buffer, 0, count);
+            }
 
-			return buffer;
-		}
+            return buffer;
+        }
 
-		public override string ToString() {
-			if (IsTempFile)
-				return String.Format("{0} [TEMP]", Name);
-			return Name;
-		}
-	}
+        public override string ToString()
+        {
+            if (IsTempFile) return String.Format("{0} [TEMP]", Name);
+            return Name;
+        }
+    }
 }

--- a/DICOM/IO/IByteSource.cs
+++ b/DICOM/IO/IByteSource.cs
@@ -1,63 +1,60 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO {
-	public delegate void ByteSourceCallback(IByteSource source, object state);
+namespace Dicom.IO
+{
+    public delegate void ByteSourceCallback(IByteSource source, object state);
 
-	public interface IByteSource {
-		Endian Endian {
-			get;
-			set;
-		}
+    public interface IByteSource
+    {
+        Endian Endian { get; set; }
 
-		long Position {
-			get;
-		}
+        long Position { get; }
 
-		long Marker {
-			get;
-		}
+        long Marker { get; }
 
-		bool IsEOF {
-			get;
-		}
+        bool IsEOF { get; }
 
-		bool CanRewind {
-			get;
-		}
+        bool CanRewind { get; }
 
-		byte GetUInt8();
+        byte GetUInt8();
 
-		short GetInt16();
-		ushort GetUInt16();
+        short GetInt16();
 
-		int GetInt32();
-		uint GetUInt32();
+        ushort GetUInt16();
 
-		long GetInt64();
-		ulong GetUInt64();
+        int GetInt32();
 
-		float GetSingle();
-		double GetDouble();
+        uint GetUInt32();
 
-		byte[] GetBytes(int count);
+        long GetInt64();
 
-		IByteBuffer GetBuffer(uint count);
+        ulong GetUInt64();
 
-		void Skip(int count);
+        float GetSingle();
 
-		void Mark();
-		void Rewind();
+        double GetDouble();
 
-		void PushMilestone(uint count);
-		void PopMilestone();
-		bool HasReachedMilestone();
+        byte[] GetBytes(int count);
 
-		bool Require(uint count);
-		bool Require(uint count, ByteSourceCallback callback, object state);
-	}
+        IByteBuffer GetBuffer(uint count);
+
+        void Skip(int count);
+
+        void Mark();
+
+        void Rewind();
+
+        void PushMilestone(uint count);
+
+        void PopMilestone();
+
+        bool HasReachedMilestone();
+
+        bool Require(uint count);
+
+        bool Require(uint count, ByteSourceCallback callback, object state);
+    }
 }

--- a/DICOM/IO/IByteTarget.cs
+++ b/DICOM/IO/IByteTarget.cs
@@ -1,35 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO.Buffer;
+namespace Dicom.IO
+{
+    public delegate void ByteTargetCallback(IByteTarget target, object state);
 
-namespace Dicom.IO {
-	public delegate void ByteTargetCallback(IByteTarget target, object state);
+    public interface IByteTarget
+    {
+        Endian Endian { get; set; }
 
-	public interface IByteTarget {
-		Endian Endian {
-			get;
-			set;
-		}
+        long Position { get; }
 
-		long Position {
-			get;
-		}
+        void Write(byte v);
 
-		void Write(byte v);
-		void Write(short v);
-		void Write(ushort v);
-		void Write(int v);
-		void Write(uint v);
-		void Write(long v);
-		void Write(ulong v);
-		void Write(float v);
-		void Write(double v);
+        void Write(short v);
 
-		void Write(byte[] buffer, uint offset=0, uint count=0xffffffff, ByteTargetCallback callback=null, object state=null);
+        void Write(ushort v);
 
-		void Close();
-	}
+        void Write(int v);
+
+        void Write(uint v);
+
+        void Write(long v);
+
+        void Write(ulong v);
+
+        void Write(float v);
+
+        void Write(double v);
+
+        void Write(
+            byte[] buffer,
+            uint offset = 0,
+            uint count = 0xffffffff,
+            ByteTargetCallback callback = null,
+            object state = null);
+
+        void Close();
+    }
 }

--- a/DICOM/IO/PinnedArray.cs
+++ b/DICOM/IO/PinnedArray.cs
@@ -1,94 +1,155 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Runtime.InteropServices;
 
-namespace Dicom.IO {
-	public class PinnedArray<T> : IDisposable {
-		#region Private Members
-		private T[] _data;
-		private int _size;
-		private int _count;
-		private GCHandle _handle;
-		private IntPtr _pointer;
-		#endregion
+namespace Dicom.IO
+{
+    public class PinnedArray<T> : IDisposable
+    {
+        #region Private Members
 
-		#region Public Properties
-		public T[] Data {
-			get { return _data; }
-		}
+        private T[] _data;
 
-		public int Count {
-			get { return _count; }
-		}
+        private int _size;
 
-		public int ByteSize {
-			get { return _size; }
-		}
+        private int _count;
 
-		public IntPtr Pointer {
-			get { return _pointer; }
-		}
+        private GCHandle _handle;
 
-		public T this[int index] {
-			get { return _data[index]; }
-			set { _data[index] = value; }
-		}
-		#endregion
+        private IntPtr _pointer;
 
-		#region Public Constructor
-		public PinnedArray(int count) {
-			_count = count;
-			_size = Marshal.SizeOf(typeof(T)) * _count;
-			_data = new T[_count];
-			_handle = GCHandle.Alloc(_data, GCHandleType.Pinned);
-			_pointer = _handle.AddrOfPinnedObject();
-		}
+        #endregion
 
-		public PinnedArray(T[] data) {
-			_count = data.Length;
-			_size = Marshal.SizeOf(typeof(T)) * _count;
-			_data = data;
-			_handle = GCHandle.Alloc(_data, GCHandleType.Pinned);
-			_pointer = _handle.AddrOfPinnedObject();
-		}
+        #region Public Properties
 
-		~PinnedArray() {
-			Dispose(false);
-		}
-		#endregion
+        public T[] Data
+        {
+            get
+            {
+                return _data;
+            }
+        }
 
-		#region Public Members
-		public void Dispose() {
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
+        public int Count
+        {
+            get
+            {
+                return _count;
+            }
+        }
 
-		public static implicit operator IntPtr(PinnedArray<T> array) {
-			return array._pointer;
-		}
-		#endregion
+        public int ByteSize
+        {
+            get
+            {
+                return _size;
+            }
+        }
 
-		#region Private Members
-		private void Dispose(bool disposing) {
-			if (_data != null) {
-				_handle.Free();
-				_pointer = IntPtr.Zero;
-				_data = null;
-			}
-		}
-		#endregion
-	}
+        public IntPtr Pointer
+        {
+            get
+            {
+                return _pointer;
+            }
+        }
 
-	public class PinnedByteArray : PinnedArray<byte> {
-		public PinnedByteArray(int count) : base(count) {
-		}
-		public PinnedByteArray(byte[] data) : base(data) {
-		}
-	}
+        public T this[int index]
+        {
+            get
+            {
+                return _data[index];
+            }
+            set
+            {
+                _data[index] = value;
+            }
+        }
 
-	public class PinnedIntArray : PinnedArray<int> {
-		public PinnedIntArray(int count) : base(count) {
-		}
-		public PinnedIntArray(int[] data) : base(data) {
-		}
-	}
+        #endregion
+
+        #region Public Constructor
+
+        public PinnedArray(int count)
+        {
+            _count = count;
+            _size = Marshal.SizeOf(typeof(T)) * _count;
+            _data = new T[_count];
+            _handle = GCHandle.Alloc(_data, GCHandleType.Pinned);
+            _pointer = _handle.AddrOfPinnedObject();
+        }
+
+        public PinnedArray(T[] data)
+        {
+            _count = data.Length;
+            _size = Marshal.SizeOf(typeof(T)) * _count;
+            _data = data;
+            _handle = GCHandle.Alloc(_data, GCHandleType.Pinned);
+            _pointer = _handle.AddrOfPinnedObject();
+        }
+
+        ~PinnedArray()
+        {
+            Dispose(false);
+        }
+
+        #endregion
+
+        #region Public Members
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public static implicit operator IntPtr(PinnedArray<T> array)
+        {
+            return array._pointer;
+        }
+
+        #endregion
+
+        #region Private Members
+
+        private void Dispose(bool disposing)
+        {
+            if (_data != null)
+            {
+                _handle.Free();
+                _pointer = IntPtr.Zero;
+                _data = null;
+            }
+        }
+
+        #endregion
+    }
+
+    public class PinnedByteArray : PinnedArray<byte>
+    {
+        public PinnedByteArray(int count)
+            : base(count)
+        {
+        }
+
+        public PinnedByteArray(byte[] data)
+            : base(data)
+        {
+        }
+    }
+
+    public class PinnedIntArray : PinnedArray<int>
+    {
+        public PinnedIntArray(int count)
+            : base(count)
+        {
+        }
+
+        public PinnedIntArray(int[] data)
+            : base(data)
+        {
+        }
+    }
 }

--- a/DICOM/IO/Reader/DicomDatasetReaderObserver.cs
+++ b/DICOM/IO/Reader/DicomDatasetReaderObserver.cs
@@ -1,131 +1,203 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
-using Dicom.IO;
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO.Reader {
-	public class DicomDatasetReaderObserver : IDicomReaderObserver {
-		private Stack<DicomDataset> _datasets;
-		private Stack<Encoding> _encodings;
-		private Stack<DicomSequence> _sequences;
-		private DicomFragmentSequence _fragment;
+namespace Dicom.IO.Reader
+{
+    public class DicomDatasetReaderObserver : IDicomReaderObserver
+    {
+        private Stack<DicomDataset> _datasets;
 
-	    public DicomDatasetReaderObserver(DicomDataset dataset) : this(dataset, DicomEncoding.Default) {
-	    }
+        private Stack<Encoding> _encodings;
 
-	    public DicomDatasetReaderObserver(DicomDataset dataset, Encoding fallbackEncoding) {
-	        if (fallbackEncoding == null)
-	        {
-	            throw new ArgumentNullException("fallbackEncoding");
-	        }
-	        _datasets = new Stack<DicomDataset>();
-			_datasets.Push(dataset);
+        private Stack<DicomSequence> _sequences;
 
-			_encodings = new Stack<Encoding>();
-			_encodings.Push(fallbackEncoding);
+        private DicomFragmentSequence _fragment;
 
-			_sequences = new Stack<DicomSequence>();
-		}
+        public DicomDatasetReaderObserver(DicomDataset dataset)
+            : this(dataset, DicomEncoding.Default)
+        {
+        }
 
-		public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data) {
-			DicomElement element;
-			switch (vr.Code) {
-				case "AE": element = new DicomApplicationEntity(tag, data); break;
-				case "AS": element = new DicomAgeString(tag, data); break;
-				case "AT": element = new DicomAttributeTag(tag, data); break;
-				case "CS": element = new DicomCodeString(tag, data); break;
-				case "DA": element = new DicomDate(tag, data); break;
-				case "DS": element = new DicomDecimalString(tag, data); break;
-				case "DT": element = new DicomDateTime(tag, data); break;
-				case "FD": element = new DicomFloatingPointDouble(tag, data); break;
-				case "FL": element = new DicomFloatingPointSingle(tag, data); break;
-				case "IS": element = new DicomIntegerString(tag, data); break;
-				case "LO": element = new DicomLongString(tag, _encodings.Peek(), data); break;
-				case "LT": element = new DicomLongText(tag, _encodings.Peek(), data); break;
-				case "OB": element = new DicomOtherByte(tag, data); break;
-				case "OD": element = new DicomOtherDouble(tag, data); break;
-				case "OF": element = new DicomOtherFloat(tag, data); break;
-				case "OW": element = new DicomOtherWord(tag, data); break;
-				case "PN": element = new DicomPersonName(tag, _encodings.Peek(), data); break;
-				case "SH": element = new DicomShortString(tag, _encodings.Peek(), data); break;
-				case "SL": element = new DicomSignedLong(tag, data); break;
-				case "SS": element = new DicomSignedShort(tag, data); break;
-				case "ST": element = new DicomShortText(tag, _encodings.Peek(), data); break;
-				case "TM": element = new DicomTime(tag, data); break;
-				case "UC": element = new DicomUnlimitedCharacters(tag, _encodings.Peek(), data); break;
-				case "UI": element = new DicomUniqueIdentifier(tag, data); break;
-				case "UL": element = new DicomUnsignedLong(tag, data); break;
-				case "UN": element = new DicomUnknown(tag, data); break;
-				case "UR": element = new DicomUniversalResource(tag, _encodings.Peek(), data); break;
-				case "US": element = new DicomUnsignedShort(tag, data); break;
-				case "UT": element = new DicomUnlimitedText(tag, _encodings.Peek(), data); break;
-				default:
-					throw new DicomDataException("Unhandled VR in DICOM parser observer: {0}", vr.Code);
-			}
+        public DicomDatasetReaderObserver(DicomDataset dataset, Encoding fallbackEncoding)
+        {
+            if (fallbackEncoding == null)
+            {
+                throw new ArgumentNullException("fallbackEncoding");
+            }
+            _datasets = new Stack<DicomDataset>();
+            _datasets.Push(dataset);
 
-			if (element.Tag == DicomTag.SpecificCharacterSet) {
-				Encoding encoding = _encodings.Peek();
-				if (element.Count > 0)
-					encoding = DicomEncoding.GetEncoding(element.Get<string>(0));
-				_encodings.Pop();
-				_encodings.Push(encoding);
-			}
+            _encodings = new Stack<Encoding>();
+            _encodings.Push(fallbackEncoding);
 
-			DicomDataset ds = _datasets.Peek();
-			ds.Add(element);
-		}
+            _sequences = new Stack<DicomSequence>();
+        }
 
-		public void OnBeginSequence(IByteSource source, DicomTag tag, uint length) {
-			DicomSequence sq = new DicomSequence(tag);
-			_sequences.Push(sq);
+        public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data)
+        {
+            DicomElement element;
+            switch (vr.Code)
+            {
+                case "AE":
+                    element = new DicomApplicationEntity(tag, data);
+                    break;
+                case "AS":
+                    element = new DicomAgeString(tag, data);
+                    break;
+                case "AT":
+                    element = new DicomAttributeTag(tag, data);
+                    break;
+                case "CS":
+                    element = new DicomCodeString(tag, data);
+                    break;
+                case "DA":
+                    element = new DicomDate(tag, data);
+                    break;
+                case "DS":
+                    element = new DicomDecimalString(tag, data);
+                    break;
+                case "DT":
+                    element = new DicomDateTime(tag, data);
+                    break;
+                case "FD":
+                    element = new DicomFloatingPointDouble(tag, data);
+                    break;
+                case "FL":
+                    element = new DicomFloatingPointSingle(tag, data);
+                    break;
+                case "IS":
+                    element = new DicomIntegerString(tag, data);
+                    break;
+                case "LO":
+                    element = new DicomLongString(tag, _encodings.Peek(), data);
+                    break;
+                case "LT":
+                    element = new DicomLongText(tag, _encodings.Peek(), data);
+                    break;
+                case "OB":
+                    element = new DicomOtherByte(tag, data);
+                    break;
+                case "OD":
+                    element = new DicomOtherDouble(tag, data);
+                    break;
+                case "OF":
+                    element = new DicomOtherFloat(tag, data);
+                    break;
+                case "OW":
+                    element = new DicomOtherWord(tag, data);
+                    break;
+                case "PN":
+                    element = new DicomPersonName(tag, _encodings.Peek(), data);
+                    break;
+                case "SH":
+                    element = new DicomShortString(tag, _encodings.Peek(), data);
+                    break;
+                case "SL":
+                    element = new DicomSignedLong(tag, data);
+                    break;
+                case "SS":
+                    element = new DicomSignedShort(tag, data);
+                    break;
+                case "ST":
+                    element = new DicomShortText(tag, _encodings.Peek(), data);
+                    break;
+                case "TM":
+                    element = new DicomTime(tag, data);
+                    break;
+                case "UC":
+                    element = new DicomUnlimitedCharacters(tag, _encodings.Peek(), data);
+                    break;
+                case "UI":
+                    element = new DicomUniqueIdentifier(tag, data);
+                    break;
+                case "UL":
+                    element = new DicomUnsignedLong(tag, data);
+                    break;
+                case "UN":
+                    element = new DicomUnknown(tag, data);
+                    break;
+                case "UR":
+                    element = new DicomUniversalResource(tag, _encodings.Peek(), data);
+                    break;
+                case "US":
+                    element = new DicomUnsignedShort(tag, data);
+                    break;
+                case "UT":
+                    element = new DicomUnlimitedText(tag, _encodings.Peek(), data);
+                    break;
+                default:
+                    throw new DicomDataException("Unhandled VR in DICOM parser observer: {0}", vr.Code);
+            }
 
-			DicomDataset ds = _datasets.Peek();
-			ds.Add(sq);
-		}
+            if (element.Tag == DicomTag.SpecificCharacterSet)
+            {
+                Encoding encoding = _encodings.Peek();
+                if (element.Count > 0) encoding = DicomEncoding.GetEncoding(element.Get<string>(0));
+                _encodings.Pop();
+                _encodings.Push(encoding);
+            }
 
-		public void OnBeginSequenceItem(IByteSource source, uint length) {
-			DicomSequence sq = _sequences.Peek();
+            DicomDataset ds = _datasets.Peek();
+            ds.Add(element);
+        }
 
-			DicomDataset item = new DicomDataset();
-			sq.Items.Add(item);
+        public void OnBeginSequence(IByteSource source, DicomTag tag, uint length)
+        {
+            DicomSequence sq = new DicomSequence(tag);
+            _sequences.Push(sq);
 
-			_datasets.Push(item);
+            DicomDataset ds = _datasets.Peek();
+            ds.Add(sq);
+        }
 
-			_encodings.Push(_encodings.Peek());
-		}
+        public void OnBeginSequenceItem(IByteSource source, uint length)
+        {
+            DicomSequence sq = _sequences.Peek();
 
-		public void OnEndSequenceItem() {
-			if (_encodings.Count > 1)
-				_encodings.Pop();
+            DicomDataset item = new DicomDataset();
+            sq.Items.Add(item);
 
-			_datasets.Pop();
-		}
+            _datasets.Push(item);
 
-		public void OnEndSequence() {
-			_sequences.Pop();
-		}
+            _encodings.Push(_encodings.Peek());
+        }
 
-		public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr) {
-			if (vr == DicomVR.OB)
-				_fragment = new DicomOtherByteFragment(tag);
-			else if (vr == DicomVR.OW)
-				_fragment = new DicomOtherWordFragment(tag);
-			else
-				throw new DicomDataException("Unexpected VR found for DICOM fragment sequence: {0}", vr.Code);
+        public void OnEndSequenceItem()
+        {
+            if (_encodings.Count > 1) _encodings.Pop();
 
-			DicomDataset ds = _datasets.Peek();
-			ds.Add(_fragment);
-		}
+            _datasets.Pop();
+        }
 
-		public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data) {
-			_fragment.Add(data);
-		}
+        public void OnEndSequence()
+        {
+            _sequences.Pop();
+        }
 
-		public void OnEndFragmentSequence() {
-			_fragment = null;
-		}
-	}
+        public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr)
+        {
+            if (vr == DicomVR.OB) _fragment = new DicomOtherByteFragment(tag);
+            else if (vr == DicomVR.OW) _fragment = new DicomOtherWordFragment(tag);
+            else throw new DicomDataException("Unexpected VR found for DICOM fragment sequence: {0}", vr.Code);
+
+            DicomDataset ds = _datasets.Peek();
+            ds.Add(_fragment);
+        }
+
+        public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data)
+        {
+            _fragment.Add(data);
+        }
+
+        public void OnEndFragmentSequence()
+        {
+            _fragment = null;
+        }
+    }
 }

--- a/DICOM/IO/Reader/DicomFileReader.cs
+++ b/DICOM/IO/Reader/DicomFileReader.cs
@@ -1,207 +1,275 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
-using System.Threading;
 
-using Dicom.IO;
+namespace Dicom.IO.Reader
+{
+    public class DicomFileReader
+    {
+        private static readonly DicomTag FileMetaInfoStopTag = new DicomTag(0x0002, 0xffff);
 
-namespace Dicom.IO.Reader {
-	public class DicomFileReader {
-		private readonly static DicomTag FileMetaInfoStopTag = new DicomTag(0x0002, 0xffff);
+        private IDicomReader _reader;
 
-		private IDicomReader _reader;
-		private EventAsyncResult _async;
-		private DicomReaderResult _result;
-		private Exception _exception;
+        private EventAsyncResult _async;
 
-		private IByteSource _source;
-		private IDicomReaderObserver _fmiObserver;
-		private IDicomReaderObserver _dataObserver;
-		private DicomFileFormat _fileFormat;
+        private DicomReaderResult _result;
 
-		private DicomTransferSyntax _syntax;
+        private Exception _exception;
 
-		public DicomFileReader() {
-			_reader = new DicomReader();
-			_fileFormat = DicomFileFormat.Unknown;
-			_syntax = DicomTransferSyntax.ExplicitVRLittleEndian;
-		}
+        private IByteSource _source;
 
-		public IByteSource Source {
-			get { return _source; }
-		}
+        private IDicomReaderObserver _fmiObserver;
 
-		public DicomFileFormat FileFormat {
-			get { return _fileFormat; }
-		}
+        private IDicomReaderObserver _dataObserver;
 
-		public DicomTransferSyntax Syntax {
-			get { return _syntax; }
-		}
+        private DicomFileFormat _fileFormat;
 
-		public DicomReaderResult Read(IByteSource source, IDicomReaderObserver fileMetaInfo, IDicomReaderObserver dataset) {
-			return EndRead(BeginRead(source, fileMetaInfo, dataset, null, null));
-		}
+        private DicomTransferSyntax _syntax;
 
-		public IAsyncResult BeginRead(IByteSource source, IDicomReaderObserver fileMetaInfo, IDicomReaderObserver dataset, AsyncCallback callback, object state) {
-			_result = DicomReaderResult.Processing;
-			_source = source;
-			_fmiObserver = fileMetaInfo;
-			_dataObserver = dataset;
-			_async = new EventAsyncResult(callback, state);
-			ParsePreamble(source, null); // ThreadPool?
-			return _async;
-		}
+        public DicomFileReader()
+        {
+            _reader = new DicomReader();
+            _fileFormat = DicomFileFormat.Unknown;
+            _syntax = DicomTransferSyntax.ExplicitVRLittleEndian;
+        }
 
-		public DicomReaderResult EndRead(IAsyncResult result) {
-			_async.AsyncWaitHandle.WaitOne();
-			if (_exception != null)
-				throw _exception;
-			return _reader.Status;
-		}
+        public IByteSource Source
+        {
+            get
+            {
+                return _source;
+            }
+        }
 
-		private void ParsePreamble(IByteSource source, object state) {
-			try {
-				if (!source.Require(132, ParsePreamble, state))
-					return;
+        public DicomFileFormat FileFormat
+        {
+            get
+            {
+                return _fileFormat;
+            }
+        }
 
-				// mark file origin
-				_source.Mark();
+        public DicomTransferSyntax Syntax
+        {
+            get
+            {
+                return _syntax;
+            }
+        }
 
-				// test for DICM preamble
-				_source.Skip(128);
-				if (_source.GetUInt8() == 'D' &&
-					_source.GetUInt8() == 'I' &&
-					_source.GetUInt8() == 'C' &&
-					_source.GetUInt8() == 'M')
-					_fileFormat = DicomFileFormat.DICOM3;
+        public DicomReaderResult Read(
+            IByteSource source,
+            IDicomReaderObserver fileMetaInfo,
+            IDicomReaderObserver dataset)
+        {
+            return EndRead(BeginRead(source, fileMetaInfo, dataset, null, null));
+        }
 
-				// test for incorrect syntax in file meta info
-				 do {
-					 if (_fileFormat == DicomFileFormat.DICOM3) {
-						 // move milestone to after preamble
-						 _source.Mark();
-					 } else {
-						 // rewind to origin milestone
-						 _source.Rewind();
-					 }
+        public IAsyncResult BeginRead(
+            IByteSource source,
+            IDicomReaderObserver fileMetaInfo,
+            IDicomReaderObserver dataset,
+            AsyncCallback callback,
+            object state)
+        {
+            _result = DicomReaderResult.Processing;
+            _source = source;
+            _fmiObserver = fileMetaInfo;
+            _dataObserver = dataset;
+            _async = new EventAsyncResult(callback, state);
+            ParsePreamble(source, null); // ThreadPool?
+            return _async;
+        }
 
-					// test for file meta info
-					var group = _source.GetUInt16();
+        public DicomReaderResult EndRead(IAsyncResult result)
+        {
+            _async.AsyncWaitHandle.WaitOne();
+            if (_exception != null) throw _exception;
+            return _reader.Status;
+        }
 
-					if (group > 0x00ff) {
-						_source.Endian = Endian.Big;
-						_syntax = DicomTransferSyntax.ExplicitVRBigEndian;
+        private void ParsePreamble(IByteSource source, object state)
+        {
+            try
+            {
+                if (!source.Require(132, ParsePreamble, state)) return;
 
-						group = Endian.Swap(group);
-					}
+                // mark file origin
+                _source.Mark();
 
-					if (group > 0x00ff) {
-						// invalid starting tag
-						_fileFormat = DicomFileFormat.Unknown;
-						_source.Rewind();
-						break;
-					}
+                // test for DICM preamble
+                _source.Skip(128);
+                if (_source.GetUInt8() == 'D' && _source.GetUInt8() == 'I' && _source.GetUInt8() == 'C'
+                    && _source.GetUInt8() == 'M') _fileFormat = DicomFileFormat.DICOM3;
 
-					if (_fileFormat == DicomFileFormat.Unknown) {
-						if (group == 0x0002)
-							_fileFormat = DicomFileFormat.DICOM3NoPreamble;
-						else
-							_fileFormat = DicomFileFormat.DICOM3NoFileMetaInfo;
-					}
+                // test for incorrect syntax in file meta info
+                do
+                {
+                    if (_fileFormat == DicomFileFormat.DICOM3)
+                    {
+                        // move milestone to after preamble
+                        _source.Mark();
+                    }
+                    else
+                    {
+                        // rewind to origin milestone
+                        _source.Rewind();
+                    }
 
-					var element = _source.GetUInt16();
-					var tag = new DicomTag(group, element);
+                    // test for file meta info
+                    var group = _source.GetUInt16();
 
-					// test for explicit VR
-					var vrt = Encoding.UTF8.GetBytes(tag.DictionaryEntry.ValueRepresentations[0].Code);
-					var vrs = _source.GetBytes(2);
+                    if (group > 0x00ff)
+                    {
+                        _source.Endian = Endian.Big;
+                        _syntax = DicomTransferSyntax.ExplicitVRBigEndian;
 
-					if (vrt[0] != vrs[0] || vrt[1] != vrs[1]) {
-						// implicit VR
-						if (_syntax.Endian == Endian.Little)
-							_syntax = DicomTransferSyntax.ImplicitVRLittleEndian;
-						else
-							_syntax = DicomTransferSyntax.ImplicitVRBigEndian;
-					}
+                        group = Endian.Swap(group);
+                    }
 
-					_source.Rewind();
-				} while (_fileFormat == DicomFileFormat.Unknown);
+                    if (group > 0x00ff)
+                    {
+                        // invalid starting tag
+                        _fileFormat = DicomFileFormat.Unknown;
+                        _source.Rewind();
+                        break;
+                    }
 
-				if (_fileFormat == DicomFileFormat.Unknown)
-					throw new DicomReaderException("Attempted to read invalid DICOM file");
+                    if (_fileFormat == DicomFileFormat.Unknown)
+                    {
+                        if (group == 0x0002) _fileFormat = DicomFileFormat.DICOM3NoPreamble;
+                        else _fileFormat = DicomFileFormat.DICOM3NoFileMetaInfo;
+                    }
 
-				var obs = new DicomReaderCallbackObserver();
-				if (_fileFormat != DicomFileFormat.DICOM3) {
-					obs.Add(DicomTag.RecognitionCodeRETIRED, (object sender, DicomReaderEventArgs ea) => {
-						try {
-							string code = Encoding.UTF8.GetString(ea.Data.Data, 0, ea.Data.Data.Length);
-							if (code == "ACR-NEMA 1.0")
-								_fileFormat = DicomFileFormat.ACRNEMA1;
-							else if (code == "ACR-NEMA 2.0")
-								_fileFormat = DicomFileFormat.ACRNEMA2;
-						} catch {
-						}
-					});
-				}
-				obs.Add(DicomTag.TransferSyntaxUID, (object sender, DicomReaderEventArgs ea) => {
-					try {
-						string uid = Encoding.UTF8.GetString(ea.Data.Data, 0, ea.Data.Data.Length);
-						_syntax = DicomTransferSyntax.Parse(uid);
-					} catch {
-					}
-				});
+                    var element = _source.GetUInt16();
+                    var tag = new DicomTag(group, element);
 
-				_source.Endian = _syntax.Endian;
-				_reader.IsExplicitVR = _syntax.IsExplicitVR;
+                    // test for explicit VR
+                    var vrt = Encoding.UTF8.GetBytes(tag.DictionaryEntry.ValueRepresentations[0].Code);
+                    var vrs = _source.GetBytes(2);
 
-				if (_fileFormat == DicomFileFormat.DICOM3NoFileMetaInfo)
-					_reader.BeginRead(_source, new DicomReaderMultiObserver(obs, _dataObserver), null, OnDatasetParseComplete, null);
-				else
-					_reader.BeginRead(_source, new DicomReaderMultiObserver(obs, _fmiObserver), FileMetaInfoStopTag, OnFileMetaInfoParseComplete, null);
-			} catch (Exception e) {
-				if (_exception == null)
-					_exception = e;
-				_result = DicomReaderResult.Error;
-			} finally {
-				if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended) {
-					_async.Set();
-				}
-			}
-		}
+                    if (vrt[0] != vrs[0] || vrt[1] != vrs[1])
+                    {
+                        // implicit VR
+                        if (_syntax.Endian == Endian.Little) _syntax = DicomTransferSyntax.ImplicitVRLittleEndian;
+                        else _syntax = DicomTransferSyntax.ImplicitVRBigEndian;
+                    }
 
-		private void OnFileMetaInfoParseComplete(IAsyncResult result) {
-			try {
-				if (_reader.EndRead(result) != DicomReaderResult.Stopped)
-					throw new DicomReaderException("DICOM File Meta Info ended prematurely");
+                    _source.Rewind();
+                }
+                while (_fileFormat == DicomFileFormat.Unknown);
 
-				// rewind to last marker (start of previous tag)... ugly because 
-				// it requires knowledge of how the parser is implemented
-				_source.Rewind();
+                if (_fileFormat == DicomFileFormat.Unknown) throw new DicomReaderException("Attempted to read invalid DICOM file");
 
-				_source.Endian = _syntax.Endian;
-				_reader.IsExplicitVR = _syntax.IsExplicitVR;
-				_reader.BeginRead(_source, _dataObserver, null, OnDatasetParseComplete, null);
-			} catch (Exception e) {
-				if (_exception == null)
-					_exception = e;
-				_result = DicomReaderResult.Error;
-			} finally {
-				if (_result == DicomReaderResult.Error) {
-					_async.Set();
-				}
-			}
-		}
+                var obs = new DicomReaderCallbackObserver();
+                if (_fileFormat != DicomFileFormat.DICOM3)
+                {
+                    obs.Add(
+                        DicomTag.RecognitionCodeRETIRED,
+                        (object sender, DicomReaderEventArgs ea) =>
+                            {
+                                try
+                                {
+                                    string code = Encoding.UTF8.GetString(ea.Data.Data, 0, ea.Data.Data.Length);
+                                    if (code == "ACR-NEMA 1.0") _fileFormat = DicomFileFormat.ACRNEMA1;
+                                    else if (code == "ACR-NEMA 2.0") _fileFormat = DicomFileFormat.ACRNEMA2;
+                                }
+                                catch
+                                {
+                                }
+                            });
+                }
+                obs.Add(
+                    DicomTag.TransferSyntaxUID,
+                    (object sender, DicomReaderEventArgs ea) =>
+                        {
+                            try
+                            {
+                                string uid = Encoding.UTF8.GetString(ea.Data.Data, 0, ea.Data.Data.Length);
+                                _syntax = DicomTransferSyntax.Parse(uid);
+                            }
+                            catch
+                            {
+                            }
+                        });
 
-		private void OnDatasetParseComplete(IAsyncResult result) {
-			try {
-				_result = _reader.EndRead(result);
-			} catch (Exception e) {
-				if (_exception == null)
-					_exception = e;
-				_result = DicomReaderResult.Error;
-			} finally {
-				_async.Set();
-			}
-		}
-	}
+                _source.Endian = _syntax.Endian;
+                _reader.IsExplicitVR = _syntax.IsExplicitVR;
+
+                if (_fileFormat == DicomFileFormat.DICOM3NoFileMetaInfo)
+                    _reader.BeginRead(
+                        _source,
+                        new DicomReaderMultiObserver(obs, _dataObserver),
+                        null,
+                        OnDatasetParseComplete,
+                        null);
+                else
+                    _reader.BeginRead(
+                        _source,
+                        new DicomReaderMultiObserver(obs, _fmiObserver),
+                        FileMetaInfoStopTag,
+                        OnFileMetaInfoParseComplete,
+                        null);
+            }
+            catch (Exception e)
+            {
+                if (_exception == null) _exception = e;
+                _result = DicomReaderResult.Error;
+            }
+            finally
+            {
+                if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended)
+                {
+                    _async.Set();
+                }
+            }
+        }
+
+        private void OnFileMetaInfoParseComplete(IAsyncResult result)
+        {
+            try
+            {
+                if (_reader.EndRead(result) != DicomReaderResult.Stopped) throw new DicomReaderException("DICOM File Meta Info ended prematurely");
+
+                // rewind to last marker (start of previous tag)... ugly because 
+                // it requires knowledge of how the parser is implemented
+                _source.Rewind();
+
+                _source.Endian = _syntax.Endian;
+                _reader.IsExplicitVR = _syntax.IsExplicitVR;
+                _reader.BeginRead(_source, _dataObserver, null, OnDatasetParseComplete, null);
+            }
+            catch (Exception e)
+            {
+                if (_exception == null) _exception = e;
+                _result = DicomReaderResult.Error;
+            }
+            finally
+            {
+                if (_result == DicomReaderResult.Error)
+                {
+                    _async.Set();
+                }
+            }
+        }
+
+        private void OnDatasetParseComplete(IAsyncResult result)
+        {
+            try
+            {
+                _result = _reader.EndRead(result);
+            }
+            catch (Exception e)
+            {
+                if (_exception == null) _exception = e;
+                _result = DicomReaderResult.Error;
+            }
+            finally
+            {
+                _async.Set();
+            }
+        }
+    }
 }

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -1,559 +1,682 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
 
-using Dicom.IO;
 using Dicom.IO.Buffer;
 
 using Dicom.Imaging.Mathematics;
 
-namespace Dicom.IO.Reader {
-	public class DicomReader : IDicomReader {
-		private const uint UndefinedLength = 0xffffffff;
-
-		public enum ParseState {
-			Tag,
-			VR,
-			Length,
-			Value
-		}
-
-		private ParseState _state;
-		private DicomTag _tag;
-		private DicomDictionaryEntry _entry;
-		private DicomVR _vr;
-		private uint _length;
-		private bool _implicit;
-
-		private int _fragmentItem;
-
-		private DicomTag _stop;
-		private IDicomReaderObserver _observer;
-		private EventAsyncResult _async;
-		private Exception _exception;
-		private volatile DicomReaderResult _result;
-
-		private bool _explicit;
-		private bool _badPrivateSequence;
-
-		private DicomDictionary _dict;
-
-		private Dictionary<uint, string> _private;
-		private Stack<object> _stack;
-
-		public DicomReader() {
-			_private = new Dictionary<uint, string>();
-			_stack = new Stack<object>();
-			_dict = DicomDictionary.Default;
-		}
-
-		public DicomDictionary Dictionary {
-			get { return _dict; }
-			set { _dict = value; }
-		}
-
-		public bool IsExplicitVR {
-			get { return _explicit; }
-			set { _explicit = value; }
-		}
-
-		public DicomReaderResult Status {
-			get { return _result; }
-		}
-
-		public DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, DicomTag stop = null) {
-			return EndRead(BeginRead(source, observer, stop, null, null));
-		}
-
-		public IAsyncResult BeginRead(IByteSource source, IDicomReaderObserver observer, DicomTag stop, AsyncCallback callback, object state) {
-			_stop = stop;
-			_observer = observer;
-			_result = DicomReaderResult.Processing;
-			_exception = null;
-			_async = new EventAsyncResult(callback, state);
-			ThreadPool.QueueUserWorkItem(ParseProc, source);
-			return _async;
-		}
-
-		public DicomReaderResult EndRead(IAsyncResult result) {
-			_async.AsyncWaitHandle.WaitOne();
-			if (_exception != null)
-				throw _exception;
-			return _result;
-		}
-
-		private void ParseProc(object state) {
-			ParseDataset(state as IByteSource, null);
-		}
-
-		private void ParseDataset(IByteSource source, object state) {
-			try {
-				_result = DicomReaderResult.Processing;
-
-				while (!source.IsEOF && !source.HasReachedMilestone() && _result == DicomReaderResult.Processing) {
-					if (_state == ParseState.Tag) {
-						source.Mark();
-
-						if (!source.Require(4, ParseDataset, state)) {
-							_result = DicomReaderResult.Suspended;
-							return;
-						}
-
-						ushort group = source.GetUInt16();
-						ushort element = source.GetUInt16();
-						DicomPrivateCreator creator = null;
-
-						if (group.IsOdd() && element > 0x00ff) {
-							string pvt = null;
-							uint card = (uint)(group << 16) + (uint)(element >> 8);
-							if (_private.TryGetValue(card, out pvt))
-								creator = Dictionary.GetPrivateCreator(pvt);
-						}
-
-						_tag = new DicomTag(group, element, creator);
-						_entry = Dictionary[_tag];
-
-						if (!_tag.IsPrivate && _entry != null && _entry.MaskTag == null)
-							_tag = _entry.Tag; // Use dictionary tag
-
-						if (_stop != null && _tag.CompareTo(_stop) >= 0) {
-							_result = DicomReaderResult.Stopped;
-							return;
-						}
-
-						_state = ParseState.VR;
-					}
-
-					while (_state == ParseState.VR) {
-						if (_tag == DicomTag.Item || _tag == DicomTag.ItemDelimitationItem || _tag == DicomTag.SequenceDelimitationItem) {
-							_vr = DicomVR.NONE;
-							_state = ParseState.Length;
-							break;
-						}
-
-						if (IsExplicitVR) {
-							if (!source.Require(2, ParseDataset, state)) {
-								_result = DicomReaderResult.Suspended;
-								return;
-							}
-
-							source.Mark();
-							byte[] bytes = source.GetBytes(2);
-							string vr = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
-							if (!DicomVR.TryParse(vr, out _vr)) {
-								// unable to parse VR; rewind VR bytes for continued attempt to interpret the data.
-								_vr = DicomVR.Implicit;
-							    source.Rewind();
-							}
-						} else {
-							if (_entry != null) {
-								if (_entry == DicomDictionary.UnknownTag)
-									_vr = DicomVR.UN;
-								else if (_entry.ValueRepresentations.Contains(DicomVR.OB) && _entry.ValueRepresentations.Contains(DicomVR.OW))
-									_vr = DicomVR.OW; // ???
-								else
-									_vr = _entry.ValueRepresentations.FirstOrDefault();
-							}
-						}
-
-						if (_vr == null)
-							_vr = DicomVR.UN;
-
-						_state = ParseState.Length;
-
-						if (_vr == DicomVR.UN) {
-							if (_tag.Element == 0x0000) {
-								// Group Length to UL
-								_vr = DicomVR.UL;
-								break;
-							} else if (IsExplicitVR) {
-								break;
-							}
-						}
-
-						if (_tag.IsPrivate) {
-							if (_tag.Element != 0x0000 && _tag.Element <= 0x00ff && _vr == DicomVR.UN)
-								_vr = DicomVR.LO; // force private creator to LO
-						}
-					}
-
-					while (_state == ParseState.Length) {
-						if (_tag == DicomTag.Item || _tag == DicomTag.ItemDelimitationItem || _tag == DicomTag.SequenceDelimitationItem) {
-							if (!source.Require(4, ParseDataset, state)) {
-								_result = DicomReaderResult.Suspended;
-								return;
-							}
-
-							_length = source.GetUInt32();
-
-							_state = ParseState.Value;
-							break;
-						}
-
-						if (IsExplicitVR) {
-							if (_vr == DicomVR.Implicit) {
-								if (!source.Require(4, ParseDataset, state)) {
-									_result = DicomReaderResult.Suspended;
-									return;
-								}
-
-								_length = source.GetUInt32();
-
-								// assume that undefined length in implicit VR element is SQ
-								if (_length == UndefinedLength)
-									_vr = DicomVR.SQ;
-							} else if (_vr.Is16bitLength) {
-								if (!source.Require(2, ParseDataset, state)) {
-									_result = DicomReaderResult.Suspended;
-									return;
-								}
-
-								_length = source.GetUInt16();
-							} else {
-								if (!source.Require(6, ParseDataset, state)) {
-									_result = DicomReaderResult.Suspended;
-									return;
-								}
-
-								source.Skip(2);
-								_length = source.GetUInt32();
-							}
-						} else {
-							if (!source.Require(4, ParseDataset, state)) {
-								_result = DicomReaderResult.Suspended;
-								return;
-							}
-
-							_length = source.GetUInt32();
-
-							// assume that undefined length in implicit dataset is SQ
-							if (_length == UndefinedLength && _vr == DicomVR.UN)
-								_vr = DicomVR.SQ;
-						}
-
-						_state = ParseState.Value;
-					}
-
-					if (_state == ParseState.Value) {
-						// check dictionary for VR after reading length to handle 16-bit lengths
-						// check before reading value to handle SQ elements
-						var parsedVR = _vr;
-
-						// check dictionary for VR after reading length to handle 16-bit lengths
-						// check before reading value to handle SQ elements
-						if (_vr == DicomVR.Implicit || (_vr == DicomVR.UN && IsExplicitVR)) {
-							var entry = Dictionary[_tag];
-							if (entry != null)
-								_vr = entry.ValueRepresentations.FirstOrDefault();
-
-							if (_vr == null)
-								_vr = DicomVR.UN;
-						}
-
-						if (_tag == DicomTag.ItemDelimitationItem) {
-							// end of sequence item
-							return;
-						}
-
-						while (_vr == DicomVR.SQ && _tag.IsPrivate) {
-							if (!IsPrivateSequence(source)) {
-								_vr = DicomVR.UN;
-								break;
-							}
-
-							if (IsPrivateSequenceBad(source)) {
-								_badPrivateSequence = true;
-								_explicit = !_explicit;
-							}
-							break;
-						}
-
-						if (_vr == DicomVR.SQ) {
-							// start of sequence
-							_observer.OnBeginSequence(source, _tag, _length);
-							_state = ParseState.Tag;
-							if (_length != UndefinedLength) {
-								_implicit = false;
-								source.PushMilestone(_length);
-							} else
-								_implicit = true;
-							PushState(state);
-							var last = source.Position;
-							ParseItemSequence(source, null);
-
-							// Aeric Sylvan - https://github.com/rcd/fo-dicom/issues/62#issuecomment-46248073
-							// Fix reading of SQ with parsed VR of UN
-							if (source.Position > last || _length == 0)
-								continue;
-							else {
-								_state = ParseState.Value;
-								_vr = parsedVR;
-							}
-						}
-
-						if (_length == UndefinedLength) {
-							_observer.OnBeginFragmentSequence(source, _tag, _vr);
-							_state = ParseState.Tag;
-							PushState(state);
-							ParseFragmentSequence(source, null);
-							continue;
-						}
-
-						if (!source.Require(_length, ParseDataset, state)) {
-							_result = DicomReaderResult.Suspended;
-							return;
-						}
-
-						IByteBuffer buffer = source.GetBuffer(_length);
-
-						if (!_vr.IsString)
-							buffer = EndianByteBuffer.Create(buffer, source.Endian, _vr.UnitSize);
-						_observer.OnElement(source, _tag, _vr, buffer);
-
-						// parse private creator value and add to lookup table
-						if (_tag.IsPrivate && _tag.Element != 0x0000 && _tag.Element <= 0x00ff) {
-							var creator = DicomEncoding.Default.GetString(buffer.Data, 0, buffer.Data.Length).TrimEnd((char)DicomVR.LO.PaddingValue);
-							var card = (uint)(_tag.Group << 16) + (uint)(_tag.Element);
-							_private[card] = creator;
-						}
-
-						ResetState();
-					}
-				}
-
-				if (source.HasReachedMilestone()) {
-					// end of explicit length sequence item
-					source.PopMilestone();
-					return;
-				}
-
-				if (_result != DicomReaderResult.Processing)
-					return;
-
-				// end of processing
-				_result = DicomReaderResult.Success;
-			} catch (Exception e) {
-				_exception = e;
-				_result = DicomReaderResult.Error;
-			} finally {
-				if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended) {
-					_async.Set();
-				}
-			}
-		}
-
-		private void ParseItemSequence(IByteSource source, object state) {
-			try {
-				_result = DicomReaderResult.Processing;
-
-				while (!source.IsEOF && !source.HasReachedMilestone()) {
-					if (_state == ParseState.Tag) {
-						source.Mark();
-
-						if (!source.Require(8, ParseItemSequence, state)) {
-							_result = DicomReaderResult.Suspended;
-							return;
-						}
-
-						ushort group = source.GetUInt16();
-						ushort element = source.GetUInt16();
-
-						_tag = new DicomTag(group, element);
-
-						if (_tag != DicomTag.Item && _tag != DicomTag.SequenceDelimitationItem) {
-							// assume invalid sequence
-							source.Rewind();
-							if (!_implicit)
-								source.PopMilestone();
-							_observer.OnEndSequence();
-							if (_badPrivateSequence) {
-								_explicit = !_explicit;
-								_badPrivateSequence = false;
-							}
-							return;
-						}
-
-						_length = source.GetUInt32();
-
-						if (_tag == DicomTag.SequenceDelimitationItem) {
-							// end of sequence
-							_observer.OnEndSequence();
-							if (_badPrivateSequence) {
-								_explicit = !_explicit;
-								_badPrivateSequence = false;
-							}
-							ResetState();
-							return;
-						}
-
-						_state = ParseState.Value;
-					}
-
-					if (_state == ParseState.Value) {
-						if (_length != UndefinedLength) {
-							if (!source.Require(_length, ParseItemSequence, state)) {
-								_result = DicomReaderResult.Suspended;
-								return;
-							}
-
-							source.PushMilestone(_length);
-						}
-
-						_observer.OnBeginSequenceItem(source, _length);
-
-						ResetState();
-						ParseDataset(source, state);
-						ResetState();
-
-						_observer.OnEndSequenceItem();
-						continue;
-					}
-				}
-
-				// end of explicit length sequence
-				if (source.HasReachedMilestone())
-					source.PopMilestone();
-
-				_observer.OnEndSequence();
-				if (_badPrivateSequence) {
-					_explicit = !_explicit;
-					_badPrivateSequence = false;
-				}
-			} catch (Exception e) {
-				_exception = e;
-				_result = DicomReaderResult.Error;
-			} finally {
-				if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended) {
-					_async.Set();
-				}
-			}
-		}
-
-		private bool IsPrivateSequence(IByteSource source) {
-			source.Mark();
-
-			try {
-				var group = source.GetUInt16();
-				var element = source.GetUInt16();
-				var tag = new DicomTag(group, element);
-
-				if (tag == DicomTag.Item || tag == DicomTag.SequenceDelimitationItem)
-					return true;
-			} finally {
-				source.Rewind();
-			}
-
-			return false;
-		}
-
-		private bool IsPrivateSequenceBad(IByteSource source) {
-			source.Mark();
-
-			try {
-				var group = source.GetUInt16();
-				var element = source.GetUInt16();
-				var tag = new DicomTag(group, element);
-				var length = source.GetUInt32();
-
-				group = source.GetUInt16();
-				element = source.GetUInt16();
-				tag = new DicomTag(group, element);
-
-				byte[] bytes = source.GetBytes(2);
-				string vr = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
-				DicomVR dummy;
-				if (DicomVR.TryParse(vr,out dummy))
-					return !_explicit;
-				// unable to parse VR
-				if (_explicit)
-					return true;
-			} finally {
-				source.Rewind();
-			}
-
-			return false;
-		}
-
-		private void ParseFragmentSequence(IByteSource source, object state) {
-			try {
-				_result = DicomReaderResult.Processing;
-
-				while (!source.IsEOF) {
-					if (_state == ParseState.Tag) {
-						source.Mark();
-
-						if (!source.Require(8, ParseFragmentSequence, state)) {
-							_result = DicomReaderResult.Suspended;
-							return;
-						}
-
-						ushort group = source.GetUInt16();
-						ushort element = source.GetUInt16();
-
-						DicomTag tag = new DicomTag(group, element);
-
-						if (tag != DicomTag.Item && tag != DicomTag.SequenceDelimitationItem)
-							throw new DicomReaderException("Unexpected tag in DICOM fragment sequence: {0}", tag);
-
-						_length = source.GetUInt32();
-
-						if (tag == DicomTag.SequenceDelimitationItem) {
-							// end of fragment
-							_observer.OnEndFragmentSequence();
-							_fragmentItem = 0;
-							ResetState();
-							ParseDataset(source, PopState());
-							return;
-						}
-
-						_fragmentItem++;
-						_state = ParseState.Value;
-					}
-
-					if (_state == ParseState.Value) {
-						if (!source.Require(_length, ParseFragmentSequence, state)) {
-							_result = DicomReaderResult.Suspended;
-							return;
-						}
-
-						IByteBuffer buffer = source.GetBuffer(_length);
-						if (_fragmentItem == 1)
-							buffer = EndianByteBuffer.Create(buffer, source.Endian, 4);
-						else
-							buffer = EndianByteBuffer.Create(buffer, source.Endian, _vr.UnitSize);
-						_observer.OnFragmentSequenceItem(source, buffer);
-
-						_state = ParseState.Tag;
-					}
-				}
-			} catch (Exception e) {
-				_exception = e;
-				_result = DicomReaderResult.Error;
-			} finally {
-				if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended) {
-					_async.Set();
-				}
-			}
-		}
-
-		private void PushState(object state) {
-			_stack.Push(state);
-		}
-
-		private object PopState() {
-			if (_stack.Count > 0)
-				return _stack.Pop();
-			return null;
-		}
-
-		private void ResetState() {
-			_state = ParseState.Tag;
-			_tag = null;
-			_entry = null;
-			_vr = null;
-			_length = 0;
-		}
-	}
+namespace Dicom.IO.Reader
+{
+    public class DicomReader : IDicomReader
+    {
+        private const uint UndefinedLength = 0xffffffff;
+
+        public enum ParseState
+        {
+            Tag,
+
+            VR,
+
+            Length,
+
+            Value
+        }
+
+        private ParseState _state;
+
+        private DicomTag _tag;
+
+        private DicomDictionaryEntry _entry;
+
+        private DicomVR _vr;
+
+        private uint _length;
+
+        private bool _implicit;
+
+        private int _fragmentItem;
+
+        private DicomTag _stop;
+
+        private IDicomReaderObserver _observer;
+
+        private EventAsyncResult _async;
+
+        private Exception _exception;
+
+        private volatile DicomReaderResult _result;
+
+        private bool _explicit;
+
+        private bool _badPrivateSequence;
+
+        private DicomDictionary _dict;
+
+        private Dictionary<uint, string> _private;
+
+        private Stack<object> _stack;
+
+        public DicomReader()
+        {
+            _private = new Dictionary<uint, string>();
+            _stack = new Stack<object>();
+            _dict = DicomDictionary.Default;
+        }
+
+        public DicomDictionary Dictionary
+        {
+            get
+            {
+                return _dict;
+            }
+            set
+            {
+                _dict = value;
+            }
+        }
+
+        public bool IsExplicitVR
+        {
+            get
+            {
+                return _explicit;
+            }
+            set
+            {
+                _explicit = value;
+            }
+        }
+
+        public DicomReaderResult Status
+        {
+            get
+            {
+                return _result;
+            }
+        }
+
+        public DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, DicomTag stop = null)
+        {
+            return EndRead(BeginRead(source, observer, stop, null, null));
+        }
+
+        public IAsyncResult BeginRead(
+            IByteSource source,
+            IDicomReaderObserver observer,
+            DicomTag stop,
+            AsyncCallback callback,
+            object state)
+        {
+            _stop = stop;
+            _observer = observer;
+            _result = DicomReaderResult.Processing;
+            _exception = null;
+            _async = new EventAsyncResult(callback, state);
+            ThreadPool.QueueUserWorkItem(ParseProc, source);
+            return _async;
+        }
+
+        public DicomReaderResult EndRead(IAsyncResult result)
+        {
+            _async.AsyncWaitHandle.WaitOne();
+            if (_exception != null) throw _exception;
+            return _result;
+        }
+
+        private void ParseProc(object state)
+        {
+            ParseDataset(state as IByteSource, null);
+        }
+
+        private void ParseDataset(IByteSource source, object state)
+        {
+            try
+            {
+                _result = DicomReaderResult.Processing;
+
+                while (!source.IsEOF && !source.HasReachedMilestone() && _result == DicomReaderResult.Processing)
+                {
+                    if (_state == ParseState.Tag)
+                    {
+                        source.Mark();
+
+                        if (!source.Require(4, ParseDataset, state))
+                        {
+                            _result = DicomReaderResult.Suspended;
+                            return;
+                        }
+
+                        ushort group = source.GetUInt16();
+                        ushort element = source.GetUInt16();
+                        DicomPrivateCreator creator = null;
+
+                        if (group.IsOdd() && element > 0x00ff)
+                        {
+                            string pvt = null;
+                            uint card = (uint)(group << 16) + (uint)(element >> 8);
+                            if (_private.TryGetValue(card, out pvt)) creator = Dictionary.GetPrivateCreator(pvt);
+                        }
+
+                        _tag = new DicomTag(group, element, creator);
+                        _entry = Dictionary[_tag];
+
+                        if (!_tag.IsPrivate && _entry != null && _entry.MaskTag == null) _tag = _entry.Tag; // Use dictionary tag
+
+                        if (_stop != null && _tag.CompareTo(_stop) >= 0)
+                        {
+                            _result = DicomReaderResult.Stopped;
+                            return;
+                        }
+
+                        _state = ParseState.VR;
+                    }
+
+                    while (_state == ParseState.VR)
+                    {
+                        if (_tag == DicomTag.Item || _tag == DicomTag.ItemDelimitationItem
+                            || _tag == DicomTag.SequenceDelimitationItem)
+                        {
+                            _vr = DicomVR.NONE;
+                            _state = ParseState.Length;
+                            break;
+                        }
+
+                        if (IsExplicitVR)
+                        {
+                            if (!source.Require(2, ParseDataset, state))
+                            {
+                                _result = DicomReaderResult.Suspended;
+                                return;
+                            }
+
+                            source.Mark();
+                            byte[] bytes = source.GetBytes(2);
+                            string vr = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+                            if (!DicomVR.TryParse(vr, out _vr))
+                            {
+                                // unable to parse VR; rewind VR bytes for continued attempt to interpret the data.
+                                _vr = DicomVR.Implicit;
+                                source.Rewind();
+                            }
+                        }
+                        else
+                        {
+                            if (_entry != null)
+                            {
+                                if (_entry == DicomDictionary.UnknownTag) _vr = DicomVR.UN;
+                                else if (_entry.ValueRepresentations.Contains(DicomVR.OB)
+                                         && _entry.ValueRepresentations.Contains(DicomVR.OW)) _vr = DicomVR.OW; // ???
+                                else _vr = _entry.ValueRepresentations.FirstOrDefault();
+                            }
+                        }
+
+                        if (_vr == null) _vr = DicomVR.UN;
+
+                        _state = ParseState.Length;
+
+                        if (_vr == DicomVR.UN)
+                        {
+                            if (_tag.Element == 0x0000)
+                            {
+                                // Group Length to UL
+                                _vr = DicomVR.UL;
+                                break;
+                            }
+                            else if (IsExplicitVR)
+                            {
+                                break;
+                            }
+                        }
+
+                        if (_tag.IsPrivate)
+                        {
+                            if (_tag.Element != 0x0000 && _tag.Element <= 0x00ff && _vr == DicomVR.UN) _vr = DicomVR.LO; // force private creator to LO
+                        }
+                    }
+
+                    while (_state == ParseState.Length)
+                    {
+                        if (_tag == DicomTag.Item || _tag == DicomTag.ItemDelimitationItem
+                            || _tag == DicomTag.SequenceDelimitationItem)
+                        {
+                            if (!source.Require(4, ParseDataset, state))
+                            {
+                                _result = DicomReaderResult.Suspended;
+                                return;
+                            }
+
+                            _length = source.GetUInt32();
+
+                            _state = ParseState.Value;
+                            break;
+                        }
+
+                        if (IsExplicitVR)
+                        {
+                            if (_vr == DicomVR.Implicit)
+                            {
+                                if (!source.Require(4, ParseDataset, state))
+                                {
+                                    _result = DicomReaderResult.Suspended;
+                                    return;
+                                }
+
+                                _length = source.GetUInt32();
+
+                                // assume that undefined length in implicit VR element is SQ
+                                if (_length == UndefinedLength) _vr = DicomVR.SQ;
+                            }
+                            else if (_vr.Is16bitLength)
+                            {
+                                if (!source.Require(2, ParseDataset, state))
+                                {
+                                    _result = DicomReaderResult.Suspended;
+                                    return;
+                                }
+
+                                _length = source.GetUInt16();
+                            }
+                            else
+                            {
+                                if (!source.Require(6, ParseDataset, state))
+                                {
+                                    _result = DicomReaderResult.Suspended;
+                                    return;
+                                }
+
+                                source.Skip(2);
+                                _length = source.GetUInt32();
+                            }
+                        }
+                        else
+                        {
+                            if (!source.Require(4, ParseDataset, state))
+                            {
+                                _result = DicomReaderResult.Suspended;
+                                return;
+                            }
+
+                            _length = source.GetUInt32();
+
+                            // assume that undefined length in implicit dataset is SQ
+                            if (_length == UndefinedLength && _vr == DicomVR.UN) _vr = DicomVR.SQ;
+                        }
+
+                        _state = ParseState.Value;
+                    }
+
+                    if (_state == ParseState.Value)
+                    {
+                        // check dictionary for VR after reading length to handle 16-bit lengths
+                        // check before reading value to handle SQ elements
+                        var parsedVR = _vr;
+
+                        // check dictionary for VR after reading length to handle 16-bit lengths
+                        // check before reading value to handle SQ elements
+                        if (_vr == DicomVR.Implicit || (_vr == DicomVR.UN && IsExplicitVR))
+                        {
+                            var entry = Dictionary[_tag];
+                            if (entry != null) _vr = entry.ValueRepresentations.FirstOrDefault();
+
+                            if (_vr == null) _vr = DicomVR.UN;
+                        }
+
+                        if (_tag == DicomTag.ItemDelimitationItem)
+                        {
+                            // end of sequence item
+                            return;
+                        }
+
+                        while (_vr == DicomVR.SQ && _tag.IsPrivate)
+                        {
+                            if (!IsPrivateSequence(source))
+                            {
+                                _vr = DicomVR.UN;
+                                break;
+                            }
+
+                            if (IsPrivateSequenceBad(source))
+                            {
+                                _badPrivateSequence = true;
+                                _explicit = !_explicit;
+                            }
+                            break;
+                        }
+
+                        if (_vr == DicomVR.SQ)
+                        {
+                            // start of sequence
+                            _observer.OnBeginSequence(source, _tag, _length);
+                            _state = ParseState.Tag;
+                            if (_length != UndefinedLength)
+                            {
+                                _implicit = false;
+                                source.PushMilestone(_length);
+                            }
+                            else _implicit = true;
+                            PushState(state);
+                            var last = source.Position;
+                            ParseItemSequence(source, null);
+
+                            // Aeric Sylvan - https://github.com/rcd/fo-dicom/issues/62#issuecomment-46248073
+                            // Fix reading of SQ with parsed VR of UN
+                            if (source.Position > last || _length == 0) continue;
+                            else
+                            {
+                                _state = ParseState.Value;
+                                _vr = parsedVR;
+                            }
+                        }
+
+                        if (_length == UndefinedLength)
+                        {
+                            _observer.OnBeginFragmentSequence(source, _tag, _vr);
+                            _state = ParseState.Tag;
+                            PushState(state);
+                            ParseFragmentSequence(source, null);
+                            continue;
+                        }
+
+                        if (!source.Require(_length, ParseDataset, state))
+                        {
+                            _result = DicomReaderResult.Suspended;
+                            return;
+                        }
+
+                        IByteBuffer buffer = source.GetBuffer(_length);
+
+                        if (!_vr.IsString) buffer = EndianByteBuffer.Create(buffer, source.Endian, _vr.UnitSize);
+                        _observer.OnElement(source, _tag, _vr, buffer);
+
+                        // parse private creator value and add to lookup table
+                        if (_tag.IsPrivate && _tag.Element != 0x0000 && _tag.Element <= 0x00ff)
+                        {
+                            var creator =
+                                DicomEncoding.Default.GetString(buffer.Data, 0, buffer.Data.Length)
+                                    .TrimEnd((char)DicomVR.LO.PaddingValue);
+                            var card = (uint)(_tag.Group << 16) + (uint)(_tag.Element);
+                            _private[card] = creator;
+                        }
+
+                        ResetState();
+                    }
+                }
+
+                if (source.HasReachedMilestone())
+                {
+                    // end of explicit length sequence item
+                    source.PopMilestone();
+                    return;
+                }
+
+                if (_result != DicomReaderResult.Processing) return;
+
+                // end of processing
+                _result = DicomReaderResult.Success;
+            }
+            catch (Exception e)
+            {
+                _exception = e;
+                _result = DicomReaderResult.Error;
+            }
+            finally
+            {
+                if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended)
+                {
+                    _async.Set();
+                }
+            }
+        }
+
+        private void ParseItemSequence(IByteSource source, object state)
+        {
+            try
+            {
+                _result = DicomReaderResult.Processing;
+
+                while (!source.IsEOF && !source.HasReachedMilestone())
+                {
+                    if (_state == ParseState.Tag)
+                    {
+                        source.Mark();
+
+                        if (!source.Require(8, ParseItemSequence, state))
+                        {
+                            _result = DicomReaderResult.Suspended;
+                            return;
+                        }
+
+                        ushort group = source.GetUInt16();
+                        ushort element = source.GetUInt16();
+
+                        _tag = new DicomTag(group, element);
+
+                        if (_tag != DicomTag.Item && _tag != DicomTag.SequenceDelimitationItem)
+                        {
+                            // assume invalid sequence
+                            source.Rewind();
+                            if (!_implicit) source.PopMilestone();
+                            _observer.OnEndSequence();
+                            if (_badPrivateSequence)
+                            {
+                                _explicit = !_explicit;
+                                _badPrivateSequence = false;
+                            }
+                            return;
+                        }
+
+                        _length = source.GetUInt32();
+
+                        if (_tag == DicomTag.SequenceDelimitationItem)
+                        {
+                            // end of sequence
+                            _observer.OnEndSequence();
+                            if (_badPrivateSequence)
+                            {
+                                _explicit = !_explicit;
+                                _badPrivateSequence = false;
+                            }
+                            ResetState();
+                            return;
+                        }
+
+                        _state = ParseState.Value;
+                    }
+
+                    if (_state == ParseState.Value)
+                    {
+                        if (_length != UndefinedLength)
+                        {
+                            if (!source.Require(_length, ParseItemSequence, state))
+                            {
+                                _result = DicomReaderResult.Suspended;
+                                return;
+                            }
+
+                            source.PushMilestone(_length);
+                        }
+
+                        _observer.OnBeginSequenceItem(source, _length);
+
+                        ResetState();
+                        ParseDataset(source, state);
+                        ResetState();
+
+                        _observer.OnEndSequenceItem();
+                        continue;
+                    }
+                }
+
+                // end of explicit length sequence
+                if (source.HasReachedMilestone()) source.PopMilestone();
+
+                _observer.OnEndSequence();
+                if (_badPrivateSequence)
+                {
+                    _explicit = !_explicit;
+                    _badPrivateSequence = false;
+                }
+            }
+            catch (Exception e)
+            {
+                _exception = e;
+                _result = DicomReaderResult.Error;
+            }
+            finally
+            {
+                if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended)
+                {
+                    _async.Set();
+                }
+            }
+        }
+
+        private bool IsPrivateSequence(IByteSource source)
+        {
+            source.Mark();
+
+            try
+            {
+                var group = source.GetUInt16();
+                var element = source.GetUInt16();
+                var tag = new DicomTag(group, element);
+
+                if (tag == DicomTag.Item || tag == DicomTag.SequenceDelimitationItem) return true;
+            }
+            finally
+            {
+                source.Rewind();
+            }
+
+            return false;
+        }
+
+        private bool IsPrivateSequenceBad(IByteSource source)
+        {
+            source.Mark();
+
+            try
+            {
+                var group = source.GetUInt16();
+                var element = source.GetUInt16();
+                var tag = new DicomTag(group, element);
+                var length = source.GetUInt32();
+
+                group = source.GetUInt16();
+                element = source.GetUInt16();
+                tag = new DicomTag(group, element);
+
+                byte[] bytes = source.GetBytes(2);
+                string vr = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+                DicomVR dummy;
+                if (DicomVR.TryParse(vr, out dummy)) return !_explicit;
+                // unable to parse VR
+                if (_explicit) return true;
+            }
+            finally
+            {
+                source.Rewind();
+            }
+
+            return false;
+        }
+
+        private void ParseFragmentSequence(IByteSource source, object state)
+        {
+            try
+            {
+                _result = DicomReaderResult.Processing;
+
+                while (!source.IsEOF)
+                {
+                    if (_state == ParseState.Tag)
+                    {
+                        source.Mark();
+
+                        if (!source.Require(8, ParseFragmentSequence, state))
+                        {
+                            _result = DicomReaderResult.Suspended;
+                            return;
+                        }
+
+                        ushort group = source.GetUInt16();
+                        ushort element = source.GetUInt16();
+
+                        DicomTag tag = new DicomTag(group, element);
+
+                        if (tag != DicomTag.Item && tag != DicomTag.SequenceDelimitationItem) throw new DicomReaderException("Unexpected tag in DICOM fragment sequence: {0}", tag);
+
+                        _length = source.GetUInt32();
+
+                        if (tag == DicomTag.SequenceDelimitationItem)
+                        {
+                            // end of fragment
+                            _observer.OnEndFragmentSequence();
+                            _fragmentItem = 0;
+                            ResetState();
+                            ParseDataset(source, PopState());
+                            return;
+                        }
+
+                        _fragmentItem++;
+                        _state = ParseState.Value;
+                    }
+
+                    if (_state == ParseState.Value)
+                    {
+                        if (!source.Require(_length, ParseFragmentSequence, state))
+                        {
+                            _result = DicomReaderResult.Suspended;
+                            return;
+                        }
+
+                        IByteBuffer buffer = source.GetBuffer(_length);
+                        if (_fragmentItem == 1) buffer = EndianByteBuffer.Create(buffer, source.Endian, 4);
+                        else buffer = EndianByteBuffer.Create(buffer, source.Endian, _vr.UnitSize);
+                        _observer.OnFragmentSequenceItem(source, buffer);
+
+                        _state = ParseState.Tag;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _exception = e;
+                _result = DicomReaderResult.Error;
+            }
+            finally
+            {
+                if (_result != DicomReaderResult.Processing && _result != DicomReaderResult.Suspended)
+                {
+                    _async.Set();
+                }
+            }
+        }
+
+        private void PushState(object state)
+        {
+            _stack.Push(state);
+        }
+
+        private object PopState()
+        {
+            if (_stack.Count > 0) return _stack.Pop();
+            return null;
+        }
+
+        private void ResetState()
+        {
+            _state = ParseState.Tag;
+            _tag = null;
+            _entry = null;
+            _vr = null;
+            _length = 0;
+        }
+    }
 }

--- a/DICOM/IO/Reader/DicomReaderCallbackObserver.cs
+++ b/DICOM/IO/Reader/DicomReaderCallbackObserver.cs
@@ -1,58 +1,70 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 
-using Dicom.IO;
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO.Reader {
-	public class DicomReaderCallbackObserver : IDicomReaderObserver {
-		private Stack<DicomReaderEventArgs> _stack;
-		private IDictionary<DicomTag, EventHandler<DicomReaderEventArgs>> _callbacks;
+namespace Dicom.IO.Reader
+{
+    public class DicomReaderCallbackObserver : IDicomReaderObserver
+    {
+        private Stack<DicomReaderEventArgs> _stack;
 
-		public DicomReaderCallbackObserver() {
-			_stack = new Stack<DicomReaderEventArgs>();
-			_callbacks = new Dictionary<DicomTag, EventHandler<DicomReaderEventArgs>>();
-		}
+        private IDictionary<DicomTag, EventHandler<DicomReaderEventArgs>> _callbacks;
 
-		public void Add(DicomTag tag, EventHandler<DicomReaderEventArgs> callback) {
-			_callbacks.Add(tag, callback);
-		}
+        public DicomReaderCallbackObserver()
+        {
+            _stack = new Stack<DicomReaderEventArgs>();
+            _callbacks = new Dictionary<DicomTag, EventHandler<DicomReaderEventArgs>>();
+        }
 
-		public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data) {
-			EventHandler<DicomReaderEventArgs> handler;
-			if (_callbacks.TryGetValue(tag, out handler))
-				handler(this, new DicomReaderEventArgs(source.Marker, tag, vr, data));
-		}
+        public void Add(DicomTag tag, EventHandler<DicomReaderEventArgs> callback)
+        {
+            _callbacks.Add(tag, callback);
+        }
 
-		public void OnBeginSequence(IByteSource source, DicomTag tag, uint length) {
-			_stack.Push(new DicomReaderEventArgs(source.Marker, tag, DicomVR.SQ, null));
-		}
+        public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data)
+        {
+            EventHandler<DicomReaderEventArgs> handler;
+            if (_callbacks.TryGetValue(tag, out handler)) handler(this, new DicomReaderEventArgs(source.Marker, tag, vr, data));
+        }
 
-		public void OnBeginSequenceItem(IByteSource source, uint length) {
-		}
+        public void OnBeginSequence(IByteSource source, DicomTag tag, uint length)
+        {
+            _stack.Push(new DicomReaderEventArgs(source.Marker, tag, DicomVR.SQ, null));
+        }
 
-		public void OnEndSequenceItem() {
-		}
+        public void OnBeginSequenceItem(IByteSource source, uint length)
+        {
+        }
 
-		public void OnEndSequence() {
-			DicomReaderEventArgs args = _stack.Pop();
-			EventHandler<DicomReaderEventArgs> handler;
-			if (_callbacks.TryGetValue(args.Tag, out handler))
-				handler(this, args);
-		}
+        public void OnEndSequenceItem()
+        {
+        }
 
-		public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr) {
-			_stack.Push(new DicomReaderEventArgs(source.Marker, tag, vr, null));
-		}
+        public void OnEndSequence()
+        {
+            DicomReaderEventArgs args = _stack.Pop();
+            EventHandler<DicomReaderEventArgs> handler;
+            if (_callbacks.TryGetValue(args.Tag, out handler)) handler(this, args);
+        }
 
-		public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data) {
-		}
+        public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr)
+        {
+            _stack.Push(new DicomReaderEventArgs(source.Marker, tag, vr, null));
+        }
 
-		public void OnEndFragmentSequence() {
-			DicomReaderEventArgs args = _stack.Pop();
-			EventHandler<DicomReaderEventArgs> handler;
-			if (_callbacks.TryGetValue(args.Tag, out handler))
-				handler(this, args);
-		}
-	}
+        public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data)
+        {
+        }
+
+        public void OnEndFragmentSequence()
+        {
+            DicomReaderEventArgs args = _stack.Pop();
+            EventHandler<DicomReaderEventArgs> handler;
+            if (_callbacks.TryGetValue(args.Tag, out handler)) handler(this, args);
+        }
+    }
 }

--- a/DICOM/IO/Reader/DicomReaderEventArgs.cs
+++ b/DICOM/IO/Reader/DicomReaderEventArgs.cs
@@ -1,18 +1,27 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO.Reader {
-	public class DicomReaderEventArgs : EventArgs {
-		public readonly long Position;
-		public readonly DicomTag Tag;
-		public readonly DicomVR VR;
-		public readonly IByteBuffer Data;
+namespace Dicom.IO.Reader
+{
+    public class DicomReaderEventArgs : EventArgs
+    {
+        public readonly long Position;
 
-		public DicomReaderEventArgs(long position, DicomTag tag, DicomVR vr, IByteBuffer data) {
-			Position = position;
-			Tag = tag;
-			VR = vr;
-			Data = data;
-		}
-	}
+        public readonly DicomTag Tag;
+
+        public readonly DicomVR VR;
+
+        public readonly IByteBuffer Data;
+
+        public DicomReaderEventArgs(long position, DicomTag tag, DicomVR vr, IByteBuffer data)
+        {
+            Position = position;
+            Tag = tag;
+            VR = vr;
+            Data = data;
+        }
+    }
 }

--- a/DICOM/IO/Reader/DicomReaderException.cs
+++ b/DICOM/IO/Reader/DicomReaderException.cs
@@ -1,17 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Reader {
-	public class DicomReaderException : DicomException {
-		public DicomReaderException(string message) : base(message) {
-		}
+using System;
 
-		public DicomReaderException(string format, params object[] args) : base(format, args) {
-		}
+namespace Dicom.IO.Reader
+{
+    public class DicomReaderException : DicomException
+    {
+        public DicomReaderException(string message)
+            : base(message)
+        {
+        }
 
-		public DicomReaderException(string message, Exception innerException) : base(message, innerException) {
-		}
-	}
+        public DicomReaderException(string format, params object[] args)
+            : base(format, args)
+        {
+        }
+
+        public DicomReaderException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/DICOM/IO/Reader/DicomReaderMultiObserver.cs
+++ b/DICOM/IO/Reader/DicomReaderMultiObserver.cs
@@ -1,54 +1,57 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO.Reader {
-	public class DicomReaderMultiObserver : IDicomReaderObserver {
-		private IDicomReaderObserver[] _observers;
+namespace Dicom.IO.Reader
+{
+    public class DicomReaderMultiObserver : IDicomReaderObserver
+    {
+        private IDicomReaderObserver[] _observers;
 
-		public DicomReaderMultiObserver(params IDicomReaderObserver[] observers) {
-			_observers = observers;
-		}
+        public DicomReaderMultiObserver(params IDicomReaderObserver[] observers)
+        {
+            _observers = observers;
+        }
 
-		public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data) {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnElement(source, tag, vr, data);
-		}
+        public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data)
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnElement(source, tag, vr, data);
+        }
 
-		public void OnBeginSequence(IByteSource source, DicomTag tag, uint length) {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnBeginSequence(source, tag, length);
-		}
+        public void OnBeginSequence(IByteSource source, DicomTag tag, uint length)
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnBeginSequence(source, tag, length);
+        }
 
-		public void OnBeginSequenceItem(IByteSource source, uint length) {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnBeginSequenceItem(source, length);
-		}
+        public void OnBeginSequenceItem(IByteSource source, uint length)
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnBeginSequenceItem(source, length);
+        }
 
-		public void OnEndSequenceItem() {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnEndSequenceItem();
-		}
+        public void OnEndSequenceItem()
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnEndSequenceItem();
+        }
 
-		public void OnEndSequence() {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnEndSequence();
-		}
+        public void OnEndSequence()
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnEndSequence();
+        }
 
-		public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr) {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnBeginFragmentSequence(source, tag, vr);
-		}
+        public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr)
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnBeginFragmentSequence(source, tag, vr);
+        }
 
-		public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data) {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnFragmentSequenceItem(source, data);
-		}
+        public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data)
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnFragmentSequenceItem(source, data);
+        }
 
-		public void OnEndFragmentSequence() {
-			foreach (IDicomReaderObserver observer in _observers)
-				observer.OnEndFragmentSequence();
-		}
-	}
+        public void OnEndFragmentSequence()
+        {
+            foreach (IDicomReaderObserver observer in _observers) observer.OnEndFragmentSequence();
+        }
+    }
 }

--- a/DICOM/IO/Reader/IDicomReader.cs
+++ b/DICOM/IO/Reader/IDicomReader.cs
@@ -1,32 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
+using System;
 
-namespace Dicom.IO.Reader {
-	public enum DicomReaderResult {
-		Processing,
-		Success,
-		Error,
-		Stopped,
-		Suspended
-	}
+namespace Dicom.IO.Reader
+{
+    public enum DicomReaderResult
+    {
+        Processing,
 
-	public interface IDicomReader {
-		bool IsExplicitVR {
-			get;
-			set;
-		}
+        Success,
 
-		DicomReaderResult Status {
-			get;
-		}
+        Error,
 
-		DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, DicomTag stop=null);
+        Stopped,
 
-		IAsyncResult BeginRead(IByteSource source, IDicomReaderObserver observer, DicomTag stop, AsyncCallback callback, object state);
-		DicomReaderResult EndRead(IAsyncResult result);
-	}
+        Suspended
+    }
+
+    public interface IDicomReader
+    {
+        bool IsExplicitVR { get; set; }
+
+        DicomReaderResult Status { get; }
+
+        DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, DicomTag stop = null);
+
+        IAsyncResult BeginRead(
+            IByteSource source,
+            IDicomReaderObserver observer,
+            DicomTag stop,
+            AsyncCallback callback,
+            object state);
+
+        DicomReaderResult EndRead(IAsyncResult result);
+    }
 }

--- a/DICOM/IO/Reader/IDicomReaderObserver.cs
+++ b/DICOM/IO/Reader/IDicomReaderObserver.cs
@@ -1,17 +1,26 @@
-﻿using Dicom.IO;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO.Reader {
-	public interface IDicomReaderObserver {
-		void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data);
+namespace Dicom.IO.Reader
+{
+    public interface IDicomReaderObserver
+    {
+        void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data);
 
-		void OnBeginSequence(IByteSource source, DicomTag tag, uint length);
-		void OnBeginSequenceItem(IByteSource source, uint length);
-		void OnEndSequenceItem();
-		void OnEndSequence();
+        void OnBeginSequence(IByteSource source, DicomTag tag, uint length);
 
-		void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr);
-		void OnFragmentSequenceItem(IByteSource source, IByteBuffer data);
-		void OnEndFragmentSequence();
-	}
+        void OnBeginSequenceItem(IByteSource source, uint length);
+
+        void OnEndSequenceItem();
+
+        void OnEndSequence();
+
+        void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr);
+
+        void OnFragmentSequenceItem(IByteSource source, IByteBuffer data);
+
+        void OnEndFragmentSequence();
+    }
 }

--- a/DICOM/IO/Reader/MockObserver.cs
+++ b/DICOM/IO/Reader/MockObserver.cs
@@ -1,38 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO.Reader {
-	public class MockObserver : IDicomReaderObserver {
-		public MockObserver() {
-		}
+namespace Dicom.IO.Reader
+{
+    public class MockObserver : IDicomReaderObserver
+    {
+        public MockObserver()
+        {
+        }
 
-		public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data) {
-		}
+        public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data)
+        {
+        }
 
-		public void OnBeginSequence(IByteSource source, DicomTag tag, uint length) {
-		}
+        public void OnBeginSequence(IByteSource source, DicomTag tag, uint length)
+        {
+        }
 
-		public void OnBeginSequenceItem(IByteSource source, uint length) {
-		}
+        public void OnBeginSequenceItem(IByteSource source, uint length)
+        {
+        }
 
-		public void OnEndSequenceItem() {
-		}
+        public void OnEndSequenceItem()
+        {
+        }
 
-		public void OnEndSequence() {
-		}
+        public void OnEndSequence()
+        {
+        }
 
-		public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr) {
-		}
+        public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr)
+        {
+        }
 
-		public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data) {
-		}
+        public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data)
+        {
+        }
 
-		public void OnEndFragmentSequence() {
-		}
-	}
+        public void OnEndFragmentSequence()
+        {
+        }
+    }
 }

--- a/DICOM/IO/StreamByteSource.cs
+++ b/DICOM/IO/StreamByteSource.cs
@@ -1,159 +1,215 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 using System.IO;
 
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO {
-	public class StreamByteSource : IByteSource {
-		private Stream _stream;
-		private Endian _endian;
-		private BinaryReader _reader;
-		private long _mark;
+namespace Dicom.IO
+{
+    public class StreamByteSource : IByteSource
+    {
+        private Stream _stream;
 
-		private int _largeObjectSize;
+        private Endian _endian;
 
-		private Stack<long> _milestones;
-		private object _lock;
+        private BinaryReader _reader;
 
-		public StreamByteSource(Stream stream) {
-			_stream = stream;
-			_endian = Endian.LocalMachine;
-			_reader = EndianBinaryReader.Create(_stream, _endian);
-			_mark = 0;
+        private long _mark;
 
-			_largeObjectSize = 64 * 1024;
+        private int _largeObjectSize;
 
-			_milestones = new Stack<long>();
-			_lock = new object();
-		}
+        private Stack<long> _milestones;
 
-		public Endian Endian {
-			get { return _endian; }
-			set {
-				if (_endian != value) {
-					lock (_lock) {
-						_endian = value;
-						_reader = EndianBinaryReader.Create(_stream, _endian);
-					}
-				}
-			}
-		}
+        private object _lock;
 
-		public long Position {
-			get { return _stream.Position; }
-		}
+        public StreamByteSource(Stream stream)
+        {
+            _stream = stream;
+            _endian = Endian.LocalMachine;
+            _reader = EndianBinaryReader.Create(_stream, _endian);
+            _mark = 0;
 
-		public long Marker {
-			get { return _mark; }
-		}
+            _largeObjectSize = 64 * 1024;
 
-		public bool IsEOF {
-			get { return _stream.Position >= _stream.Length; }
-		}
+            _milestones = new Stack<long>();
+            _lock = new object();
+        }
 
-		public bool CanRewind {
-			get { return _stream.CanSeek; }
-		}
+        public Endian Endian
+        {
+            get
+            {
+                return _endian;
+            }
+            set
+            {
+                if (_endian != value)
+                {
+                    lock (_lock)
+                    {
+                        _endian = value;
+                        _reader = EndianBinaryReader.Create(_stream, _endian);
+                    }
+                }
+            }
+        }
 
-		public int LargeObjectSize {
-			get { return _largeObjectSize; }
-			set { _largeObjectSize = value; }
-		}
+        public long Position
+        {
+            get
+            {
+                return _stream.Position;
+            }
+        }
 
-		public byte GetUInt8() {
-			return _reader.ReadByte();
-		}
+        public long Marker
+        {
+            get
+            {
+                return _mark;
+            }
+        }
 
-		public short GetInt16() {
-			return _reader.ReadInt16();
-		}
+        public bool IsEOF
+        {
+            get
+            {
+                return _stream.Position >= _stream.Length;
+            }
+        }
 
-		public ushort GetUInt16() {
-			return _reader.ReadUInt16();
-		}
+        public bool CanRewind
+        {
+            get
+            {
+                return _stream.CanSeek;
+            }
+        }
 
-		public int GetInt32() {
-			return _reader.ReadInt32();
-		}
+        public int LargeObjectSize
+        {
+            get
+            {
+                return _largeObjectSize;
+            }
+            set
+            {
+                _largeObjectSize = value;
+            }
+        }
 
-		public uint GetUInt32() {
-			return _reader.ReadUInt32();
-		}
+        public byte GetUInt8()
+        {
+            return _reader.ReadByte();
+        }
 
-		public long GetInt64() {
-			return _reader.ReadInt64();
-		}
+        public short GetInt16()
+        {
+            return _reader.ReadInt16();
+        }
 
-		public ulong GetUInt64() {
-			return _reader.ReadUInt64();
-		}
+        public ushort GetUInt16()
+        {
+            return _reader.ReadUInt16();
+        }
 
-		public float GetSingle() {
-			return _reader.ReadSingle();
-		}
+        public int GetInt32()
+        {
+            return _reader.ReadInt32();
+        }
 
-		public double GetDouble() {
-			return _reader.ReadDouble();
-		}
+        public uint GetUInt32()
+        {
+            return _reader.ReadUInt32();
+        }
 
-		public byte[] GetBytes(int count) {
-			return _reader.ReadBytes(count);
-		}
+        public long GetInt64()
+        {
+            return _reader.ReadInt64();
+        }
 
-		public IByteBuffer GetBuffer(uint count) {
-			IByteBuffer buffer = null;
-			if (count == 0)
-				buffer = EmptyBuffer.Value;
-			else if (count >= _largeObjectSize) {
-				buffer = new StreamByteBuffer(_stream, _stream.Position, count);
-				_stream.Seek((int)count, SeekOrigin.Current);
-			} else
-				buffer = new MemoryByteBuffer(GetBytes((int)count));
-			return buffer;
-		}
+        public ulong GetUInt64()
+        {
+            return _reader.ReadUInt64();
+        }
 
-		public void Skip(int count) {
-			_stream.Seek(count, SeekOrigin.Current);
-		}
+        public float GetSingle()
+        {
+            return _reader.ReadSingle();
+        }
 
-		public void Mark() {
-			_mark = _stream.Position;
-		}
+        public double GetDouble()
+        {
+            return _reader.ReadDouble();
+        }
 
-		public void Rewind() {
-			_stream.Position = _mark;
-		}
+        public byte[] GetBytes(int count)
+        {
+            return _reader.ReadBytes(count);
+        }
 
-		public void PushMilestone(uint count) {
-			lock (_lock)
-				_milestones.Push(_stream.Position + count);
-		}
+        public IByteBuffer GetBuffer(uint count)
+        {
+            IByteBuffer buffer = null;
+            if (count == 0) buffer = EmptyBuffer.Value;
+            else if (count >= _largeObjectSize)
+            {
+                buffer = new StreamByteBuffer(_stream, _stream.Position, count);
+                _stream.Seek((int)count, SeekOrigin.Current);
+            }
+            else buffer = new MemoryByteBuffer(GetBytes((int)count));
+            return buffer;
+        }
 
-		public void PopMilestone() {
-			lock (_lock)
-				_milestones.Pop();
-		}
+        public void Skip(int count)
+        {
+            _stream.Seek(count, SeekOrigin.Current);
+        }
 
-		public bool HasReachedMilestone() {
-			lock (_lock) {
-				if (_milestones.Count > 0 && _stream.Position >= _milestones.Peek())
-					return true;
-				return false;
-			}
-		}
+        public void Mark()
+        {
+            _mark = _stream.Position;
+        }
 
-		public bool Require(uint count) {
-			return Require(count, null, null);
-		}
+        public void Rewind()
+        {
+            _stream.Position = _mark;
+        }
 
-		public bool Require(uint count, ByteSourceCallback callback, object state) {
-			lock (_lock) {
-				if ((_stream.Length - _stream.Position) >= count)
-					return true;
+        public void PushMilestone(uint count)
+        {
+            lock (_lock) _milestones.Push(_stream.Position + count);
+        }
 
-				throw new DicomIoException("Requested {0} bytes past end of fixed length stream.", count);
-			}
-		}
-	}
+        public void PopMilestone()
+        {
+            lock (_lock) _milestones.Pop();
+        }
+
+        public bool HasReachedMilestone()
+        {
+            lock (_lock)
+            {
+                if (_milestones.Count > 0 && _stream.Position >= _milestones.Peek()) return true;
+                return false;
+            }
+        }
+
+        public bool Require(uint count)
+        {
+            return Require(count, null, null);
+        }
+
+        public bool Require(uint count, ByteSourceCallback callback, object state)
+        {
+            lock (_lock)
+            {
+                if ((_stream.Length - _stream.Position) >= count) return true;
+
+                throw new DicomIoException("Requested {0} bytes past end of fixed length stream.", count);
+            }
+        }
+    }
 }

--- a/DICOM/IO/StreamByteTarget.cs
+++ b/DICOM/IO/StreamByteTarget.cs
@@ -1,103 +1,149 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 
-using Dicom.IO.Buffer;
+namespace Dicom.IO
+{
+    public class StreamByteTarget : IDisposable, IByteTarget
+    {
+        private Stream _stream;
 
-namespace Dicom.IO {
-	public class StreamByteTarget : IDisposable, IByteTarget {
-		private Stream _stream;
-		private Endian _endian;
-		private BinaryWriter _writer;
-		private object _lock;
+        private Endian _endian;
 
-		public StreamByteTarget(Stream stream) {
-			_stream = stream;
-			_endian = Endian.LocalMachine;
-			_writer = EndianBinaryWriter.Create(_stream, _endian);
-			_lock = new object();
-		}
+        private BinaryWriter _writer;
 
-		public Endian Endian {
-			get { return _endian; }
-			set {
-				if (_endian != value) {
-					lock (_lock) {
-						_endian = value;
-						_writer = EndianBinaryWriter.Create(_stream, _endian);
-					}
-				}
-			}
-		}
+        private object _lock;
 
-		public long Position {
-			get { return _stream.Position; }
-		}
+        public StreamByteTarget(Stream stream)
+        {
+            _stream = stream;
+            _endian = Endian.LocalMachine;
+            _writer = EndianBinaryWriter.Create(_stream, _endian);
+            _lock = new object();
+        }
 
-		public void Write(byte v) {
-			_writer.Write(v);
-		}
+        public Endian Endian
+        {
+            get
+            {
+                return _endian;
+            }
+            set
+            {
+                if (_endian != value)
+                {
+                    lock (_lock)
+                    {
+                        _endian = value;
+                        _writer = EndianBinaryWriter.Create(_stream, _endian);
+                    }
+                }
+            }
+        }
 
-		public void Write(short v) {
-			_writer.Write(v);
-		}
+        public long Position
+        {
+            get
+            {
+                return _stream.Position;
+            }
+        }
 
-		public void Write(ushort v) {
-			_writer.Write(v);
-		}
+        public void Write(byte v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(int v) {
-			_writer.Write(v);
-		}
+        public void Write(short v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(uint v) {
-			_writer.Write(v);
-		}
+        public void Write(ushort v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(long v) {
-			_writer.Write(v);
-		}
+        public void Write(int v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(ulong v) {
-			_writer.Write(v);
-		}
+        public void Write(uint v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(float v) {
-			_writer.Write(v);
-		}
+        public void Write(long v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(double v) {
-			_writer.Write(v);
-		}
+        public void Write(ulong v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Write(byte[] buffer, uint offset=0, uint count=uint.MaxValue, ByteTargetCallback callback=null, object state=null) {
-			if (count == uint.MaxValue)
-				count = (uint)buffer.Length - offset;
+        public void Write(float v)
+        {
+            _writer.Write(v);
+        }
 
-			if (callback != null)
-				_stream.BeginWrite(buffer, (int)offset, (int)count, OnEndWrite, new Tuple<ByteTargetCallback, object>(callback, state));
-			else
-				_stream.Write(buffer, (int)offset, (int)count);
-		}
-		private void OnEndWrite(IAsyncResult result) {
-			try {
-				_stream.EndWrite(result);
-			} catch {
-			} finally {
-				if (result.AsyncState != null) {
-					Tuple<ByteTargetCallback, object> state = result.AsyncState as Tuple<ByteTargetCallback, object>;
-					state.Item1(this, state.Item2);
-				}
-			}
-		}
+        public void Write(double v)
+        {
+            _writer.Write(v);
+        }
 
-		public void Close() {
-			// don't close stream
-			//_stream.Close();
-			//_stream = null;
-		}
+        public void Write(
+            byte[] buffer,
+            uint offset = 0,
+            uint count = uint.MaxValue,
+            ByteTargetCallback callback = null,
+            object state = null)
+        {
+            if (count == uint.MaxValue) count = (uint)buffer.Length - offset;
 
-		public void Dispose() {
-			Close();
-		}
-	}
+            if (callback != null)
+                _stream.BeginWrite(
+                    buffer,
+                    (int)offset,
+                    (int)count,
+                    OnEndWrite,
+                    new Tuple<ByteTargetCallback, object>(callback, state));
+            else _stream.Write(buffer, (int)offset, (int)count);
+        }
+
+        private void OnEndWrite(IAsyncResult result)
+        {
+            try
+            {
+                _stream.EndWrite(result);
+            }
+            catch
+            {
+            }
+            finally
+            {
+                if (result.AsyncState != null)
+                {
+                    Tuple<ByteTargetCallback, object> state = result.AsyncState as Tuple<ByteTargetCallback, object>;
+                    state.Item1(this, state.Item2);
+                }
+            }
+        }
+
+        public void Close()
+        {
+            // don't close stream
+            //_stream.Close();
+            //_stream = null;
+        }
+
+        public void Dispose()
+        {
+            Close();
+        }
+    }
 }

--- a/DICOM/IO/TemporaryFile.cs
+++ b/DICOM/IO/TemporaryFile.cs
@@ -1,71 +1,92 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
-using System.Linq;
-using System.Text;
 
-namespace Dicom.IO {
-	public class TemporaryFile : IDisposable {
-		private string _file;
+namespace Dicom.IO
+{
+    public class TemporaryFile : IDisposable
+    {
+        private string _file;
 
-		public TemporaryFile() {
-			_file = Create();
-		}
+        public TemporaryFile()
+        {
+            _file = Create();
+        }
 
-		~TemporaryFile() {
-			TemporaryFileRemover.Delete(_file);
-		}
+        ~TemporaryFile()
+        {
+            TemporaryFileRemover.Delete(_file);
+        }
 
-		public void Dispose() {
-			TemporaryFileRemover.Delete(_file);
-			GC.SuppressFinalize(this);
-		}
+        public void Dispose()
+        {
+            TemporaryFileRemover.Delete(_file);
+            GC.SuppressFinalize(this);
+        }
 
-		public string Name {
-			get { return _file; }
-		}
+        public string Name
+        {
+            get
+            {
+                return _file;
+            }
+        }
 
-		#region Static
-		private static string _path = null;
-		public static string StoragePath {
-			get {
-				if (_path != null)
-					return _path;
-				return Path.GetTempPath();
-			}
-			set {
-				_path = value;
-				if (!Directory.Exists(_path))
-					Directory.CreateDirectory(_path);
-			}
-		}
+        #region Static
 
-		public static string Create() {
-			string path = null;
+        private static string _path = null;
 
-			if (_path != null) {
-				// create file in user specified path
-				path = Path.Combine(_path, Guid.NewGuid().ToString());
-				File.Create(path).Close();
-			} else {
-				// allow OS to create file in system temp path
-				path = Path.GetTempFileName();
-			}
+        public static string StoragePath
+        {
+            get
+            {
+                if (_path != null) return _path;
+                return Path.GetTempPath();
+            }
+            set
+            {
+                _path = value;
+                if (!Directory.Exists(_path)) Directory.CreateDirectory(_path);
+            }
+        }
 
-			try {
-				// set temporary file attribute so that the file system
-				// will attempt to keep all of the data in memory
-				File.SetAttributes(path, File.GetAttributes(path) | FileAttributes.Temporary);
-			} catch {
-				// sometimes fails with invalid argument exception
-			}
+        public static string Create()
+        {
+            string path = null;
 
-			return path;
-		}
-		#endregion
+            if (_path != null)
+            {
+                // create file in user specified path
+                path = Path.Combine(_path, Guid.NewGuid().ToString());
+                File.Create(path).Close();
+            }
+            else
+            {
+                // allow OS to create file in system temp path
+                path = Path.GetTempFileName();
+            }
 
-		public override string ToString() {
-			return String.Format("{0} [TEMP]", Name);
-		}
-	}
+            try
+            {
+                // set temporary file attribute so that the file system
+                // will attempt to keep all of the data in memory
+                File.SetAttributes(path, File.GetAttributes(path) | FileAttributes.Temporary);
+            }
+            catch
+            {
+                // sometimes fails with invalid argument exception
+            }
+
+            return path;
+        }
+
+        #endregion
+
+        public override string ToString()
+        {
+            return String.Format("{0} [TEMP]", Name);
+        }
+    }
 }

--- a/DICOM/IO/TemporaryFileRemover.cs
+++ b/DICOM/IO/TemporaryFileRemover.cs
@@ -1,77 +1,107 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 
-namespace Dicom.IO {
-	public class TemporaryFileRemover : IDisposable {
-		private static TemporaryFileRemover _instance = new TemporaryFileRemover();
-		private object _lock = new object();
-		private List<string> _files = new List<string>();
-		private Timer _timer;
-		private bool _running = false;
+namespace Dicom.IO
+{
+    public class TemporaryFileRemover : IDisposable
+    {
+        private static TemporaryFileRemover _instance = new TemporaryFileRemover();
 
-		private TemporaryFileRemover() {
-			_timer = new Timer(OnTick);
-		}
+        private object _lock = new object();
 
-		~TemporaryFileRemover() {
-			DeleteAllRemainingFiles();
-		}
+        private List<string> _files = new List<string>();
 
-		public void Dispose() {
-			DeleteAllRemainingFiles();
-			GC.SuppressFinalize(this);
-		}
+        private Timer _timer;
 
-		private void DeleteAllRemainingFiles() {
-			// one last try to delete all of the files
-			for (int i = 0; i < _files.Count; i++) {
-				try {
-					File.Delete(_files[i]);
-				} catch {
-				}
-			}
-		}
+        private bool _running = false;
 
-		public static void Delete(string file) {
-			_instance.DeletePrivate(file);
-		}
+        private TemporaryFileRemover()
+        {
+            _timer = new Timer(OnTick);
+        }
 
-		private void DeletePrivate(string file) {
-			try {
-				if (File.Exists(file))
-					File.Delete(file);
-			} catch {
-				if (File.Exists(file)) {
-					lock (_lock) {
-						_files.Add(file);
-						if (!_running) {
-							_timer.Change(1000, 1000);
-							_running = true;
-						}
-					}
-				}
-			}
-		}
+        ~TemporaryFileRemover()
+        {
+            DeleteAllRemainingFiles();
+        }
 
-		private void OnTick(object state) {
-			lock (_lock) {
-				for (int i = 0; i < _files.Count; i++) {
-					try {
-						File.Delete(_files[i]);
-						_files.RemoveAt(i--);
-					} catch {
-						if (!File.Exists(_files[i]))
-							_files.RemoveAt(i--);
-					}
-				}
+        public void Dispose()
+        {
+            DeleteAllRemainingFiles();
+            GC.SuppressFinalize(this);
+        }
 
-				if (_files.Count == 0) {
-					_timer.Change(Timeout.Infinite, Timeout.Infinite);
-					_running = false;
-				}
-			}
-		}
-	}
+        private void DeleteAllRemainingFiles()
+        {
+            // one last try to delete all of the files
+            for (int i = 0; i < _files.Count; i++)
+            {
+                try
+                {
+                    File.Delete(_files[i]);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        public static void Delete(string file)
+        {
+            _instance.DeletePrivate(file);
+        }
+
+        private void DeletePrivate(string file)
+        {
+            try
+            {
+                if (File.Exists(file)) File.Delete(file);
+            }
+            catch
+            {
+                if (File.Exists(file))
+                {
+                    lock (_lock)
+                    {
+                        _files.Add(file);
+                        if (!_running)
+                        {
+                            _timer.Change(1000, 1000);
+                            _running = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void OnTick(object state)
+        {
+            lock (_lock)
+            {
+                for (int i = 0; i < _files.Count; i++)
+                {
+                    try
+                    {
+                        File.Delete(_files[i]);
+                        _files.RemoveAt(i--);
+                    }
+                    catch
+                    {
+                        if (!File.Exists(_files[i])) _files.RemoveAt(i--);
+                    }
+                }
+
+                if (_files.Count == 0)
+                {
+                    _timer.Change(Timeout.Infinite, Timeout.Infinite);
+                    _running = false;
+                }
+            }
+        }
+    }
 }

--- a/DICOM/IO/Writer/DicomDatasetExtensions.cs
+++ b/DICOM/IO/Writer/DicomDatasetExtensions.cs
@@ -1,85 +1,97 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Dicom.IO.Writer {
-	public static class DicomDatasetExtensions {
-		/// <summary>
-		/// Recalculates the group length element for the specified group. Removes the group length element if no elements exist for the specified group.
-		/// </summary>
-		/// <remarks>For most use cases, this method will be called by the library as needed and will not need to be called by the user.</remarks>
-		/// <param name="dataset">DICOM dataset</param>
-		/// <param name="group">DICOM tag group</param>
-		/// <param name="createIfMissing">If set to <c>true</c>, the group length element will be created if missing. If set to <c>false</c>, the group length will only be calculated if the group length element exists.</param>
-		public static void RecalculateGroupLength(this DicomDataset dataset, ushort group, bool createIfMissing = true) {
-			var items = dataset.EnumerateGroup(group).ToList();
+namespace Dicom.IO.Writer
+{
+    public static class DicomDatasetExtensions
+    {
+        /// <summary>
+        /// Recalculates the group length element for the specified group. Removes the group length element if no elements exist for the specified group.
+        /// </summary>
+        /// <remarks>For most use cases, this method will be called by the library as needed and will not need to be called by the user.</remarks>
+        /// <param name="dataset">DICOM dataset</param>
+        /// <param name="group">DICOM tag group</param>
+        /// <param name="createIfMissing">If set to <c>true</c>, the group length element will be created if missing. If set to <c>false</c>, the group length will only be calculated if the group length element exists.</param>
+        public static void RecalculateGroupLength(this DicomDataset dataset, ushort group, bool createIfMissing = true)
+        {
+            var items = dataset.EnumerateGroup(group).ToList();
 
-			if (items.Count == 0) {
-				// no items exist for the specified group; remove
-				dataset.Remove(new DicomTag(group, 0x0000));
-				return;
-			}
+            if (items.Count == 0)
+            {
+                // no items exist for the specified group; remove
+                dataset.Remove(new DicomTag(group, 0x0000));
+                return;
+            }
 
-			var calculator = new DicomWriteLengthCalculator(dataset.InternalTransferSyntax, DicomWriteOptions.Default);
+            var calculator = new DicomWriteLengthCalculator(dataset.InternalTransferSyntax, DicomWriteOptions.Default);
 
-			uint length = calculator.Calculate(items);
-			dataset.Add(new DicomTag(group, 0x0000), length);
-		}
+            uint length = calculator.Calculate(items);
+            dataset.Add(new DicomTag(group, 0x0000), length);
+        }
 
-		/// <summary>
-		/// Recalculates the group lengths for all groups in the <paramref name="dataset"/>. Removes any group lengths for groups with out elements.
-		/// </summary>
-		/// <remarks>For most use cases, this method will be called by the library as needed and will not need to be called by the user.</remarks>
-		/// <param name="dataset">DICOM dataset</param>
-		/// <param name="createIfMissing">If set to <c>true</c>, group length elements will be created if missing. If set to <c>false</c>, only groups with existing group lengths will be recalculated.</param>
-		public static void RecalculateGroupLengths(this DicomDataset dataset, bool createIfMissing = true) {
-			// recalculate group lengths for sequences first
-			foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>()) {
-				foreach (var item in sq.Items) {
-					item.RecalculateGroupLengths(createIfMissing);
-				}
-			}
+        /// <summary>
+        /// Recalculates the group lengths for all groups in the <paramref name="dataset"/>. Removes any group lengths for groups with out elements.
+        /// </summary>
+        /// <remarks>For most use cases, this method will be called by the library as needed and will not need to be called by the user.</remarks>
+        /// <param name="dataset">DICOM dataset</param>
+        /// <param name="createIfMissing">If set to <c>true</c>, group length elements will be created if missing. If set to <c>false</c>, only groups with existing group lengths will be recalculated.</param>
+        public static void RecalculateGroupLengths(this DicomDataset dataset, bool createIfMissing = true)
+        {
+            // recalculate group lengths for sequences first
+            foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>())
+            {
+                foreach (var item in sq.Items)
+                {
+                    item.RecalculateGroupLengths(createIfMissing);
+                }
+            }
 
-			var calculator = new DicomWriteLengthCalculator(dataset.InternalTransferSyntax, DicomWriteOptions.Default);
+            var calculator = new DicomWriteLengthCalculator(dataset.InternalTransferSyntax, DicomWriteOptions.Default);
 
-			IEnumerable<ushort> groups = null;
-			if (createIfMissing)
-				groups = dataset.Select(x => x.Tag.Group).Distinct();
-			else
-				groups = dataset.Where(x => x.Tag.Element == 0x0000).Select(x => x.Tag.Group);
+            IEnumerable<ushort> groups = null;
+            if (createIfMissing) groups = dataset.Select(x => x.Tag.Group).Distinct();
+            else groups = dataset.Where(x => x.Tag.Element == 0x0000).Select(x => x.Tag.Group);
 
-			foreach (var group in groups.ToList()) {
-				var items = dataset.EnumerateGroup(group).ToList();
+            foreach (var group in groups.ToList())
+            {
+                var items = dataset.EnumerateGroup(group).ToList();
 
-				if (items.Count == 0) {
-					// no items exist for the specified group; remove
-					dataset.Remove(new DicomTag(group, 0x0000));
-					return;
-				}
+                if (items.Count == 0)
+                {
+                    // no items exist for the specified group; remove
+                    dataset.Remove(new DicomTag(group, 0x0000));
+                    return;
+                }
 
-				uint length = calculator.Calculate(items);
-				dataset.Add(new DicomTag(group, 0x0000), length);
-			}
-		}
+                uint length = calculator.Calculate(items);
+                dataset.Add(new DicomTag(group, 0x0000), length);
+            }
+        }
 
-		/// <summary>
-		/// Removes group length elements from the DICOM dataset.
-		/// </summary>
-		/// <remarks>For most use cases, this method will be called by the library as needed and will not need to be called by the user.</remarks>
-		/// <param name="dataset">DICOM dataset</param>
-		/// <param name="firstLevelOnly">If set to <c>true</c>, group length elements will only be removed from the first level of the dataset. If set to <c>false</c>, group lengths will also be removed from sequence items.</param>
-		public static void RemoveGroupLengths(this DicomDataset dataset, bool firstLevelOnly = false) {
-			dataset.Remove(x => x.Tag.Element == 0x0000);
+        /// <summary>
+        /// Removes group length elements from the DICOM dataset.
+        /// </summary>
+        /// <remarks>For most use cases, this method will be called by the library as needed and will not need to be called by the user.</remarks>
+        /// <param name="dataset">DICOM dataset</param>
+        /// <param name="firstLevelOnly">If set to <c>true</c>, group length elements will only be removed from the first level of the dataset. If set to <c>false</c>, group lengths will also be removed from sequence items.</param>
+        public static void RemoveGroupLengths(this DicomDataset dataset, bool firstLevelOnly = false)
+        {
+            dataset.Remove(x => x.Tag.Element == 0x0000);
 
-			if (!firstLevelOnly) {
-				// remove group lengths from sequences
-				foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>()) {
-					foreach (var item in sq.Items) {
-						item.RemoveGroupLengths(firstLevelOnly);
-					}
-				}
-			}
-		}
-	}
+            if (!firstLevelOnly)
+            {
+                // remove group lengths from sequences
+                foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>())
+                {
+                    foreach (var item in sq.Items)
+                    {
+                        item.RemoveGroupLengths(firstLevelOnly);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/DICOM/IO/Writer/DicomFileWriter.cs
+++ b/DICOM/IO/Writer/DicomFileWriter.cs
@@ -1,108 +1,138 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
+using System;
 
-namespace Dicom.IO.Writer {
-	public class DicomFileWriter {
-		private EventAsyncResult _async;
-		private Exception _exception;
+namespace Dicom.IO.Writer
+{
+    public class DicomFileWriter
+    {
+        private EventAsyncResult _async;
 
-		private IByteTarget _target;
-		private DicomFileMetaInformation _fileMetaInfo;
-		private DicomDataset _dataset;
+        private Exception _exception;
 
-		private DicomWriteOptions _options;
+        private IByteTarget _target;
 
-		public DicomFileWriter(DicomWriteOptions options) {
-			_options = options;
-		}
+        private DicomFileMetaInformation _fileMetaInfo;
 
-		public IByteTarget Target {
-			get { return _target; }
-		}
+        private DicomDataset _dataset;
 
-		public void Write(IByteTarget target, DicomFileMetaInformation fileMetaInfo, DicomDataset dataset) {
-			EndWrite(BeginWrite(target, fileMetaInfo, dataset, null, null));
-		}
+        private DicomWriteOptions _options;
 
-		public IAsyncResult BeginWrite(IByteTarget target, DicomFileMetaInformation fileMetaInfo, DicomDataset dataset, AsyncCallback callback, object state) {
-			_target = target;
-			_fileMetaInfo = fileMetaInfo;
-			_dataset = dataset;
+        public DicomFileWriter(DicomWriteOptions options)
+        {
+            _options = options;
+        }
 
-			_async = new EventAsyncResult(callback, state);
+        public IByteTarget Target
+        {
+            get
+            {
+                return _target;
+            }
+        }
 
-			byte[] preamble = new byte[132];
-			preamble[128] = (byte)'D';
-			preamble[129] = (byte)'I';
-			preamble[130] = (byte)'C';
-			preamble[131] = (byte)'M';
+        public void Write(IByteTarget target, DicomFileMetaInformation fileMetaInfo, DicomDataset dataset)
+        {
+            EndWrite(BeginWrite(target, fileMetaInfo, dataset, null, null));
+        }
 
-			_target.Write(preamble, 0, 132, OnCompletePreamble, null);
+        public IAsyncResult BeginWrite(
+            IByteTarget target,
+            DicomFileMetaInformation fileMetaInfo,
+            DicomDataset dataset,
+            AsyncCallback callback,
+            object state)
+        {
+            _target = target;
+            _fileMetaInfo = fileMetaInfo;
+            _dataset = dataset;
 
-			return _async;
-		}
+            _async = new EventAsyncResult(callback, state);
 
-		public void EndWrite(IAsyncResult result) {
-			_async.AsyncWaitHandle.WaitOne();
-			if (_exception != null)
-				throw _exception;
-		}
+            byte[] preamble = new byte[132];
+            preamble[128] = (byte)'D';
+            preamble[129] = (byte)'I';
+            preamble[130] = (byte)'C';
+            preamble[131] = (byte)'M';
 
-		private void OnCompletePreamble(IByteTarget target, object state) {
-			// recalculate FMI group length as required by standard
-			_fileMetaInfo.RecalculateGroupLengths();
+            _target.Write(preamble, 0, 132, OnCompletePreamble, null);
 
-			DicomWriter writer = new DicomWriter(DicomTransferSyntax.ExplicitVRLittleEndian, _options, _target);
-			DicomDatasetWalker walker = new DicomDatasetWalker(_fileMetaInfo);
-			walker.BeginWalk(writer, OnCompleteFileMetaInfo, walker);
-		}
+            return _async;
+        }
 
-		private void OnCompleteFileMetaInfo(IAsyncResult result) {
-			try {
-				DicomDatasetWalker walker;
+        public void EndWrite(IAsyncResult result)
+        {
+            _async.AsyncWaitHandle.WaitOne();
+            if (_exception != null) throw _exception;
+        }
 
-				if (result != null) {
-					walker = result.AsyncState as DicomDatasetWalker;
-					walker.EndWalk(result);
-				}
+        private void OnCompletePreamble(IByteTarget target, object state)
+        {
+            // recalculate FMI group length as required by standard
+            _fileMetaInfo.RecalculateGroupLengths();
 
-				DicomTransferSyntax syntax = _fileMetaInfo.TransferSyntax;
+            DicomWriter writer = new DicomWriter(DicomTransferSyntax.ExplicitVRLittleEndian, _options, _target);
+            DicomDatasetWalker walker = new DicomDatasetWalker(_fileMetaInfo);
+            walker.BeginWalk(writer, OnCompleteFileMetaInfo, walker);
+        }
 
-				if (_options.KeepGroupLengths) {
-					// update transfer syntax and recalculate existing group lengths
-					_dataset.InternalTransferSyntax = syntax;
-					_dataset.RecalculateGroupLengths(false);
-				} else {
-					// remove group lengths as suggested in PS 3.5 7.2
-					//
-					//	2. It is recommended that Group Length elements be removed during storage or transfer 
-					//	   in order to avoid the risk of inconsistencies arising during coercion of data 
-					//	   element values and changes in transfer syntax.
-					_dataset.RemoveGroupLengths();
-				}
+        private void OnCompleteFileMetaInfo(IAsyncResult result)
+        {
+            try
+            {
+                DicomDatasetWalker walker;
 
-				DicomWriter writer = new DicomWriter(syntax, _options, _target);
-				walker = new DicomDatasetWalker(_dataset);
-				walker.BeginWalk(writer, OnCompleteDataset, walker);
-			} catch (Exception e) {
-				_exception = e;
-				_async.Set();
-			}
-		}
+                if (result != null)
+                {
+                    walker = result.AsyncState as DicomDatasetWalker;
+                    walker.EndWalk(result);
+                }
 
-		private void OnCompleteDataset(IAsyncResult result) {
-			try {
-				DicomDatasetWalker walker = result.AsyncState as DicomDatasetWalker;
-				walker.EndWalk(result);
-			} catch (Exception e) {
-				_exception = e;
-			} finally {
-				_async.Set();
-			}
-		}
-	}
+                DicomTransferSyntax syntax = _fileMetaInfo.TransferSyntax;
+
+                if (_options.KeepGroupLengths)
+                {
+                    // update transfer syntax and recalculate existing group lengths
+                    _dataset.InternalTransferSyntax = syntax;
+                    _dataset.RecalculateGroupLengths(false);
+                }
+                else
+                {
+                    // remove group lengths as suggested in PS 3.5 7.2
+                    //
+                    //	2. It is recommended that Group Length elements be removed during storage or transfer 
+                    //	   in order to avoid the risk of inconsistencies arising during coercion of data 
+                    //	   element values and changes in transfer syntax.
+                    _dataset.RemoveGroupLengths();
+                }
+
+                DicomWriter writer = new DicomWriter(syntax, _options, _target);
+                walker = new DicomDatasetWalker(_dataset);
+                walker.BeginWalk(writer, OnCompleteDataset, walker);
+            }
+            catch (Exception e)
+            {
+                _exception = e;
+                _async.Set();
+            }
+        }
+
+        private void OnCompleteDataset(IAsyncResult result)
+        {
+            try
+            {
+                DicomDatasetWalker walker = result.AsyncState as DicomDatasetWalker;
+                walker.EndWalk(result);
+            }
+            catch (Exception e)
+            {
+                _exception = e;
+            }
+            finally
+            {
+                _async.Set();
+            }
+        }
+    }
 }

--- a/DICOM/IO/Writer/DicomWriteLengthCalculator.cs
+++ b/DICOM/IO/Writer/DicomWriteLengthCalculator.cs
@@ -1,96 +1,118 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 
 using Dicom.IO.Buffer;
 
-namespace Dicom.IO.Writer {
-	public class DicomWriteLengthCalculator {
-		private DicomTransferSyntax _syntax;
-		private DicomWriteOptions _options;
+namespace Dicom.IO.Writer
+{
+    public class DicomWriteLengthCalculator
+    {
+        private DicomTransferSyntax _syntax;
 
-		public DicomWriteLengthCalculator(DicomTransferSyntax syntax, DicomWriteOptions options) {
-			_syntax = syntax;
-			_options = options;
-		}
+        private DicomWriteOptions _options;
 
-		public uint Calculate(IEnumerable<DicomItem> items) {
-			uint length = 0;
-			foreach (DicomItem item in items)
-				length += Calculate(item);
-			return length;
-		}
+        public DicomWriteLengthCalculator(DicomTransferSyntax syntax, DicomWriteOptions options)
+        {
+            _syntax = syntax;
+            _options = options;
+        }
 
-		public uint Calculate(DicomItem item) {
-			// skip group lengths if not writing to file
-			if (!_options.KeepGroupLengths && item.Tag.Element == 0x0000)
-				return 0;
+        public uint Calculate(IEnumerable<DicomItem> items)
+        {
+            uint length = 0;
+            foreach (DicomItem item in items) length += Calculate(item);
+            return length;
+        }
 
-			uint length = 0;
-			length += 4; // tag
+        public uint Calculate(DicomItem item)
+        {
+            // skip group lengths if not writing to file
+            if (!_options.KeepGroupLengths && item.Tag.Element == 0x0000) return 0;
 
-			if (_syntax.IsExplicitVR) {
-				length += 2; // vr
-				if (item.ValueRepresentation.Is16bitLength) {
-					length += 2; // length
-				} else {
-					length += 2; // reserved
-					length += 4; // length
-				}
-			} else {
-				length += 4; // length
-			}
+            uint length = 0;
+            length += 4; // tag
 
-			if (item is DicomElement) {
-				length += (uint)(item as DicomElement).Buffer.Size;
-			} else if (item is DicomFragmentSequence) {
-				DicomFragmentSequence sq = item as DicomFragmentSequence;
-				// fragment item (offset table)
-				length += 4; // tag
-				length += 4; // length
-				length += (uint)(sq.OffsetTable.Count / 4);
+            if (_syntax.IsExplicitVR)
+            {
+                length += 2; // vr
+                if (item.ValueRepresentation.Is16bitLength)
+                {
+                    length += 2; // length
+                }
+                else
+                {
+                    length += 2; // reserved
+                    length += 4; // length
+                }
+            }
+            else
+            {
+                length += 4; // length
+            }
 
-				foreach (IByteBuffer fragment in sq) {
-					// fragment item
-					length += 4; // tag
-					length += 4; // length
-					length += fragment.Size;
-				}
+            if (item is DicomElement)
+            {
+                length += (uint)(item as DicomElement).Buffer.Size;
+            }
+            else if (item is DicomFragmentSequence)
+            {
+                DicomFragmentSequence sq = item as DicomFragmentSequence;
+                // fragment item (offset table)
+                length += 4; // tag
+                length += 4; // length
+                length += (uint)(sq.OffsetTable.Count / 4);
 
-				// sequence delimitation item
-				length += 4; // tag
-				length += 4; // length
-			} else if (item is DicomSequence) {
-				DicomSequence sq = item as DicomSequence;
-				length += Calculate(sq);
-			}
+                foreach (IByteBuffer fragment in sq)
+                {
+                    // fragment item
+                    length += 4; // tag
+                    length += 4; // length
+                    length += fragment.Size;
+                }
 
-			return length;
-		}
+                // sequence delimitation item
+                length += 4; // tag
+                length += 4; // length
+            }
+            else if (item is DicomSequence)
+            {
+                DicomSequence sq = item as DicomSequence;
+                length += Calculate(sq);
+            }
 
-		public uint Calculate(DicomSequence sq) {
-			uint length = 0;
+            return length;
+        }
 
-			foreach (DicomDataset sqi in sq) {
-				// sequence item
-				length += 4; // tag
-				length += 4; // length
+        public uint Calculate(DicomSequence sq)
+        {
+            uint length = 0;
 
-				length += Calculate(sqi);
+            foreach (DicomDataset sqi in sq)
+            {
+                // sequence item
+                length += 4; // tag
+                length += 4; // length
 
-				if (!_options.ExplicitLengthSequenceItems) {
-					// sequence item delimitation item
-					length += 4; // tag
-					length += 4; // length
-				}
-			}
+                length += Calculate(sqi);
 
-			if (!_options.ExplicitLengthSequences && !sq.Tag.IsPrivate) {
-				// sequence delimitation item
-				length += 4; // tag
-				length += 4; // length
-			}
+                if (!_options.ExplicitLengthSequenceItems)
+                {
+                    // sequence item delimitation item
+                    length += 4; // tag
+                    length += 4; // length
+                }
+            }
 
-			return length;
-		}
-	}
+            if (!_options.ExplicitLengthSequences && !sq.Tag.IsPrivate)
+            {
+                // sequence delimitation item
+                length += 4; // tag
+                length += 4; // length
+            }
+
+            return length;
+        }
+    }
 }

--- a/DICOM/IO/Writer/DicomWriteOptions.cs
+++ b/DICOM/IO/Writer/DicomWriteOptions.cs
@@ -1,52 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.IO.Writer {
-	public class DicomWriteOptions {
-		public DicomWriteOptions() {
-			ExplicitLengthSequences = false;
-			ExplicitLengthSequenceItems = false;
-			KeepGroupLengths = false;
-			LargeObjectSize = 16*1024;
-		}
+namespace Dicom.IO.Writer
+{
+    public class DicomWriteOptions
+    {
+        public DicomWriteOptions()
+        {
+            ExplicitLengthSequences = false;
+            ExplicitLengthSequenceItems = false;
+            KeepGroupLengths = false;
+            LargeObjectSize = 16 * 1024;
+        }
 
-		public DicomWriteOptions(DicomWriteOptions options) {
-			ExplicitLengthSequences = options.ExplicitLengthSequences;
-			ExplicitLengthSequenceItems = options.ExplicitLengthSequenceItems;
-			KeepGroupLengths = options.KeepGroupLengths;
-			LargeObjectSize = options.LargeObjectSize;
-		}
+        public DicomWriteOptions(DicomWriteOptions options)
+        {
+            ExplicitLengthSequences = options.ExplicitLengthSequences;
+            ExplicitLengthSequenceItems = options.ExplicitLengthSequenceItems;
+            KeepGroupLengths = options.KeepGroupLengths;
+            LargeObjectSize = options.LargeObjectSize;
+        }
 
-		private static DicomWriteOptions _default;
-		public static DicomWriteOptions Default {
-			get {
-				if (_default == null) {
-					_default = new DicomWriteOptions();
-				}
-				return _default;
-			}
-		}
+        private static DicomWriteOptions _default;
 
-		public bool ExplicitLengthSequences {
-			get;
-			set;
-		}
+        public static DicomWriteOptions Default
+        {
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new DicomWriteOptions();
+                }
+                return _default;
+            }
+        }
 
-		public bool ExplicitLengthSequenceItems {
-			get;
-			set;
-		}
+        public bool ExplicitLengthSequences { get; set; }
 
-		public bool KeepGroupLengths {
-			get;
-			set;
-		}
+        public bool ExplicitLengthSequenceItems { get; set; }
 
-		public uint LargeObjectSize {
-			get;
-			set;
-		}
-	}
+        public bool KeepGroupLengths { get; set; }
+
+        public uint LargeObjectSize { get; set; }
+    }
 }

--- a/DICOM/Imaging/Algorithms/BilinearInterpolation.cs
+++ b/DICOM/Imaging/Algorithms/BilinearInterpolation.cs
@@ -1,183 +1,242 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Threading.Tasks;
 
-namespace Dicom.Imaging.Algorithms {
-	public static class BilinearInterpolation {
-		public static byte[] RescaleGrayscale(byte[] input, int inputWidth, int inputHeight, int outputWidth, int outputHeight) {
-			byte[] output = new byte[outputWidth * outputHeight];
+namespace Dicom.Imaging.Algorithms
+{
+    public static class BilinearInterpolation
+    {
+        public static byte[] RescaleGrayscale(
+            byte[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
+        {
+            byte[] output = new byte[outputWidth * outputHeight];
 
-			double xF = (double)inputWidth / (double)outputWidth;
-			double yF = (double)inputHeight / (double)outputHeight;
+            double xF = (double)inputWidth / (double)outputWidth;
+            double yF = (double)inputHeight / (double)outputHeight;
 
-			int xMax = inputWidth - 1;
-			int yMax = inputHeight - 1;
+            int xMax = inputWidth - 1;
+            int yMax = inputHeight - 1;
 
-			unchecked {
-				Parallel.For(0, outputHeight, y => {
-					double oy0 = y * yF;
-					int oy1 = (int)oy0; // rounds down
-					int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+            unchecked
+            {
+                Parallel.For(
+                    0,
+                    outputHeight,
+                    y =>
+                        {
+                            double oy0 = y * yF;
+                            int oy1 = (int)oy0; // rounds down
+                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-					double dy1 = oy0 - oy1;
-					double dy2 = 1.0 - dy1;
+                            double dy1 = oy0 - oy1;
+                            double dy2 = 1.0 - dy1;
 
-					int yo0 = outputWidth * y;
-					int yo1 = inputWidth * oy1;
-					int yo2 = inputWidth * oy2;
+                            int yo0 = outputWidth * y;
+                            int yo1 = inputWidth * oy1;
+                            int yo2 = inputWidth * oy2;
 
-					double ox0, dx1, dx2;
-					int ox1, ox2;
+                            double ox0, dx1, dx2;
+                            int ox1, ox2;
 
-					for (int x = 0; x < outputWidth; x++) {
-						ox0 = x * xF;
-						ox1 = (int)ox0;
-						ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                            for (int x = 0; x < outputWidth; x++)
+                            {
+                                ox0 = x * xF;
+                                ox1 = (int)ox0;
+                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-						dx1 = ox0 - ox1;
-						dx2 = 1.0 - dx1;
+                                dx1 = ox0 - ox1;
+                                dx2 = 1.0 - dx1;
 
-						output[yo0 + x] =
-							(byte)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								   (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-					}
-				});
-			}
+                                output[yo0 + x] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                            }
+                        });
+            }
 
-			return output;
-		}
+            return output;
+        }
 
-		public static short[] RescaleGrayscale(short[] input, int inputWidth, int inputHeight, int outputWidth, int outputHeight) {
-			short[] output = new short[outputWidth * outputHeight];
+        public static short[] RescaleGrayscale(
+            short[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
+        {
+            short[] output = new short[outputWidth * outputHeight];
 
-			double xF = (double)inputWidth / (double)outputWidth;
-			double yF = (double)inputHeight / (double)outputHeight;
+            double xF = (double)inputWidth / (double)outputWidth;
+            double yF = (double)inputHeight / (double)outputHeight;
 
-			int xMax = inputWidth - 1;
-			int yMax = inputHeight - 1;
+            int xMax = inputWidth - 1;
+            int yMax = inputHeight - 1;
 
-			unchecked {
-				Parallel.For(0, outputHeight, y => {
-					double oy0 = y * yF;
-					int oy1 = (int)oy0; // rounds down
-					int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+            unchecked
+            {
+                Parallel.For(
+                    0,
+                    outputHeight,
+                    y =>
+                        {
+                            double oy0 = y * yF;
+                            int oy1 = (int)oy0; // rounds down
+                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-					double dy1 = oy0 - oy1;
-					double dy2 = 1.0 - dy1;
+                            double dy1 = oy0 - oy1;
+                            double dy2 = 1.0 - dy1;
 
-					int yo0 = outputWidth * y;
-					int yo1 = inputWidth * oy1;
-					int yo2 = inputWidth * oy2;
+                            int yo0 = outputWidth * y;
+                            int yo1 = inputWidth * oy1;
+                            int yo2 = inputWidth * oy2;
 
-					double ox0, dx1, dx2;
-					int ox1, ox2;
+                            double ox0, dx1, dx2;
+                            int ox1, ox2;
 
-					for (int x = 0; x < outputWidth; x++) {
-						ox0 = x * xF;
-						ox1 = (int)ox0;
-						ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                            for (int x = 0; x < outputWidth; x++)
+                            {
+                                ox0 = x * xF;
+                                ox1 = (int)ox0;
+                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-						dx1 = ox0 - ox1;
-						dx2 = 1.0 - dx1;
+                                dx1 = ox0 - ox1;
+                                dx2 = 1.0 - dx1;
 
-						output[yo0 + x] =
-							(short)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								    (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-					}
-				});
-			}
+                                output[yo0 + x] =
+                                    (short)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                            }
+                        });
+            }
 
-			return output;
-		}
+            return output;
+        }
 
-		public static ushort[] RescaleGrayscale(ushort[] input, int inputWidth, int inputHeight, int outputWidth, int outputHeight) {
-			ushort[] output = new ushort[outputWidth * outputHeight];
+        public static ushort[] RescaleGrayscale(
+            ushort[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
+        {
+            ushort[] output = new ushort[outputWidth * outputHeight];
 
-			double xF = (double)inputWidth / (double)outputWidth;
-			double yF = (double)inputHeight / (double)outputHeight;
+            double xF = (double)inputWidth / (double)outputWidth;
+            double yF = (double)inputHeight / (double)outputHeight;
 
-			int xMax = inputWidth - 1;
-			int yMax = inputHeight - 1;
+            int xMax = inputWidth - 1;
+            int yMax = inputHeight - 1;
 
-			unchecked {
-				Parallel.For(0, outputHeight, y => {
-					double oy0 = y * yF;
-					int oy1 = (int)oy0; // rounds down
-					int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+            unchecked
+            {
+                Parallel.For(
+                    0,
+                    outputHeight,
+                    y =>
+                        {
+                            double oy0 = y * yF;
+                            int oy1 = (int)oy0; // rounds down
+                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-					double dy1 = oy0 - oy1;
-					double dy2 = 1.0 - dy1;
+                            double dy1 = oy0 - oy1;
+                            double dy2 = 1.0 - dy1;
 
-					int yo0 = outputWidth * y;
-					int yo1 = inputWidth * oy1;
-					int yo2 = inputWidth * oy2;
+                            int yo0 = outputWidth * y;
+                            int yo1 = inputWidth * oy1;
+                            int yo2 = inputWidth * oy2;
 
-					double ox0, dx1, dx2;
-					int ox1, ox2;
+                            double ox0, dx1, dx2;
+                            int ox1, ox2;
 
-					for (int x = 0; x < outputWidth; x++) {
-						ox0 = x * xF;
-						ox1 = (int)ox0;
-						ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                            for (int x = 0; x < outputWidth; x++)
+                            {
+                                ox0 = x * xF;
+                                ox1 = (int)ox0;
+                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-						dx1 = ox0 - ox1;
-						dx2 = 1.0 - dx1;
+                                dx1 = ox0 - ox1;
+                                dx2 = 1.0 - dx1;
 
-						output[yo0 + x] =
-							(ushort)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								     (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-					}
-				});
-			}
+                                output[yo0 + x] =
+                                    (ushort)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                            }
+                        });
+            }
 
-			return output;
-		}
+            return output;
+        }
 
-		public static int[] RescaleGrayscale(int[] input, int inputWidth, int inputHeight, int outputWidth, int outputHeight) {
-			int[] output = new int[outputWidth * outputHeight];
+        public static int[] RescaleGrayscale(
+            int[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
+        {
+            int[] output = new int[outputWidth * outputHeight];
 
-			double xF = (double)inputWidth / (double)outputWidth;
-			double yF = (double)inputHeight / (double)outputHeight;
+            double xF = (double)inputWidth / (double)outputWidth;
+            double yF = (double)inputHeight / (double)outputHeight;
 
-			int xMax = inputWidth - 1;
-			int yMax = inputHeight - 1;
+            int xMax = inputWidth - 1;
+            int yMax = inputHeight - 1;
 
-			unchecked {
-				Parallel.For(0, outputHeight, y => {
-					double oy0 = y * yF;
-					int oy1 = (int)oy0; // rounds down
-					int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+            unchecked
+            {
+                Parallel.For(
+                    0,
+                    outputHeight,
+                    y =>
+                        {
+                            double oy0 = y * yF;
+                            int oy1 = (int)oy0; // rounds down
+                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-					double dy1 = oy0 - oy1;
-					double dy2 = 1.0 - dy1;
+                            double dy1 = oy0 - oy1;
+                            double dy2 = 1.0 - dy1;
 
-					int yo0 = outputWidth * y;
-					int yo1 = inputWidth * oy1;
-					int yo2 = inputWidth * oy2;
+                            int yo0 = outputWidth * y;
+                            int yo1 = inputWidth * oy1;
+                            int yo2 = inputWidth * oy2;
 
-					double ox0, dx1, dx2;
-					int ox1, ox2;
+                            double ox0, dx1, dx2;
+                            int ox1, ox2;
 
-					for (int x = 0; x < outputWidth; x++) {
-						ox0 = x * xF;
-						ox1 = (int)ox0;
-						ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                            for (int x = 0; x < outputWidth; x++)
+                            {
+                                ox0 = x * xF;
+                                ox1 = (int)ox0;
+                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-						dx1 = ox0 - ox1;
-						dx2 = 1.0 - dx1;
+                                dx1 = ox0 - ox1;
+                                dx2 = 1.0 - dx1;
 
-						output[yo0 + x] =
-							(int)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								  (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-					}
-				});
-			}
+                                output[yo0 + x] =
+                                    (int)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                            }
+                        });
+            }
 
-			return output;
-		}
+            return output;
+        }
 
-        public static uint[] RescaleGrayscale(uint[] input, int inputWidth, int inputHeight, int outputWidth, int outputHeight)
+        public static uint[] RescaleGrayscale(
+            uint[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
         {
             uint[] output = new uint[outputWidth * outputHeight];
 
@@ -189,156 +248,204 @@ namespace Dicom.Imaging.Algorithms {
 
             unchecked
             {
-                Parallel.For(0, outputHeight, y =>
-                {
-                    double oy0 = y * yF;
-                    int oy1 = (int)oy0; // rounds down
-                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+                Parallel.For(
+                    0,
+                    outputHeight,
+                    y =>
+                        {
+                            double oy0 = y * yF;
+                            int oy1 = (int)oy0; // rounds down
+                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                    double dy1 = oy0 - oy1;
-                    double dy2 = 1.0 - dy1;
+                            double dy1 = oy0 - oy1;
+                            double dy2 = 1.0 - dy1;
 
-                    int yo0 = outputWidth * y;
-                    int yo1 = inputWidth * oy1;
-                    int yo2 = inputWidth * oy2;
+                            int yo0 = outputWidth * y;
+                            int yo1 = inputWidth * oy1;
+                            int yo2 = inputWidth * oy2;
 
-                    double ox0, dx1, dx2;
-                    int ox1, ox2;
+                            double ox0, dx1, dx2;
+                            int ox1, ox2;
 
-                    for (int x = 0; x < outputWidth; x++)
-                    {
-                        ox0 = x * xF;
-                        ox1 = (int)ox0;
-                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                            for (int x = 0; x < outputWidth; x++)
+                            {
+                                ox0 = x * xF;
+                                ox1 = (int)ox0;
+                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                        dx1 = ox0 - ox1;
-                        dx2 = 1.0 - dx1;
+                                dx1 = ox0 - ox1;
+                                dx2 = 1.0 - dx1;
 
-                        output[yo0 + x] =
-                            (uint) ((dy2*((dx2*input[yo1 + ox1]) + (dx1*input[yo1 + ox2]))) +
-                                    (dy1*((dx2*input[yo2 + ox1]) + (dx1*input[yo2 + ox2]))));
-                    }
-                });
+                                output[yo0 + x] =
+                                    (uint)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                            }
+                        });
             }
 
             return output;
         }
 
-        public static byte[] RescaleColor24(byte[] input, int inputWidth, int inputHeight, int outputWidth, int outputHeight)
+        public static byte[] RescaleColor24(
+            byte[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
         {
-			byte[] output = new byte[outputWidth * outputHeight * 3];
+            byte[] output = new byte[outputWidth * outputHeight * 3];
 
-			double xF = (double)inputWidth / (double)outputWidth;
-			double yF = (double)inputHeight / (double)outputHeight;
+            double xF = (double)inputWidth / (double)outputWidth;
+            double yF = (double)inputHeight / (double)outputHeight;
 
-			int xMax = inputWidth - 1;
-			int yMax = inputHeight - 1;
+            int xMax = inputWidth - 1;
+            int yMax = inputHeight - 1;
 
-			unchecked {
-				Parallel.For(0, outputHeight, y => {
-					double oy0 = y * yF;
-					int oy1 = (int)oy0; // rounds down
-					int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+            unchecked
+            {
+                Parallel.For(
+                    0,
+                    outputHeight,
+                    y =>
+                        {
+                            double oy0 = y * yF;
+                            int oy1 = (int)oy0; // rounds down
+                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-					double dy1 = oy0 - oy1;
-					double dy2 = 1.0 - dy1;
+                            double dy1 = oy0 - oy1;
+                            double dy2 = 1.0 - dy1;
 
-					int yo0 = outputWidth * y * 3;
-					int yo1 = inputWidth * oy1 * 3;
-					int yo2 = inputWidth * oy2 * 3;
+                            int yo0 = outputWidth * y * 3;
+                            int yo1 = inputWidth * oy1 * 3;
+                            int yo2 = inputWidth * oy2 * 3;
 
-					double ox0, dx1, dx2;
-					int ox1, ox2;
+                            double ox0, dx1, dx2;
+                            int ox1, ox2;
 
-					for (int x = 0, px = 0; x < outputWidth; x++) {
-						ox0 = x * xF;
-						ox1 = (int)ox0;
-						ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                            for (int x = 0, px = 0; x < outputWidth; x++)
+                            {
+                                ox0 = x * xF;
+                                ox1 = (int)ox0;
+                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-						dx1 = ox0 - ox1;
-						dx2 = 1.0 - dx1;
+                                dx1 = ox0 - ox1;
+                                dx2 = 1.0 - dx1;
 
-                        int x1 =  ox1 * 3;//first byte of first pixel
-                        int x2 =  ox2 * 3;//first byte of second pixel
+                                int x1 = ox1 * 3; //first byte of first pixel
+                                int x2 = ox2 * 3; //first byte of second pixel
 
-                        output[yo0 + px] =
-                            (byte)((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2]))) +
-                                   (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
-                        px++; x1++; x2++;
+                                output[yo0 + px] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
+                                     + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
+                                px++;
+                                x1++;
+                                x2++;
 
-                        output[yo0 + px] =
-                            (byte)((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2]))) +
-                                   (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
-                        px++; x1++; x2++;
+                                output[yo0 + px] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
+                                     + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
+                                px++;
+                                x1++;
+                                x2++;
 
-                        output[yo0 + px] =
-                            (byte)((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2]))) +
-                                   (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
-                        px++; x1++; x2++;
-					}
-				});
-			}
+                                output[yo0 + px] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
+                                     + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
+                                px++;
+                                x1++;
+                                x2++;
+                            }
+                        });
+            }
 
-			return output;
-		}
+            return output;
+        }
 
-		public static byte[] RescaleColor32(byte[] input, int inputWidth, int inputHeight, int outputWidth, int outputHeight) {
-			byte[] output = new byte[outputWidth * outputHeight * 4];
+        public static byte[] RescaleColor32(
+            byte[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
+        {
+            byte[] output = new byte[outputWidth * outputHeight * 4];
 
-			double xF = (double)inputWidth / (double)outputWidth;
-			double yF = (double)inputHeight / (double)outputHeight;
+            double xF = (double)inputWidth / (double)outputWidth;
+            double yF = (double)inputHeight / (double)outputHeight;
 
-			int xMax = inputWidth - 1;
-			int yMax = inputHeight - 1;
+            int xMax = inputWidth - 1;
+            int yMax = inputHeight - 1;
 
-			unchecked {
-				Parallel.For(0, outputHeight, y => {
-					double oy0 = y * yF;
-					int oy1 = (int)oy0; // rounds down
-					int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+            unchecked
+            {
+                Parallel.For(
+                    0,
+                    outputHeight,
+                    y =>
+                        {
+                            double oy0 = y * yF;
+                            int oy1 = (int)oy0; // rounds down
+                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-					double dy1 = oy0 - oy1;
-					double dy2 = 1.0 - dy1;
+                            double dy1 = oy0 - oy1;
+                            double dy2 = 1.0 - dy1;
 
-					int yo0 = outputWidth * y * 4;
-					int yo1 = inputWidth * oy1 * 4;
-					int yo2 = inputWidth * oy2 * 4;
+                            int yo0 = outputWidth * y * 4;
+                            int yo1 = inputWidth * oy1 * 4;
+                            int yo2 = inputWidth * oy2 * 4;
 
-					double ox0, dx1, dx2;
-					int ox1, ox2;
+                            double ox0, dx1, dx2;
+                            int ox1, ox2;
 
-					for (int x = 0, px = 0; x < outputWidth; x++) {
-						ox0 = x * xF;
-						ox1 = (int)ox0;
-						ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                            for (int x = 0, px = 0; x < outputWidth; x++)
+                            {
+                                ox0 = x * xF;
+                                ox1 = (int)ox0;
+                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-						dx1 = ox0 - ox1;
-						dx2 = 1.0 - dx1;
+                                dx1 = ox0 - ox1;
+                                dx2 = 1.0 - dx1;
 
-						output[yo0 + px] =
-							(byte)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								   (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-						px++; ox1++; ox2++;
+                                output[yo0 + px] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                                px++;
+                                ox1++;
+                                ox2++;
 
-						output[yo0 + px] =
-							(byte)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								   (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-						px++; ox1++; ox2++;
+                                output[yo0 + px] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                                px++;
+                                ox1++;
+                                ox2++;
 
-						output[yo0 + px] =
-							(byte)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								   (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-						px++; ox1++; ox2++;
+                                output[yo0 + px] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                                px++;
+                                ox1++;
+                                ox2++;
 
-						output[yo0 + px] =
-							(byte)((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2]))) +
-								   (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-						px++; ox1++; ox2++;
-					}
-				});
-			}
+                                output[yo0 + px] =
+                                    (byte)
+                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                                px++;
+                                ox1++;
+                                ox2++;
+                            }
+                        });
+            }
 
-			return output;
-		}
-	}
+            return output;
+        }
+    }
 }

--- a/DICOM/Imaging/BitDepth.cs
+++ b/DICOM/Imaging/BitDepth.cs
@@ -1,128 +1,138 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Text;
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// Extract image bit depth infomation from dataset and provide information for image rendering process
-	/// </summary>
-	public class BitDepth {
-		/// <summary>
-		/// Initialize the bit depth information using passed parameters
-		/// </summary>
-		/// <param name="allocated">Number of bits allocated per pixel sample (8,16,32) </param>
-		/// <param name="stored">Number of bits stored per pixel sample (from LSB to MSB)</param>
-		/// <param name="highBit">The high bit zero based index</param>
-		/// <param name="signed">True if pixel data signed (sign will be stored in the high bit)</param>
-		public BitDepth(int allocated, int stored, int highBit, bool signed) {
-			BitsAllocated = allocated;
-			BitsStored = stored;
-			HighBit = highBit;
-			IsSigned = signed;
-		}
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// Extract image bit depth infomation from dataset and provide information for image rendering process
+    /// </summary>
+    public class BitDepth
+    {
+        /// <summary>
+        /// Initialize the bit depth information using passed parameters
+        /// </summary>
+        /// <param name="allocated">Number of bits allocated per pixel sample (8,16,32) </param>
+        /// <param name="stored">Number of bits stored per pixel sample (from LSB to MSB)</param>
+        /// <param name="highBit">The high bit zero based index</param>
+        /// <param name="signed">True if pixel data signed (sign will be stored in the high bit)</param>
+        public BitDepth(int allocated, int stored, int highBit, bool signed)
+        {
+            BitsAllocated = allocated;
+            BitsStored = stored;
+            HighBit = highBit;
+            IsSigned = signed;
+        }
 
-		/// <summary>Number of bits allocated per sample. Generally 1, 4, 8, or 16.</summary>
-		public int BitsAllocated {
-			get; private set;
-		}
+        /// <summary>Number of bits allocated per sample. Generally 1, 4, 8, or 16.</summary>
+        public int BitsAllocated { get; private set; }
 
-		/// <summary>Number of bits stored per sample.</summary>
-		public int BitsStored {
-			get; private set;
-		}
+        /// <summary>Number of bits stored per sample.</summary>
+        public int BitsStored { get; private set; }
 
-		/// <summary>Highest value bit in sample.</summary>
-		public int HighBit {
-			get; private set;
-		}
+        /// <summary>Highest value bit in sample.</summary>
+        public int HighBit { get; private set; }
 
-		/// <summary>Samples are signed values if true.</summary>
-		public bool IsSigned {
-			get; private set;
-		}
-		/// <summary>
-		/// The maximum possible pixel value from stored bits
-		/// </summary>
-		public int MaximumValue {
-			get { return GetMaximumValue(BitsStored, IsSigned); }
-		}
+        /// <summary>Samples are signed values if true.</summary>
+        public bool IsSigned { get; private set; }
 
-		/// <summary>
-		/// The minimum possible pixel value from stored bits
-		/// </summary>
-		public int MinimumValue {
-			get { return GetMinimumValue(BitsStored, IsSigned); }
-		}
+        /// <summary>
+        /// The maximum possible pixel value from stored bits
+        /// </summary>
+        public int MaximumValue
+        {
+            get
+            {
+                return GetMaximumValue(BitsStored, IsSigned);
+            }
+        }
 
-		/// <summary>Rounds up to the next power of 2.</summary>
-		/// <param name="value"></param>
-		/// <returns>Next power of 2 or current value if already power of 2.</returns>
-		public static int GetNextPowerOf2(int value) {
-			// http://bits.stephan-brumme.com/roundUpToNextPowerOfTwo.html
-			value--;
-			value |= value >> 1;  // handle  2 bit numbers
-			value |= value >> 2;  // handle  4 bit numbers
-			value |= value >> 4;  // handle  8 bit numbers
-			value |= value >> 8;  // handle 16 bit numbers
-			value |= value >> 16; // handle 32 bit numbers
-			return value + 1;
-		}
+        /// <summary>
+        /// The minimum possible pixel value from stored bits
+        /// </summary>
+        public int MinimumValue
+        {
+            get
+            {
+                return GetMinimumValue(BitsStored, IsSigned);
+            }
+        }
 
-		/// <summary>
-		/// Calculate the minimum value for specified bits and sign
-		/// </summary>
-		/// <param name="bitsStored">Number of bits</param>
-		/// <param name="isSigned">True if signed</param>
-		/// <returns>The minimum value</returns>
-		public static int GetMinimumValue(int bitsStored, bool isSigned) {
-			if (isSigned) return -(1 << (bitsStored - 1));
-			return 0;
-		}
+        /// <summary>Rounds up to the next power of 2.</summary>
+        /// <param name="value"></param>
+        /// <returns>Next power of 2 or current value if already power of 2.</returns>
+        public static int GetNextPowerOf2(int value)
+        {
+            // http://bits.stephan-brumme.com/roundUpToNextPowerOfTwo.html
+            value--;
+            value |= value >> 1; // handle  2 bit numbers
+            value |= value >> 2; // handle  4 bit numbers
+            value |= value >> 4; // handle  8 bit numbers
+            value |= value >> 8; // handle 16 bit numbers
+            value |= value >> 16; // handle 32 bit numbers
+            return value + 1;
+        }
 
-		/// <summary>
-		/// Calculate the maximum value for specified bits and sign
-		/// </summary>
-		/// <param name="bitsStored">Number of bits</param>
-		/// <param name="isSigned">True if signed</param>
-		/// <returns>The maximum value</returns>
-		public static int GetMaximumValue(int bitsStored, bool isSigned) {
-			if (isSigned) return (1 << (bitsStored - 1)) - 1;
-			return (1 << bitsStored) - 1;
-		}
+        /// <summary>
+        /// Calculate the minimum value for specified bits and sign
+        /// </summary>
+        /// <param name="bitsStored">Number of bits</param>
+        /// <param name="isSigned">True if signed</param>
+        /// <returns>The minimum value</returns>
+        public static int GetMinimumValue(int bitsStored, bool isSigned)
+        {
+            if (isSigned) return -(1 << (bitsStored - 1));
+            return 0;
+        }
 
-		/// <summary>
-		/// Return the high data bit index (excluding sign bit if data is signed)
-		/// </summary>
-		/// <param name="bitsStored">Number of bits</param>
-		/// <param name="isSigned">True if signed</param>
-		/// <returns>Index of high data bit (excluding sign bit if data is signed)</returns>
-		public static int GetHighBit(int bitsStored, bool isSigned) {
-			if (isSigned) return bitsStored - 1;
-			return bitsStored;
-		}
+        /// <summary>
+        /// Calculate the maximum value for specified bits and sign
+        /// </summary>
+        /// <param name="bitsStored">Number of bits</param>
+        /// <param name="isSigned">True if signed</param>
+        /// <returns>The maximum value</returns>
+        public static int GetMaximumValue(int bitsStored, bool isSigned)
+        {
+            if (isSigned) return (1 << (bitsStored - 1)) - 1;
+            return (1 << bitsStored) - 1;
+        }
 
-		/// <summary>
-		/// Create new instance of <seealso cref="BitDpeth"/> from input <paramref name="dataset"/>
-		/// </summary>
-		/// <param name="dataset">Input dataset to extract bit depth information from</param>
-		/// <returns>New <seealso cref="BitDepth"/> instance</returns>
-		public static BitDepth FromDataset(DicomDataset dataset) {
-			var allocated = dataset.Get<ushort>(DicomTag.BitsAllocated);
-			var stored = dataset.Get<ushort>(DicomTag.BitsStored);
-			var signed = dataset.Get<PixelRepresentation>(DicomTag.PixelRepresentation) == PixelRepresentation.Signed;
-			return new BitDepth(allocated, stored, GetHighBit(stored, signed), signed);
-		}
+        /// <summary>
+        /// Return the high data bit index (excluding sign bit if data is signed)
+        /// </summary>
+        /// <param name="bitsStored">Number of bits</param>
+        /// <param name="isSigned">True if signed</param>
+        /// <returns>Index of high data bit (excluding sign bit if data is signed)</returns>
+        public static int GetHighBit(int bitsStored, bool isSigned)
+        {
+            if (isSigned) return bitsStored - 1;
+            return bitsStored;
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendLine("Bits: {");
-			sb.AppendFormat("    Allocated: {0}\n", BitsAllocated);
-			sb.AppendFormat("       Stored: {0}\n", BitsStored);
-			sb.AppendFormat("     High Bit: {0}\n", HighBit);
-			sb.AppendFormat("       Signed: {0}\n", IsSigned);
-			sb.AppendLine("}");
-			return sb.ToString();
-		}
-	}
+        /// <summary>
+        /// Create new instance of <seealso cref="BitDpeth"/> from input <paramref name="dataset"/>
+        /// </summary>
+        /// <param name="dataset">Input dataset to extract bit depth information from</param>
+        /// <returns>New <seealso cref="BitDepth"/> instance</returns>
+        public static BitDepth FromDataset(DicomDataset dataset)
+        {
+            var allocated = dataset.Get<ushort>(DicomTag.BitsAllocated);
+            var stored = dataset.Get<ushort>(DicomTag.BitsStored);
+            var signed = dataset.Get<PixelRepresentation>(DicomTag.PixelRepresentation) == PixelRepresentation.Signed;
+            return new BitDepth(allocated, stored, GetHighBit(stored, signed), signed);
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("Bits: {");
+            sb.AppendFormat("    Allocated: {0}\n", BitsAllocated);
+            sb.AppendFormat("       Stored: {0}\n", BitsStored);
+            sb.AppendFormat("     High Bit: {0}\n", HighBit);
+            sb.AppendFormat("       Signed: {0}\n", IsSigned);
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Imaging/Codec/DicomCodecException.cs
+++ b/DICOM/Imaging/Codec/DicomCodecException.cs
@@ -1,17 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Codec {
-	public class DicomCodecException : DicomException {
-		public DicomCodecException(string message) : base(message) {
-		}
+using System;
 
-		public DicomCodecException(string format, params object[] args) : base(format, args) {
-		}
+namespace Dicom.Imaging.Codec
+{
+    public class DicomCodecException : DicomException
+    {
+        public DicomCodecException(string message)
+            : base(message)
+        {
+        }
 
-		public DicomCodecException(string message, Exception innerException) : base(message, innerException) {
-		}
-	}
+        public DicomCodecException(string format, params object[] args)
+            : base(format, args)
+        {
+        }
+
+        public DicomCodecException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/DICOM/Imaging/Codec/DicomCodecExtensions.cs
+++ b/DICOM/Imaging/Codec/DicomCodecExtensions.cs
@@ -1,22 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Codec {
-	public static class DicomCodecExtensions {
-		public static DicomFile ChangeTransferSyntax(this DicomFile file, DicomTransferSyntax syntax, DicomCodecParams parameters = null) {
-			DicomTranscoder transcoder = new DicomTranscoder(file.FileMetaInfo.TransferSyntax, syntax);
-			transcoder.InputCodecParams = parameters;
-			transcoder.OutputCodecParams = parameters;
-			return transcoder.Transcode(file);
-		}
+namespace Dicom.Imaging.Codec
+{
+    public static class DicomCodecExtensions
+    {
+        public static DicomFile ChangeTransferSyntax(
+            this DicomFile file,
+            DicomTransferSyntax syntax,
+            DicomCodecParams parameters = null)
+        {
+            DicomTranscoder transcoder = new DicomTranscoder(file.FileMetaInfo.TransferSyntax, syntax);
+            transcoder.InputCodecParams = parameters;
+            transcoder.OutputCodecParams = parameters;
+            return transcoder.Transcode(file);
+        }
 
-		public static DicomDataset ChangeTransferSyntax(this DicomDataset dataset, DicomTransferSyntax syntax, DicomCodecParams parameters = null) {
-			DicomTranscoder transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, syntax);
-			transcoder.InputCodecParams = parameters;
-			transcoder.OutputCodecParams = parameters;
-			return transcoder.Transcode(dataset);
-		}
-	}
+        public static DicomDataset ChangeTransferSyntax(
+            this DicomDataset dataset,
+            DicomTransferSyntax syntax,
+            DicomCodecParams parameters = null)
+        {
+            DicomTranscoder transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, syntax);
+            transcoder.InputCodecParams = parameters;
+            transcoder.OutputCodecParams = parameters;
+            return transcoder.Transcode(dataset);
+        }
+    }
 }

--- a/DICOM/Imaging/Codec/DicomCodecParams.cs
+++ b/DICOM/Imaging/Codec/DicomCodecParams.cs
@@ -1,16 +1,17 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
 using Dicom.Log;
 
-namespace Dicom.Imaging.Codec {
-	public class DicomCodecParams {
-		protected DicomCodecParams() {
-			Logger = LogManager.Default.GetLogger("Dicom.Imaging.Codec");
-		}
+namespace Dicom.Imaging.Codec
+{
+    public class DicomCodecParams
+    {
+        protected DicomCodecParams()
+        {
+            Logger = LogManager.Default.GetLogger("Dicom.Imaging.Codec");
+        }
 
-		public Logger Logger {
-			get;
-			protected set;
-		}
-	}
+        public Logger Logger { get; protected set; }
+    }
 }

--- a/DICOM/Imaging/Codec/DicomJpeg2000Codec.cs
+++ b/DICOM/Imaging/Codec/DicomJpeg2000Codec.cs
@@ -1,88 +1,155 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Codec {
-	public class DicomJpeg2000Params : DicomCodecParams {
-		private bool _irreversible;
-		private int _rate;
-		private int[] _rates;
-		private bool _isVerbose;
-		private bool _enableMct;
-		private bool _updatePmi;
-		private bool _signedAsUnsigned;
+namespace Dicom.Imaging.Codec
+{
+    public class DicomJpeg2000Params : DicomCodecParams
+    {
+        private bool _irreversible;
 
-		public DicomJpeg2000Params() {
-			_irreversible = true;
-			_rate = 20;
-			_isVerbose = false;
-			_enableMct = true;
-			_updatePmi = true;
-			_signedAsUnsigned = false;
+        private int _rate;
 
-			_rates = new int[9];
-			_rates[0] = 1280;
-			_rates[1] = 640;
-			_rates[2] = 320;
-			_rates[3] = 160;
-			_rates[4] = 80;
-			_rates[5] = 40;
-			_rates[6] = 20;
-			_rates[7] = 10;
-			_rates[8] = 5;
-		}
+        private int[] _rates;
 
-		public bool Irreversible {
-			get { return _irreversible; }
-			set { _irreversible = value; }
-		}
+        private bool _isVerbose;
 
-		public int Rate {
-			get { return _rate; }
-			set { _rate = value; }
-		}
+        private bool _enableMct;
 
-		public int[] RateLevels {
-			get { return _rates; }
-			set { _rates = value; }
-		}
+        private bool _updatePmi;
 
-		public bool IsVerbose {
-			get { return _isVerbose; }
-			set { _isVerbose = value; }
-		}
+        private bool _signedAsUnsigned;
 
-		public bool AllowMCT {
-			get { return _enableMct; }
-			set { _enableMct = value; }
-		}
+        public DicomJpeg2000Params()
+        {
+            _irreversible = true;
+            _rate = 20;
+            _isVerbose = false;
+            _enableMct = true;
+            _updatePmi = true;
+            _signedAsUnsigned = false;
 
-		public bool UpdatePhotometricInterpretation {
-			get { return _updatePmi; }
-			set { _updatePmi = value; }
-		}
+            _rates = new int[9];
+            _rates[0] = 1280;
+            _rates[1] = 640;
+            _rates[2] = 320;
+            _rates[3] = 160;
+            _rates[4] = 80;
+            _rates[5] = 40;
+            _rates[6] = 20;
+            _rates[7] = 10;
+            _rates[8] = 5;
+        }
 
-		public bool EncodeSignedPixelValuesAsUnsigned {
-			get { return _signedAsUnsigned; }
-			set { _signedAsUnsigned = value; }
-		}
-	}
+        public bool Irreversible
+        {
+            get
+            {
+                return _irreversible;
+            }
+            set
+            {
+                _irreversible = value;
+            }
+        }
 
-	public abstract class DicomJpeg2000Codec : IDicomCodec {
-		public string Name {
-			get { return TransferSyntax.UID.Name; }
-		}
+        public int Rate
+        {
+            get
+            {
+                return _rate;
+            }
+            set
+            {
+                _rate = value;
+            }
+        }
 
-		public abstract DicomTransferSyntax TransferSyntax {
-			get;
-		}
+        public int[] RateLevels
+        {
+            get
+            {
+                return _rates;
+            }
+            set
+            {
+                _rates = value;
+            }
+        }
 
-		public DicomCodecParams GetDefaultParameters() {
-			return new DicomJpeg2000Params();
-		}
+        public bool IsVerbose
+        {
+            get
+            {
+                return _isVerbose;
+            }
+            set
+            {
+                _isVerbose = value;
+            }
+        }
 
-		public abstract void Encode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-		public abstract void Decode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-	}
+        public bool AllowMCT
+        {
+            get
+            {
+                return _enableMct;
+            }
+            set
+            {
+                _enableMct = value;
+            }
+        }
+
+        public bool UpdatePhotometricInterpretation
+        {
+            get
+            {
+                return _updatePmi;
+            }
+            set
+            {
+                _updatePmi = value;
+            }
+        }
+
+        public bool EncodeSignedPixelValuesAsUnsigned
+        {
+            get
+            {
+                return _signedAsUnsigned;
+            }
+            set
+            {
+                _signedAsUnsigned = value;
+            }
+        }
+    }
+
+    public abstract class DicomJpeg2000Codec : IDicomCodec
+    {
+        public string Name
+        {
+            get
+            {
+                return TransferSyntax.UID.Name;
+            }
+        }
+
+        public abstract DicomTransferSyntax TransferSyntax { get; }
+
+        public DicomCodecParams GetDefaultParameters()
+        {
+            return new DicomJpeg2000Params();
+        }
+
+        public abstract void Encode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+
+        public abstract void Decode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+    }
 }

--- a/DICOM/Imaging/Codec/DicomJpegCodec.cs
+++ b/DICOM/Imaging/Codec/DicomJpegCodec.cs
@@ -1,186 +1,253 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.IO;
 
 using Dicom.IO;
 using Dicom.IO.Buffer;
 
-namespace Dicom.Imaging.Codec {
-	public enum DicomJpegSampleFactor {
-		SF444,
-		SF422,
-		Unknown
-	}
+namespace Dicom.Imaging.Codec
+{
+    public enum DicomJpegSampleFactor
+    {
+        SF444,
 
-	public class DicomJpegParams : DicomCodecParams {
-		private int _quality;
-		private int _smoothing;
-		private bool _convertColorspace;
-		private DicomJpegSampleFactor _sample;
-		private int _predictor;
-		private int _pointTransform;
+        SF422,
 
-		public DicomJpegParams() {
-			_quality = 90;
-			_smoothing = 0;
-			_convertColorspace = false;
-			_sample = DicomJpegSampleFactor.SF444;
-			_predictor = 1;
-			_pointTransform = 0;
-		}
+        Unknown
+    }
 
-		public int Quality {
-			get { return _quality; }
-			set { _quality = value; }
-		}
+    public class DicomJpegParams : DicomCodecParams
+    {
+        private int _quality;
 
-		public int SmoothingFactor {
-			get { return _smoothing; }
-			set { _smoothing = value; }
-		}
+        private int _smoothing;
 
-		public bool ConvertColorspaceToRGB {
-			get { return _convertColorspace; }
-			set { _convertColorspace = value; }
-		}
+        private bool _convertColorspace;
 
-		public DicomJpegSampleFactor SampleFactor {
-			get { return _sample; }
-			set { _sample = value; }
-		}
+        private DicomJpegSampleFactor _sample;
 
-		public int Predictor {
-			get { return _predictor; }
-			set { _predictor = value; }
-		}
+        private int _predictor;
 
-		public int PointTransform {
-			get { return _pointTransform; }
-			set { _pointTransform = value; }
-		}
-	}
+        private int _pointTransform;
 
-	public abstract class DicomJpegCodec : IDicomCodec {
-		public string Name {
-			get { return TransferSyntax.UID.Name; }
-		}
+        public DicomJpegParams()
+        {
+            _quality = 90;
+            _smoothing = 0;
+            _convertColorspace = false;
+            _sample = DicomJpegSampleFactor.SF444;
+            _predictor = 1;
+            _pointTransform = 0;
+        }
 
-		public abstract DicomTransferSyntax TransferSyntax {
-			get;
-		}
+        public int Quality
+        {
+            get
+            {
+                return _quality;
+            }
+            set
+            {
+                _quality = value;
+            }
+        }
 
-		public DicomCodecParams GetDefaultParameters() {
-			return new DicomJpegParams();
-		}
+        public int SmoothingFactor
+        {
+            get
+            {
+                return _smoothing;
+            }
+            set
+            {
+                _smoothing = value;
+            }
+        }
 
-		public abstract void Encode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-		public abstract void Decode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-	}
+        public bool ConvertColorspaceToRGB
+        {
+            get
+            {
+                return _convertColorspace;
+            }
+            set
+            {
+                _convertColorspace = value;
+            }
+        }
 
-namespace Jpeg {
-	public static class JpegHelper {
-		//DCMTK djcodecd.cxx
-		public static int ScanJpegForBitDepth(DicomPixelData pixelData) {
-			DicomItem item = pixelData.Dataset.Get<DicomItem>(DicomTag.PixelData);
-			IByteBuffer buffer;
-			if (item is DicomFragmentSequence)
-				buffer = (item as DicomFragmentSequence).Fragments[0];
-			else
-				buffer = (item as DicomElement).Buffer;
-			MemoryStream ms = new MemoryStream(buffer.Data);
-			BinaryReader br = EndianBinaryReader.Create(ms, Endian.Big);
+        public DicomJpegSampleFactor SampleFactor
+        {
+            get
+            {
+                return _sample;
+            }
+            set
+            {
+                _sample = value;
+            }
+        }
 
-			long length = ms.Length;
-			while (ms.Position < length) {
-				ushort marker = br.ReadUInt16();
-				switch (marker) {
-				case 0xffc0: // SOF_0: JPEG baseline
-				case 0xffc1: // SOF_1: JPEG extended sequential DCT
-				case 0xffc2: // SOF_2: JPEG progressive DCT
-				case 0xffc3: // SOF_3: JPEG lossless sequential
-				case 0xffc5: // SOF_5: differential (hierarchical) extended sequential, Huffman
-				case 0xffc6: // SOF_6: differential (hierarchical) progressive, Huffman
-				case 0xffc7: // SOF_7: differential (hierarchical) lossless, Huffman
-					ms.Seek(2, SeekOrigin.Current);
-					return (int)br.ReadByte();
-				case 0xffc8: // Reserved for JPEG extentions
-					ms.Seek(br.ReadUInt16() - 2, SeekOrigin.Current);
-					break;
-				case 0xffc9: // SOF_9: extended sequential, arithmetic
-				case 0xffca: // SOF_10: progressive, arithmetic
-				case 0xffcb: // SOF_11: lossless, arithmetic
-				case 0xffcd: // SOF_13: differential (hierarchical) extended sequential, arithmetic
-				case 0xffce: // SOF_14: differential (hierarchical) progressive, arithmetic
-				case 0xffcf: // SOF_15: differential (hierarchical) lossless, arithmetic
-					ms.Seek(2, SeekOrigin.Current);
-					return (int)br.ReadByte();
-				case 0xffc4: // DHT
-				case 0xffcc: // DAC
-					ms.Seek(br.ReadUInt16() - 2, SeekOrigin.Current);
-					break;
-				case 0xffd0: // RST m
-				case 0xffd1:
-				case 0xffd2:
-				case 0xffd3:
-				case 0xffd4:
-				case 0xffd5:
-				case 0xffd6:
-				case 0xffd7:
-				case 0xffd8: // SOI
-				case 0xffd9: // EOI
-					break;
-				case 0xffda: // SOS
-				case 0xffdb: // DQT
-				case 0xffdc: // DNL
-				case 0xffdd: // DRI
-				case 0xffde: // DHP
-				case 0xffdf: // EXP
-				case 0xffe0: // APPn
-				case 0xffe1:
-				case 0xffe2:
-				case 0xffe3:
-				case 0xffe4:
-				case 0xffe5:
-				case 0xffe6:
-				case 0xffe7:
-				case 0xffe8:
-				case 0xffe9:
-				case 0xffea:
-				case 0xffeb:
-				case 0xffec:
-				case 0xffed:
-				case 0xffee:
-				case 0xffef:
-				case 0xfff0: // JPGn
-				case 0xfff1:
-				case 0xfff2:
-				case 0xfff3:
-				case 0xfff4:
-				case 0xfff5:
-				case 0xfff6:
-				case 0xfff7:
-				case 0xfff8:
-				case 0xfff9:
-				case 0xfffa:
-				case 0xfffb:
-				case 0xfffc:
-				case 0xfffd:
-				case 0xfffe: // COM
-					ms.Seek(br.ReadUInt16() - 2, SeekOrigin.Current);
-					break;
-				case 0xff01: // TEM
-					break;
-				default:
-					int b1 = br.ReadByte();
-					int b2 = br.ReadByte();
-					if (b1 == 0xff && b2 > 2 && b2 <= 0xbf) // RES reserved markers
-						break;
-					else
-						throw new DicomCodecException("Unable to determine bit depth: JPEG syntax error!");
-				}
-			}
-			throw new DicomCodecException("Unable to determine bit depth: no JPEG SOF marker found!");
-		}
-	}
-}
+        public int Predictor
+        {
+            get
+            {
+                return _predictor;
+            }
+            set
+            {
+                _predictor = value;
+            }
+        }
+
+        public int PointTransform
+        {
+            get
+            {
+                return _pointTransform;
+            }
+            set
+            {
+                _pointTransform = value;
+            }
+        }
+    }
+
+    public abstract class DicomJpegCodec : IDicomCodec
+    {
+        public string Name
+        {
+            get
+            {
+                return TransferSyntax.UID.Name;
+            }
+        }
+
+        public abstract DicomTransferSyntax TransferSyntax { get; }
+
+        public DicomCodecParams GetDefaultParameters()
+        {
+            return new DicomJpegParams();
+        }
+
+        public abstract void Encode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+
+        public abstract void Decode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+    }
+
+    namespace Jpeg
+    {
+        public static class JpegHelper
+        {
+            //DCMTK djcodecd.cxx
+            public static int ScanJpegForBitDepth(DicomPixelData pixelData)
+            {
+                DicomItem item = pixelData.Dataset.Get<DicomItem>(DicomTag.PixelData);
+                IByteBuffer buffer;
+                if (item is DicomFragmentSequence) buffer = (item as DicomFragmentSequence).Fragments[0];
+                else buffer = (item as DicomElement).Buffer;
+                MemoryStream ms = new MemoryStream(buffer.Data);
+                BinaryReader br = EndianBinaryReader.Create(ms, Endian.Big);
+
+                long length = ms.Length;
+                while (ms.Position < length)
+                {
+                    ushort marker = br.ReadUInt16();
+                    switch (marker)
+                    {
+                        case 0xffc0: // SOF_0: JPEG baseline
+                        case 0xffc1: // SOF_1: JPEG extended sequential DCT
+                        case 0xffc2: // SOF_2: JPEG progressive DCT
+                        case 0xffc3: // SOF_3: JPEG lossless sequential
+                        case 0xffc5: // SOF_5: differential (hierarchical) extended sequential, Huffman
+                        case 0xffc6: // SOF_6: differential (hierarchical) progressive, Huffman
+                        case 0xffc7: // SOF_7: differential (hierarchical) lossless, Huffman
+                            ms.Seek(2, SeekOrigin.Current);
+                            return (int)br.ReadByte();
+                        case 0xffc8: // Reserved for JPEG extentions
+                            ms.Seek(br.ReadUInt16() - 2, SeekOrigin.Current);
+                            break;
+                        case 0xffc9: // SOF_9: extended sequential, arithmetic
+                        case 0xffca: // SOF_10: progressive, arithmetic
+                        case 0xffcb: // SOF_11: lossless, arithmetic
+                        case 0xffcd: // SOF_13: differential (hierarchical) extended sequential, arithmetic
+                        case 0xffce: // SOF_14: differential (hierarchical) progressive, arithmetic
+                        case 0xffcf: // SOF_15: differential (hierarchical) lossless, arithmetic
+                            ms.Seek(2, SeekOrigin.Current);
+                            return (int)br.ReadByte();
+                        case 0xffc4: // DHT
+                        case 0xffcc: // DAC
+                            ms.Seek(br.ReadUInt16() - 2, SeekOrigin.Current);
+                            break;
+                        case 0xffd0: // RST m
+                        case 0xffd1:
+                        case 0xffd2:
+                        case 0xffd3:
+                        case 0xffd4:
+                        case 0xffd5:
+                        case 0xffd6:
+                        case 0xffd7:
+                        case 0xffd8: // SOI
+                        case 0xffd9: // EOI
+                            break;
+                        case 0xffda: // SOS
+                        case 0xffdb: // DQT
+                        case 0xffdc: // DNL
+                        case 0xffdd: // DRI
+                        case 0xffde: // DHP
+                        case 0xffdf: // EXP
+                        case 0xffe0: // APPn
+                        case 0xffe1:
+                        case 0xffe2:
+                        case 0xffe3:
+                        case 0xffe4:
+                        case 0xffe5:
+                        case 0xffe6:
+                        case 0xffe7:
+                        case 0xffe8:
+                        case 0xffe9:
+                        case 0xffea:
+                        case 0xffeb:
+                        case 0xffec:
+                        case 0xffed:
+                        case 0xffee:
+                        case 0xffef:
+                        case 0xfff0: // JPGn
+                        case 0xfff1:
+                        case 0xfff2:
+                        case 0xfff3:
+                        case 0xfff4:
+                        case 0xfff5:
+                        case 0xfff6:
+                        case 0xfff7:
+                        case 0xfff8:
+                        case 0xfff9:
+                        case 0xfffa:
+                        case 0xfffb:
+                        case 0xfffc:
+                        case 0xfffd:
+                        case 0xfffe: // COM
+                            ms.Seek(br.ReadUInt16() - 2, SeekOrigin.Current);
+                            break;
+                        case 0xff01: // TEM
+                            break;
+                        default:
+                            int b1 = br.ReadByte();
+                            int b2 = br.ReadByte();
+                            if (b1 == 0xff && b2 > 2 && b2 <= 0xbf) // RES reserved markers
+                                break;
+                            else throw new DicomCodecException("Unable to determine bit depth: JPEG syntax error!");
+                    }
+                }
+                throw new DicomCodecException("Unable to determine bit depth: no JPEG SOF marker found!");
+            }
+        }
+    }
 }

--- a/DICOM/Imaging/Codec/DicomJpegLsCodec.cs
+++ b/DICOM/Imaging/Codec/DicomJpegLsCodec.cs
@@ -1,63 +1,105 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Codec {
-	public enum DicomJpegLsInterleaveMode {
-		None = 0,
-		Line = 1,
-		Sample = 2
-	};
+namespace Dicom.Imaging.Codec
+{
+    public enum DicomJpegLsInterleaveMode
+    {
+        None = 0,
 
-	public enum DicomJpegLsColorTransform {
-		None = 0,
-		HP1 = 1,
-		HP2 = 2,
-		HP3 = 3
-	};
+        Line = 1,
 
-	public class DicomJpegLsParams : DicomCodecParams {
-		private int _allowedError;
-		private DicomJpegLsInterleaveMode _ilMode;
-		private DicomJpegLsColorTransform _colorTransform;
+        Sample = 2
+    };
 
-		public DicomJpegLsParams() {
-			_allowedError = 3;
-			_ilMode = DicomJpegLsInterleaveMode.Line;
-			_colorTransform = DicomJpegLsColorTransform.HP1;
-		}
+    public enum DicomJpegLsColorTransform
+    {
+        None = 0,
 
-		public int AllowedError {
-			get { return _allowedError; }
-			set { _allowedError = value; }
-		}
+        HP1 = 1,
 
-		public DicomJpegLsInterleaveMode InterleaveMode {
-			get { return _ilMode; }
-			set { _ilMode = value; }
-		}
+        HP2 = 2,
 
-		public DicomJpegLsColorTransform ColorTransform {
-			get { return _colorTransform; }
-			set { _colorTransform = value; }
-		}
-	};
+        HP3 = 3
+    };
 
-	public abstract class DicomJpegLsCodec : IDicomCodec {
-		public string Name {
-			get { return TransferSyntax.UID.Name; }
-		}
+    public class DicomJpegLsParams : DicomCodecParams
+    {
+        private int _allowedError;
 
-		public abstract DicomTransferSyntax TransferSyntax {
-			get;
-		}
+        private DicomJpegLsInterleaveMode _ilMode;
 
-		public DicomCodecParams GetDefaultParameters() {
-			return new DicomJpegLsParams();
-		}
+        private DicomJpegLsColorTransform _colorTransform;
 
-		public abstract void Encode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-		public abstract void Decode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-	};
+        public DicomJpegLsParams()
+        {
+            _allowedError = 3;
+            _ilMode = DicomJpegLsInterleaveMode.Line;
+            _colorTransform = DicomJpegLsColorTransform.HP1;
+        }
+
+        public int AllowedError
+        {
+            get
+            {
+                return _allowedError;
+            }
+            set
+            {
+                _allowedError = value;
+            }
+        }
+
+        public DicomJpegLsInterleaveMode InterleaveMode
+        {
+            get
+            {
+                return _ilMode;
+            }
+            set
+            {
+                _ilMode = value;
+            }
+        }
+
+        public DicomJpegLsColorTransform ColorTransform
+        {
+            get
+            {
+                return _colorTransform;
+            }
+            set
+            {
+                _colorTransform = value;
+            }
+        }
+    };
+
+    public abstract class DicomJpegLsCodec : IDicomCodec
+    {
+        public string Name
+        {
+            get
+            {
+                return TransferSyntax.UID.Name;
+            }
+        }
+
+        public abstract DicomTransferSyntax TransferSyntax { get; }
+
+        public DicomCodecParams GetDefaultParameters()
+        {
+            return new DicomJpegLsParams();
+        }
+
+        public abstract void Encode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+
+        public abstract void Decode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+    };
 }

--- a/DICOM/Imaging/Codec/DicomRleCodec.cs
+++ b/DICOM/Imaging/Codec/DicomRleCodec.cs
@@ -1,23 +1,39 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Codec {
-	public abstract class DicomRleCodec : IDicomCodec {
-		public string Name {
-			get { return DicomTransferSyntax.RLELossless.UID.Name; }
-		}
+namespace Dicom.Imaging.Codec
+{
+    public abstract class DicomRleCodec : IDicomCodec
+    {
+        public string Name
+        {
+            get
+            {
+                return DicomTransferSyntax.RLELossless.UID.Name;
+            }
+        }
 
-		public DicomTransferSyntax TransferSyntax {
-			get { return DicomTransferSyntax.RLELossless; }
-		}
+        public DicomTransferSyntax TransferSyntax
+        {
+            get
+            {
+                return DicomTransferSyntax.RLELossless;
+            }
+        }
 
-		public DicomCodecParams GetDefaultParameters() {
-			return null;
-		}
+        public DicomCodecParams GetDefaultParameters()
+        {
+            return null;
+        }
 
-		public abstract void Encode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-		public abstract void Decode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-	}
+        public abstract void Encode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+
+        public abstract void Decode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+    }
 }

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -1,297 +1,322 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.ComponentModel.Composition.Hosting;
 
 using Dicom.Imaging.Render;
-using Dicom.IO;
 using Dicom.IO.Buffer;
 using Dicom.IO.Writer;
 using Dicom.Log;
 
-namespace Dicom.Imaging.Codec {
-	public class DicomTranscoder {
-		#region Static
-		private static Dictionary<DicomTransferSyntax,IDicomCodec> _codecs = new Dictionary<DicomTransferSyntax,IDicomCodec>();
-
-		static DicomTranscoder() {
-			LoadCodecs();
-		}
-
-		public static IDicomCodec GetCodec(DicomTransferSyntax syntax) {
-			IDicomCodec codec = null;
-			if (!_codecs.TryGetValue(syntax, out codec))
-				throw new DicomCodecException("No codec registered for tranfer syntax: {0}", syntax);
-			return codec;
-		}
-
-		public static void LoadCodecs(string path = null, string search = null) {
-			if (path == null)
-				path = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
-
-		    if (search == null)
-		        search = "Dicom.Native*.dll";
-
-			var log = LogManager.Default.GetLogger("Dicom.Imaging.Codec");
-		    log.Debug("Searching {path}\\{wildcard} for Dicom codecs", path, search);
-
-		    var foundAnyCodecs = false;
-
-		    DirectoryCatalog catalog;
-		    try {
-		        catalog = new DirectoryCatalog(path, search);
-		    }
-		    catch (Exception ex) {
-		        log.Error("Error encountered creating new DirectCatalog({path}, {search}) - {@exception}", path, search, ex);
-		        throw;
-		    }
-
-			var container = new CompositionContainer(catalog);
-			foreach (var lazy in container.GetExports<IDicomCodec>()) {
-			    foundAnyCodecs = true;
-				var codec = lazy.Value;
-				log.Debug("Codec: {codecName}", codec.TransferSyntax.UID.Name);
-				_codecs[codec.TransferSyntax] = codec;
-			}
-
-		    if (!foundAnyCodecs) {
-		        log.Warn("No Dicom codecs were found after searching {path}\\{wildcard}", path, search);
-		    }
-		}
-		#endregion
-
-		public DicomTranscoder(DicomTransferSyntax input, DicomTransferSyntax output) {
-			InputSyntax = input;
-			OutputSyntax = output;
-		}
-
-		public DicomTransferSyntax InputSyntax {
-			get;
-			private set;
-		}
-
-		public DicomCodecParams InputCodecParams {
-			get;
-			set;
-		}
-
-		private IDicomCodec _inputCodec;
-		private IDicomCodec InputCodec {
-			get {
-				if (InputSyntax.IsEncapsulated && _inputCodec == null)
-					_inputCodec = GetCodec(InputSyntax);
-				return _inputCodec;
-			}
-		}
-
-		public DicomTransferSyntax OutputSyntax {
-			get;
-			private set;
-		}
-
-		public DicomCodecParams OutputCodecParams {
-			get;
-			set;
-		}
-
-		private IDicomCodec _outputCodec;
-		private IDicomCodec OutputCodec {
-			get {
-				if (OutputSyntax.IsEncapsulated && _outputCodec == null)
-					_outputCodec = GetCodec(OutputSyntax);
-				return _outputCodec;
-			}
-		}
-
-		public DicomFile Transcode(DicomFile file) {
-			DicomFile f = new DicomFile();
-			f.FileMetaInfo.Add(file.FileMetaInfo);
-			f.FileMetaInfo.TransferSyntax = OutputSyntax;
-			f.Dataset.InternalTransferSyntax = OutputSyntax;
-			f.Dataset.Add(Transcode(file.Dataset));
-			return f;
-		}
-
-		public DicomDataset Transcode(DicomDataset dataset) {
-			if (!dataset.Contains(DicomTag.PixelData)) {
-				var newDataset = dataset.Clone();
-				newDataset.InternalTransferSyntax = OutputSyntax;
-				newDataset.RecalculateGroupLengths(false);
-				return newDataset;
-			}
-
-			if (!InputSyntax.IsEncapsulated && !OutputSyntax.IsEncapsulated) {
-				// transcode from uncompressed to uncompressed
-				var newDataset = dataset.Clone();
-				newDataset.InternalTransferSyntax = OutputSyntax;
-
-				var oldPixelData = DicomPixelData.Create(dataset, false);
-				var newPixelData = DicomPixelData.Create(newDataset, true);
-
-				for (int i = 0; i < oldPixelData.NumberOfFrames; i++) {
-					var frame = oldPixelData.GetFrame(i);
-					newPixelData.AddFrame(frame);
-				}
-
-				ProcessOverlays(dataset, newDataset);
-
-				newDataset.RecalculateGroupLengths(false);
-
-				return newDataset;
-			}
-
-			if (InputSyntax.IsEncapsulated && OutputSyntax.IsEncapsulated) {
-				// transcode from compressed to compressed
-				var temp = Decode(dataset, DicomTransferSyntax.ExplicitVRLittleEndian, InputCodec, InputCodecParams);
-				return Encode(temp, OutputSyntax, OutputCodec, OutputCodecParams);
-			}
-
-			if (InputSyntax.IsEncapsulated) {
-				// transcode from compressed to uncompressed
-				return Decode(dataset, OutputSyntax, InputCodec, InputCodecParams);
-			}
-
-			if (OutputSyntax.IsEncapsulated) {
-				// transcode from uncompressed to compressed
-				return Encode(dataset, OutputSyntax, OutputCodec, OutputCodecParams);
-			}
-
-			throw new DicomCodecException("Unable to find transcoding solution for {0} to {1}", InputSyntax.UID.Name, OutputSyntax.UID.Name);
-		}
-
-		/// <summary>
-		/// Decompress single frame from DICOM dataset and return uncompressed frame buffer.
-		/// </summary>
-		/// <param name="dataset">DICOM dataset</param>
-		/// <param name="frame">Frame number</param>
-		/// <returns>Uncompressed frame buffer</returns>
-		public IByteBuffer DecodeFrame(DicomDataset dataset, int frame) {
-			var pixelData = DicomPixelData.Create(dataset, false);
-			var buffer = pixelData.GetFrame(frame);
-
-			// is pixel data already uncompressed?
-			if (!dataset.InternalTransferSyntax.IsEncapsulated)
-				return buffer;
-
-			// clone dataset to prevent changes to source
-			var cloneDataset = dataset.Clone();
-
-			var oldPixelData = DicomPixelData.Create(cloneDataset, true);
-			oldPixelData.AddFrame(buffer);
-
-			var newDataset = Decode(cloneDataset, OutputSyntax, InputCodec, InputCodecParams);
-			var newPixelData = DicomPixelData.Create(newDataset, false);
-
-			return newPixelData.GetFrame(0);
-		}
-
-		public IPixelData DecodePixelData(DicomDataset dataset, int frame) {
-			var pixelData = DicomPixelData.Create(dataset, false);
-			
-			// is pixel data already uncompressed?
-			if (!dataset.InternalTransferSyntax.IsEncapsulated)
-				return PixelDataFactory.Create(pixelData, frame);
-
-			var buffer = pixelData.GetFrame(frame);
-
-			// clone dataset to prevent changes to source
-			var cloneDataset = dataset.Clone();
-
-			var oldPixelData = DicomPixelData.Create(cloneDataset, true);
-			oldPixelData.AddFrame(buffer);
-
-			var newDataset = Decode(cloneDataset, OutputSyntax, InputCodec, InputCodecParams);
-			var newPixelData = DicomPixelData.Create(newDataset, false);
-
-			return PixelDataFactory.Create(newPixelData, 0);
-		}
-
-		private DicomDataset Decode(DicomDataset oldDataset, DicomTransferSyntax outSyntax, IDicomCodec codec, DicomCodecParams parameters) {
-			DicomPixelData oldPixelData = DicomPixelData.Create(oldDataset, false);
-
-			DicomDataset newDataset = oldDataset.Clone();
-			newDataset.InternalTransferSyntax = outSyntax;
-			DicomPixelData newPixelData = DicomPixelData.Create(newDataset, true);
-
-			codec.Decode(oldPixelData, newPixelData, parameters);
-
-			ProcessOverlays(oldDataset, newDataset);
-
-			newDataset.RecalculateGroupLengths(false);
-
-			return newDataset;
-		}
-
-		private DicomDataset Encode(DicomDataset oldDataset, DicomTransferSyntax inSyntax, IDicomCodec codec, DicomCodecParams parameters) {
-			DicomPixelData oldPixelData = DicomPixelData.Create(oldDataset, false);
-
-			DicomDataset newDataset = oldDataset.Clone();
-			newDataset.InternalTransferSyntax = codec.TransferSyntax;
-			DicomPixelData newPixelData = DicomPixelData.Create(newDataset, true);
-
-			codec.Encode(oldPixelData, newPixelData, parameters);
-
-			if (codec.TransferSyntax.IsLossy && newPixelData.NumberOfFrames > 0) {
-				newDataset.Add(new DicomCodeString(DicomTag.LossyImageCompression, "01"));
-
-				List<string> methods = new List<string>();
-				if (newDataset.Contains(DicomTag.LossyImageCompressionMethod))
-					methods.AddRange(newDataset.Get<string[]>(DicomTag.LossyImageCompressionMethod));
-				methods.Add(codec.TransferSyntax.LossyCompressionMethod);
-				newDataset.Add(new DicomCodeString(DicomTag.LossyImageCompressionMethod, methods.ToArray()));
-
-				double oldSize = oldPixelData.GetFrame(0).Size;
-				double newSize = newPixelData.GetFrame(0).Size;
-				string ratio = String.Format("{0:0.000}", oldSize / newSize);
-				newDataset.Add(new DicomDecimalString(DicomTag.LossyImageCompressionRatio, ratio));
-			}
-
-			ProcessOverlays(oldDataset, newDataset);
-
-			newDataset.RecalculateGroupLengths(false);
-
-			return newDataset;
-		}
-
-		private static void ProcessOverlays(DicomDataset input, DicomDataset output) {
-			DicomOverlayData[] overlays = null;
-			if (input.InternalTransferSyntax.IsEncapsulated)
-				overlays = DicomOverlayData.FromDataset(output);
-			else
-				overlays = DicomOverlayData.FromDataset(input);
-
-			foreach (var overlay in overlays) {
-				var dataTag = new DicomTag(overlay.Group, DicomTag.OverlayData.Element);
-
-				// don't run conversion on non-embedded overlays
-				if (output.Contains(dataTag))
-					continue;
-
-				output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), (ushort)1);
-				output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitPosition.Element), (ushort)0);
-
-				var data = overlay.Data;
-				if (output.InternalTransferSyntax.IsExplicitVR)
-					output.Add(new DicomOtherByte(dataTag, data));
-				else
-					output.Add(new DicomOtherWord(dataTag, data));
-			}
-		}
-
-		public static DicomDataset ExtractOverlays(DicomDataset dataset) {
-			if (!DicomOverlayData.HasEmbeddedOverlays(dataset))
-				return dataset;
-
-			dataset = dataset.Clone();
-
-			var input = dataset;
-			if (input.InternalTransferSyntax.IsEncapsulated)
-				input = input.ChangeTransferSyntax(DicomTransferSyntax.ExplicitVRLittleEndian);
-
-			ProcessOverlays(input, dataset);
-
-			return dataset;
-		}
-	}
+namespace Dicom.Imaging.Codec
+{
+    public class DicomTranscoder
+    {
+        #region Static
+
+        private static Dictionary<DicomTransferSyntax, IDicomCodec> _codecs =
+            new Dictionary<DicomTransferSyntax, IDicomCodec>();
+
+        static DicomTranscoder()
+        {
+            LoadCodecs();
+        }
+
+        public static IDicomCodec GetCodec(DicomTransferSyntax syntax)
+        {
+            IDicomCodec codec = null;
+            if (!_codecs.TryGetValue(syntax, out codec)) throw new DicomCodecException("No codec registered for tranfer syntax: {0}", syntax);
+            return codec;
+        }
+
+        public static void LoadCodecs(string path = null, string search = null)
+        {
+            if (path == null) path = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
+
+            if (search == null) search = "Dicom.Native*.dll";
+
+            var log = LogManager.Default.GetLogger("Dicom.Imaging.Codec");
+            log.Debug("Searching {path}\\{wildcard} for Dicom codecs", path, search);
+
+            var foundAnyCodecs = false;
+
+            DirectoryCatalog catalog;
+            try
+            {
+                catalog = new DirectoryCatalog(path, search);
+            }
+            catch (Exception ex)
+            {
+                log.Error(
+                    "Error encountered creating new DirectCatalog({path}, {search}) - {@exception}",
+                    path,
+                    search,
+                    ex);
+                throw;
+            }
+
+            var container = new CompositionContainer(catalog);
+            foreach (var lazy in container.GetExports<IDicomCodec>())
+            {
+                foundAnyCodecs = true;
+                var codec = lazy.Value;
+                log.Debug("Codec: {codecName}", codec.TransferSyntax.UID.Name);
+                _codecs[codec.TransferSyntax] = codec;
+            }
+
+            if (!foundAnyCodecs)
+            {
+                log.Warn("No Dicom codecs were found after searching {path}\\{wildcard}", path, search);
+            }
+        }
+
+        #endregion
+
+        public DicomTranscoder(DicomTransferSyntax input, DicomTransferSyntax output)
+        {
+            InputSyntax = input;
+            OutputSyntax = output;
+        }
+
+        public DicomTransferSyntax InputSyntax { get; private set; }
+
+        public DicomCodecParams InputCodecParams { get; set; }
+
+        private IDicomCodec _inputCodec;
+
+        private IDicomCodec InputCodec
+        {
+            get
+            {
+                if (InputSyntax.IsEncapsulated && _inputCodec == null) _inputCodec = GetCodec(InputSyntax);
+                return _inputCodec;
+            }
+        }
+
+        public DicomTransferSyntax OutputSyntax { get; private set; }
+
+        public DicomCodecParams OutputCodecParams { get; set; }
+
+        private IDicomCodec _outputCodec;
+
+        private IDicomCodec OutputCodec
+        {
+            get
+            {
+                if (OutputSyntax.IsEncapsulated && _outputCodec == null) _outputCodec = GetCodec(OutputSyntax);
+                return _outputCodec;
+            }
+        }
+
+        public DicomFile Transcode(DicomFile file)
+        {
+            DicomFile f = new DicomFile();
+            f.FileMetaInfo.Add(file.FileMetaInfo);
+            f.FileMetaInfo.TransferSyntax = OutputSyntax;
+            f.Dataset.InternalTransferSyntax = OutputSyntax;
+            f.Dataset.Add(Transcode(file.Dataset));
+            return f;
+        }
+
+        public DicomDataset Transcode(DicomDataset dataset)
+        {
+            if (!dataset.Contains(DicomTag.PixelData))
+            {
+                var newDataset = dataset.Clone();
+                newDataset.InternalTransferSyntax = OutputSyntax;
+                newDataset.RecalculateGroupLengths(false);
+                return newDataset;
+            }
+
+            if (!InputSyntax.IsEncapsulated && !OutputSyntax.IsEncapsulated)
+            {
+                // transcode from uncompressed to uncompressed
+                var newDataset = dataset.Clone();
+                newDataset.InternalTransferSyntax = OutputSyntax;
+
+                var oldPixelData = DicomPixelData.Create(dataset, false);
+                var newPixelData = DicomPixelData.Create(newDataset, true);
+
+                for (int i = 0; i < oldPixelData.NumberOfFrames; i++)
+                {
+                    var frame = oldPixelData.GetFrame(i);
+                    newPixelData.AddFrame(frame);
+                }
+
+                ProcessOverlays(dataset, newDataset);
+
+                newDataset.RecalculateGroupLengths(false);
+
+                return newDataset;
+            }
+
+            if (InputSyntax.IsEncapsulated && OutputSyntax.IsEncapsulated)
+            {
+                // transcode from compressed to compressed
+                var temp = Decode(dataset, DicomTransferSyntax.ExplicitVRLittleEndian, InputCodec, InputCodecParams);
+                return Encode(temp, OutputSyntax, OutputCodec, OutputCodecParams);
+            }
+
+            if (InputSyntax.IsEncapsulated)
+            {
+                // transcode from compressed to uncompressed
+                return Decode(dataset, OutputSyntax, InputCodec, InputCodecParams);
+            }
+
+            if (OutputSyntax.IsEncapsulated)
+            {
+                // transcode from uncompressed to compressed
+                return Encode(dataset, OutputSyntax, OutputCodec, OutputCodecParams);
+            }
+
+            throw new DicomCodecException(
+                "Unable to find transcoding solution for {0} to {1}",
+                InputSyntax.UID.Name,
+                OutputSyntax.UID.Name);
+        }
+
+        /// <summary>
+        /// Decompress single frame from DICOM dataset and return uncompressed frame buffer.
+        /// </summary>
+        /// <param name="dataset">DICOM dataset</param>
+        /// <param name="frame">Frame number</param>
+        /// <returns>Uncompressed frame buffer</returns>
+        public IByteBuffer DecodeFrame(DicomDataset dataset, int frame)
+        {
+            var pixelData = DicomPixelData.Create(dataset, false);
+            var buffer = pixelData.GetFrame(frame);
+
+            // is pixel data already uncompressed?
+            if (!dataset.InternalTransferSyntax.IsEncapsulated) return buffer;
+
+            // clone dataset to prevent changes to source
+            var cloneDataset = dataset.Clone();
+
+            var oldPixelData = DicomPixelData.Create(cloneDataset, true);
+            oldPixelData.AddFrame(buffer);
+
+            var newDataset = Decode(cloneDataset, OutputSyntax, InputCodec, InputCodecParams);
+            var newPixelData = DicomPixelData.Create(newDataset, false);
+
+            return newPixelData.GetFrame(0);
+        }
+
+        public IPixelData DecodePixelData(DicomDataset dataset, int frame)
+        {
+            var pixelData = DicomPixelData.Create(dataset, false);
+
+            // is pixel data already uncompressed?
+            if (!dataset.InternalTransferSyntax.IsEncapsulated) return PixelDataFactory.Create(pixelData, frame);
+
+            var buffer = pixelData.GetFrame(frame);
+
+            // clone dataset to prevent changes to source
+            var cloneDataset = dataset.Clone();
+
+            var oldPixelData = DicomPixelData.Create(cloneDataset, true);
+            oldPixelData.AddFrame(buffer);
+
+            var newDataset = Decode(cloneDataset, OutputSyntax, InputCodec, InputCodecParams);
+            var newPixelData = DicomPixelData.Create(newDataset, false);
+
+            return PixelDataFactory.Create(newPixelData, 0);
+        }
+
+        private DicomDataset Decode(
+            DicomDataset oldDataset,
+            DicomTransferSyntax outSyntax,
+            IDicomCodec codec,
+            DicomCodecParams parameters)
+        {
+            DicomPixelData oldPixelData = DicomPixelData.Create(oldDataset, false);
+
+            DicomDataset newDataset = oldDataset.Clone();
+            newDataset.InternalTransferSyntax = outSyntax;
+            DicomPixelData newPixelData = DicomPixelData.Create(newDataset, true);
+
+            codec.Decode(oldPixelData, newPixelData, parameters);
+
+            ProcessOverlays(oldDataset, newDataset);
+
+            newDataset.RecalculateGroupLengths(false);
+
+            return newDataset;
+        }
+
+        private DicomDataset Encode(
+            DicomDataset oldDataset,
+            DicomTransferSyntax inSyntax,
+            IDicomCodec codec,
+            DicomCodecParams parameters)
+        {
+            DicomPixelData oldPixelData = DicomPixelData.Create(oldDataset, false);
+
+            DicomDataset newDataset = oldDataset.Clone();
+            newDataset.InternalTransferSyntax = codec.TransferSyntax;
+            DicomPixelData newPixelData = DicomPixelData.Create(newDataset, true);
+
+            codec.Encode(oldPixelData, newPixelData, parameters);
+
+            if (codec.TransferSyntax.IsLossy && newPixelData.NumberOfFrames > 0)
+            {
+                newDataset.Add(new DicomCodeString(DicomTag.LossyImageCompression, "01"));
+
+                List<string> methods = new List<string>();
+                if (newDataset.Contains(DicomTag.LossyImageCompressionMethod)) methods.AddRange(newDataset.Get<string[]>(DicomTag.LossyImageCompressionMethod));
+                methods.Add(codec.TransferSyntax.LossyCompressionMethod);
+                newDataset.Add(new DicomCodeString(DicomTag.LossyImageCompressionMethod, methods.ToArray()));
+
+                double oldSize = oldPixelData.GetFrame(0).Size;
+                double newSize = newPixelData.GetFrame(0).Size;
+                string ratio = String.Format("{0:0.000}", oldSize / newSize);
+                newDataset.Add(new DicomDecimalString(DicomTag.LossyImageCompressionRatio, ratio));
+            }
+
+            ProcessOverlays(oldDataset, newDataset);
+
+            newDataset.RecalculateGroupLengths(false);
+
+            return newDataset;
+        }
+
+        private static void ProcessOverlays(DicomDataset input, DicomDataset output)
+        {
+            DicomOverlayData[] overlays = null;
+            if (input.InternalTransferSyntax.IsEncapsulated) overlays = DicomOverlayData.FromDataset(output);
+            else overlays = DicomOverlayData.FromDataset(input);
+
+            foreach (var overlay in overlays)
+            {
+                var dataTag = new DicomTag(overlay.Group, DicomTag.OverlayData.Element);
+
+                // don't run conversion on non-embedded overlays
+                if (output.Contains(dataTag)) continue;
+
+                output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), (ushort)1);
+                output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitPosition.Element), (ushort)0);
+
+                var data = overlay.Data;
+                if (output.InternalTransferSyntax.IsExplicitVR) output.Add(new DicomOtherByte(dataTag, data));
+                else output.Add(new DicomOtherWord(dataTag, data));
+            }
+        }
+
+        public static DicomDataset ExtractOverlays(DicomDataset dataset)
+        {
+            if (!DicomOverlayData.HasEmbeddedOverlays(dataset)) return dataset;
+
+            dataset = dataset.Clone();
+
+            var input = dataset;
+            if (input.InternalTransferSyntax.IsEncapsulated) input = input.ChangeTransferSyntax(DicomTransferSyntax.ExplicitVRLittleEndian);
+
+            ProcessOverlays(input, dataset);
+
+            return dataset;
+        }
+    }
 }

--- a/DICOM/Imaging/Codec/IDicomCodec.cs
+++ b/DICOM/Imaging/Codec/IDicomCodec.cs
@@ -1,16 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Codec {
-	public interface IDicomCodec {
-		string Name { get; }
-		DicomTransferSyntax TransferSyntax { get; }
+namespace Dicom.Imaging.Codec
+{
+    public interface IDicomCodec
+    {
+        string Name { get; }
 
-		DicomCodecParams GetDefaultParameters();
+        DicomTransferSyntax TransferSyntax { get; }
 
-		void Encode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-		void Decode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
-	}
+        DicomCodecParams GetDefaultParameters();
+
+        void Encode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
+
+        void Decode(DicomPixelData oldPixelData, DicomPixelData newPixelData, DicomCodecParams parameters);
+    }
 }

--- a/DICOM/Imaging/Color32.cs
+++ b/DICOM/Imaging/Color32.cs
@@ -1,49 +1,82 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging {
-	public struct Color32 {
-		public Color32(byte a, byte r, byte g, byte b) : this() {
-			A = a;
-			R = r;
-			G = g;
-			B = b;
-		}
+namespace Dicom.Imaging
+{
+    public struct Color32
+    {
+        public Color32(byte a, byte r, byte g, byte b)
+            : this()
+        {
+            A = a;
+            R = r;
+            G = g;
+            B = b;
+        }
 
-		public Color32(int c) : this() {
-			Value = c;
-		}
+        public Color32(int c)
+            : this()
+        {
+            Value = c;
+        }
 
-		/// <summary>Alpha</summary>
-		public byte A {
-			get { return (byte)unchecked((Value & 0xff000000) >> 24); }
-			set { Value = (int)unchecked((Value & 0x00ffffff) | ((int)value << 24)); }
-		}
+        /// <summary>Alpha</summary>
+        public byte A
+        {
+            get
+            {
+                return (byte)unchecked((Value & 0xff000000) >> 24);
+            }
+            set
+            {
+                Value = (int)unchecked((Value & 0x00ffffff) | ((int)value << 24));
+            }
+        }
 
-		/// <summary>Red</summary>
-		public byte R {
-			get { return (byte)unchecked((Value & 0x00ff0000) >> 16); }
-			set { Value = (int)unchecked((Value & 0xff00ffff) | ((uint)value << 16)); }
-		}
+        /// <summary>Red</summary>
+        public byte R
+        {
+            get
+            {
+                return (byte)unchecked((Value & 0x00ff0000) >> 16);
+            }
+            set
+            {
+                Value = (int)unchecked((Value & 0xff00ffff) | ((uint)value << 16));
+            }
+        }
 
-		/// <summary>Green</summary>
-		public byte G {
-			get { return (byte)unchecked((Value & 0x0000ff00) >> 8); }
-			set { Value = (int)unchecked((Value & 0xffff00ff) | ((uint)value << 8)); }
-		}
+        /// <summary>Green</summary>
+        public byte G
+        {
+            get
+            {
+                return (byte)unchecked((Value & 0x0000ff00) >> 8);
+            }
+            set
+            {
+                Value = (int)unchecked((Value & 0xffff00ff) | ((uint)value << 8));
+            }
+        }
 
-		/// <summary>Blue</summary>
-		public byte B {
-			get { return (byte)unchecked(Value & 0x000000ff); }
-			set { Value = (int)unchecked((Value & 0xffffff00) | value); }
-		}
+        /// <summary>Blue</summary>
+        public byte B
+        {
+            get
+            {
+                return (byte)unchecked(Value & 0x000000ff);
+            }
+            set
+            {
+                Value = (int)unchecked((Value & 0xffffff00) | value);
+            }
+        }
 
-		/// <summary>ARGB</summary>
-		public int Value {
-			get;
-			set;
-		}
+        /// <summary>ARGB</summary>
+        public int Value { get; set; }
 
-		public readonly static Color32 Black = new Color32(0xff, 0x00, 0x00, 0x00);
-		public readonly static Color32 White = new Color32(0xff, 0xff, 0xff, 0xff);
-	}
+        public static readonly Color32 Black = new Color32(0xff, 0x00, 0x00, 0x00);
+
+        public static readonly Color32 White = new Color32(0xff, 0xff, 0xff, 0xff);
+    }
 }

--- a/DICOM/Imaging/ColorSpace.cs
+++ b/DICOM/Imaging/ColorSpace.cs
@@ -1,80 +1,102 @@
-﻿using System;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	public class ColorSpace {
-		public ColorSpace(string name, params Component[] components) {
-			Name = name;
-			Components = components;
-		}
+using System;
 
-		public string Name {
-			get;
-			private set;
-		}
+namespace Dicom
+{
+    public class ColorSpace
+    {
+        public ColorSpace(string name, params Component[] components)
+        {
+            Name = name;
+            Components = components;
+        }
 
-		public Component[] Components {
-			get;
-			private set;
-		}
+        public string Name { get; private set; }
 
-		public static bool operator ==(ColorSpace a, ColorSpace b) {
-			if ((object)a == null || (object)b == null) return false;
-			return a.Name == b.Name;
-		}
-		public static bool operator !=(ColorSpace a, ColorSpace b) {
-			if ((object)a == null || (object)b == null) return true;
-			return a.Name != b.Name;
-		}
+        public Component[] Components { get; private set; }
 
-		protected bool Equals(ColorSpace other) {
-			return String.Equals(Name, other.Name);
-		}
+        public static bool operator ==(ColorSpace a, ColorSpace b)
+        {
+            if ((object)a == null || (object)b == null) return false;
+            return a.Name == b.Name;
+        }
 
-		public override bool Equals(object obj) {
-			if (ReferenceEquals(null, obj)) return false;
-			if (ReferenceEquals(this, obj)) return true;
-			var other = obj as ColorSpace;
-			return other != null && Equals(other);
-		}
+        public static bool operator !=(ColorSpace a, ColorSpace b)
+        {
+            if ((object)a == null || (object)b == null) return true;
+            return a.Name != b.Name;
+        }
 
-		public override int GetHashCode() {
-			return (Name != null ? Name.GetHashCode() : 0);
-		}
+        protected bool Equals(ColorSpace other)
+        {
+            return String.Equals(Name, other.Name);
+        }
 
-		public override string ToString() {
-			return Name;
-		}
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            var other = obj as ColorSpace;
+            return other != null && Equals(other);
+        }
 
-		public class Component {
-			public Component(string name, int subSampleX, int subSampleY) {
-				Name = name;
-				SubSampleX = subSampleX;
-				SubSampleY = subSampleY;
-			}
+        public override int GetHashCode()
+        {
+            return (Name != null ? Name.GetHashCode() : 0);
+        }
 
-			public string Name {
-				get;
-				private set;
-			}
+        public override string ToString()
+        {
+            return Name;
+        }
 
-			public int SubSampleX {
-				get;
-				private set;
-			}
+        public class Component
+        {
+            public Component(string name, int subSampleX, int subSampleY)
+            {
+                Name = name;
+                SubSampleX = subSampleX;
+                SubSampleY = subSampleY;
+            }
 
-			public int SubSampleY {
-				get;
-				private set;
-			}
-		}
+            public string Name { get; private set; }
 
-		public readonly static ColorSpace OneBit = new ColorSpace("1-bit", new Component("Value", 1, 1));
-		public readonly static ColorSpace Grayscale = new ColorSpace("Grayscale", new Component("Value", 1, 1));
-		public readonly static ColorSpace Indexed = new ColorSpace("Indexed", new Component("Value", 1, 1));
-		public readonly static ColorSpace RGB = new ColorSpace("RGB", new Component("Red", 1, 1), new Component("Green", 1, 1), new Component("Blue", 1, 1));
-		public readonly static ColorSpace BGR = new ColorSpace("BGR", new Component("Blue", 1, 1), new Component("Green", 1, 1), new Component("Red", 1, 1));
-		public readonly static ColorSpace RGBA = new ColorSpace("RGBA", new Component("Red", 1, 1), new Component("Green", 1, 1), new Component("Blue", 1, 1), new Component("Alpha", 1, 1));
-		public readonly static ColorSpace YCbCrJPEG = new ColorSpace("Y'CbCr 4:4:4 (JPEG)", new Component("Luminance", 1, 1), new Component("Blue Chroma", 1, 1), new Component("Red Chroma", 1, 1));
-	}
+            public int SubSampleX { get; private set; }
+
+            public int SubSampleY { get; private set; }
+        }
+
+        public static readonly ColorSpace OneBit = new ColorSpace("1-bit", new Component("Value", 1, 1));
+
+        public static readonly ColorSpace Grayscale = new ColorSpace("Grayscale", new Component("Value", 1, 1));
+
+        public static readonly ColorSpace Indexed = new ColorSpace("Indexed", new Component("Value", 1, 1));
+
+        public static readonly ColorSpace RGB = new ColorSpace(
+            "RGB",
+            new Component("Red", 1, 1),
+            new Component("Green", 1, 1),
+            new Component("Blue", 1, 1));
+
+        public static readonly ColorSpace BGR = new ColorSpace(
+            "BGR",
+            new Component("Blue", 1, 1),
+            new Component("Green", 1, 1),
+            new Component("Red", 1, 1));
+
+        public static readonly ColorSpace RGBA = new ColorSpace(
+            "RGBA",
+            new Component("Red", 1, 1),
+            new Component("Green", 1, 1),
+            new Component("Blue", 1, 1),
+            new Component("Alpha", 1, 1));
+
+        public static readonly ColorSpace YCbCrJPEG = new ColorSpace(
+            "Y'CbCr 4:4:4 (JPEG)",
+            new Component("Luminance", 1, 1),
+            new Component("Blue Chroma", 1, 1),
+            new Component("Red Chroma", 1, 1));
+    }
 }

--- a/DICOM/Imaging/ColorTable.cs
+++ b/DICOM/Imaging/ColorTable.cs
@@ -1,58 +1,76 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 
-namespace Dicom.Imaging {
-	public static class ColorTable {
-		public readonly static Color32[] Monochrome1 = InitGrayscaleLUT(true);
-		public readonly static Color32[] Monochrome2 = InitGrayscaleLUT(false);
+namespace Dicom.Imaging
+{
+    public static class ColorTable
+    {
+        public static readonly Color32[] Monochrome1 = InitGrayscaleLUT(true);
 
-		private static Color32[] InitGrayscaleLUT(bool reverse) {
-			Color32[] LUT = new Color32[256];
-			int i;
-			byte b;
-			if (reverse) {
-				for (i = 0, b = 255; i < 256; i++, b--) {
-					LUT[i] = new Color32(0xff, b, b, b);
-				}
-			} else {
-				for (i = 0, b = 0; i < 256; i++, b++) {
-					LUT[i] = new Color32(0xff, b, b, b);
-				}
-			}
-			return LUT;
-		}
+        public static readonly Color32[] Monochrome2 = InitGrayscaleLUT(false);
 
-		public static Color32[] Reverse(Color32[] lut) {
-			Color32[] clone = new Color32[lut.Length];
-			Array.Copy(lut, clone, clone.Length);
-			Array.Reverse(clone);
-			return clone;
-		}
+        private static Color32[] InitGrayscaleLUT(bool reverse)
+        {
+            Color32[] LUT = new Color32[256];
+            int i;
+            byte b;
+            if (reverse)
+            {
+                for (i = 0, b = 255; i < 256; i++, b--)
+                {
+                    LUT[i] = new Color32(0xff, b, b, b);
+                }
+            }
+            else
+            {
+                for (i = 0, b = 0; i < 256; i++, b++)
+                {
+                    LUT[i] = new Color32(0xff, b, b, b);
+                }
+            }
+            return LUT;
+        }
 
-		public static Color32[] LoadLUT(string file) {
-			try {
-				byte[] data = File.ReadAllBytes(file);
-				if (data.Length != (256 * 3))
-					return null;
+        public static Color32[] Reverse(Color32[] lut)
+        {
+            Color32[] clone = new Color32[lut.Length];
+            Array.Copy(lut, clone, clone.Length);
+            Array.Reverse(clone);
+            return clone;
+        }
 
-				Color32[] LUT = new Color32[256];
-				for (int i = 0; i < 256; i++) {
-					LUT[i] = new Color32(0xff, data[i], data[i + 256], data[i + 512]);
-				}
-				return LUT;
-			} catch {
-				return null;
-			}
-		}
+        public static Color32[] LoadLUT(string file)
+        {
+            try
+            {
+                byte[] data = File.ReadAllBytes(file);
+                if (data.Length != (256 * 3)) return null;
 
-		public static void SaveLUT(string file, Color32[] lut) {
-			if (lut.Length != 256) return;
-			FileStream fs = new FileStream(file, FileMode.Create);
-			for (int i = 0; i < 256; i++) fs.WriteByte(lut[i].R);
-			for (int i = 0; i < 256; i++) fs.WriteByte(lut[i].G);
-			for (int i = 0; i < 256; i++) fs.WriteByte(lut[i].B);
-			fs.Close();
-		}
-	}
+                Color32[] LUT = new Color32[256];
+                for (int i = 0; i < 256; i++)
+                {
+                    LUT[i] = new Color32(0xff, data[i], data[i + 256], data[i + 512]);
+                }
+                return LUT;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static void SaveLUT(string file, Color32[] lut)
+        {
+            if (lut.Length != 256) return;
+            FileStream fs = new FileStream(file, FileMode.Create);
+            for (int i = 0; i < 256; i++) fs.WriteByte(lut[i].R);
+            for (int i = 0; i < 256; i++) fs.WriteByte(lut[i].G);
+            for (int i = 0; i < 256; i++) fs.WriteByte(lut[i].B);
+            fs.Close();
+        }
+    }
 }
 

--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -1,321 +1,391 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #if !SILVERLIGHT
 using System.Drawing;
-using System.Drawing.Imaging;
 #endif
 using System.Linq;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Text;
 
-using Dicom;
 using Dicom.Imaging.Codec;
-using Dicom.Imaging.LUT;
 using Dicom.Imaging.Render;
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// DICOM Image calss with capability of
-	/// </summary>
-	public class DicomImage {
-		#region Private Members
-		private IPixelData _pixelData;
-		private IPipeline _pipeline;
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// DICOM Image calss with capability of
+    /// </summary>
+    public class DicomImage
+    {
+        #region Private Members
 
-		private double _scale;
-		private GrayscaleRenderOptions _renderOptions;
+        private IPixelData _pixelData;
 
-		private DicomOverlayData[] _overlays;
-		private int _overlayColor = unchecked((int)0xffff00ff);
-		#endregion
+        private IPipeline _pipeline;
 
-		/// <summary>Creates DICOM image object from dataset</summary>
-		/// <param name="dataset">Source dataset</param>
-		/// <param name="frame">Zero indexed frame number</param>
-		public DicomImage(DicomDataset dataset, int frame = 0) {
-			_scale = 1.0;
-			ShowOverlays = true;
-			Load(dataset, frame);
-		}
+        private double _scale;
+
+        private GrayscaleRenderOptions _renderOptions;
+
+        private DicomOverlayData[] _overlays;
+
+        private int _overlayColor = unchecked((int)0xffff00ff);
+
+        #endregion
+
+        /// <summary>Creates DICOM image object from dataset</summary>
+        /// <param name="dataset">Source dataset</param>
+        /// <param name="frame">Zero indexed frame number</param>
+        public DicomImage(DicomDataset dataset, int frame = 0)
+        {
+            _scale = 1.0;
+            ShowOverlays = true;
+            Load(dataset, frame);
+        }
 
 #if !SILVERLIGHT
-		/// <summary>Creates DICOM image object from file</summary>
-		/// <param name="fileName">Source file</param>
-		/// <param name="frame">Zero indexed frame number</param>
-		public DicomImage(string fileName, int frame = 0) {
-			_scale = 1.0;
-			ShowOverlays = true;
-			var file = DicomFile.Open(fileName);
-			Load(file.Dataset, frame);
-		}
+        /// <summary>Creates DICOM image object from file</summary>
+        /// <param name="fileName">Source file</param>
+        /// <param name="frame">Zero indexed frame number</param>
+        public DicomImage(string fileName, int frame = 0)
+        {
+            _scale = 1.0;
+            ShowOverlays = true;
+            var file = DicomFile.Open(fileName);
+            Load(file.Dataset, frame);
+        }
 #endif
 
-		/// <summary>Source DICOM dataset</summary>
-		public DicomDataset Dataset {
-			get;
-			private set;
-		}
+        /// <summary>Source DICOM dataset</summary>
+        public DicomDataset Dataset { get; private set; }
 
-		/// <summary>DICOM pixel data</summary>
-		public DicomPixelData PixelData {
-			get;
-			private set;
-		}
+        /// <summary>DICOM pixel data</summary>
+        public DicomPixelData PixelData { get; private set; }
 
-		/// <summary>Width of image in pixels</summary>
-		public int Width {
-			get { return PixelData.Width; }
-		}
-
-		/// <summary>Height of image in pixels</summary>
-		public int Height {
-			get { return PixelData.Height; }
-		}
-
-		/// <summary>Scaling factor of the rendered image</summary>
-		public double Scale {
-			get { return _scale; }
-			set {
-				_scale = value;
-				_pixelData = null;
-			}
-		}
-		/// <summary>Photometric interpretation of pixel data.</summary>
-		public PhotometricInterpretation PhotometricInterpretation {
-			get;
-			private set;
-		}
-
-		/// <summary>Number of frames contained in image data.</summary>
-		public int NumberOfFrames {
-			get { return PixelData.NumberOfFrames; }
-		}
-
-		/// <summary>Window width of rendered gray scale image </summary>
-        public virtual double WindowWidth {
-			get {
-                if (_pipeline == null) {
-                    CreatePipeline();
-                }
-                return _pipeline is GenericGrayscalePipeline ?_renderOptions.WindowWidth: 255;
-			}
-			set {
-                if (_pipeline == null) {
-                    CreatePipeline();
-                }
-                if (_pipeline is GenericGrayscalePipeline) {
-					_renderOptions.WindowWidth = value;
-			}
-		}
+        /// <summary>Width of image in pixels</summary>
+        public int Width
+        {
+            get
+            {
+                return PixelData.Width;
+            }
         }
 
-		/// <summary>Window center of rendered gray scale image </summary>
-        public virtual double WindowCenter {
-			get {
-                if (_pipeline == null) {
-                    CreatePipeline();
-                }
-                return _pipeline is GenericGrayscalePipeline ? _renderOptions.WindowCenter: 127;
-			}
-			set {
-                if (_pipeline == null) {
-                    CreatePipeline();
-                }
-                if (_pipeline is GenericGrayscalePipeline) {
-					_renderOptions.WindowCenter = value;
-			}
-		}
+        /// <summary>Height of image in pixels</summary>
+        public int Height
+        {
+            get
+            {
+                return PixelData.Height;
+            }
         }
 
-		/// <summary>Show or hide DICOM overlays</summary>
-		public bool ShowOverlays {
-			get;
-			set;
-		}
+        /// <summary>Scaling factor of the rendered image</summary>
+        public double Scale
+        {
+            get
+            {
+                return _scale;
+            }
+            set
+            {
+                _scale = value;
+                _pixelData = null;
+            }
+        }
 
-		/// <summary>Color used for displaying DICOM overlays. Default is magenta.</summary>
-		public int OverlayColor {
-			get { return _overlayColor; }
-			set { _overlayColor = value; }
-		}
+        /// <summary>Photometric interpretation of pixel data.</summary>
+        public PhotometricInterpretation PhotometricInterpretation { get; private set; }
+
+        /// <summary>Number of frames contained in image data.</summary>
+        public int NumberOfFrames
+        {
+            get
+            {
+                return PixelData.NumberOfFrames;
+            }
+        }
+
+        /// <summary>Window width of rendered gray scale image </summary>
+        public virtual double WindowWidth
+        {
+            get
+            {
+                if (_pipeline == null)
+                {
+                    CreatePipeline();
+                }
+                return _pipeline is GenericGrayscalePipeline ? _renderOptions.WindowWidth : 255;
+            }
+            set
+            {
+                if (_pipeline == null)
+                {
+                    CreatePipeline();
+                }
+                if (_pipeline is GenericGrayscalePipeline)
+                {
+                    _renderOptions.WindowWidth = value;
+                }
+            }
+        }
+
+        /// <summary>Window center of rendered gray scale image </summary>
+        public virtual double WindowCenter
+        {
+            get
+            {
+                if (_pipeline == null)
+                {
+                    CreatePipeline();
+                }
+                return _pipeline is GenericGrayscalePipeline ? _renderOptions.WindowCenter : 127;
+            }
+            set
+            {
+                if (_pipeline == null)
+                {
+                    CreatePipeline();
+                }
+                if (_pipeline is GenericGrayscalePipeline)
+                {
+                    _renderOptions.WindowCenter = value;
+                }
+            }
+        }
+
+        /// <summary>Show or hide DICOM overlays</summary>
+        public bool ShowOverlays { get; set; }
+
+        /// <summary>Color used for displaying DICOM overlays. Default is magenta.</summary>
+        public int OverlayColor
+        {
+            get
+            {
+                return _overlayColor;
+            }
+            set
+            {
+                _overlayColor = value;
+            }
+        }
 
 
         public int CurrentFrame { get; private set; }
 
 #if !SILVERLIGHT
-		/// <summary>Renders DICOM image to System.Drawing.Image</summary>
-		/// <param name="frame">Zero indexed frame number</param>
-		/// <returns>Rendered image</returns>
-        public virtual Image RenderImage(int frame = 0) {
-            if (frame != CurrentFrame || _pixelData == null)
-				Load(Dataset, frame);
+        /// <summary>Renders DICOM image to System.Drawing.Image</summary>
+        /// <param name="frame">Zero indexed frame number</param>
+        /// <returns>Rendered image</returns>
+        public virtual Image RenderImage(int frame = 0)
+        {
+            if (frame != CurrentFrame || _pixelData == null) Load(Dataset, frame);
 
-			var graphic = new ImageGraphic(_pixelData);
+            var graphic = new ImageGraphic(_pixelData);
 
-            try {
-                if (ShowOverlays) {
-                    foreach (var overlay in _overlays) {
-						if ((frame + 1) < overlay.OriginFrame || (frame + 1) > (overlay.OriginFrame + overlay.NumberOfFrames - 1))
-							continue;
+            try
+            {
+                if (ShowOverlays)
+                {
+                    foreach (var overlay in _overlays)
+                    {
+                        if ((frame + 1) < overlay.OriginFrame
+                            || (frame + 1) > (overlay.OriginFrame + overlay.NumberOfFrames - 1)) continue;
 
-						var og = new OverlayGraphic(PixelDataFactory.Create(overlay), overlay.OriginX - 1, overlay.OriginY - 1, OverlayColor);
-						graphic.AddOverlay(og);
-						og.Scale(this._scale);
-					}
-				}
+                        var og = new OverlayGraphic(
+                            PixelDataFactory.Create(overlay),
+                            overlay.OriginX - 1,
+                            overlay.OriginY - 1,
+                            OverlayColor);
+                        graphic.AddOverlay(og);
+                        og.Scale(this._scale);
+                    }
+                }
 
                 var image = graphic.RenderImage(_pipeline.LUT);
 
                 return new Bitmap(image);
-            } finally {
-                if (graphic != null) {
+            }
+            finally
+            {
+                if (graphic != null)
+                {
                     graphic.Dispose();
                 }
             }
-		}
+        }
 #endif
 
-		/// <summary>
-		/// Renders DICOM image to <see cref="System.Windows.Media.ImageSource"/> 
-		/// </summary>
-		/// <param name="frame">Zero indexed frame nu,ber</param>
-		/// <returns>Rendered image</returns>
-		public ImageSource RenderImageSource(int frame = 0) {
-            if (frame != CurrentFrame || _pixelData == null)
-				Load(Dataset, frame);
+        /// <summary>
+        /// Renders DICOM image to <see cref="System.Windows.Media.ImageSource"/> 
+        /// </summary>
+        /// <param name="frame">Zero indexed frame nu,ber</param>
+        /// <returns>Rendered image</returns>
+        public ImageSource RenderImageSource(int frame = 0)
+        {
+            if (frame != CurrentFrame || _pixelData == null) Load(Dataset, frame);
 
-			var graphic = new ImageGraphic(_pixelData);
+            var graphic = new ImageGraphic(_pixelData);
 
-            try {
-				if (ShowOverlays) {
-					foreach (var overlay in _overlays) {
-						if ((frame + 1) < overlay.OriginFrame || (frame + 1) > (overlay.OriginFrame + overlay.NumberOfFrames - 1))
-							continue;
+            try
+            {
+                if (ShowOverlays)
+                {
+                    foreach (var overlay in _overlays)
+                    {
+                        if ((frame + 1) < overlay.OriginFrame
+                            || (frame + 1) > (overlay.OriginFrame + overlay.NumberOfFrames - 1)) continue;
 
-						var og = new OverlayGraphic(PixelDataFactory.Create(overlay), overlay.OriginX - 1, overlay.OriginY - 1, OverlayColor);
-						graphic.AddOverlay(og);
-						og.Scale(this._scale);
-					}
-				}
+                        var og = new OverlayGraphic(
+                            PixelDataFactory.Create(overlay),
+                            overlay.OriginX - 1,
+                            overlay.OriginY - 1,
+                            OverlayColor);
+                        graphic.AddOverlay(og);
+                        og.Scale(this._scale);
+                    }
+                }
 
-				return graphic.RenderImageSource(_pipeline.LUT);
-            } finally {
-                if (graphic != null) {
+                return graphic.RenderImageSource(_pipeline.LUT);
+            }
+            finally
+            {
+                if (graphic != null)
+                {
                     graphic.Dispose();
                 }
             }
-		}
+        }
 
 
-		/// <summary>
-		/// Loads the pixel data for specified frame and set the internal dataset
-		/// 
-		/// </summary>
-		/// <param name="dataset">dataset to load pixeldata from</param>
-		/// <param name="frame">The frame number to create pixeldata for</param>
-		private void Load(DicomDataset dataset, int frame) {
-			Dataset = DicomTranscoder.ExtractOverlays(dataset);
+        /// <summary>
+        /// Loads the pixel data for specified frame and set the internal dataset
+        /// 
+        /// </summary>
+        /// <param name="dataset">dataset to load pixeldata from</param>
+        /// <param name="frame">The frame number to create pixeldata for</param>
+        private void Load(DicomDataset dataset, int frame)
+        {
+            Dataset = DicomTranscoder.ExtractOverlays(dataset);
 
-			if (PixelData == null) {
-				PixelData = DicomPixelData.Create(Dataset);
-				PhotometricInterpretation = PixelData.PhotometricInterpretation;
-			}
-            if (frame < 0) {
+            if (PixelData == null)
+            {
+                PixelData = DicomPixelData.Create(Dataset);
+                PhotometricInterpretation = PixelData.PhotometricInterpretation;
+            }
+            if (frame < 0)
+            {
                 CurrentFrame = frame;
                 return;
             }
 
 
-			if (Dataset.InternalTransferSyntax.IsEncapsulated) {
-				// decompress single frame from source dataset
-				DicomCodecParams cparams = null;
-				if (Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1 || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4) {
-					cparams = new DicomJpegParams {
-						ConvertColorspaceToRGB = true
-					};
-				}
+            if (Dataset.InternalTransferSyntax.IsEncapsulated)
+            {
+                // decompress single frame from source dataset
+                DicomCodecParams cparams = null;
+                if (Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1
+                    || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4)
+                {
+                    cparams = new DicomJpegParams { ConvertColorspaceToRGB = true };
+                }
 
-				var transcoder = new DicomTranscoder(Dataset.InternalTransferSyntax, DicomTransferSyntax.ExplicitVRLittleEndian);
-				transcoder.InputCodecParams = cparams;
-				transcoder.OutputCodecParams = cparams;
-				var buffer = transcoder.DecodeFrame(Dataset, frame);
+                var transcoder = new DicomTranscoder(
+                    Dataset.InternalTransferSyntax,
+                    DicomTransferSyntax.ExplicitVRLittleEndian);
+                transcoder.InputCodecParams = cparams;
+                transcoder.OutputCodecParams = cparams;
+                var buffer = transcoder.DecodeFrame(Dataset, frame);
 
-				// clone the dataset because modifying the pixel data modifies the dataset
-				var clone = Dataset.Clone();
-				clone.InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
+                // clone the dataset because modifying the pixel data modifies the dataset
+                var clone = Dataset.Clone();
+                clone.InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
 
-				var pixelData = DicomPixelData.Create(clone, true);
-				pixelData.AddFrame(buffer);
+                var pixelData = DicomPixelData.Create(clone, true);
+                pixelData.AddFrame(buffer);
 
-				// temporary fix for JPEG compressed YBR images
-				if ((Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1 || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4) && pixelData.SamplesPerPixel == 3)
-					pixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
+                // temporary fix for JPEG compressed YBR images
+                if ((Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1
+                     || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4)
+                    && pixelData.SamplesPerPixel == 3) pixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
 
-				// temporary fix for JPEG 2000 Lossy images
-				if (pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrIct || pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrRct)
-					pixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
+                // temporary fix for JPEG 2000 Lossy images
+                if (pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrIct
+                    || pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrRct) pixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
 
-				_pixelData = PixelDataFactory.Create(pixelData, 0);
-			} else {
-				// pull uncompressed frame from source pixel data
-				_pixelData = PixelDataFactory.Create(PixelData, frame);
-			}
+                _pixelData = PixelDataFactory.Create(pixelData, 0);
+            }
+            else
+            {
+                // pull uncompressed frame from source pixel data
+                _pixelData = PixelDataFactory.Create(PixelData, frame);
+            }
 
-			_pixelData = _pixelData.Rescale(_scale);
+            _pixelData = _pixelData.Rescale(_scale);
 
-			_overlays = DicomOverlayData.FromDataset(Dataset).Where(x => x.Type == DicomOverlayType.Graphics && x.Data != null).ToArray();
+            _overlays =
+                DicomOverlayData.FromDataset(Dataset)
+                    .Where(x => x.Type == DicomOverlayType.Graphics && x.Data != null)
+                    .ToArray();
 
             CurrentFrame = frame;
 
-			CreatePipeline();
-		}
+            CreatePipeline();
+        }
 
-		/// <summary>
-		/// Create image rendering pipeline according to the Dataset <see cref="PhotometricInterpretation"/>.
-		/// </summary>
-		private void CreatePipeline() {
-			if (_pipeline != null)
-				return;
+        /// <summary>
+        /// Create image rendering pipeline according to the Dataset <see cref="PhotometricInterpretation"/>.
+        /// </summary>
+        private void CreatePipeline()
+        {
+            if (_pipeline != null) return;
 
-			var pi = Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation);
-			var samples = Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 0, 0);
+            var pi = Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation);
+            var samples = Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 0, 0);
 
-			// temporary fix for JPEG compressed YBR images
-			if ((Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1 || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4) && samples == 3)
-				pi = PhotometricInterpretation.Rgb;
+            // temporary fix for JPEG compressed YBR images
+            if ((Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1
+                 || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4) && samples == 3) pi = PhotometricInterpretation.Rgb;
 
-			// temporary fix for JPEG 2000 Lossy images
-			if (pi == PhotometricInterpretation.YbrIct || pi == PhotometricInterpretation.YbrRct)
-				pi = PhotometricInterpretation.Rgb;
+            // temporary fix for JPEG 2000 Lossy images
+            if (pi == PhotometricInterpretation.YbrIct || pi == PhotometricInterpretation.YbrRct) pi = PhotometricInterpretation.Rgb;
 
-			if (pi == null) {
-				// generally ACR-NEMA
-				if (samples == 0 || samples == 1) {
-					if (Dataset.Contains(DicomTag.RedPaletteColorLookupTableData))
-						pi = PhotometricInterpretation.PaletteColor;
-					else
-						pi = PhotometricInterpretation.Monochrome2;
-				} else {
-					// assume, probably incorrectly, that the image is RGB
-					pi = PhotometricInterpretation.Rgb;
-				}
-			}
+            if (pi == null)
+            {
+                // generally ACR-NEMA
+                if (samples == 0 || samples == 1)
+                {
+                    if (Dataset.Contains(DicomTag.RedPaletteColorLookupTableData)) pi = PhotometricInterpretation.PaletteColor;
+                    else pi = PhotometricInterpretation.Monochrome2;
+                }
+                else
+                {
+                    // assume, probably incorrectly, that the image is RGB
+                    pi = PhotometricInterpretation.Rgb;
+                }
+            }
 
-			if (pi == PhotometricInterpretation.Monochrome1 || pi == PhotometricInterpretation.Monochrome2) {
-				//Monochrom1 or Monochrome2 for grayscale image
-				if (_renderOptions == null)
-					_renderOptions = GrayscaleRenderOptions.FromDataset(Dataset);
-				_pipeline = new GenericGrayscalePipeline(_renderOptions);
-            } else if (pi == PhotometricInterpretation.Rgb || pi == PhotometricInterpretation.YbrFull || pi == PhotometricInterpretation.YbrFull422 || pi == PhotometricInterpretation.YbrPartial422) {
-				//RGB for color image
-				_pipeline = new RgbColorPipeline();
-			} else if (pi == PhotometricInterpretation.PaletteColor) {
-				//PALETTE COLOR for Palette image
-				_pipeline = new PaletteColorPipeline(PixelData);
-			} else {
-				throw new DicomImagingException("Unsupported pipeline photometric interpretation: {0}", pi.Value);
-			}
-		}
-	}
+            if (pi == PhotometricInterpretation.Monochrome1 || pi == PhotometricInterpretation.Monochrome2)
+            {
+                //Monochrom1 or Monochrome2 for grayscale image
+                if (_renderOptions == null) _renderOptions = GrayscaleRenderOptions.FromDataset(Dataset);
+                _pipeline = new GenericGrayscalePipeline(_renderOptions);
+            }
+            else if (pi == PhotometricInterpretation.Rgb || pi == PhotometricInterpretation.YbrFull
+                     || pi == PhotometricInterpretation.YbrFull422 || pi == PhotometricInterpretation.YbrPartial422)
+            {
+                //RGB for color image
+                _pipeline = new RgbColorPipeline();
+            }
+            else if (pi == PhotometricInterpretation.PaletteColor)
+            {
+                //PALETTE COLOR for Palette image
+                _pipeline = new PaletteColorPipeline(PixelData);
+            }
+            else
+            {
+                throw new DicomImagingException("Unsupported pipeline photometric interpretation: {0}", pi.Value);
+            }
+        }
+    }
 }

--- a/DICOM/Imaging/DicomImagingException.cs
+++ b/DICOM/Imaging/DicomImagingException.cs
@@ -1,34 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// <seealso cref="DicomImage"/> operations related exceptions
-	/// </summary>
-	public class DicomImagingException : DicomException {
-		/// <summary>
-		/// Initialize new instance of <seealso cref="DicomImagingException"/> class
-		/// </summary>
-		/// <param name="message">The message that describes the error</param>
-		public DicomImagingException(string message) : base(message) {
-		}
+using System;
 
-		/// <summary>
-		/// Initialize new instance of <seealso cref="DicomImagingException"/> class
-		/// </summary>
-		/// <param name="format">The format string the describes the error</param>
-		/// <param name="args">The format string parameters</param>
-		public DicomImagingException(string format, params object[] args) : base(format, args) {
-		}
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// <seealso cref="DicomImage"/> operations related exceptions
+    /// </summary>
+    public class DicomImagingException : DicomException
+    {
+        /// <summary>
+        /// Initialize new instance of <seealso cref="DicomImagingException"/> class
+        /// </summary>
+        /// <param name="message">The message that describes the error</param>
+        public DicomImagingException(string message)
+            : base(message)
+        {
+        }
 
-		/// <summary>
-		/// Initialize new instance of <seealso cref="DicomImagingException"/> class
-		/// </summary>
-		/// <param name="message">The message that describes the error</param>
-		/// <param name="innerException">The exception that is the cause of the current exception</param>
-		public DicomImagingException(string message, Exception innerException) : base(message, innerException) {
-		}
-	}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="DicomImagingException"/> class
+        /// </summary>
+        /// <param name="format">The format string the describes the error</param>
+        /// <param name="args">The format string parameters</param>
+        public DicomImagingException(string format, params object[] args)
+            : base(format, args)
+        {
+        }
+
+        /// <summary>
+        /// Initialize new instance of <seealso cref="DicomImagingException"/> class
+        /// </summary>
+        /// <param name="message">The message that describes the error</param>
+        /// <param name="innerException">The exception that is the cause of the current exception</param>
+        public DicomImagingException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -1,331 +1,445 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Text;
 
 using Dicom.Imaging.Mathematics;
 using Dicom.IO.Buffer;
 
-namespace Dicom.Imaging {
-	public enum DicomOverlayType {
-		/// <summary>Graphic overlay</summary>
-		Graphics,
+namespace Dicom.Imaging
+{
+    public enum DicomOverlayType
+    {
+        /// <summary>Graphic overlay</summary>
+        Graphics,
 
-		/// <summary>Region of Interest</summary>
-		ROI
-	}
+        /// <summary>Region of Interest</summary>
+        ROI
+    }
 
-	/// <summary>
-	/// DICOM image overlay class
-	/// </summary>
-	public class DicomOverlayData {
-		#region Public Constructors
-		/// <summary>
-		/// Initializes overlay from DICOM dataset and overlay group.
-		/// </summary>
-		/// <param name="ds">Dataset</param>
-		/// <param name="group">Overlay group</param>
-		public DicomOverlayData(DicomDataset ds, ushort group) {
-			Group = group;
-			Dataset = ds;
-		}
-		#endregion
+    /// <summary>
+    /// DICOM image overlay class
+    /// </summary>
+    public class DicomOverlayData
+    {
+        #region Public Constructors
 
-		#region Public Properties
-		/// <summary>
-		/// DICOM Dataset
-		/// </summary>
-		public DicomDataset Dataset {
-			get;
-			private set;
-		}
+        /// <summary>
+        /// Initializes overlay from DICOM dataset and overlay group.
+        /// </summary>
+        /// <param name="ds">Dataset</param>
+        /// <param name="group">Overlay group</param>
+        public DicomOverlayData(DicomDataset ds, ushort group)
+        {
+            Group = group;
+            Dataset = ds;
+        }
 
-		/// <summary>
-		/// Overlay group
-		/// </summary>
-		public ushort Group {
-			get;
-			private set;
-		}
+        #endregion
 
-		/// <summary>
-		/// Number of rows in overlay
-		/// </summary>
-		public int Rows {
-			get { return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayRows)); }
-			set { Dataset.Add(OverlayTag(DicomTag.OverlayRows), (ushort)value); }
-		}
+        #region Public Properties
 
-		/// <summary>
-		/// Number of columns in overlay
-		/// </summary>
-		public int Columns {
-			get { return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayColumns)); }
-			set { Dataset.Add(OverlayTag(DicomTag.OverlayColumns), (ushort)value); }
-		}
+        /// <summary>
+        /// DICOM Dataset
+        /// </summary>
+        public DicomDataset Dataset { get; private set; }
 
-		/// <summary>
-		/// Overlay type
-		/// </summary>
-		public DicomOverlayType Type {
-			get {
-				var type = Dataset.Get<string>(OverlayTag(DicomTag.OverlayType), "Unknown");
-				if (type.StartsWith("R"))
-					return DicomOverlayType.ROI;
-				else
-					return DicomOverlayType.Graphics;
-			}
-			set {
-				Dataset.Add(OverlayTag(DicomTag.OverlayType), value.ToString().ToUpper());
-			}
-		}
+        /// <summary>
+        /// Overlay group
+        /// </summary>
+        public ushort Group { get; private set; }
 
-		/// <summary>
-		/// Number of bits allocated in overlay data
-		/// </summary>
-		public int BitsAllocated {
-			get { return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayBitsAllocated), 0, 1); }
-			set { Dataset.Add(OverlayTag(DicomTag.OverlayBitsAllocated), (ushort)value); }
-		}
+        /// <summary>
+        /// Number of rows in overlay
+        /// </summary>
+        public int Rows
+        {
+            get
+            {
+                return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayRows));
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.OverlayRows), (ushort)value);
+            }
+        }
 
-		/// <summary>
-		/// Bit position of embedded overlay
-		/// </summary>
-		public int BitPosition {
-			get { return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayBitPosition), 0, 1); }
-			set { Dataset.Add(OverlayTag(DicomTag.OverlayBitPosition), (ushort)value); }
-		}
+        /// <summary>
+        /// Number of columns in overlay
+        /// </summary>
+        public int Columns
+        {
+            get
+            {
+                return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayColumns));
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.OverlayColumns), (ushort)value);
+            }
+        }
 
-		/// <summary>
-		/// Description of overlay
-		/// </summary>
-		public string Description {
-			get { return Dataset.Get<string>(OverlayTag(DicomTag.OverlayDescription), String.Empty); }
-			set { Dataset.Add(DicomTag.OverlayDescription, value); }
-		}
+        /// <summary>
+        /// Overlay type
+        /// </summary>
+        public DicomOverlayType Type
+        {
+            get
+            {
+                var type = Dataset.Get<string>(OverlayTag(DicomTag.OverlayType), "Unknown");
+                if (type.StartsWith("R")) return DicomOverlayType.ROI;
+                else return DicomOverlayType.Graphics;
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.OverlayType), value.ToString().ToUpper());
+            }
+        }
 
-		/// <summary>
-		/// Subtype
-		/// </summary>
-		public string Subtype {
-			get { return Dataset.Get<string>(OverlayTag(DicomTag.OverlaySubtype), String.Empty); }
-			set { Dataset.Add(DicomTag.OverlaySubtype, value); }
-		}
+        /// <summary>
+        /// Number of bits allocated in overlay data
+        /// </summary>
+        public int BitsAllocated
+        {
+            get
+            {
+                return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayBitsAllocated), 0, 1);
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.OverlayBitsAllocated), (ushort)value);
+            }
+        }
 
-		/// <summary>
-		/// Overlay label
-		/// </summary>
-		public string Label {
-			get { return Dataset.Get<string>(OverlayTag(DicomTag.OverlayLabel), String.Empty); }
-			set { Dataset.Add(DicomTag.OverlayLabel, value); }
-		}
+        /// <summary>
+        /// Bit position of embedded overlay
+        /// </summary>
+        public int BitPosition
+        {
+            get
+            {
+                return Dataset.Get<ushort>(OverlayTag(DicomTag.OverlayBitPosition), 0, 1);
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.OverlayBitPosition), (ushort)value);
+            }
+        }
 
-		/// <summary>
-		/// Number of frames
-		/// </summary>
-		public int NumberOfFrames {
-			get { return Dataset.Get<int>(OverlayTag(DicomTag.NumberOfFramesInOverlay), 0, 1); }
-			set { Dataset.Add(OverlayTag(DicomTag.NumberOfFramesInOverlay), value); }
-		}
+        /// <summary>
+        /// Description of overlay
+        /// </summary>
+        public string Description
+        {
+            get
+            {
+                return Dataset.Get<string>(OverlayTag(DicomTag.OverlayDescription), String.Empty);
+            }
+            set
+            {
+                Dataset.Add(DicomTag.OverlayDescription, value);
+            }
+        }
 
-		/// <summary>
-		/// First frame of overlay
-		/// </summary>
-		public int OriginFrame {
-			get { return Dataset.Get<ushort>(OverlayTag(DicomTag.ImageFrameOrigin), 0, 1); }
-			set { Dataset.Add(OverlayTag(DicomTag.ImageFrameOrigin), (ushort)value); }
-		}
+        /// <summary>
+        /// Subtype
+        /// </summary>
+        public string Subtype
+        {
+            get
+            {
+                return Dataset.Get<string>(OverlayTag(DicomTag.OverlaySubtype), String.Empty);
+            }
+            set
+            {
+                Dataset.Add(DicomTag.OverlaySubtype, value);
+            }
+        }
 
-		/// <summary>
-		/// Position of the first column of an overlay
-		/// </summary>
-		public int OriginX {
-			get { return Dataset.Get<short>(OverlayTag(DicomTag.OverlayOrigin), 0, 1); }
-			set { Dataset.Add(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginY); }
-		}
+        /// <summary>
+        /// Overlay label
+        /// </summary>
+        public string Label
+        {
+            get
+            {
+                return Dataset.Get<string>(OverlayTag(DicomTag.OverlayLabel), String.Empty);
+            }
+            set
+            {
+                Dataset.Add(DicomTag.OverlayLabel, value);
+            }
+        }
 
-		/// <summary>
-		/// Position of the first row of an overlay
-		/// </summary>
-		public int OriginY {
-			get { return Dataset.Get<short>(OverlayTag(DicomTag.OverlayOrigin), 1, 1); }
-			set { Dataset.Add(OverlayTag(DicomTag.OverlayOrigin), (short)OriginX, (short)value); }
-		}
+        /// <summary>
+        /// Number of frames
+        /// </summary>
+        public int NumberOfFrames
+        {
+            get
+            {
+                return Dataset.Get<int>(OverlayTag(DicomTag.NumberOfFramesInOverlay), 0, 1);
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.NumberOfFramesInOverlay), value);
+            }
+        }
 
-		/// <summary>
-		/// Overlay data
-		/// </summary>
-		public IByteBuffer Data {
-			get { return Load(); }
-			set { Dataset.Add(new DicomOtherWord(OverlayTag(DicomTag.OverlayData), value)); }
-		}
-		#endregion
+        /// <summary>
+        /// First frame of overlay
+        /// </summary>
+        public int OriginFrame
+        {
+            get
+            {
+                return Dataset.Get<ushort>(OverlayTag(DicomTag.ImageFrameOrigin), 0, 1);
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.ImageFrameOrigin), (ushort)value);
+            }
+        }
 
-		#region Public Members
-		/// <summary>
-		/// Gets the overlay data.
-		/// </summary>
-		/// <param name="bg">Background color</param>
-		/// <param name="fg">Foreground color</param>
-		/// <returns>Overlay data</returns>
-		public int[] GetOverlayDataS32(int bg, int fg) {
-			int[] overlay = new int[Rows * Columns];
-			BitArray bits = new BitArray(Data.Data);
-			if (bits.Length < overlay.Length)
-				throw new DicomDataException("Invalid overlay length: " + bits.Length);
-			for (int i = 0, c = overlay.Length; i < c; i++) {
-				if (bits.Get(i))
-					overlay[i] = fg;
-				else
-					overlay[i] = bg;
-			}
-			return overlay;
-		}
+        /// <summary>
+        /// Position of the first column of an overlay
+        /// </summary>
+        public int OriginX
+        {
+            get
+            {
+                return Dataset.Get<short>(OverlayTag(DicomTag.OverlayOrigin), 0, 1);
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginY);
+            }
+        }
 
-		/// <summary>
-		/// Gets all overlays in a DICOM dataset.
-		/// </summary>
-		/// <param name="ds">Dataset</param>
-		/// <returns>Array of overlays</returns>
-		public static DicomOverlayData[] FromDataset(DicomDataset ds) {
-			var groups = new List<ushort>();
-			groups.AddRange(ds.Where(x => x.Tag.Group >= 0x6000 && x.Tag.Group <= 0x60FF && x.Tag.Element == 0x0010).Select(x => x.Tag.Group));
-			var overlays = new List<DicomOverlayData>();
-			foreach (var group in groups) {
-				// ensure that 6000 group is actually an overlay group
-				if (ds.Get<DicomElement>(new DicomTag(group, 0x0010)).ValueRepresentation != DicomVR.US)
-					continue;
+        /// <summary>
+        /// Position of the first row of an overlay
+        /// </summary>
+        public int OriginY
+        {
+            get
+            {
+                return Dataset.Get<short>(OverlayTag(DicomTag.OverlayOrigin), 1, 1);
+            }
+            set
+            {
+                Dataset.Add(OverlayTag(DicomTag.OverlayOrigin), (short)OriginX, (short)value);
+            }
+        }
 
-				try {
-					DicomOverlayData overlay = new DicomOverlayData(ds, group);
-					overlays.Add(overlay);
-				} catch {
-					// bail out if not an overlay group
-				}
-			}
-			return overlays.ToArray();
-		}
+        /// <summary>
+        /// Overlay data
+        /// </summary>
+        public IByteBuffer Data
+        {
+            get
+            {
+                return Load();
+            }
+            set
+            {
+                Dataset.Add(new DicomOtherWord(OverlayTag(DicomTag.OverlayData), value));
+            }
+        }
 
-		/// <summary>
-		/// Creates a DICOM overlay from a GDI+ Bitmap.
-		/// </summary>
-		/// <param name="ds">Dataset</param>
-		/// <param name="bitmap">Bitmap</param>
-		/// <param name="mask">Color mask for overlay</param>
-		/// <returns>DICOM overlay</returns>
-		public static DicomOverlayData FromBitmap(DicomDataset ds, Bitmap bitmap, Color mask) {
-			ushort group = 0x6000;
-			while (ds.Contains(new DicomTag(group, DicomTag.OverlayBitPosition.Element)))
-				group += 2;
+        #endregion
 
-			var overlay = new DicomOverlayData(ds, group);
-			overlay.Type = DicomOverlayType.Graphics;
-			overlay.Rows = bitmap.Height;
-			overlay.Columns = bitmap.Width;
-			overlay.OriginX = 1;
-			overlay.OriginY = 1;
-			overlay.BitsAllocated = 1;
-			overlay.BitPosition = 1;
+        #region Public Members
 
-			var count = overlay.Rows * overlay.Columns / 8;
-			if ((overlay.Rows * overlay.Columns) % 8 > 0)
-				count++;
+        /// <summary>
+        /// Gets the overlay data.
+        /// </summary>
+        /// <param name="bg">Background color</param>
+        /// <param name="fg">Foreground color</param>
+        /// <returns>Overlay data</returns>
+        public int[] GetOverlayDataS32(int bg, int fg)
+        {
+            int[] overlay = new int[Rows * Columns];
+            BitArray bits = new BitArray(Data.Data);
+            if (bits.Length < overlay.Length) throw new DicomDataException("Invalid overlay length: " + bits.Length);
+            for (int i = 0, c = overlay.Length; i < c; i++)
+            {
+                if (bits.Get(i)) overlay[i] = fg;
+                else overlay[i] = bg;
+            }
+            return overlay;
+        }
 
-			var array = new BitList();
-			array.Capacity = overlay.Rows * overlay.Columns;
+        /// <summary>
+        /// Gets all overlays in a DICOM dataset.
+        /// </summary>
+        /// <param name="ds">Dataset</param>
+        /// <returns>Array of overlays</returns>
+        public static DicomOverlayData[] FromDataset(DicomDataset ds)
+        {
+            var groups = new List<ushort>();
+            groups.AddRange(
+                ds.Where(x => x.Tag.Group >= 0x6000 && x.Tag.Group <= 0x60FF && x.Tag.Element == 0x0010)
+                    .Select(x => x.Tag.Group));
+            var overlays = new List<DicomOverlayData>();
+            foreach (var group in groups)
+            {
+                // ensure that 6000 group is actually an overlay group
+                if (ds.Get<DicomElement>(new DicomTag(group, 0x0010)).ValueRepresentation != DicomVR.US) continue;
 
-			int p = 0;
-			for (int y = 0; y < bitmap.Height; y++) {
-				for (int x = 0; x < bitmap.Width; x++, p++) {
-					if (bitmap.GetPixel(x, y).ToArgb() == mask.ToArgb())
-						array[p] = true;
-				}
-			}
+                try
+                {
+                    DicomOverlayData overlay = new DicomOverlayData(ds, group);
+                    overlays.Add(overlay);
+                }
+                catch
+                {
+                    // bail out if not an overlay group
+                }
+            }
+            return overlays.ToArray();
+        }
 
-			overlay.Data = EvenLengthBuffer.Create(
-									new MemoryByteBuffer(array.Array));
+        /// <summary>
+        /// Creates a DICOM overlay from a GDI+ Bitmap.
+        /// </summary>
+        /// <param name="ds">Dataset</param>
+        /// <param name="bitmap">Bitmap</param>
+        /// <param name="mask">Color mask for overlay</param>
+        /// <returns>DICOM overlay</returns>
+        public static DicomOverlayData FromBitmap(DicomDataset ds, Bitmap bitmap, Color mask)
+        {
+            ushort group = 0x6000;
+            while (ds.Contains(new DicomTag(group, DicomTag.OverlayBitPosition.Element))) group += 2;
 
-			return overlay;
-		}
+            var overlay = new DicomOverlayData(ds, group);
+            overlay.Type = DicomOverlayType.Graphics;
+            overlay.Rows = bitmap.Height;
+            overlay.Columns = bitmap.Width;
+            overlay.OriginX = 1;
+            overlay.OriginY = 1;
+            overlay.BitsAllocated = 1;
+            overlay.BitPosition = 1;
 
-		public static bool HasEmbeddedOverlays(DicomDataset ds) {
-			var groups = new List<ushort>();
-			groups.AddRange(ds.Where(x => x.Tag.Group >= 0x6000 && x.Tag.Group <= 0x60FF && x.Tag.Element == 0x0010).Select(x => x.Tag.Group));
+            var count = overlay.Rows * overlay.Columns / 8;
+            if ((overlay.Rows * overlay.Columns) % 8 > 0) count++;
 
-			foreach (var group in groups) {
-				if (!ds.Contains(new DicomTag(group, DicomTag.OverlayData.Element)))
-					return true;
-			}
+            var array = new BitList();
+            array.Capacity = overlay.Rows * overlay.Columns;
 
-			return false;
-		}
-		#endregion
+            int p = 0;
+            for (int y = 0; y < bitmap.Height; y++)
+            {
+                for (int x = 0; x < bitmap.Width; x++, p++)
+                {
+                    if (bitmap.GetPixel(x, y).ToArgb() == mask.ToArgb()) array[p] = true;
+                }
+            }
 
-		#region Private Methods
-		private DicomTag OverlayTag(DicomTag tag) {
-			return new DicomTag(Group, tag.Element);
-		}
+            overlay.Data = EvenLengthBuffer.Create(new MemoryByteBuffer(array.Array));
 
-		private IByteBuffer Load() {
-			var tag = OverlayTag(DicomTag.OverlayData);
-			if (Dataset.Contains(tag)) {
-				var elem = Dataset.FirstOrDefault(x => x.Tag == tag) as DicomElement;
-				return elem.Buffer;
-			} else {
-				// overlay embedded in high bits of pixel data
-				if (Dataset.InternalTransferSyntax.IsEncapsulated)
-					throw new DicomImagingException("Attempted to extract embedded overlay from compressed pixel data. Decompress pixel data before attempting this operation.");
+            return overlay;
+        }
 
-				var pixels = DicomPixelData.Create(Dataset);
+        public static bool HasEmbeddedOverlays(DicomDataset ds)
+        {
+            var groups = new List<ushort>();
+            groups.AddRange(
+                ds.Where(x => x.Tag.Group >= 0x6000 && x.Tag.Group <= 0x60FF && x.Tag.Element == 0x0010)
+                    .Select(x => x.Tag.Group));
 
-				// (1,1) indicates top left pixel of image
-				int ox = Math.Max(0, OriginX - 1);
-				int oy = Math.Max(0, OriginY - 1);
-				int ow = Rows - (pixels.Width - Rows - ox);
-				int oh = Columns - (pixels.Height - Columns - oy);
+            foreach (var group in groups)
+            {
+                if (!ds.Contains(new DicomTag(group, DicomTag.OverlayData.Element))) return true;
+            }
 
-				var frame = pixels.GetFrame(0);
+            return false;
+        }
 
-				var bits = new BitList();
-				bits.Capacity = Rows * Columns;
-				int mask = 1 << BitPosition;
+        #endregion
 
-				if (pixels.BitsAllocated == 8) {
-					var data = ByteBufferEnumerator<byte>.Create(frame).ToArray();
+        #region Private Methods
 
-					for (int y = oy; y < oh; y++) {
-						int n = (y * pixels.Width) + ox;
-						int i = (y - oy) * Columns;
-						for (int x = ox; x < ow; x++) {
-							if ((data[n] & mask) != 0)
-								bits[i] = true;
-							n++;
-							i++;
-						}
-					}
-				} else if (pixels.BitsAllocated == 16) {
-					// we don't really care if the pixel data is signed or not
-					var data = ByteBufferEnumerator<ushort>.Create(frame).ToArray();
+        private DicomTag OverlayTag(DicomTag tag)
+        {
+            return new DicomTag(Group, tag.Element);
+        }
 
-					for (int y = oy; y < oh; y++) {
-						int n = (y * pixels.Width) + ox;
-						int i = (y - oy) * Columns;
-						for (int x = ox; x < ow; x++) {
-							if ((data[n] & mask) != 0)
-								bits[i] = true;
-							n++;
-							i++;
-						}
-					}
-				} else {
-					throw new DicomImagingException("Unable to extract embedded overlay from pixel data with bits stored greater than 16.");
-				}
+        private IByteBuffer Load()
+        {
+            var tag = OverlayTag(DicomTag.OverlayData);
+            if (Dataset.Contains(tag))
+            {
+                var elem = Dataset.FirstOrDefault(x => x.Tag == tag) as DicomElement;
+                return elem.Buffer;
+            }
+            else
+            {
+                // overlay embedded in high bits of pixel data
+                if (Dataset.InternalTransferSyntax.IsEncapsulated)
+                    throw new DicomImagingException(
+                        "Attempted to extract embedded overlay from compressed pixel data. Decompress pixel data before attempting this operation.");
 
-				return new MemoryByteBuffer(bits.Array);
-			}
-		}
-		#endregion
-	}
+                var pixels = DicomPixelData.Create(Dataset);
+
+                // (1,1) indicates top left pixel of image
+                int ox = Math.Max(0, OriginX - 1);
+                int oy = Math.Max(0, OriginY - 1);
+                int ow = Rows - (pixels.Width - Rows - ox);
+                int oh = Columns - (pixels.Height - Columns - oy);
+
+                var frame = pixels.GetFrame(0);
+
+                var bits = new BitList();
+                bits.Capacity = Rows * Columns;
+                int mask = 1 << BitPosition;
+
+                if (pixels.BitsAllocated == 8)
+                {
+                    var data = ByteBufferEnumerator<byte>.Create(frame).ToArray();
+
+                    for (int y = oy; y < oh; y++)
+                    {
+                        int n = (y * pixels.Width) + ox;
+                        int i = (y - oy) * Columns;
+                        for (int x = ox; x < ow; x++)
+                        {
+                            if ((data[n] & mask) != 0) bits[i] = true;
+                            n++;
+                            i++;
+                        }
+                    }
+                }
+                else if (pixels.BitsAllocated == 16)
+                {
+                    // we don't really care if the pixel data is signed or not
+                    var data = ByteBufferEnumerator<ushort>.Create(frame).ToArray();
+
+                    for (int y = oy; y < oh; y++)
+                    {
+                        int n = (y * pixels.Width) + ox;
+                        int i = (y - oy) * Columns;
+                        for (int x = ox; x < ow; x++)
+                        {
+                            if ((data[n] & mask) != 0) bits[i] = true;
+                            n++;
+                            i++;
+                        }
+                    }
+                }
+                else
+                {
+                    throw new DicomImagingException(
+                        "Unable to extract embedded overlay from pixel data with bits stored greater than 16.");
+                }
+
+                return new MemoryByteBuffer(bits.Array);
+            }
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -1,480 +1,581 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
+using System;
+using System.Linq;
+
 using Dicom.IO.Buffer;
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// DICOM Pixel Data abstract class for reading and writing DICOM images pixel data according to the specified transfer syntax
-	/// </summary>
-	public abstract class DicomPixelData {
-		/// <summary>
-		/// Initialize new instance of <seealso cref="DicomPixelData"/> using passed <paramref name="dataset"/>
-		/// </summary>
-		/// <param name="dataset"></param>
-		protected DicomPixelData(DicomDataset dataset) {
-			Dataset = dataset;
-			Syntax = dataset.InternalTransferSyntax;
-		}
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// DICOM Pixel Data abstract class for reading and writing DICOM images pixel data according to the specified transfer syntax
+    /// </summary>
+    public abstract class DicomPixelData
+    {
+        /// <summary>
+        /// Initialize new instance of <seealso cref="DicomPixelData"/> using passed <paramref name="dataset"/>
+        /// </summary>
+        /// <param name="dataset"></param>
+        protected DicomPixelData(DicomDataset dataset)
+        {
+            Dataset = dataset;
+            Syntax = dataset.InternalTransferSyntax;
+        }
 
-		/// <summary>
-		/// Dicom Dataset
-		/// </summary>
-		public DicomDataset Dataset {
-			get;
-			private set;
-		}
+        /// <summary>
+        /// Dicom Dataset
+        /// </summary>
+        public DicomDataset Dataset { get; private set; }
 
-		/// <summary>
-		/// The transfer syntax used to encode the DICOM iamge pixel data
-		/// </summary>
-		public DicomTransferSyntax Syntax {
-			get;
-			private set;
-		}
+        /// <summary>
+        /// The transfer syntax used to encode the DICOM iamge pixel data
+        /// </summary>
+        public DicomTransferSyntax Syntax { get; private set; }
 
-		/// <summary>
-		/// DICOM image width (columns) in pixels
-		/// </summary>
-		public ushort Width {
-			get { return Dataset.Get<ushort>(DicomTag.Columns); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.Columns, value)); }
-		}
+        /// <summary>
+        /// DICOM image width (columns) in pixels
+        /// </summary>
+        public ushort Width
+        {
+            get
+            {
+                return Dataset.Get<ushort>(DicomTag.Columns);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.Columns, value));
+            }
+        }
 
-		/// <summary>
-		/// DICOM image height (rows) in pixels
-		/// </summary>
-		public ushort Height {
-			get { return Dataset.Get<ushort>(DicomTag.Rows); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.Rows, value)); }
-		}
+        /// <summary>
+        /// DICOM image height (rows) in pixels
+        /// </summary>
+        public ushort Height
+        {
+            get
+            {
+                return Dataset.Get<ushort>(DicomTag.Rows);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.Rows, value));
+            }
+        }
 
 
-		/// <summary>
-		/// DICOM image Number of frames. This value usually equals 1 for single frame images
-		/// </summary>
-		public int NumberOfFrames {
-			get { return Dataset.Get<ushort>(DicomTag.NumberOfFrames, 0, 1); }
-			set { Dataset.Add(new DicomIntegerString(DicomTag.NumberOfFrames, value)); }
-		}
+        /// <summary>
+        /// DICOM image Number of frames. This value usually equals 1 for single frame images
+        /// </summary>
+        public int NumberOfFrames
+        {
+            get
+            {
+                return Dataset.Get<ushort>(DicomTag.NumberOfFrames, 0, 1);
+            }
+            set
+            {
+                Dataset.Add(new DicomIntegerString(DicomTag.NumberOfFrames, value));
+            }
+        }
 
-		/// <summary>
-		/// Return new instance of <seealso cref="BitDepth"/> using dataset information
-		/// </summary>
-		public BitDepth BitDepth {
-			get {
-				return new BitDepth(BitsAllocated, BitsStored, HighBit, PixelRepresentation == PixelRepresentation.Signed);
-			}
-		}
+        /// <summary>
+        /// Return new instance of <seealso cref="BitDepth"/> using dataset information
+        /// </summary>
+        public BitDepth BitDepth
+        {
+            get
+            {
+                return new BitDepth(
+                    BitsAllocated,
+                    BitsStored,
+                    HighBit,
+                    PixelRepresentation == PixelRepresentation.Signed);
+            }
+        }
 
-		/// <summary>
-		/// Number of bits allocated per pixel sample (0028,0100)
-		/// </summary>
-		public ushort BitsAllocated {
-			get { return Dataset.Get<ushort>(DicomTag.BitsAllocated); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.BitsAllocated, value)); }
-		}
+        /// <summary>
+        /// Number of bits allocated per pixel sample (0028,0100)
+        /// </summary>
+        public ushort BitsAllocated
+        {
+            get
+            {
+                return Dataset.Get<ushort>(DicomTag.BitsAllocated);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.BitsAllocated, value));
+            }
+        }
 
-		/// <summary>
-		/// Number of bits stored per pixel sample (0028,0101)
-		/// </summary>
-		public ushort BitsStored {
-			get { return Dataset.Get<ushort>(DicomTag.BitsStored); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.BitsStored, value)); }
-		}
+        /// <summary>
+        /// Number of bits stored per pixel sample (0028,0101)
+        /// </summary>
+        public ushort BitsStored
+        {
+            get
+            {
+                return Dataset.Get<ushort>(DicomTag.BitsStored);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.BitsStored, value));
+            }
+        }
 
-		/// <summary>
-		/// Index of the most signficant bit (MSB) of pixel sample(0028,0102)
-		/// </summary>
-		public ushort HighBit {
-			get { return Dataset.Get<ushort>(DicomTag.HighBit); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.HighBit, value)); }
-		}
+        /// <summary>
+        /// Index of the most signficant bit (MSB) of pixel sample(0028,0102)
+        /// </summary>
+        public ushort HighBit
+        {
+            get
+            {
+                return Dataset.Get<ushort>(DicomTag.HighBit);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.HighBit, value));
+            }
+        }
 
-		/// <summary>
-		/// Number of samples per pixel (0028,0002), usually 1 for grayscale and 3 for color (RGB and YBR)
-		/// </summary> 
-		public ushort SamplesPerPixel {
-			get { return Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 0, 1); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.SamplesPerPixel, value)); }
-		}
+        /// <summary>
+        /// Number of samples per pixel (0028,0002), usually 1 for grayscale and 3 for color (RGB and YBR)
+        /// </summary> 
+        public ushort SamplesPerPixel
+        {
+            get
+            {
+                return Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 0, 1);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.SamplesPerPixel, value));
+            }
+        }
 
-		/// <summary>
-		/// Pixel Representation (0028,0103) represents signed/unsigned data of the pixel samples 
-		/// </summary>
-		public PixelRepresentation PixelRepresentation {
-			get { return Dataset.Get<PixelRepresentation>(DicomTag.PixelRepresentation); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.PixelRepresentation, (ushort)value)); }
-		}
+        /// <summary>
+        /// Pixel Representation (0028,0103) represents signed/unsigned data of the pixel samples 
+        /// </summary>
+        public PixelRepresentation PixelRepresentation
+        {
+            get
+            {
+                return Dataset.Get<PixelRepresentation>(DicomTag.PixelRepresentation);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.PixelRepresentation, (ushort)value));
+            }
+        }
 
-		/// <summary>
-		/// Planar Configuration (0028,0006) indicates whether the color pixel data are sent color-by-plane
-		/// or color-by-pixel
-		/// </summary>
-		public PlanarConfiguration PlanarConfiguration {
-			get { return Dataset.Get<PlanarConfiguration>(DicomTag.PlanarConfiguration); }
-			set { Dataset.Add(new DicomUnsignedShort(DicomTag.PlanarConfiguration, (ushort)value)); }
-		}
+        /// <summary>
+        /// Planar Configuration (0028,0006) indicates whether the color pixel data are sent color-by-plane
+        /// or color-by-pixel
+        /// </summary>
+        public PlanarConfiguration PlanarConfiguration
+        {
+            get
+            {
+                return Dataset.Get<PlanarConfiguration>(DicomTag.PlanarConfiguration);
+            }
+            set
+            {
+                Dataset.Add(new DicomUnsignedShort(DicomTag.PlanarConfiguration, (ushort)value));
+            }
+        }
 
-		/// <summary>
-		/// Photometric Interpretation
-		/// </summary>
-		public PhotometricInterpretation PhotometricInterpretation {
-			get { return Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation); }
-			set { Dataset.Add(new DicomCodeString(DicomTag.PhotometricInterpretation, value.Value)); }
-		}
+        /// <summary>
+        /// Photometric Interpretation
+        /// </summary>
+        public PhotometricInterpretation PhotometricInterpretation
+        {
+            get
+            {
+                return Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation);
+            }
+            set
+            {
+                Dataset.Add(new DicomCodeString(DicomTag.PhotometricInterpretation, value.Value));
+            }
+        }
 
-		/// <summary>
-		/// Lossy image compression (0028,2110), returns true if stored value is "01"
-		/// </summary>
-		public bool IsLossy {
-			get { return Dataset.Get<string>(DicomTag.LossyImageCompression, "00") == "01"; }
-		}
+        /// <summary>
+        /// Lossy image compression (0028,2110), returns true if stored value is "01"
+        /// </summary>
+        public bool IsLossy
+        {
+            get
+            {
+                return Dataset.Get<string>(DicomTag.LossyImageCompression, "00") == "01";
+            }
+        }
 
-		/// <summary>
-		/// Lossy image compression method (0028,2114)
-		/// </summary>
-		public string LossyCompressionMethod {
-			get { return Dataset.Get<string>(DicomTag.LossyImageCompressionMethod); }
-		}
+        /// <summary>
+        /// Lossy image compression method (0028,2114)
+        /// </summary>
+        public string LossyCompressionMethod
+        {
+            get
+            {
+                return Dataset.Get<string>(DicomTag.LossyImageCompressionMethod);
+            }
+        }
 
-		/// <summary>
-		/// Lossy image compression ration (0028,2112)
-		/// </summary>
-		public decimal LossyCompressionRatio {
-			get { return Dataset.Get<decimal>(DicomTag.LossyImageCompressionRatio); }
-		}
+        /// <summary>
+        /// Lossy image compression ration (0028,2112)
+        /// </summary>
+        public decimal LossyCompressionRatio
+        {
+            get
+            {
+                return Dataset.Get<decimal>(DicomTag.LossyImageCompressionRatio);
+            }
+        }
 
-		/// <summary>
-		/// Number of bytes allocated per pixel sample
-		/// </summary>
-		public int BytesAllocated {
-			get {
-				int bytes = BitsAllocated / 8;
-				if ((BitsAllocated % 8) > 0)
-					bytes++;
-				return bytes;
-			}
-		}
+        /// <summary>
+        /// Number of bytes allocated per pixel sample
+        /// </summary>
+        public int BytesAllocated
+        {
+            get
+            {
+                int bytes = BitsAllocated / 8;
+                if ((BitsAllocated % 8) > 0) bytes++;
+                return bytes;
+            }
+        }
 
-		/// <summary>
-		/// Uncompressed frame size in bytes
-		/// </summary>
-		public int UncompressedFrameSize {
-			get {
-				if (BitsAllocated == 1) {
-					var bytes = (Width * Height) / 8;
-					if (((Width * Height) % 8) > 0)
-						bytes++;
-					return bytes;
-				}
-				return BytesAllocated * SamplesPerPixel * Width * Height;
-			}
-		}
-		/// <summary>
-		/// Plaette color LUT, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
-		/// </summary>
-		public Color32[] PaletteColorLUT {
-			get { return GetPaletteColorLUT(); }
-			set { throw new NotImplementedException(); }
-		}
+        /// <summary>
+        /// Uncompressed frame size in bytes
+        /// </summary>
+        public int UncompressedFrameSize
+        {
+            get
+            {
+                if (BitsAllocated == 1)
+                {
+                    var bytes = (Width * Height) / 8;
+                    if (((Width * Height) % 8) > 0) bytes++;
+                    return bytes;
+                }
+                return BytesAllocated * SamplesPerPixel * Width * Height;
+            }
+        }
 
-		/// <summary>
-		/// Extracts the palette color LUT from DICOM dataset, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
-		/// </summary>
-		/// <returns>Palette color LUT</returns>
-		/// <exception cref="DicomImagingException">Invalid photometric interpretation or plaette color lUT missing from database</exception>
-		private Color32[] GetPaletteColorLUT() {
-			if (PhotometricInterpretation != PhotometricInterpretation.PaletteColor)
-				throw new DicomImagingException("Attempted to get Palette Color LUT from image with invalid photometric interpretation.");
+        /// <summary>
+        /// Plaette color LUT, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
+        /// </summary>
+        public Color32[] PaletteColorLUT
+        {
+            get
+            {
+                return GetPaletteColorLUT();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
 
-			if (!Dataset.Contains(DicomTag.RedPaletteColorLookupTableDescriptor))
-				throw new DicomImagingException("Palette Color LUT missing from dataset.");
+        /// <summary>
+        /// Extracts the palette color LUT from DICOM dataset, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
+        /// </summary>
+        /// <returns>Palette color LUT</returns>
+        /// <exception cref="DicomImagingException">Invalid photometric interpretation or plaette color lUT missing from database</exception>
+        private Color32[] GetPaletteColorLUT()
+        {
+            if (PhotometricInterpretation != PhotometricInterpretation.PaletteColor)
+                throw new DicomImagingException(
+                    "Attempted to get Palette Color LUT from image with invalid photometric interpretation.");
 
-			int size = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 0);
-			int first = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 1);
-			int bits = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 2);
+            if (!Dataset.Contains(DicomTag.RedPaletteColorLookupTableDescriptor)) throw new DicomImagingException("Palette Color LUT missing from dataset.");
 
-			var r = Dataset.Get<byte[]>(DicomTag.RedPaletteColorLookupTableData);
-			var g = Dataset.Get<byte[]>(DicomTag.GreenPaletteColorLookupTableData);
-			var b = Dataset.Get<byte[]>(DicomTag.BluePaletteColorLookupTableData);
-           
+            int size = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 0);
+            int first = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 1);
+            int bits = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 2);
+
+            var r = Dataset.Get<byte[]>(DicomTag.RedPaletteColorLookupTableData);
+            var g = Dataset.Get<byte[]>(DicomTag.GreenPaletteColorLookupTableData);
+            var b = Dataset.Get<byte[]>(DicomTag.BluePaletteColorLookupTableData);
+
             // If the LUT size is 0, that means it's 65536 in size.
-            if (size == 0)
-                size = 65536;
-			
+            if (size == 0) size = 65536;
+
             var lut = new Color32[size];
 
-			if (r.Length == size) {
-				// 8-bit LUT entries
-				for (int i = 0; i < size; i++)
-					lut[i] = new Color32(0xff, r[i], g[i], b[i]);
-			} else {
-				// 16-bit LUT entries... we only support 8-bit until someone can find a sample image with a 16-bit palette
+            if (r.Length == size)
+            {
+                // 8-bit LUT entries
+                for (int i = 0; i < size; i++) lut[i] = new Color32(0xff, r[i], g[i], b[i]);
+            }
+            else
+            {
+                // 16-bit LUT entries... we only support 8-bit until someone can find a sample image with a 16-bit palette
 
-				// 8-bit entries with 16-bits allocated
-				int offset = 0;
+                // 8-bit entries with 16-bits allocated
+                int offset = 0;
 
-				// 16-bit entries with 8-bits stored
-				if (bits == 16)
-					offset = 1;
+                // 16-bit entries with 8-bits stored
+                if (bits == 16) offset = 1;
 
-				for (int i = 0; i < size; i++, offset += 2)
-					lut[i] = new Color32(0xff, r[offset], g[offset], b[offset]);
-			}
+                for (int i = 0; i < size; i++, offset += 2) lut[i] = new Color32(0xff, r[offset], g[offset], b[offset]);
+            }
 
-			return lut;
-		}
+            return lut;
+        }
 
-		/// <summary>
-		/// Abstract GetFrame method to extract specific frame byte buffer <paramref name="frame"/> dataset
-		/// </summary>
-		/// <param name="frame">Frame index</param>
-		/// <returns>Frame byte buffer</returns>
-		public abstract IByteBuffer GetFrame(int frame);
+        /// <summary>
+        /// Abstract GetFrame method to extract specific frame byte buffer <paramref name="frame"/> dataset
+        /// </summary>
+        /// <param name="frame">Frame index</param>
+        /// <returns>Frame byte buffer</returns>
+        public abstract IByteBuffer GetFrame(int frame);
 
-		/// <summary>
-		/// Abstract AddFrame method to add new frame into dataset pixel dataset. new frame will be appended to existing frames
-		/// </summary>
-		/// <param name="data">Frame byte buffer</param>
-		public abstract void AddFrame(IByteBuffer data);
+        /// <summary>
+        /// Abstract AddFrame method to add new frame into dataset pixel dataset. new frame will be appended to existing frames
+        /// </summary>
+        /// <param name="data">Frame byte buffer</param>
+        public abstract void AddFrame(IByteBuffer data);
 
-		/// <summary>
-		/// A factory method to initialize new instance of <seealso cref="DicomPixelData"/> implementation either 
-		/// <seealso cref="OtherWordPixelData"/>, <seealso cref="OtherBytePixelData"/>, or <seealso cref="EncapsulatedPixelData"/>
-		/// </summary>
-		/// <param name="dataset">Source DICOM Dataset</param>
-		/// <param name="newPixelData">true if new <seealso cref="DicomPixelData"/>will be created for current dataset,
-		/// false to read <seealso cref="DicomPixelData"/> from <paramref name="dataset"/>.
-		/// Default is false (read)</param>
-		/// <returns>New instance of DicomPixelData</returns>
-		public static DicomPixelData Create(DicomDataset dataset, bool newPixelData = false) {
-			var syntax = dataset.InternalTransferSyntax;
+        /// <summary>
+        /// A factory method to initialize new instance of <seealso cref="DicomPixelData"/> implementation either 
+        /// <seealso cref="OtherWordPixelData"/>, <seealso cref="OtherBytePixelData"/>, or <seealso cref="EncapsulatedPixelData"/>
+        /// </summary>
+        /// <param name="dataset">Source DICOM Dataset</param>
+        /// <param name="newPixelData">true if new <seealso cref="DicomPixelData"/>will be created for current dataset,
+        /// false to read <seealso cref="DicomPixelData"/> from <paramref name="dataset"/>.
+        /// Default is false (read)</param>
+        /// <returns>New instance of DicomPixelData</returns>
+        public static DicomPixelData Create(DicomDataset dataset, bool newPixelData = false)
+        {
+            var syntax = dataset.InternalTransferSyntax;
 
-			if (newPixelData) {
-				if (syntax == DicomTransferSyntax.ImplicitVRLittleEndian)
-					return new OtherWordPixelData(dataset, true);
+            if (newPixelData)
+            {
+                if (syntax == DicomTransferSyntax.ImplicitVRLittleEndian) return new OtherWordPixelData(dataset, true);
 
-				if (syntax.IsEncapsulated)
-					return new EncapsulatedPixelData(dataset, true);
+                if (syntax.IsEncapsulated) return new EncapsulatedPixelData(dataset, true);
 
-				if (dataset.Get<ushort>(DicomTag.BitsAllocated) == 16)
-					return new OtherWordPixelData(dataset, true);
-				else
-					return new OtherBytePixelData(dataset, true);
-			} else {
-				var item = dataset.Get<DicomItem>(DicomTag.PixelData);
-				if (item == null)
-					throw new DicomImagingException("DICOM dataset is missing pixel data element.");
+                if (dataset.Get<ushort>(DicomTag.BitsAllocated) == 16) return new OtherWordPixelData(dataset, true);
+                else return new OtherBytePixelData(dataset, true);
+            }
+            else
+            {
+                var item = dataset.Get<DicomItem>(DicomTag.PixelData);
+                if (item == null) throw new DicomImagingException("DICOM dataset is missing pixel data element.");
 
-				if (item is DicomOtherByte)
-					return new OtherBytePixelData(dataset, false);
-				if (item is DicomOtherWord)
-					return new OtherWordPixelData(dataset, false);
-				if (item is DicomOtherByteFragment || item is DicomOtherWordFragment)
-					return new EncapsulatedPixelData(dataset, false);
+                if (item is DicomOtherByte) return new OtherBytePixelData(dataset, false);
+                if (item is DicomOtherWord) return new OtherWordPixelData(dataset, false);
+                if (item is DicomOtherByteFragment || item is DicomOtherWordFragment) return new EncapsulatedPixelData(dataset, false);
 
-				throw new DicomImagingException("Unexpected or unhandled pixel data element type: {0}", item.GetType());
-			}
-		}
+                throw new DicomImagingException("Unexpected or unhandled pixel data element type: {0}", item.GetType());
+            }
+        }
 
-		/// <summary>
-		/// Other Byte (OB) implementation of <seealso cref="DicomPixelData"/>
-		/// </summary>
-		private class OtherBytePixelData : DicomPixelData {
-			/// <summary>
-			/// Initialize new instance of OtherBytePixelData
-			/// </summary>
-			/// <param name="dataset">The source dataset to extract from or create new pixel data for</param>
-			/// <param name="newPixelData">True to create new pixel data, false to read pixel data</param>
-			public OtherBytePixelData(DicomDataset dataset, bool newPixelData) : base(dataset) {
-				if (newPixelData) {
-					NumberOfFrames = 0;
-					Element = new DicomOtherByte(DicomTag.PixelData, new CompositeByteBuffer());
-					Dataset.Add(Element);
-				} else
-					Element = dataset.Get<DicomOtherByte>(DicomTag.PixelData);
-			}
+        /// <summary>
+        /// Other Byte (OB) implementation of <seealso cref="DicomPixelData"/>
+        /// </summary>
+        private class OtherBytePixelData : DicomPixelData
+        {
+            /// <summary>
+            /// Initialize new instance of OtherBytePixelData
+            /// </summary>
+            /// <param name="dataset">The source dataset to extract from or create new pixel data for</param>
+            /// <param name="newPixelData">True to create new pixel data, false to read pixel data</param>
+            public OtherBytePixelData(DicomDataset dataset, bool newPixelData)
+                : base(dataset)
+            {
+                if (newPixelData)
+                {
+                    NumberOfFrames = 0;
+                    Element = new DicomOtherByte(DicomTag.PixelData, new CompositeByteBuffer());
+                    Dataset.Add(Element);
+                }
+                else Element = dataset.Get<DicomOtherByte>(DicomTag.PixelData);
+            }
 
-			/// <summary>
-			/// The pixel data other byte (OB) element
-			/// </summary>
-			public DicomOtherByte Element {
-				get;
-				private set;
-			}
-			public override IByteBuffer GetFrame(int frame) {
-                if (frame < 0 || frame >= NumberOfFrames)
-                    throw new IndexOutOfRangeException("Requested frame out of range!");
+            /// <summary>
+            /// The pixel data other byte (OB) element
+            /// </summary>
+            public DicomOtherByte Element { get; private set; }
 
-				int offset = UncompressedFrameSize * frame;
-				return new RangeByteBuffer(Element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
-			}
+            public override IByteBuffer GetFrame(int frame)
+            {
+                if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
 
-			public override void AddFrame(IByteBuffer data) {
-				if (!(Element.Buffer is CompositeByteBuffer))
-					throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer");
+                int offset = UncompressedFrameSize * frame;
+                return new RangeByteBuffer(Element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
+            }
 
-				CompositeByteBuffer buffer = Element.Buffer as CompositeByteBuffer;
-				buffer.Buffers.Add(data);
+            public override void AddFrame(IByteBuffer data)
+            {
+                if (!(Element.Buffer is CompositeByteBuffer)) throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer");
 
-				NumberOfFrames++;
-			}
-		}
+                CompositeByteBuffer buffer = Element.Buffer as CompositeByteBuffer;
+                buffer.Buffers.Add(data);
 
-		/// <summary>
-		/// Other Word (OW) implementation of <seealso cref="DicomPixelData"/>
-		/// </summary>
-		private class OtherWordPixelData : DicomPixelData {
-			/// <summary>
-			/// Initialize new instance of OtherWordPixelData
-			/// </summary>
-			/// <param name="dataset">The source dataset to extract from or create new pixel data for</param>
-			/// <param name="newPixelData">True to create new pixel data, false to read pixel data</param>
-			public OtherWordPixelData(DicomDataset dataset, bool newPixelData) : base(dataset) {
-				if (newPixelData) {
-					NumberOfFrames = 0;
-					Element = new DicomOtherWord(DicomTag.PixelData, new CompositeByteBuffer());
-					Dataset.Add(Element);
-				} else
-					Element = dataset.Get<DicomOtherWord>(DicomTag.PixelData);
-			}
+                NumberOfFrames++;
+            }
+        }
 
-			/// <summary>
-			/// The pixel data other word (OW) element
-			/// </summary>
-			public DicomOtherWord Element {
-				get;
-				private set;
-			}
+        /// <summary>
+        /// Other Word (OW) implementation of <seealso cref="DicomPixelData"/>
+        /// </summary>
+        private class OtherWordPixelData : DicomPixelData
+        {
+            /// <summary>
+            /// Initialize new instance of OtherWordPixelData
+            /// </summary>
+            /// <param name="dataset">The source dataset to extract from or create new pixel data for</param>
+            /// <param name="newPixelData">True to create new pixel data, false to read pixel data</param>
+            public OtherWordPixelData(DicomDataset dataset, bool newPixelData)
+                : base(dataset)
+            {
+                if (newPixelData)
+                {
+                    NumberOfFrames = 0;
+                    Element = new DicomOtherWord(DicomTag.PixelData, new CompositeByteBuffer());
+                    Dataset.Add(Element);
+                }
+                else Element = dataset.Get<DicomOtherWord>(DicomTag.PixelData);
+            }
 
-			public override IByteBuffer GetFrame(int frame) {
-                if (frame < 0 || frame >= NumberOfFrames)
-                    throw new IndexOutOfRangeException("Requested frame out of range!");
+            /// <summary>
+            /// The pixel data other word (OW) element
+            /// </summary>
+            public DicomOtherWord Element { get; private set; }
 
-				int offset = UncompressedFrameSize * frame;
-				IByteBuffer buffer = new RangeByteBuffer(Element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
+            public override IByteBuffer GetFrame(int frame)
+            {
+                if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
 
-				// mainly for GE Private Implicit VR Big Endian
-				if (Syntax.SwapPixelData)
-					buffer = new SwapByteBuffer(buffer, 2);
+                int offset = UncompressedFrameSize * frame;
+                IByteBuffer buffer = new RangeByteBuffer(Element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
 
-				return buffer;
-			}
+                // mainly for GE Private Implicit VR Big Endian
+                if (Syntax.SwapPixelData) buffer = new SwapByteBuffer(buffer, 2);
 
-			public override void AddFrame(IByteBuffer data) {
-				if (!(Element.Buffer is CompositeByteBuffer))
-					throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer.");
+                return buffer;
+            }
 
-				CompositeByteBuffer buffer = Element.Buffer as CompositeByteBuffer;
+            public override void AddFrame(IByteBuffer data)
+            {
+                if (!(Element.Buffer is CompositeByteBuffer)) throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer.");
 
-				if (Syntax.SwapPixelData)
-					data = new SwapByteBuffer(data , 2);
+                CompositeByteBuffer buffer = Element.Buffer as CompositeByteBuffer;
 
-				buffer.Buffers.Add(data);
-				NumberOfFrames++;
-			}
-		}
+                if (Syntax.SwapPixelData) data = new SwapByteBuffer(data, 2);
 
-		/// <summary>
-		/// Other Byte Fragment implementation of <seealso cref="DicomPixelData"/>, used for handling encapsulated (compressed)
-		/// pixel data
-		/// </summary>
-		private class EncapsulatedPixelData : DicomPixelData {
-			/// <summary>
-			/// Initialize new instance of EncapsulatedPixelData
-			/// </summary>
-			/// <param name="dataset">The source dataset to extract from or create new pixel data for</param>
-			/// <param name="newPixelData">True to create new pixel data, false to read pixel data</param>
-			public EncapsulatedPixelData(DicomDataset dataset, bool newPixelData) : base(dataset) {
-				if (newPixelData) {
-					NumberOfFrames = 0;
-					Element = new DicomOtherByteFragment(DicomTag.PixelData);
-					Dataset.Add(Element);
-				} else
-					Element = dataset.Get<DicomFragmentSequence>(DicomTag.PixelData);
-			}
+                buffer.Buffers.Add(data);
+                NumberOfFrames++;
+            }
+        }
 
-			/// <summary>
-			/// The pixel data framgent sequence element
-			/// </summary>
-			public DicomFragmentSequence Element {
-				get;
-				private set;
-			}
+        /// <summary>
+        /// Other Byte Fragment implementation of <seealso cref="DicomPixelData"/>, used for handling encapsulated (compressed)
+        /// pixel data
+        /// </summary>
+        private class EncapsulatedPixelData : DicomPixelData
+        {
+            /// <summary>
+            /// Initialize new instance of EncapsulatedPixelData
+            /// </summary>
+            /// <param name="dataset">The source dataset to extract from or create new pixel data for</param>
+            /// <param name="newPixelData">True to create new pixel data, false to read pixel data</param>
+            public EncapsulatedPixelData(DicomDataset dataset, bool newPixelData)
+                : base(dataset)
+            {
+                if (newPixelData)
+                {
+                    NumberOfFrames = 0;
+                    Element = new DicomOtherByteFragment(DicomTag.PixelData);
+                    Dataset.Add(Element);
+                }
+                else Element = dataset.Get<DicomFragmentSequence>(DicomTag.PixelData);
+            }
 
-			public override IByteBuffer GetFrame(int frame) {
-                if (frame < 0 || frame >= NumberOfFrames)
-                    throw new IndexOutOfRangeException("Requested frame out of range!");
+            /// <summary>
+            /// The pixel data framgent sequence element
+            /// </summary>
+            public DicomFragmentSequence Element { get; private set; }
+
+            public override IByteBuffer GetFrame(int frame)
+            {
+                if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
 
                 IByteBuffer buffer = null;
 
-				if (NumberOfFrames == 1) {
-					if (Element.Fragments.Count == 1)
-						buffer = Element.Fragments[0];
-					else
-						buffer = new CompositeByteBuffer(Element.Fragments.ToArray());
-				}
-				else if (Element.Fragments.Count == NumberOfFrames)
-					buffer = Element.Fragments[frame];
-				else if (Element.OffsetTable.Count == NumberOfFrames) {
-					uint start = Element.OffsetTable[frame];
-					uint stop = (Element.OffsetTable.Count == (frame + 1)) ? uint.MaxValue : Element.OffsetTable[frame + 1];
+                if (NumberOfFrames == 1)
+                {
+                    if (Element.Fragments.Count == 1) buffer = Element.Fragments[0];
+                    else buffer = new CompositeByteBuffer(Element.Fragments.ToArray());
+                }
+                else if (Element.Fragments.Count == NumberOfFrames) buffer = Element.Fragments[frame];
+                else if (Element.OffsetTable.Count == NumberOfFrames)
+                {
+                    uint start = Element.OffsetTable[frame];
+                    uint stop = (Element.OffsetTable.Count == (frame + 1))
+                                    ? uint.MaxValue
+                                    : Element.OffsetTable[frame + 1];
 
-					var composite = new CompositeByteBuffer();
+                    var composite = new CompositeByteBuffer();
 
-					uint pos = 0;
-					int frag = 0;
+                    uint pos = 0;
+                    int frag = 0;
 
-					while (pos < start && frag < Element.Fragments.Count) {
-						pos += 8;
-						pos += Element.Fragments[frag].Size;
-						frag++;
-					}
+                    while (pos < start && frag < Element.Fragments.Count)
+                    {
+                        pos += 8;
+                        pos += Element.Fragments[frag].Size;
+                        frag++;
+                    }
 
-					if (pos != start)
-						throw new DicomImagingException("Fragment start position does not match offset table.");
+                    if (pos != start) throw new DicomImagingException("Fragment start position does not match offset table.");
 
-					while (pos < stop && frag < Element.Fragments.Count) {
-						composite.Buffers.Add(Element.Fragments[frag]);
+                    while (pos < stop && frag < Element.Fragments.Count)
+                    {
+                        composite.Buffers.Add(Element.Fragments[frag]);
 
-						pos += 8;
-						pos += Element.Fragments[frag].Size;
-						frag++;
-					}
+                        pos += 8;
+                        pos += Element.Fragments[frag].Size;
+                        frag++;
+                    }
 
-					if (pos < stop && stop != uint.MaxValue)
-						throw new DicomImagingException("Image frame truncated while reading fragments from offset table.");
+                    if (pos < stop && stop != uint.MaxValue)
+                        throw new DicomImagingException(
+                            "Image frame truncated while reading fragments from offset table.");
 
-					buffer = composite;
-				}
-				else
-					throw new DicomImagingException("Support for multi-frame images with varying fragment sizes and no offset table has not been implemented.");
+                    buffer = composite;
+                }
+                else
+                    throw new DicomImagingException(
+                        "Support for multi-frame images with varying fragment sizes and no offset table has not been implemented.");
 
-				// mainly for GE Private Implicit VR Little Endian
-				if (!Syntax.IsEncapsulated && BitsAllocated == 16 && Syntax.SwapPixelData)
-					buffer = new SwapByteBuffer(buffer, 2);
+                // mainly for GE Private Implicit VR Little Endian
+                if (!Syntax.IsEncapsulated && BitsAllocated == 16 && Syntax.SwapPixelData) buffer = new SwapByteBuffer(buffer, 2);
 
-				return EndianByteBuffer.Create(buffer, Syntax.Endian, BytesAllocated);
-			}
+                return EndianByteBuffer.Create(buffer, Syntax.Endian, BytesAllocated);
+            }
 
-			public override void AddFrame(IByteBuffer data) {
-				NumberOfFrames++;
+            public override void AddFrame(IByteBuffer data)
+            {
+                NumberOfFrames++;
 
-				long pos = Element.Fragments.Sum(x => (long)x.Size + 8);
-				if (pos < uint.MaxValue) {
-					Element.OffsetTable.Add((uint)pos);
-				} else {
-					// do not create an offset table for very large datasets
-					Element.OffsetTable.Clear();
-				}
+                long pos = Element.Fragments.Sum(x => (long)x.Size + 8);
+                if (pos < uint.MaxValue)
+                {
+                    Element.OffsetTable.Add((uint)pos);
+                }
+                else
+                {
+                    // do not create an offset table for very large datasets
+                    Element.OffsetTable.Clear();
+                }
 
-				data = EndianByteBuffer.Create(data, Syntax.Endian, BytesAllocated);
-				Element.Fragments.Add(data);
-			}
-		}
-	}
+                data = EndianByteBuffer.Create(data, Syntax.Endian, BytesAllocated);
+                Element.Fragments.Add(data);
+            }
+        }
+    }
 }

--- a/DICOM/Imaging/GrayscaleRenderOptions.cs
+++ b/DICOM/Imaging/GrayscaleRenderOptions.cs
@@ -1,242 +1,244 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 
 using Dicom.Imaging.Codec;
-using Dicom.Imaging.Render;
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// Grayscale rendering options class
-	/// </summary>
-	public class GrayscaleRenderOptions {
-		/// <summary>
-		/// GrayscaleRenderOptions constructor using BitDepth values
-		/// </summary>
-		/// <param name="bits">Bit depth information</param>
-		public GrayscaleRenderOptions(BitDepth bits) {
-			BitDepth = bits;
-			RescaleSlope = 1.0;
-			RescaleIntercept = 0.0;
-			VOILUTFunction = "LINEAR";
-			WindowWidth = bits.MaximumValue - bits.MinimumValue;
-			WindowCenter = (bits.MaximumValue + bits.MinimumValue) / 2.0;
-			Monochrome1 = false;
-			Invert = false;
-		}
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// Grayscale rendering options class
+    /// </summary>
+    public class GrayscaleRenderOptions
+    {
+        /// <summary>
+        /// GrayscaleRenderOptions constructor using BitDepth values
+        /// </summary>
+        /// <param name="bits">Bit depth information</param>
+        public GrayscaleRenderOptions(BitDepth bits)
+        {
+            BitDepth = bits;
+            RescaleSlope = 1.0;
+            RescaleIntercept = 0.0;
+            VOILUTFunction = "LINEAR";
+            WindowWidth = bits.MaximumValue - bits.MinimumValue;
+            WindowCenter = (bits.MaximumValue + bits.MinimumValue) / 2.0;
+            Monochrome1 = false;
+            Invert = false;
+        }
 
-		/// <summary>
-		/// BitDepth used to initialize the GrayscaleRenderOptions
-		/// </summary>
-		public BitDepth BitDepth {
-			get;
-			set;
-		}
-		/// <summary>
-		/// Pixel data rescale slope
-		/// </summary>
-		public double RescaleSlope {
-			get;
-			set;
-		}
+        /// <summary>
+        /// BitDepth used to initialize the GrayscaleRenderOptions
+        /// </summary>
+        public BitDepth BitDepth { get; set; }
 
-		/// <summary>
-		/// Pixel data resclae interception
-		/// </summary>
-		public double RescaleIntercept {
-			get;
-			set;
-		}
+        /// <summary>
+        /// Pixel data rescale slope
+        /// </summary>
+        public double RescaleSlope { get; set; }
 
-		/// <summary>
-		/// VOI LUT function (LINEAR or SEGMOID)
-		/// </summary>
-		public string VOILUTFunction {
-			get;
-			set;
-		}
+        /// <summary>
+        /// Pixel data resclae interception
+        /// </summary>
+        public double RescaleIntercept { get; set; }
 
-		/// <summary>
-		/// Window width
-		/// </summary>
-		public double WindowWidth {
-			get;
-			set;
-		}
+        /// <summary>
+        /// VOI LUT function (LINEAR or SEGMOID)
+        /// </summary>
+        public string VOILUTFunction { get; set; }
 
-		/// <summary>
-		/// Window center
-		/// </summary>
-		public double WindowCenter {
-			get;
-			set;
-		}
+        /// <summary>
+        /// Window width
+        /// </summary>
+        public double WindowWidth { get; set; }
 
-		/// <summary>
-		/// Specify if this grey scale image is Monochrome1 or Monorchrome2, true means Monochrome1
-		/// </summary>
-		public bool Monochrome1 {
-			get;
-			set;
-		}
+        /// <summary>
+        /// Window center
+        /// </summary>
+        public double WindowCenter { get; set; }
 
-		/// <summary>
-		/// Set to true to render the output in inverted grey
-		/// </summary>
-		public bool Invert {
-			get;
-			set;
-		}
+        /// <summary>
+        /// Specify if this grey scale image is Monochrome1 or Monorchrome2, true means Monochrome1
+        /// </summary>
+        public bool Monochrome1 { get; set; }
 
-		/// <summary>
-		/// Create <see cref="GrayscaleRenderOptions"/>  from <paramref name="dataset"/> and populate the options properties with values:
-		/// Bit Depth
-		/// Rescale Slope
-		/// Rescale Intercept
-		/// Window Width
-		/// Window Center
-		/// </summary>
-		/// <param name="dataset">Dataset to extract <see cref="GrayscaleRenderOptions"/> from</param>
-		/// <returns>New grayscale render options instance</returns>
-		public static GrayscaleRenderOptions FromDataset(DicomDataset dataset) {
-			var bits = BitDepth.FromDataset(dataset);
-			var options = new GrayscaleRenderOptions(bits);
+        /// <summary>
+        /// Set to true to render the output in inverted grey
+        /// </summary>
+        public bool Invert { get; set; }
 
-			options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
-			options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
+        /// <summary>
+        /// Create <see cref="GrayscaleRenderOptions"/>  from <paramref name="dataset"/> and populate the options properties with values:
+        /// Bit Depth
+        /// Rescale Slope
+        /// Rescale Intercept
+        /// Window Width
+        /// Window Center
+        /// </summary>
+        /// <param name="dataset">Dataset to extract <see cref="GrayscaleRenderOptions"/> from</param>
+        /// <returns>New grayscale render options instance</returns>
+        public static GrayscaleRenderOptions FromDataset(DicomDataset dataset)
+        {
+            var bits = BitDepth.FromDataset(dataset);
+            var options = new GrayscaleRenderOptions(bits);
 
-			if (dataset.Contains(DicomTag.WindowWidth) && dataset.Get<double>(DicomTag.WindowWidth) != 0.0) {
-				//If dataset contains WindowWidth and WindowCenter valid attributes used initially for the grayscale options
-				return FromWindowLevel(dataset);
-			} else if (dataset.Contains(DicomTag.SmallestImagePixelValue) && dataset.Contains(DicomTag.LargestImagePixelValue)) {
-				//If dataset contains valid SmallesImagePixelValue and LargesImagePixelValue attributes, use range to calculate
-				//WindowWidth and WindowCenter
-				return FromImagePixelValueTags(dataset);
-			} else {
-				//If reached here, minimum and maximum pixel values calculated from pixels data to calculate
-				//WindowWidth and WindowCenter
-				return FromMinMax(dataset);
-			}
+            options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
+            options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
 
-			options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
-			options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation) == PhotometricInterpretation.Monochrome1;
+            if (dataset.Contains(DicomTag.WindowWidth) && dataset.Get<double>(DicomTag.WindowWidth) != 0.0)
+            {
+                //If dataset contains WindowWidth and WindowCenter valid attributes used initially for the grayscale options
+                return FromWindowLevel(dataset);
+            }
+            else if (dataset.Contains(DicomTag.SmallestImagePixelValue)
+                     && dataset.Contains(DicomTag.LargestImagePixelValue))
+            {
+                //If dataset contains valid SmallesImagePixelValue and LargesImagePixelValue attributes, use range to calculate
+                //WindowWidth and WindowCenter
+                return FromImagePixelValueTags(dataset);
+            }
+            else
+            {
+                //If reached here, minimum and maximum pixel values calculated from pixels data to calculate
+                //WindowWidth and WindowCenter
+                return FromMinMax(dataset);
+            }
 
-			return options;
-		}
+            options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
+            options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
+                                  == PhotometricInterpretation.Monochrome1;
 
-		public static GrayscaleRenderOptions FromWindowLevel(DicomDataset dataset) {
-			var bits = BitDepth.FromDataset(dataset);
-			var options = new GrayscaleRenderOptions(bits);
+            return options;
+        }
 
-			options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
-			options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
+        public static GrayscaleRenderOptions FromWindowLevel(DicomDataset dataset)
+        {
+            var bits = BitDepth.FromDataset(dataset);
+            var options = new GrayscaleRenderOptions(bits);
 
-			options.WindowWidth = dataset.Get<double>(DicomTag.WindowWidth);
-			options.WindowCenter = dataset.Get<double>(DicomTag.WindowCenter);
+            options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
+            options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
 
-			options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
-			options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation) == PhotometricInterpretation.Monochrome1;
+            options.WindowWidth = dataset.Get<double>(DicomTag.WindowWidth);
+            options.WindowCenter = dataset.Get<double>(DicomTag.WindowCenter);
 
-			return options;
-		}
+            options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
+            options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
+                                  == PhotometricInterpretation.Monochrome1;
 
-		public static GrayscaleRenderOptions FromImagePixelValueTags(DicomDataset dataset) {
-			var bits = BitDepth.FromDataset(dataset);
-			var options = new GrayscaleRenderOptions(bits);
+            return options;
+        }
 
-			options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
-			options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
+        public static GrayscaleRenderOptions FromImagePixelValueTags(DicomDataset dataset)
+        {
+            var bits = BitDepth.FromDataset(dataset);
+            var options = new GrayscaleRenderOptions(bits);
 
-			int smallValue = dataset.Get<int>(DicomTag.SmallestImagePixelValue, 0);
-			int largeValue = dataset.Get<int>(DicomTag.LargestImagePixelValue, 0);
+            options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
+            options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
 
-			if (smallValue != 0 || largeValue != 0) {
-				options.WindowWidth = Math.Abs(largeValue - smallValue);
-				options.WindowCenter = (largeValue + smallValue) / 2.0;
-			}
+            int smallValue = dataset.Get<int>(DicomTag.SmallestImagePixelValue, 0);
+            int largeValue = dataset.Get<int>(DicomTag.LargestImagePixelValue, 0);
 
-			options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
-			options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation) == PhotometricInterpretation.Monochrome1;
+            if (smallValue != 0 || largeValue != 0)
+            {
+                options.WindowWidth = Math.Abs(largeValue - smallValue);
+                options.WindowCenter = (largeValue + smallValue) / 2.0;
+            }
 
-			return options;
-		}
+            options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
+            options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
+                                  == PhotometricInterpretation.Monochrome1;
 
-		public static GrayscaleRenderOptions FromMinMax(DicomDataset dataset) {
-			var bits = BitDepth.FromDataset(dataset);
-			var options = new GrayscaleRenderOptions(bits);
+            return options;
+        }
 
-			options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
-			options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
+        public static GrayscaleRenderOptions FromMinMax(DicomDataset dataset)
+        {
+            var bits = BitDepth.FromDataset(dataset);
+            var options = new GrayscaleRenderOptions(bits);
 
-			int padding = dataset.Get<int>(DicomTag.PixelPaddingValue, 0, Int32.MinValue);
+            options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
+            options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
 
-			var transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, DicomTransferSyntax.ExplicitVRLittleEndian);
+            int padding = dataset.Get<int>(DicomTag.PixelPaddingValue, 0, Int32.MinValue);
 
-			var pixels = transcoder.DecodePixelData(dataset, 0);
-			var range = pixels.GetMinMax(padding);
+            var transcoder = new DicomTranscoder(
+                dataset.InternalTransferSyntax,
+                DicomTransferSyntax.ExplicitVRLittleEndian);
 
-			if (range.Minimum < bits.MinimumValue || range.Minimum == Double.MaxValue)
-				range.Minimum = bits.MinimumValue;
-			if (range.Maximum > bits.MaximumValue || range.Maximum == Double.MinValue)
-				range.Maximum = bits.MaximumValue;
+            var pixels = transcoder.DecodePixelData(dataset, 0);
+            var range = pixels.GetMinMax(padding);
 
-			var min = range.Minimum * options.RescaleSlope + options.RescaleIntercept;
-			var max = range.Maximum * options.RescaleSlope + options.RescaleIntercept;
+            if (range.Minimum < bits.MinimumValue || range.Minimum == Double.MaxValue) range.Minimum = bits.MinimumValue;
+            if (range.Maximum > bits.MaximumValue || range.Maximum == Double.MinValue) range.Maximum = bits.MaximumValue;
 
-			options.WindowWidth = Math.Abs(max - min);
-			options.WindowCenter = (max + min) / 2.0;
+            var min = range.Minimum * options.RescaleSlope + options.RescaleIntercept;
+            var max = range.Maximum * options.RescaleSlope + options.RescaleIntercept;
 
-			options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
-			options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation) == PhotometricInterpretation.Monochrome1;
+            options.WindowWidth = Math.Abs(max - min);
+            options.WindowCenter = (max + min) / 2.0;
 
-			return options;
-		}
+            options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
+            options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
+                                  == PhotometricInterpretation.Monochrome1;
 
-		public static GrayscaleRenderOptions FromBitRange(DicomDataset dataset) {
-			var bits = BitDepth.FromDataset(dataset);
-			var options = new GrayscaleRenderOptions(bits);
+            return options;
+        }
 
-			options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
-			options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
+        public static GrayscaleRenderOptions FromBitRange(DicomDataset dataset)
+        {
+            var bits = BitDepth.FromDataset(dataset);
+            var options = new GrayscaleRenderOptions(bits);
 
-			var min = bits.MinimumValue * options.RescaleSlope + options.RescaleIntercept;
-			var max = bits.MaximumValue * options.RescaleSlope + options.RescaleIntercept;
+            options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
+            options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
 
-			options.WindowWidth = Math.Abs(max - min);
-			options.WindowCenter = (max + min) / 2.0;
+            var min = bits.MinimumValue * options.RescaleSlope + options.RescaleIntercept;
+            var max = bits.MaximumValue * options.RescaleSlope + options.RescaleIntercept;
 
-			options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
-			options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation) == PhotometricInterpretation.Monochrome1;
+            options.WindowWidth = Math.Abs(max - min);
+            options.WindowCenter = (max + min) / 2.0;
 
-			return options;
-		}
+            options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
+            options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
+                                  == PhotometricInterpretation.Monochrome1;
 
-		public static GrayscaleRenderOptions FromHistogram(DicomDataset dataset, int percent = 90) {
-			var bits = BitDepth.FromDataset(dataset);
-			var options = new GrayscaleRenderOptions(bits);
+            return options;
+        }
 
-			options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
-			options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
+        public static GrayscaleRenderOptions FromHistogram(DicomDataset dataset, int percent = 90)
+        {
+            var bits = BitDepth.FromDataset(dataset);
+            var options = new GrayscaleRenderOptions(bits);
 
-			var transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, DicomTransferSyntax.ExplicitVRLittleEndian);
+            options.RescaleSlope = dataset.Get<double>(DicomTag.RescaleSlope, 1.0);
+            options.RescaleIntercept = dataset.Get<double>(DicomTag.RescaleIntercept, 0.0);
 
-			var pixels = transcoder.DecodePixelData(dataset, 0);
-			var histogram = pixels.GetHistogram(0);
+            var transcoder = new DicomTranscoder(
+                dataset.InternalTransferSyntax,
+                DicomTransferSyntax.ExplicitVRLittleEndian);
 
-			int padding = dataset.Get<int>(DicomTag.PixelPaddingValue, 0, Int32.MinValue);
-			if (padding != Int32.MinValue)
-				histogram.Clear(padding);
+            var pixels = transcoder.DecodePixelData(dataset, 0);
+            var histogram = pixels.GetHistogram(0);
 
-			histogram.ApplyWindow(percent);
+            int padding = dataset.Get<int>(DicomTag.PixelPaddingValue, 0, Int32.MinValue);
+            if (padding != Int32.MinValue) histogram.Clear(padding);
 
-			var min = histogram.WindowStart * options.RescaleSlope + options.RescaleIntercept;
-			var max = histogram.WindowEnd * options.RescaleSlope + options.RescaleIntercept;
+            histogram.ApplyWindow(percent);
 
-			options.WindowWidth = Math.Abs(max - min);
-			options.WindowCenter = (max + min) / 2.0;
+            var min = histogram.WindowStart * options.RescaleSlope + options.RescaleIntercept;
+            var max = histogram.WindowEnd * options.RescaleSlope + options.RescaleIntercept;
 
-			options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
-			options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation) == PhotometricInterpretation.Monochrome1;
+            options.WindowWidth = Math.Abs(max - min);
+            options.WindowCenter = (max + min) / 2.0;
 
-			return options;
-		}
-	}
+            options.VOILUTFunction = dataset.Get<string>(DicomTag.VOILUTFunction, "LINEAR");
+            options.Monochrome1 = dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
+                                  == PhotometricInterpretation.Monochrome1;
+
+            return options;
+        }
+    }
 }

--- a/DICOM/Imaging/LUT/CompositeLUT.cs
+++ b/DICOM/Imaging/LUT/CompositeLUT.cs
@@ -1,74 +1,96 @@
-using System;
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 
-namespace Dicom.Imaging.LUT {
-	public class CompositeLUT : ILUT {
-		#region Private Members
-		private List<ILUT> _luts = new List<ILUT>();
-		#endregion
+namespace Dicom.Imaging.LUT
+{
+    public class CompositeLUT : ILUT
+    {
+        #region Private Members
 
-		#region Public Properties
-		public ILUT FinalLUT {
-			get {
-				if (_luts.Count > 0)
-					return _luts[_luts.Count - 1];
-				return null;
-			}
-		}
-		#endregion
+        private List<ILUT> _luts = new List<ILUT>();
 
-		#region Public Constructor
-		public CompositeLUT() {
-		}
-		#endregion
+        #endregion
 
-		#region Public Members
-		public void Add(ILUT lut) {
-			_luts.Add(lut);
-		}
-		#endregion
+        #region Public Properties
 
-		#region ILUT Members
-		public int MinimumOutputValue {
-			get {
-				ILUT lut = FinalLUT;
-				if (lut != null)
-					return lut.MinimumOutputValue;
-				return 0;
-			}
-		}
+        public ILUT FinalLUT
+        {
+            get
+            {
+                if (_luts.Count > 0) return _luts[_luts.Count - 1];
+                return null;
+            }
+        }
 
-		public int MaximumOutputValue {
-			get {
-				ILUT lut = FinalLUT;
-				if (lut != null)
-					return lut.MaximumOutputValue;
-				return 255;
-			}
-		}
+        #endregion
 
-		public bool IsValid {
-			get {
-				foreach (ILUT lut in _luts) {
-					if (!lut.IsValid)
-						return false;
-				}
-				return true;
-			}
-		}
+        #region Public Constructor
 
-		public int this[int value] {
-			get {
-				foreach (ILUT lut in _luts)
-					value = lut[value];
-				return value;
-			}
-		}
+        public CompositeLUT()
+        {
+        }
 
-		public void Recalculate() {
-			foreach (ILUT lut in _luts)
-				lut.Recalculate();
-		}
-		#endregion
-	}
+        #endregion
+
+        #region Public Members
+
+        public void Add(ILUT lut)
+        {
+            _luts.Add(lut);
+        }
+
+        #endregion
+
+        #region ILUT Members
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                ILUT lut = FinalLUT;
+                if (lut != null) return lut.MinimumOutputValue;
+                return 0;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                ILUT lut = FinalLUT;
+                if (lut != null) return lut.MaximumOutputValue;
+                return 255;
+            }
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                foreach (ILUT lut in _luts)
+                {
+                    if (!lut.IsValid) return false;
+                }
+                return true;
+            }
+        }
+
+        public int this[int value]
+        {
+            get
+            {
+                foreach (ILUT lut in _luts) value = lut[value];
+                return value;
+            }
+        }
+
+        public void Recalculate()
+        {
+            foreach (ILUT lut in _luts) lut.Recalculate();
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/LUT/ILUT.cs
+++ b/DICOM/Imaging/LUT/ILUT.cs
@@ -1,41 +1,38 @@
-﻿namespace Dicom.Imaging.LUT {
-	/// <summary>
-	/// Interface for Lookup table definition
-	/// </summary>
-	public interface ILUT {
-		/// <summary>
-		/// Returns true if the lookup table is valid
-		/// </summary>
-		bool IsValid {
-			get;
-		}
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-		/// <summary>
-		/// Get the minimum output value
-		/// </summary>
-		int MinimumOutputValue {
-			get;
-		}
+namespace Dicom.Imaging.LUT
+{
+    /// <summary>
+    /// Interface for Lookup table definition
+    /// </summary>
+    public interface ILUT
+    {
+        /// <summary>
+        /// Returns true if the lookup table is valid
+        /// </summary>
+        bool IsValid { get; }
 
-		/// <summary>
-		/// Get the maximum output value
-		/// </summary>
-		int MaximumOutputValue {
-			get;
-		}
+        /// <summary>
+        /// Get the minimum output value
+        /// </summary>
+        int MinimumOutputValue { get; }
 
-		/// <summary>
-		/// Indexer to taransfrom input value into output value
-		/// </summary>
-		/// <param name="input">Input value</param>
-		/// <returns>Output value</returns>
-		int this[int input] {
-			get;
-		}
+        /// <summary>
+        /// Get the maximum output value
+        /// </summary>
+        int MaximumOutputValue { get; }
 
-		/// <summary>
-		/// Forct the recalculation of LUT
-		/// </summary>
-		void Recalculate();
-	}
+        /// <summary>
+        /// Indexer to taransfrom input value into output value
+        /// </summary>
+        /// <param name="input">Input value</param>
+        /// <returns>Output value</returns>
+        int this[int input] { get; }
+
+        /// <summary>
+        /// Forct the recalculation of LUT
+        /// </summary>
+        void Recalculate();
+    }
 }

--- a/DICOM/Imaging/LUT/InvertLUT.cs
+++ b/DICOM/Imaging/LUT/InvertLUT.cs
@@ -1,48 +1,78 @@
-using System;
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.LUT {
-	/// <summary>
-	/// Invert LUT implementation of <seealso cref="ILUT"/> to invert grayscale images
-	/// </summary>
-	public class InvertLUT : ILUT {
-		#region Private Members
-		private int _minValue;
-		private int _maxValue;
-		#endregion
+namespace Dicom.Imaging.LUT
+{
+    /// <summary>
+    /// Invert LUT implementation of <seealso cref="ILUT"/> to invert grayscale images
+    /// </summary>
+    public class InvertLUT : ILUT
+    {
+        #region Private Members
 
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="InvertLUT"/> 
-		/// </summary>
-		/// <param name="minValue">Miniumum input value</param>
-		/// <param name="maxValue">Maximum output value</param>
-		public InvertLUT(int minValue, int maxValue) {
-			_minValue = minValue;
-			_maxValue = maxValue;
-		}
-		#endregion
+        private int _minValue;
 
-		#region Public Properties
-		public bool IsValid {
-			get { return true; }
-		}
+        private int _maxValue;
 
-		public int MinimumOutputValue {
-			get { return _minValue; }
-		}
+        #endregion
 
-		public int MaximumOutputValue {
-			get { return _maxValue; }
-		}
+        #region Public Constructors
 
-		public int this[int value] {
-			get { return _maxValue - value; }
-		}
-		#endregion
+        /// <summary>
+        /// Initialize new instance of <seealso cref="InvertLUT"/> 
+        /// </summary>
+        /// <param name="minValue">Miniumum input value</param>
+        /// <param name="maxValue">Maximum output value</param>
+        public InvertLUT(int minValue, int maxValue)
+        {
+            _minValue = minValue;
+            _maxValue = maxValue;
+        }
 
-		#region Public Methods
-		public void Recalculate() {
-		}
-		#endregion
-	}
+        #endregion
+
+        #region Public Properties
+
+        public bool IsValid
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                return _minValue;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                return _maxValue;
+            }
+        }
+
+        public int this[int value]
+        {
+            get
+            {
+                return _maxValue - value;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Recalculate()
+        {
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/LUT/ModalityLUT.cs
+++ b/DICOM/Imaging/LUT/ModalityLUT.cs
@@ -1,65 +1,102 @@
-using System;
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.LUT {
-	/// <summary>
-	/// Modalit LUT implementation of <seealso cref="ILUT"/>
-	/// </summary>
-	public class ModalityLUT : ILUT {
-		#region Private Members
-		private GrayscaleRenderOptions _renderOptions;
-		private int _minValue;
-		private int _maxValue;
-		#endregion
+namespace Dicom.Imaging.LUT
+{
+    /// <summary>
+    /// Modalit LUT implementation of <seealso cref="ILUT"/>
+    /// </summary>
+    public class ModalityLUT : ILUT
+    {
+        #region Private Members
 
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="ModalityLUT"/> using the specified slope and intercept parameters
-		/// </summary>
-		/// <param name="options">Render options</param>
-		public ModalityLUT(GrayscaleRenderOptions options) {
-			_renderOptions = options;
-			_minValue = this[options.BitDepth.MinimumValue];
-			_maxValue = this[options.BitDepth.MaximumValue];
-		}
-		#endregion
+        private GrayscaleRenderOptions _renderOptions;
 
-		#region Public Properties
-		/// <summary>
-		/// The modality rescale slope
-		/// </summary>
-		public double RescaleSlope {
-			get { return _renderOptions.RescaleSlope; }
-		}
+        private int _minValue;
 
-		/// <summary>
-		/// The modality rescale intercept
-		/// </summary>
-		public double RescaleIntercept {
-			get { return _renderOptions.RescaleIntercept; }
-		}
+        private int _maxValue;
 
-		public bool IsValid {
-			get { return true; }
-		}
+        #endregion
 
-		public int MinimumOutputValue {
-			get { return _minValue; }
-		}
+        #region Public Constructors
 
-		public int MaximumOutputValue {
-			get { return _maxValue; }
-		}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="ModalityLUT"/> using the specified slope and intercept parameters
+        /// </summary>
+        /// <param name="options">Render options</param>
+        public ModalityLUT(GrayscaleRenderOptions options)
+        {
+            _renderOptions = options;
+            _minValue = this[options.BitDepth.MinimumValue];
+            _maxValue = this[options.BitDepth.MaximumValue];
+        }
 
-		public int this[int value] {
-			get {
-				return unchecked((int)((value * RescaleSlope) + RescaleIntercept));
-			}
-		}
-		#endregion
+        #endregion
 
-		#region Public Methods
-		public void Recalculate() {
-		}
-		#endregion
-	}
+        #region Public Properties
+
+        /// <summary>
+        /// The modality rescale slope
+        /// </summary>
+        public double RescaleSlope
+        {
+            get
+            {
+                return _renderOptions.RescaleSlope;
+            }
+        }
+
+        /// <summary>
+        /// The modality rescale intercept
+        /// </summary>
+        public double RescaleIntercept
+        {
+            get
+            {
+                return _renderOptions.RescaleIntercept;
+            }
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                return _minValue;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                return _maxValue;
+            }
+        }
+
+        public int this[int value]
+        {
+            get
+            {
+                return unchecked((int)((value * RescaleSlope) + RescaleIntercept));
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Recalculate()
+        {
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/LUT/OutputLUT.cs
+++ b/DICOM/Imaging/LUT/OutputLUT.cs
@@ -1,67 +1,96 @@
-using System;
-using System.IO;
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.LUT {
-	/// <summary>
-	/// Output LUT implementation of <seealso cref="ILUT"/> used to map grayscale images to RGB grays, or colorize grayscale 
-	/// images using custom color map
-	/// </summary>
-	public class OutputLUT : ILUT {
-		#region Private Members
-		private Color32[] _lut;
-		#endregion
+namespace Dicom.Imaging.LUT
+{
+    /// <summary>
+    /// Output LUT implementation of <seealso cref="ILUT"/> used to map grayscale images to RGB grays, or colorize grayscale 
+    /// images using custom color map
+    /// </summary>
+    public class OutputLUT : ILUT
+    {
+        #region Private Members
 
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="OutputLUT"/> 
-		/// </summary>
-		/// <param name="lut">The color palette map to use for the output</param>
-		public OutputLUT(Color32[] lut) {
-			ColorMap = lut;
-		}
-		#endregion
+        private Color32[] _lut;
 
-		#region Public Properties
-		/// <summary>
-		/// The color map
-		/// </summary>
-		public Color32[] ColorMap {
-			get { return _lut; }
-			set {
-				if (value == null || value.Length != 256)
-					throw new DicomImagingException("Expected 256 entry color map");
-				_lut = value;
-			}
-		}
+        #endregion
 
-		public int MinimumOutputValue {
-			get { return int.MinValue; }
-		}
+        #region Public Constructors
 
-		public int MaximumOutputValue {
-			get { return int.MaxValue; }
-		}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="OutputLUT"/> 
+        /// </summary>
+        /// <param name="lut">The color palette map to use for the output</param>
+        public OutputLUT(Color32[] lut)
+        {
+            ColorMap = lut;
+        }
 
-		public bool IsValid {
-			get { return _lut != null; }
-		}
+        #endregion
 
-		public int this[int value] {
-			get {
-				unchecked {
-					if (value < 0)
-						return _lut[0].Value;
-					if (value > 255)
-						return _lut[255].Value;
-					return _lut[value].Value;
-				}
-			}
-		}
-		#endregion
+        #region Public Properties
 
-		#region Public Methods
-		public void Recalculate() {
-		}
-		#endregion
-	}
+        /// <summary>
+        /// The color map
+        /// </summary>
+        public Color32[] ColorMap
+        {
+            get
+            {
+                return _lut;
+            }
+            set
+            {
+                if (value == null || value.Length != 256) throw new DicomImagingException("Expected 256 entry color map");
+                _lut = value;
+            }
+        }
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                return int.MinValue;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                return int.MaxValue;
+            }
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                return _lut != null;
+            }
+        }
+
+        public int this[int value]
+        {
+            get
+            {
+                unchecked
+                {
+                    if (value < 0) return _lut[0].Value;
+                    if (value > 255) return _lut[255].Value;
+                    return _lut[value].Value;
+                }
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Recalculate()
+        {
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/LUT/PaddingLUT.cs
+++ b/DICOM/Imaging/LUT/PaddingLUT.cs
@@ -1,50 +1,82 @@
-using System;
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.LUT {
-	public class PaddingLUT : ILUT {
-		#region Private Members
-		private int _paddingValue;
-		private int _minValue;
-		private int _maxValue;
-		#endregion
-		
-		#region Public Constructors
-		public PaddingLUT(int minValue, int maxValue, int paddingValue) {
-			_paddingValue = paddingValue;
-			_minValue = minValue;
-			_maxValue = maxValue;
-		}
-		#endregion
+namespace Dicom.Imaging.LUT
+{
+    public class PaddingLUT : ILUT
+    {
+        #region Private Members
 
-		#region Public Properties
-		public double PixelPaddingValue {
-			get { return _paddingValue; }
-		}
+        private int _paddingValue;
 
-		public int MinimumOutputValue {
-			get { return _minValue; }
-		}
+        private int _minValue;
 
-		public int MaximumOutputValue {
-			get { return _maxValue; }
-		}
+        private int _maxValue;
 
-		public bool IsValid {
-			get { return true; }
-		}
+        #endregion
 
-		public int this[int value] {
-			get {
-				if (value == _paddingValue)
-					return _minValue;
-				return value;
-			}
-		}
-		#endregion
+        #region Public Constructors
 
-		#region Public Methods
-		public void Recalculate() {
-		}
-		#endregion
-	}
+        public PaddingLUT(int minValue, int maxValue, int paddingValue)
+        {
+            _paddingValue = paddingValue;
+            _minValue = minValue;
+            _maxValue = maxValue;
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public double PixelPaddingValue
+        {
+            get
+            {
+                return _paddingValue;
+            }
+        }
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                return _minValue;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                return _maxValue;
+            }
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        public int this[int value]
+        {
+            get
+            {
+                if (value == _paddingValue) return _minValue;
+                return value;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Recalculate()
+        {
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/LUT/PaletteColorLUT.cs
+++ b/DICOM/Imaging/LUT/PaletteColorLUT.cs
@@ -1,59 +1,93 @@
-﻿using System;
-using System.IO;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.LUT {
-	/// <summary>
-	/// Paletter color LUT implementation of <seealso cref="ILUT"/> maps PALETTE COLOR images
-	/// </summary>
-	public class PaletteColorLUT : ILUT {
-		#region Private Members
-		private int _first;
-		private Color32[] _lut;
-		#endregion
+namespace Dicom.Imaging.LUT
+{
+    /// <summary>
+    /// Paletter color LUT implementation of <seealso cref="ILUT"/> maps PALETTE COLOR images
+    /// </summary>
+    public class PaletteColorLUT : ILUT
+    {
+        #region Private Members
 
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="PaletteColorLUT"/>
-		/// </summary>
-		/// <param name="firstEntry">The first entry (minium value)</param>
-		/// <param name="lut">The palette color LUT</param>
-		public PaletteColorLUT(int firstEntry, Color32[] lut) {
-			_first = firstEntry;
-			ColorMap = lut;
-		}
-		#endregion
+        private int _first;
 
-		#region Public Properties
-		/// <summary>
-		/// The color map
-		/// </summary>
-		public Color32[] ColorMap {
-			get { return _lut; }
-			set { _lut = value; }
-		}
+        private Color32[] _lut;
 
-		public int MinimumOutputValue {
-			get { return int.MinValue; }
-		}
+        #endregion
 
-		public int MaximumOutputValue {
-			get { return int.MaxValue; }
-		}
+        #region Public Constructors
 
-		public bool IsValid {
-			get { return _lut != null; }
-		}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="PaletteColorLUT"/>
+        /// </summary>
+        /// <param name="firstEntry">The first entry (minium value)</param>
+        /// <param name="lut">The palette color LUT</param>
+        public PaletteColorLUT(int firstEntry, Color32[] lut)
+        {
+            _first = firstEntry;
+            ColorMap = lut;
+        }
 
-		public int this[int value] {
-			get {
-				return _lut[value + _first].Value;
-			}
-		}
-		#endregion
+        #endregion
 
-		#region Public Methods
-		public void Recalculate() {
-		}
-		#endregion
-	}
+        #region Public Properties
+
+        /// <summary>
+        /// The color map
+        /// </summary>
+        public Color32[] ColorMap
+        {
+            get
+            {
+                return _lut;
+            }
+            set
+            {
+                _lut = value;
+            }
+        }
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                return int.MinValue;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                return int.MaxValue;
+            }
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                return _lut != null;
+            }
+        }
+
+        public int this[int value]
+        {
+            get
+            {
+                return _lut[value + _first].Value;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Recalculate()
+        {
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/LUT/PrecalculatedLUT.cs
+++ b/DICOM/Imaging/LUT/PrecalculatedLUT.cs
@@ -1,65 +1,93 @@
-using System;
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.LUT {
-	public class PrecalculatedLUT : ILUT {
-		#region Private Members
-		private ILUT _lut;
+namespace Dicom.Imaging.LUT
+{
+    public class PrecalculatedLUT : ILUT
+    {
+        #region Private Members
 
-		private int _minValue;
-		private int _maxValue;
+        private ILUT _lut;
 
-		private int[] _table;
-		private int _offset;
-		#endregion
+        private int _minValue;
 
-		#region Public Constructor
-		public PrecalculatedLUT(ILUT lut, int minValue, int maxValue) {
-			_minValue = minValue;
-			_maxValue = maxValue;
-			_offset = -_minValue;
-			_table = new int[_maxValue - _minValue + 1];
-			_lut = lut;
-		}
-		#endregion
+        private int _maxValue;
 
-		#region Public Properties
-		public bool IsValid {
-			get { return _lut.IsValid; }
-		}
+        private int[] _table;
 
-		public int MinimumOutputValue {
-			get { return _lut.MinimumOutputValue; }
-		}
+        private int _offset;
 
-		public int MaximumOutputValue {
-			get { return _lut.MaximumOutputValue; }
-		}
+        #endregion
 
-		public int this[int value] {
-			get {
-				unchecked {
-					int p = value + _offset;
-					if (p < 0)
-						return _table[0];
-					if (p >= _table.Length)
-						p = _table[_table.Length - 1];
-					return _table[p];
-				}
-			}
-		}
-		#endregion
+        #region Public Constructor
 
-		#region Public Methods
-		public void Recalculate() {
-			if (IsValid)
-				return;
+        public PrecalculatedLUT(ILUT lut, int minValue, int maxValue)
+        {
+            _minValue = minValue;
+            _maxValue = maxValue;
+            _offset = -_minValue;
+            _table = new int[_maxValue - _minValue + 1];
+            _lut = lut;
+        }
 
-			_lut.Recalculate();
+        #endregion
 
-			for (int i = _minValue; i <= _maxValue; i++) {
-				_table[i + _offset] = _lut[i];
-			}
-		}
-		#endregion
-	}
+        #region Public Properties
+
+        public bool IsValid
+        {
+            get
+            {
+                return _lut.IsValid;
+            }
+        }
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                return _lut.MinimumOutputValue;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                return _lut.MaximumOutputValue;
+            }
+        }
+
+        public int this[int value]
+        {
+            get
+            {
+                unchecked
+                {
+                    int p = value + _offset;
+                    if (p < 0) return _table[0];
+                    if (p >= _table.Length) p = _table[_table.Length - 1];
+                    return _table[p];
+                }
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Recalculate()
+        {
+            if (IsValid) return;
+
+            _lut.Recalculate();
+
+            for (int i = _minValue; i <= _maxValue; i++)
+            {
+                _table[i + _offset] = _lut[i];
+            }
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/LUT/VOILUT.cs
+++ b/DICOM/Imaging/LUT/VOILUT.cs
@@ -1,170 +1,248 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.LUT {
+using System;
 
-	/// <summary>
-	/// Abstract VOI LUT implementation of <seealso cref="ILUT"/>
-	/// </summary>
-	public abstract class VOILUT : ILUT {
-		#region Private Members
-		private GrayscaleRenderOptions _renderOptions;
+namespace Dicom.Imaging.LUT
+{
 
-		private double _windowCenter;
-		private double _windowWidth;
+    /// <summary>
+    /// Abstract VOI LUT implementation of <seealso cref="ILUT"/>
+    /// </summary>
+    public abstract class VOILUT : ILUT
+    {
+        #region Private Members
 
-		private double _windowCenterMin05;
-		private double _windowWidthMin1;
-		private double _windowWidthDiv2;
-		private int _windowStart;
-		private int _windowEnd;
-		#endregion
+        private GrayscaleRenderOptions _renderOptions;
 
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="VOUTLUT"/>
-		/// </summary>
-		/// <param name="options">Render options</param>
-		public VOILUT(GrayscaleRenderOptions options) {
-			_renderOptions = options;
-			Recalculate();
-		}
-		#endregion
+        private double _windowCenter;
 
-		#region Public Properties
-		protected double WindowCenter {
-			get { return _windowCenter; }
-		}
+        private double _windowWidth;
 
-		protected double WindowWidth {
-			get { return _windowWidth; }
-		}
+        private double _windowCenterMin05;
 
-		protected double WindowCenterMin05 {
-			get { return _windowCenterMin05; }
-		}
+        private double _windowWidthMin1;
 
-		protected double WindowWidthMin1 {
-			get { return _windowWidthMin1; }
-		}
+        private double _windowWidthDiv2;
 
-		protected double WindowWidthDiv2 {
-			get { return _windowWidthDiv2; }
-		}
+        private int _windowStart;
 
-		protected int WindowStart {
-			get { return _windowStart; }
-		}
+        private int _windowEnd;
 
-		protected int WindowEnd {
-			get { return _windowEnd; }
-		}
+        #endregion
 
-		public int MinimumOutputValue {
-			get { return 0; }
-		}
+        #region Public Constructors
 
-		public int MaximumOutputValue {
-			get { return 255; }
-		}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="VOUTLUT"/>
+        /// </summary>
+        /// <param name="options">Render options</param>
+        public VOILUT(GrayscaleRenderOptions options)
+        {
+            _renderOptions = options;
+            Recalculate();
+        }
 
-		public bool IsValid {
-			get {
-				// always recalculate
-				return false;
-			}
-		}
+        #endregion
 
-		public abstract int this[int value] {
-			get;
-		}
-		#endregion
+        #region Public Properties
 
-		#region Public Methods
-		public void Recalculate() {
-			if (_renderOptions.WindowWidth != _windowWidth || _renderOptions.WindowCenter != _windowCenter) {
-				_windowWidth = _renderOptions.WindowWidth;
-				_windowCenter = _renderOptions.WindowCenter;
-				_windowCenterMin05 = _windowCenter - 0.5;
-				_windowWidthMin1 = _windowWidth - 1;
-				_windowWidthDiv2 = _windowWidthMin1 / 2;
-				_windowStart = (int)(_windowCenterMin05 - _windowWidthDiv2);
-				_windowEnd = (int)(_windowCenterMin05 + _windowWidthDiv2);
-			}
-		}
-		#endregion
+        protected double WindowCenter
+        {
+            get
+            {
+                return _windowCenter;
+            }
+        }
 
-		#region Factory Methods
-		/// <summary>
-		/// Create a new VOILUT according to <paramref name="function"/>, <paramref name=" windowCenter"/>
-		/// and <paramref name="windowWidth"/>
-		/// </summary>
-		/// <param name="options">Render options</param>
-		/// <returns></returns>
-		public static VOILUT Create(GrayscaleRenderOptions options) {
-			switch (options.VOILUTFunction.ToUpper()) {
-			case "SIGMOID":
-				return new VOISigmoidLUT(options);
-			default:
-				break;
-			}
+        protected double WindowWidth
+        {
+            get
+            {
+                return _windowWidth;
+            }
+        }
 
-			return new VOILinearLUT(options);
-		}
-		#endregion
-	}
+        protected double WindowCenterMin05
+        {
+            get
+            {
+                return _windowCenterMin05;
+            }
+        }
 
-	/// <summary>
-	/// LINEAR VOI LUT
-	/// </summary>
-	public class VOILinearLUT : VOILUT {
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="VOILinearLUT"/>
-		/// </summary>
-		/// <param name="options">Render options</param>
-		public VOILinearLUT(GrayscaleRenderOptions options) : base(options) {
-		}
-		#endregion
+        protected double WindowWidthMin1
+        {
+            get
+            {
+                return _windowWidthMin1;
+            }
+        }
 
-		#region Public Properties
-		public override int this[int value] {
-			get {
+        protected double WindowWidthDiv2
+        {
+            get
+            {
+                return _windowWidthDiv2;
+            }
+        }
+
+        protected int WindowStart
+        {
+            get
+            {
+                return _windowStart;
+            }
+        }
+
+        protected int WindowEnd
+        {
+            get
+            {
+                return _windowEnd;
+            }
+        }
+
+        public int MinimumOutputValue
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public int MaximumOutputValue
+        {
+            get
+            {
+                return 255;
+            }
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                // always recalculate
+                return false;
+            }
+        }
+
+        public abstract int this[int value] { get; }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Recalculate()
+        {
+            if (_renderOptions.WindowWidth != _windowWidth || _renderOptions.WindowCenter != _windowCenter)
+            {
+                _windowWidth = _renderOptions.WindowWidth;
+                _windowCenter = _renderOptions.WindowCenter;
+                _windowCenterMin05 = _windowCenter - 0.5;
+                _windowWidthMin1 = _windowWidth - 1;
+                _windowWidthDiv2 = _windowWidthMin1 / 2;
+                _windowStart = (int)(_windowCenterMin05 - _windowWidthDiv2);
+                _windowEnd = (int)(_windowCenterMin05 + _windowWidthDiv2);
+            }
+        }
+
+        #endregion
+
+        #region Factory Methods
+
+        /// <summary>
+        /// Create a new VOILUT according to <paramref name="function"/>, <paramref name=" windowCenter"/>
+        /// and <paramref name="windowWidth"/>
+        /// </summary>
+        /// <param name="options">Render options</param>
+        /// <returns></returns>
+        public static VOILUT Create(GrayscaleRenderOptions options)
+        {
+            switch (options.VOILUTFunction.ToUpper())
+            {
+                case "SIGMOID":
+                    return new VOISigmoidLUT(options);
+                default:
+                    break;
+            }
+
+            return new VOILinearLUT(options);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// LINEAR VOI LUT
+    /// </summary>
+    public class VOILinearLUT : VOILUT
+    {
+        #region Public Constructors
+
+        /// <summary>
+        /// Initialize new instance of <seealso cref="VOILinearLUT"/>
+        /// </summary>
+        /// <param name="options">Render options</param>
+        public VOILinearLUT(GrayscaleRenderOptions options)
+            : base(options)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override int this[int value]
+        {
+            get
+            {
                 //if (value <= WindowStart)
                 //    return MinimumOutputValue;
                 //if (value > WindowEnd)
                 //    return MaximumOutputValue;
-				unchecked {
-					return (int)Math.Round((((value - WindowCenterMin05) / WindowWidthMin1) + 0.5) * 255.0);
-				}
-			}
-		}
-		#endregion
-	}
+                unchecked
+                {
+                    return (int)Math.Round((((value - WindowCenterMin05) / WindowWidthMin1) + 0.5) * 255.0);
+                }
+            }
+        }
 
-	/// <summary>
-	/// SIGMOID VOI LUT
-	/// </summary>
-	public class VOISigmoidLUT : VOILUT {
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="VOISigmoidLUT"/>
-		/// </summary>
-		/// <param name="options">Render options</param>
-		public VOISigmoidLUT(GrayscaleRenderOptions options) : base(options) {
-		}
-		#endregion
+        #endregion
+    }
 
-		#region Public Properties
-		public override int this[int value] {
-			get {
-				unchecked {
-					return (int)Math.Round(255.0 / (1.0 + Math.Exp(-4.0 * ((value - WindowCenter) / WindowWidth))));
-				}
-			}
-		}
-		#endregion
-	}
+    /// <summary>
+    /// SIGMOID VOI LUT
+    /// </summary>
+    public class VOISigmoidLUT : VOILUT
+    {
+        #region Public Constructors
+
+        /// <summary>
+        /// Initialize new instance of <seealso cref="VOISigmoidLUT"/>
+        /// </summary>
+        /// <param name="options">Render options</param>
+        public VOISigmoidLUT(GrayscaleRenderOptions options)
+            : base(options)
+        {
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public override int this[int value]
+        {
+            get
+            {
+                unchecked
+                {
+                    return (int)Math.Round(255.0 / (1.0 + Math.Exp(-4.0 * ((value - WindowCenter) / WindowWidth))));
+                }
+            }
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/Mathematics/BitList.cs
+++ b/DICOM/Imaging/Mathematics/BitList.cs
@@ -1,59 +1,72 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace Dicom.Imaging.Mathematics {
-	public class BitList {
-		private List<byte> _bytes;
+namespace Dicom.Imaging.Mathematics
+{
+    public class BitList
+    {
+        private List<byte> _bytes;
 
-		public BitList() {
-			_bytes = new List<byte>();
-		}
+        public BitList()
+        {
+            _bytes = new List<byte>();
+        }
 
-		public int Capacity {
-			get { return _bytes.Count * 8; }
-			set {
-				int count = value / 8;
-				if (value % 8 > 0)
-					count++;
-				while (_bytes.Count < count)
-					_bytes.Add(0);
-			}
-		}
+        public int Capacity
+        {
+            get
+            {
+                return _bytes.Count * 8;
+            }
+            set
+            {
+                int count = value / 8;
+                if (value % 8 > 0) count++;
+                while (_bytes.Count < count) _bytes.Add(0);
+            }
+        }
 
-		public List<byte> List {
-			get { return _bytes; }
-		}
+        public List<byte> List
+        {
+            get
+            {
+                return _bytes;
+            }
+        }
 
-		public byte[] Array {
-			get { return _bytes.ToArray(); }
-		}
+        public byte[] Array
+        {
+            get
+            {
+                return _bytes.ToArray();
+            }
+        }
 
-		public bool this[int pos] {
-			get {
-				int p = pos / 8;
-				int m = pos % 8;
+        public bool this[int pos]
+        {
+            get
+            {
+                int p = pos / 8;
+                int m = pos % 8;
 
-				if (p >= _bytes.Count)
-					return false;
+                if (p >= _bytes.Count) return false;
 
-				var b = _bytes[p];
+                var b = _bytes[p];
 
-				return (b & (1 << m)) != 0;
-			}
-			set {
-				int p = pos / 8;
-				int m = pos % 8;
+                return (b & (1 << m)) != 0;
+            }
+            set
+            {
+                int p = pos / 8;
+                int m = pos % 8;
 
-				if (p >= _bytes.Count)
-					Capacity = pos + 1;
+                if (p >= _bytes.Count) Capacity = pos + 1;
 
-				if (value)
-					_bytes[p] |= (byte)(1 << m);
-				else
-					_bytes[p] -= (byte)(1 << m);
-			}
-		}
-	}
+                if (value) _bytes[p] |= (byte)(1 << m);
+                else _bytes[p] -= (byte)(1 << m);
+            }
+        }
+    }
 }

--- a/DICOM/Imaging/Mathematics/Extensions.cs
+++ b/DICOM/Imaging/Mathematics/Extensions.cs
@@ -1,40 +1,58 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Mathematics {
-	public static class Extensions {
-		public static bool IsOdd(this byte v) {
-			return (v & 1) == 1;
-		}
-		public static bool IsOdd(this short v) {
-			return (v & 1) == 1;
-		}
-		public static bool IsOdd(this ushort v) {
-			return (v & 1) == 1;
-		}
-		public static bool IsOdd(this int v) {
-			return (v & 1) == 1;
-		}
-		public static bool IsOdd(this uint v) {
-			return (v & 1) == 1;
-		}
+namespace Dicom.Imaging.Mathematics
+{
+    public static class Extensions
+    {
+        public static bool IsOdd(this byte v)
+        {
+            return (v & 1) == 1;
+        }
 
-		public static bool IsEven(this byte v) {
-			return (v & 1) == 0;
-		}
-		public static bool IsEven(this short v) {
-			return (v & 1) == 0;
-		}
-		public static bool IsEven(this ushort v) {
-			return (v & 1) == 0;
-		}
-		public static bool IsEven(this int v) {
-			return (v & 1) == 0;
-		}
-		public static bool IsEven(this uint v) {
-			return (v & 1) == 0;
-		}
-	}
+        public static bool IsOdd(this short v)
+        {
+            return (v & 1) == 1;
+        }
+
+        public static bool IsOdd(this ushort v)
+        {
+            return (v & 1) == 1;
+        }
+
+        public static bool IsOdd(this int v)
+        {
+            return (v & 1) == 1;
+        }
+
+        public static bool IsOdd(this uint v)
+        {
+            return (v & 1) == 1;
+        }
+
+        public static bool IsEven(this byte v)
+        {
+            return (v & 1) == 0;
+        }
+
+        public static bool IsEven(this short v)
+        {
+            return (v & 1) == 0;
+        }
+
+        public static bool IsEven(this ushort v)
+        {
+            return (v & 1) == 0;
+        }
+
+        public static bool IsEven(this int v)
+        {
+            return (v & 1) == 0;
+        }
+
+        public static bool IsEven(this uint v)
+        {
+            return (v & 1) == 0;
+        }
+    }
 }

--- a/DICOM/Imaging/Mathematics/Geometry3D.cs
+++ b/DICOM/Imaging/Mathematics/Geometry3D.cs
@@ -1,796 +1,1140 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Dicom.Imaging.Mathematics {
-	public class Vector3D {
-		#region Constants
-		public static readonly Vector3D Zero = new Vector3D(0.0, 0.0, 0.0);
-		public static readonly Vector3D Epsilon = new Vector3D(Double.Epsilon, Double.Epsilon, Double.Epsilon);
-		public static readonly Vector3D MinValue = new Vector3D(Double.MinValue, Double.MinValue, Double.MinValue);
-		public static readonly Vector3D MaxValue = new Vector3D(Double.MaxValue, Double.MaxValue, Double.MaxValue);
-
-		public static readonly Vector3D AxisX = new Vector3D(1.0, 0.0, 0.0);
-		public static readonly Vector3D AxisY = new Vector3D(0.0, 1.0, 0.0);
-		public static readonly Vector3D AxisZ = new Vector3D(0.0, 0.0, 1.0);
-		#endregion
-
-		#region Private Members
-		private double _x;
-		private double _y;
-		private double _z;
-		#endregion
-
-		#region Public Constructors
-		public Vector3D() {
-		}
-
-		public Vector3D(Vector3D v) {
-			_x = v.X;
-			_y = v.Y;
-			_z = v.Z;
-		}
-
-		public Vector3D(double x, double y, double z) {
-			_x = x;
-			_y = y;
-			_z = z;
-		}
-		public Vector3D(double[] v) {
-			_x = v[0];
-			_y = v[1];
-			_z = v[2];
-		}
-		public Vector3D(double[] v, int start) {
-			_x = v[start];
-			_y = v[start + 1];
-			_z = v[start + 2];
-		}
-
-		public Vector3D(float x, float y, float z) {
-			_x = x;
-			_y = y;
-			_z = z;
-		}
-		public Vector3D(float[] v) {
-			_x = v[0];
-			_y = v[1];
-			_z = v[2];
-		}
-		public Vector3D(float[] v, int start) {
-			_x = v[start];
-			_y = v[start + 1];
-			_z = v[start + 2];
-		}
-
-		public Vector3D(int x, int y, int z) {
-			_x = x;
-			_y = y;
-			_z = z;
-		}
-		public Vector3D(int[] v) {
-			_x = v[0];
-			_y = v[1];
-			_z = v[2];
-		}
-		public Vector3D(int[] v, int start) {
-			_x = v[start];
-			_y = v[start + 1];
-			_z = v[start + 2];
-		}
-		#endregion
-
-		#region Public Properties
-		public double X {
-			get { return _x; }
-			set { _x = value; }
-		}
-
-		public double Y {
-			get { return _y; }
-			set { _y = value; }
-		}
-
-		public double Z {
-			get { return _z; }
-			set { _z = value; }
-		}
-		#endregion
-
-		#region Public Methods
-		public double Length() {
-			return Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
-		}
-
-		public Vector3D Round() {
-			return new Vector3D(Math.Round(X), Math.Round(Y), Math.Round(Z));
-		}
-
-		public double Magnitude() {
-			return Math.Sqrt(DotProduct(this));
-		}
-
-		public Vector3D Normalize() {
-			return this * (1 / Magnitude());
-		}
-
-		public double DotProduct(Vector3D b) {
-			return (X * b.X) + (Y * b.Y) + (Z * b.Z);
-		}
-
-		public Vector3D CrossProduct(Vector3D b) {
-			return new Vector3D((Y * b.Z) - (Z * b.Y),
-								(Z * b.X) - (X * b.Z),
-								(X * b.Y) - (Y * b.X));
-		}
-
-		public double Distance(Vector3D b) {
-			return Math.Sqrt((X - b.X) * (X - b.X) +
-							 (Y - b.Y) * (Y - b.Y) +
-							 (Z - b.Z) * (Z - b.Z));
-		}
-
-		public bool IsPerpendicular(Vector3D b) {
-			return DotProduct(b) == 0;
-		}
-
-		public static Vector3D Max(Vector3D a, Vector3D b) {
-			return (a >= b) ? a : b;
-		}
-
-		public static Vector3D Min(Vector3D a, Vector3D b) {
-			return (a <= b) ? a : b;
-		}
-
-		public Vector3D Rotate(Vector3D axis, double angle) {
-			axis = axis.Normalize();
-			Vector3D parallel = axis * DotProduct(axis);
-			Vector3D perpendicular = this - parallel;
-			Vector3D mutualPerpendicular = axis.CrossProduct(perpendicular);
-			Vector3D rotatePerpendicular = (perpendicular * Math.Cos(angle)) + (mutualPerpendicular * Math.Sin(angle));
-			return rotatePerpendicular + parallel;
-		}
-
-		public Vector3D Reflect(Vector3D normal) {
-			double dot = DotProduct(normal);
-			return new Vector3D(
-					X - ((dot * 2.0f) * normal.X),
-					Y - ((dot * 2.0f) * normal.Y),
-					Z - ((dot * 2.0f) * normal.Z)
-				);
-		}
-
-		public Vector3D NearestAxis() {
-			Vector3D b = Vector3D.Zero.Clone();
-			double xabs = Math.Abs(X);
-			double yabs = Math.Abs(Y);
-			double zabs = Math.Abs(Z);
-
-			if (xabs >= yabs && xabs >= zabs)
-				b.X = (X > 0.0) ? 1.0 : -1.0;
-			else if (yabs >= zabs)
-				b.Y = (Y > 0.0) ? 1.0 : -1.0;
-			else
-				b.Z = (Z > 0.0) ? 1.0 : -1.0;
-
-			return b;
-		}
-
-		public override int GetHashCode() {
-			return (int)((X + Y + Z) % int.MaxValue);
-		}
-		public override bool Equals(object obj) {
-			if (obj is Vector3D)
-				return this == (Vector3D)obj;
-			return false;
-		}
-		public override string ToString() {
-			return String.Format("({0}, {1}, {2})", X, Y, Z);
-		}
-
-		public Vector3D Clone() {
-			return new Vector3D(X, Y, Z);
-		}
-
-		public Point3D ToPoint() {
-			return new Point3D(X, Y, Z);
-		}
-		#endregion
-
-		#region Operators
-		public static Vector3D operator +(Vector3D a, Vector3D b) {
-			return new Vector3D(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
-		}
-
-		public static Vector3D operator -(Vector3D a, Vector3D b) {
-			return new Vector3D(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
-		}
-
-		public static Vector3D operator *(Vector3D a, double b) {
-			return new Vector3D(a.X * b, a.Y * b, a.Z * b);
-		}
-		public static Vector3D operator *(Vector3D a, float b) {
-			return new Vector3D(a.X * b, a.Y * b, a.Z * b);
-		}
-		public static Vector3D operator *(Vector3D a, int b) {
-			return new Vector3D(a.X * b, a.Y * b, a.Z * b);
-		}
-
-		public static Vector3D operator *(double a, Vector3D b) {
-			return a * b;
-		}
-		public static Vector3D operator *(float a, Vector3D b) {
-			return a * b;
-		}
-		public static Vector3D operator *(int a, Vector3D b) {
-			return a * b;
-		}
-
-		public static Vector3D operator /(Vector3D a, double b) {
-			return new Vector3D(a.X / b, a.Y / b, a.Z / b);
-		}
-		public static Vector3D operator /(Vector3D a, float b) {
-			return new Vector3D(a.X / b, a.Y / b, a.Z / b);
-		}
-		public static Vector3D operator /(Vector3D a, int b) {
-			return new Vector3D(a.X / b, a.Y / b, a.Z / b);
-		}
-
-		public static Vector3D operator -(Vector3D a) {
-			return new Vector3D(-a.X, -a.Y, -a.Z);
-		}
-
-		public static Vector3D operator +(Vector3D a) {
-			return new Vector3D(+a.X, +a.Y, +a.Z);
-		}
-
-		public static bool operator <(Vector3D a, Vector3D b) {
-			return a.DotProduct(a) < b.DotProduct(b);
-		}
-
-		public static bool operator >(Vector3D a, Vector3D b) {
-			return a.DotProduct(a) > b.DotProduct(b);
-		}
-
-		public static bool operator <=(Vector3D a, Vector3D b) {
-			return a.DotProduct(a) <= b.DotProduct(b);
-		}
-
-		public static bool operator >=(Vector3D a, Vector3D b) {
-			return a.DotProduct(a) >= b.DotProduct(b);
-		}
-
-		public static bool operator ==(Vector3D a, Vector3D b) {
-			if (ReferenceEquals(a, b))
-				return true;
-
-			if (((object)a == null) || ((object)b == null))
-				return false;
-
-			return Math.Abs(a.X - b.X) <= Double.Epsilon &&
-					Math.Abs(a.Y - b.Y) <= Double.Epsilon &&
-					Math.Abs(a.Z - b.Z) <= Double.Epsilon;
-		}
-
-		public static bool operator !=(Vector3D a, Vector3D b) {
-			return !(a == b);
-		}
-		#endregion
-	}
-
-	public class Point3D {
-		#region Constants
-		public static readonly Point3D Zero = new Point3D(0, 0, 0);
-		#endregion
-
-		#region Private Members
-		private double _x;
-		private double _y;
-		private double _z;
-		#endregion
-
-		#region Public Constructors
-		public Point3D() {
-		}
-
-		public Point3D(Point3D v) {
-			_x = v.X;
-			_y = v.Y;
-			_z = v.Z;
-		}
-
-		public Point3D(double x, double y, double z) {
-			_x = x;
-			_y = y;
-			_z = z;
-		}
-		public Point3D(double[] v) {
-			_x = v[0];
-			_y = v[1];
-			_z = v[2];
-		}
-		public Point3D(double[] v, int start) {
-			_x = v[start];
-			_y = v[start + 1];
-			_z = v[start + 2];
-		}
-
-		public Point3D(float x, float y, float z) {
-			_x = x;
-			_y = y;
-			_z = z;
-		}
-		public Point3D(float[] v) {
-			_x = v[0];
-			_y = v[1];
-			_z = v[2];
-		}
-		public Point3D(float[] v, int start) {
-			_x = v[start];
-			_y = v[start + 1];
-			_z = v[start + 2];
-		}
-
-		public Point3D(int x, int y, int z) {
-			_x = x;
-			_y = y;
-			_z = z;
-		}
-		public Point3D(int[] v) {
-			_x = v[0];
-			_y = v[1];
-			_z = v[2];
-		}
-		public Point3D(int[] v, int start) {
-			_x = v[start];
-			_y = v[start + 1];
-			_z = v[start + 2];
-		}
-		#endregion
-
-		#region Public Properties
-		public double X {
-			get { return _x; }
-			set { _x = value; }
-		}
-
-		public double Y {
-			get { return _y; }
-			set { _y = value; }
-		}
-
-		public double Z {
-			get { return _z; }
-			set { _z = value; }
-		}
-		#endregion
-
-		#region Public Methods
-		public double Distance(Point3D b) {
-			return Math.Sqrt((X - b.X) * (X - b.X) +
-							 (Y - b.Y) * (Y - b.Y) +
-							 (Z - b.Z) * (Z - b.Z));
-		}
-
-		public Point3D Move(Vector3D axis, double distance) {
-			return this + (axis.Normalize() * distance);
-		}
-
-		public Point3D Clone() {
-			return new Point3D(X, Y, Z);
-		}
-		public Vector3D ToVector() {
-			return new Vector3D(X, Y, Z);
-		}
-		#endregion
-
-		#region Operators
-		public static Point3D operator +(Point3D p, Vector3D v) {
-			return new Point3D(p.X + v.X, p.Y + v.Y, p.Z + v.Z);
-		}
-
-		public static bool operator ==(Point3D a, Point3D b) {
-			return Math.Abs(a.X - b.X) <= Double.Epsilon &&
-				   Math.Abs(a.Y - b.Y) <= Double.Epsilon &&
-				   Math.Abs(a.Z - b.Z) <= Double.Epsilon;
-		}
-
-		public static bool operator !=(Point3D a, Point3D b) {
-			return !(a == b);
-		}
-
-		public override int GetHashCode() {
-			return (int)((X + Y + Z) % int.MaxValue);
-		}
-		public override bool Equals(object obj) {
-			if (obj is Point3D)
-				return this == (Point3D)obj;
-			return false;
-		}
-		public override string ToString() {
-			return String.Format("({0}, {1}, {2})", X, Y, Z);
-		}
-		#endregion
-	}
-
-	public class Line3D {
-		#region Private Members
-		private Vector3D _vector;
-		private Point3D _point;
-		#endregion
-
-		#region Public Constructors
-		public Line3D() {
-			_point = Point3D.Zero.Clone();
-			_vector = Vector3D.Zero.Clone();
-		}
-
-		public Line3D(Point3D p, Vector3D v) {
-			_point = p.Clone();
-			_vector = v.Clone();
-		}
-
-		public Line3D(Line3D line) {
-			_point = line.Point.Clone();
-			_vector = line.Vector.Clone();
-		}
-		#endregion
-
-		#region Public Properties
-		public Point3D Point {
-			get { return _point; }
-			set { _point = value; }
-		}
-
-		public Vector3D Vector {
-			get { return _vector; }
-			set { _vector = value; }
-		}
-		#endregion
-
-		#region Public Members
-		public Point3D ClosestPoint(Point3D point) {
-			double n = (point.ToVector() - Point.ToVector()).DotProduct(Vector);
-			double d = Vector.Length();
-			return Point + (Vector * (n / d));
-		}
-
-		public bool ClosestPoints(Line3D b, out Point3D pa, out Point3D pb) {
-			pa = null;
-			pb = null;
-
-			if (Vector == b.Vector || Vector == -b.Vector)
-				return false;
-
-			Vector3D p0 = Point.ToVector();
-			Vector3D p1 = b.Point.ToVector();
-			Vector3D d0 = Vector;
-			Vector3D d1 = b.Vector;
-			Vector3D d0n = d0.Normalize();
-
-			Vector3D c = new Vector3D();
-			Vector3D d = new Vector3D();
-
-			d.X = d1.X - d0n.X * (d0.X * d1.X + d0.Y * d1.Y + d0.Z * d1.Z);
-			c.X = p1.X - p0.X + d0n.X * (d0.X * p0.X + d0.Y * p0.Y + d0.Z * p0.Z);
-
-			d.Y = d1.Y - d0n.Y * (d0.X * d1.X + d0.Y * d1.Y + d0.Z * d1.Z);
-			c.Y = p1.Y - p0.Y + d0n.Y * (d0.X * p0.X + d0.Y * p0.Y + d0.Z * p0.Z);
-
-			d.Z = d1.Z - d0n.Z * (d0.X * d1.X + d0.Y * d1.Y + d0.Z * d1.Z);
-			c.Z = p1.Z - p0.Z + d0n.Z * (d0.X * p0.X + d0.Y * p0.Y + d0.Z * p0.Z);
-
-			double t = -(c.X * d.X + c.Y * d.Y + c.Z * d.Z) / (d.X * d.X + d.Y * d.Y + d.Z * d.Z);
-
-			pb = b.Point + (b.Vector * t);
-			pa = ClosestPoint(pb);
-
-			return true;
-		}
-		#endregion
-	}
-
-	public class Segment3D {
-		#region Private Members
-		private Point3D _a;
-		private Point3D _b;
-		#endregion
-
-		#region Public Constructors
-		public Segment3D() {
-			_a = Point3D.Zero.Clone();
-			_b = Point3D.Zero.Clone();
-		}
-
-		public Segment3D(Point3D a, Point3D b) {
-			_a = a.Clone();
-			_b = b.Clone();
-		}
-		#endregion
-
-		#region Public Properties
-		public Point3D A {
-			get { return _a; }
-			set { _a = value; }
-		}
-
-		public Point3D B {
-			get { return _b; }
-			set { _b = value; }
-		}
-
-		public double Length {
-			get { return _a.Distance(_b); }
-		}
-
-		public Vector3D Vector {
-			get { return new Vector3D(_b.X - _a.X, _b.Y - _a.Y, _b.Z - _a.Z); }
-		}
-
-		public Vector3D NormalVector {
-			get { return Vector.Normalize(); }
-		}
-		#endregion
-	}
-
-	public class Plane3D {
-		#region Private Members
-		Vector3D _normal;
-		Point3D _point;
-		#endregion
-
-		#region Public Constructors
-		public Plane3D(Vector3D normal, Point3D point) {
-			_normal = normal;
-			_point = point;
-		}
-
-		public Plane3D(Point3D a, Point3D b, Point3D c) {
-			Vector3D av = a.ToVector();
-			Vector3D bv = b.ToVector();
-			Vector3D cv = c.ToVector();
-
-			_normal = (bv - av).CrossProduct(cv - av).Normalize();
-			_point = a;
-		}
-		#endregion
-
-		#region Public Properties
-		public Vector3D Normal {
-			get { return _normal; }
-			set { _normal = value; }
-		}
-
-		public Point3D Point {
-			get { return _point; }
-			set { _point = value; }
-		}
-
-		public double Distance {
-			get { return Point.Distance(Point3D.Zero); }
-		}
-		#endregion
-
-		#region Public Members
-		public bool IsParallel(Line3D line) {
-			return line.Vector.DotProduct(Normal) == 0.0;
-		}
-
-		public bool IsParallel(Plane3D plane) {
-			return Normal == plane.Normal;
-		}
-
-		public bool Intersect(Line3D line, out Point3D intersection) {
-			if (IsParallel(line)) {
-				intersection = null;
-				return false;
-			}
-			double t = (Distance - Normal.DotProduct(line.Point.ToVector())) / Normal.DotProduct(line.Vector);
-			intersection = line.Point + (t * line.Vector);
-			return true;
-		}
-
-		public bool Intersect(Plane3D b, out Line3D intersection) {
-			intersection = null;
-
-			if (IsParallel(b))
-				return false;
-
-			Point3D p;
-			Vector3D v1 = Normal.CrossProduct(b.Normal);
-			Vector3D v2 = new Vector3D(v1.X * v1.X, v1.Y * v1.Y, v1.Z * v1.Z);
-			double w1 = -Distance;
-			double w2 = -b.Distance;
-			double id;
-
-			if ((v2.Z > v2.Y) && (v2.Z > v2.X) && (v2.Z > Double.Epsilon)) {
-				// point on XY plane
-				id = 1.0 / v1.Z;
-				p = new Point3D(Normal.Y * w2 - b.Normal.Y * w1,
-								b.Normal.X * w1 - Normal.X * w2,
-								0.0);
-			} else if ((v2.Y > v2.X) && (v2.Y > Double.Epsilon)) {
-				// point on XZ plane
-				id = -1.0 / v1.Y;
-				p = new Point3D(Normal.Z * w2 - b.Normal.Z * w1,
-								0.0,
-								b.Normal.Y * w1 - Normal.Y * w2);
-			} else if (v2.X > Double.Epsilon) {
-				// point on YZ plane
-				id = 1.0 / v1.X;
-				p = new Point3D(0.0,
-								  Normal.Z * w2 - b.Normal.Z * w1,
-								b.Normal.Y * w1 - Normal.Y * w2);
-			} else
-				return false;
-
-			p = (p.ToVector() * id).ToPoint();
-			id = 1.0 / Math.Sqrt(v2.X + v2.Y + v2.Z);
-			v1 *= id;
-
-			intersection = new Line3D(p, p.ToVector() + v1);
-
-			return true;
-		}
-
-		public Point3D ClosestPoint(Point3D point) {
-			Vector3D pv = point.ToVector();
-			double d = Normal.DotProduct(pv - Point.ToVector());
-			return (pv - (Normal * d)).ToPoint();
-		}
-		#endregion
-	}
-
-	public class Slice3D {
-		#region Private Members
-		Vector3D _normal;
-		Point3D _topLeft;
-		Point3D _topRight;
-		Point3D _bottomLeft;
-		Point3D _bottomRight;
-		double _width;
-		double _height;
-		Plane3D _plane;
-		#endregion
-
-		#region Public Constructors
-		public Slice3D(Vector3D normal, Point3D topLeft, double width, double height) {
-			Vector3D right = normal.Rotate(Vector3D.AxisY, -90.0);
-			Vector3D down = normal.Rotate(Vector3D.AxisX, -90.0);
-
-			_topLeft = topLeft;
-			_topRight = _topLeft + (right * width);
-			_bottomLeft = _topLeft + (down * height);
-			_bottomRight = _bottomLeft + (right * width);
-
-			_normal = normal;
-			_width = width;
-			_height = height;
-			_plane = new Plane3D(normal, _topLeft);
-		}
-		#endregion
-
-		#region Public Properties
-		public Vector3D Normal {
-			get { return _normal; }
-		}
-
-		public Plane3D Plane {
-			get { return _plane; }
-		}
-
-		public Point3D TopLeft {
-			get { return _topLeft; }
-		}
-
-		public Point3D TopRight {
-			get { return _topRight; }
-		}
-
-		public Point3D BottomLeft {
-			get { return _bottomLeft; }
-		}
-
-		public Point3D BottomRight {
-			get { return _bottomRight; }
-		}
-
-		public double Width {
-			get { return _width; }
-		}
-
-		public double Height {
-			get { return _height; }
-		}
-		#endregion
-
-		#region Public Methods
-		public Point3D Project(Point3D point) {
-			Point3D p = Plane.ClosestPoint(point);
-			//normal vector?
-			throw new NotImplementedException();
-			return p;
-		}
-
-		public Segment3D Project(Segment3D segment) {
-			return new Segment3D(Project(segment.A), Project(segment.B));
-		}
-
-		public bool Intersect(Slice3D b, out Segment3D intersection) {
-			intersection = null;
-
-			Line3D line;
-			if (!Plane.Intersect(b.Plane, out line))
-				return false;
-
-			return false;
-		}
-		#endregion
-	}
-
-	public class Orientation3D {
-		#region Private Members
-		private Vector3D _forward;
-		private Vector3D _down;
-		#endregion
-
-		#region Public Constructors
-		public Orientation3D() {
-			_forward = new Vector3D(1.0, 0.0, 0.0);
-			_down = new Vector3D(0.0, 0.0, 1.0);
-		}
-
-		public Orientation3D(Vector3D forward, Vector3D down) {
-			_forward = forward;
-			_down = down;
-		}
-
-		public Orientation3D(Orientation3D orientation) {
-			_forward = orientation.Forward.Clone();
-			_down = orientation.Down.Clone();
-		}
-		#endregion
-
-		#region Public Properties
-		public Vector3D Forward {
-			get { return _forward; }
-		}
-
-		public Vector3D Backward {
-			get { return -Forward; }
-		}
-
-		public Vector3D Left {
-			get { return -Right; }
-		}
-
-		public Vector3D Right {
-			get { return Down.CrossProduct(Forward); }
-		}
-
-		public Vector3D Up {
-			get { return -Down; }
-		}
-
-		public Vector3D Down {
-			get { return _down; }
-		}
-		#endregion
-
-		#region Public Methods
-		public void Pitch(double angle) {
-			Vector3D right = Right;
-			_forward = _forward.Rotate(right, angle);
-			_down = _down.Rotate(right, angle);
-		}
-
-		public void Roll(double angle) {
-			_down = _down.Rotate(_forward, angle);
-		}
-
-		public void Yaw(double angle) {
-			_forward = _forward.Rotate(_down, angle);
-		}
-		#endregion
-	}
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
+
+namespace Dicom.Imaging.Mathematics
+{
+    public class Vector3D
+    {
+        #region Constants
+
+        public static readonly Vector3D Zero = new Vector3D(0.0, 0.0, 0.0);
+
+        public static readonly Vector3D Epsilon = new Vector3D(Double.Epsilon, Double.Epsilon, Double.Epsilon);
+
+        public static readonly Vector3D MinValue = new Vector3D(Double.MinValue, Double.MinValue, Double.MinValue);
+
+        public static readonly Vector3D MaxValue = new Vector3D(Double.MaxValue, Double.MaxValue, Double.MaxValue);
+
+        public static readonly Vector3D AxisX = new Vector3D(1.0, 0.0, 0.0);
+
+        public static readonly Vector3D AxisY = new Vector3D(0.0, 1.0, 0.0);
+
+        public static readonly Vector3D AxisZ = new Vector3D(0.0, 0.0, 1.0);
+
+        #endregion
+
+        #region Private Members
+
+        private double _x;
+
+        private double _y;
+
+        private double _z;
+
+        #endregion
+
+        #region Public Constructors
+
+        public Vector3D()
+        {
+        }
+
+        public Vector3D(Vector3D v)
+        {
+            _x = v.X;
+            _y = v.Y;
+            _z = v.Z;
+        }
+
+        public Vector3D(double x, double y, double z)
+        {
+            _x = x;
+            _y = y;
+            _z = z;
+        }
+
+        public Vector3D(double[] v)
+        {
+            _x = v[0];
+            _y = v[1];
+            _z = v[2];
+        }
+
+        public Vector3D(double[] v, int start)
+        {
+            _x = v[start];
+            _y = v[start + 1];
+            _z = v[start + 2];
+        }
+
+        public Vector3D(float x, float y, float z)
+        {
+            _x = x;
+            _y = y;
+            _z = z;
+        }
+
+        public Vector3D(float[] v)
+        {
+            _x = v[0];
+            _y = v[1];
+            _z = v[2];
+        }
+
+        public Vector3D(float[] v, int start)
+        {
+            _x = v[start];
+            _y = v[start + 1];
+            _z = v[start + 2];
+        }
+
+        public Vector3D(int x, int y, int z)
+        {
+            _x = x;
+            _y = y;
+            _z = z;
+        }
+
+        public Vector3D(int[] v)
+        {
+            _x = v[0];
+            _y = v[1];
+            _z = v[2];
+        }
+
+        public Vector3D(int[] v, int start)
+        {
+            _x = v[start];
+            _y = v[start + 1];
+            _z = v[start + 2];
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public double X
+        {
+            get
+            {
+                return _x;
+            }
+            set
+            {
+                _x = value;
+            }
+        }
+
+        public double Y
+        {
+            get
+            {
+                return _y;
+            }
+            set
+            {
+                _y = value;
+            }
+        }
+
+        public double Z
+        {
+            get
+            {
+                return _z;
+            }
+            set
+            {
+                _z = value;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public double Length()
+        {
+            return Math.Sqrt((X * X) + (Y * Y) + (Z * Z));
+        }
+
+        public Vector3D Round()
+        {
+            return new Vector3D(Math.Round(X), Math.Round(Y), Math.Round(Z));
+        }
+
+        public double Magnitude()
+        {
+            return Math.Sqrt(DotProduct(this));
+        }
+
+        public Vector3D Normalize()
+        {
+            return this * (1 / Magnitude());
+        }
+
+        public double DotProduct(Vector3D b)
+        {
+            return (X * b.X) + (Y * b.Y) + (Z * b.Z);
+        }
+
+        public Vector3D CrossProduct(Vector3D b)
+        {
+            return new Vector3D((Y * b.Z) - (Z * b.Y), (Z * b.X) - (X * b.Z), (X * b.Y) - (Y * b.X));
+        }
+
+        public double Distance(Vector3D b)
+        {
+            return Math.Sqrt((X - b.X) * (X - b.X) + (Y - b.Y) * (Y - b.Y) + (Z - b.Z) * (Z - b.Z));
+        }
+
+        public bool IsPerpendicular(Vector3D b)
+        {
+            return DotProduct(b) == 0;
+        }
+
+        public static Vector3D Max(Vector3D a, Vector3D b)
+        {
+            return (a >= b) ? a : b;
+        }
+
+        public static Vector3D Min(Vector3D a, Vector3D b)
+        {
+            return (a <= b) ? a : b;
+        }
+
+        public Vector3D Rotate(Vector3D axis, double angle)
+        {
+            axis = axis.Normalize();
+            Vector3D parallel = axis * DotProduct(axis);
+            Vector3D perpendicular = this - parallel;
+            Vector3D mutualPerpendicular = axis.CrossProduct(perpendicular);
+            Vector3D rotatePerpendicular = (perpendicular * Math.Cos(angle)) + (mutualPerpendicular * Math.Sin(angle));
+            return rotatePerpendicular + parallel;
+        }
+
+        public Vector3D Reflect(Vector3D normal)
+        {
+            double dot = DotProduct(normal);
+            return new Vector3D(
+                X - ((dot * 2.0f) * normal.X),
+                Y - ((dot * 2.0f) * normal.Y),
+                Z - ((dot * 2.0f) * normal.Z));
+        }
+
+        public Vector3D NearestAxis()
+        {
+            Vector3D b = Vector3D.Zero.Clone();
+            double xabs = Math.Abs(X);
+            double yabs = Math.Abs(Y);
+            double zabs = Math.Abs(Z);
+
+            if (xabs >= yabs && xabs >= zabs) b.X = (X > 0.0) ? 1.0 : -1.0;
+            else if (yabs >= zabs) b.Y = (Y > 0.0) ? 1.0 : -1.0;
+            else b.Z = (Z > 0.0) ? 1.0 : -1.0;
+
+            return b;
+        }
+
+        public override int GetHashCode()
+        {
+            return (int)((X + Y + Z) % int.MaxValue);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Vector3D) return this == (Vector3D)obj;
+            return false;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("({0}, {1}, {2})", X, Y, Z);
+        }
+
+        public Vector3D Clone()
+        {
+            return new Vector3D(X, Y, Z);
+        }
+
+        public Point3D ToPoint()
+        {
+            return new Point3D(X, Y, Z);
+        }
+
+        #endregion
+
+        #region Operators
+
+        public static Vector3D operator +(Vector3D a, Vector3D b)
+        {
+            return new Vector3D(a.X + b.X, a.Y + b.Y, a.Z + b.Z);
+        }
+
+        public static Vector3D operator -(Vector3D a, Vector3D b)
+        {
+            return new Vector3D(a.X - b.X, a.Y - b.Y, a.Z - b.Z);
+        }
+
+        public static Vector3D operator *(Vector3D a, double b)
+        {
+            return new Vector3D(a.X * b, a.Y * b, a.Z * b);
+        }
+
+        public static Vector3D operator *(Vector3D a, float b)
+        {
+            return new Vector3D(a.X * b, a.Y * b, a.Z * b);
+        }
+
+        public static Vector3D operator *(Vector3D a, int b)
+        {
+            return new Vector3D(a.X * b, a.Y * b, a.Z * b);
+        }
+
+        public static Vector3D operator *(double a, Vector3D b)
+        {
+            return a * b;
+        }
+
+        public static Vector3D operator *(float a, Vector3D b)
+        {
+            return a * b;
+        }
+
+        public static Vector3D operator *(int a, Vector3D b)
+        {
+            return a * b;
+        }
+
+        public static Vector3D operator /(Vector3D a, double b)
+        {
+            return new Vector3D(a.X / b, a.Y / b, a.Z / b);
+        }
+
+        public static Vector3D operator /(Vector3D a, float b)
+        {
+            return new Vector3D(a.X / b, a.Y / b, a.Z / b);
+        }
+
+        public static Vector3D operator /(Vector3D a, int b)
+        {
+            return new Vector3D(a.X / b, a.Y / b, a.Z / b);
+        }
+
+        public static Vector3D operator -(Vector3D a)
+        {
+            return new Vector3D(-a.X, -a.Y, -a.Z);
+        }
+
+        public static Vector3D operator +(Vector3D a)
+        {
+            return new Vector3D(+a.X, +a.Y, +a.Z);
+        }
+
+        public static bool operator <(Vector3D a, Vector3D b)
+        {
+            return a.DotProduct(a) < b.DotProduct(b);
+        }
+
+        public static bool operator >(Vector3D a, Vector3D b)
+        {
+            return a.DotProduct(a) > b.DotProduct(b);
+        }
+
+        public static bool operator <=(Vector3D a, Vector3D b)
+        {
+            return a.DotProduct(a) <= b.DotProduct(b);
+        }
+
+        public static bool operator >=(Vector3D a, Vector3D b)
+        {
+            return a.DotProduct(a) >= b.DotProduct(b);
+        }
+
+        public static bool operator ==(Vector3D a, Vector3D b)
+        {
+            if (ReferenceEquals(a, b)) return true;
+
+            if (((object)a == null) || ((object)b == null)) return false;
+
+            return Math.Abs(a.X - b.X) <= Double.Epsilon && Math.Abs(a.Y - b.Y) <= Double.Epsilon
+                   && Math.Abs(a.Z - b.Z) <= Double.Epsilon;
+        }
+
+        public static bool operator !=(Vector3D a, Vector3D b)
+        {
+            return !(a == b);
+        }
+
+        #endregion
+    }
+
+    public class Point3D
+    {
+        #region Constants
+
+        public static readonly Point3D Zero = new Point3D(0, 0, 0);
+
+        #endregion
+
+        #region Private Members
+
+        private double _x;
+
+        private double _y;
+
+        private double _z;
+
+        #endregion
+
+        #region Public Constructors
+
+        public Point3D()
+        {
+        }
+
+        public Point3D(Point3D v)
+        {
+            _x = v.X;
+            _y = v.Y;
+            _z = v.Z;
+        }
+
+        public Point3D(double x, double y, double z)
+        {
+            _x = x;
+            _y = y;
+            _z = z;
+        }
+
+        public Point3D(double[] v)
+        {
+            _x = v[0];
+            _y = v[1];
+            _z = v[2];
+        }
+
+        public Point3D(double[] v, int start)
+        {
+            _x = v[start];
+            _y = v[start + 1];
+            _z = v[start + 2];
+        }
+
+        public Point3D(float x, float y, float z)
+        {
+            _x = x;
+            _y = y;
+            _z = z;
+        }
+
+        public Point3D(float[] v)
+        {
+            _x = v[0];
+            _y = v[1];
+            _z = v[2];
+        }
+
+        public Point3D(float[] v, int start)
+        {
+            _x = v[start];
+            _y = v[start + 1];
+            _z = v[start + 2];
+        }
+
+        public Point3D(int x, int y, int z)
+        {
+            _x = x;
+            _y = y;
+            _z = z;
+        }
+
+        public Point3D(int[] v)
+        {
+            _x = v[0];
+            _y = v[1];
+            _z = v[2];
+        }
+
+        public Point3D(int[] v, int start)
+        {
+            _x = v[start];
+            _y = v[start + 1];
+            _z = v[start + 2];
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public double X
+        {
+            get
+            {
+                return _x;
+            }
+            set
+            {
+                _x = value;
+            }
+        }
+
+        public double Y
+        {
+            get
+            {
+                return _y;
+            }
+            set
+            {
+                _y = value;
+            }
+        }
+
+        public double Z
+        {
+            get
+            {
+                return _z;
+            }
+            set
+            {
+                _z = value;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public double Distance(Point3D b)
+        {
+            return Math.Sqrt((X - b.X) * (X - b.X) + (Y - b.Y) * (Y - b.Y) + (Z - b.Z) * (Z - b.Z));
+        }
+
+        public Point3D Move(Vector3D axis, double distance)
+        {
+            return this + (axis.Normalize() * distance);
+        }
+
+        public Point3D Clone()
+        {
+            return new Point3D(X, Y, Z);
+        }
+
+        public Vector3D ToVector()
+        {
+            return new Vector3D(X, Y, Z);
+        }
+
+        #endregion
+
+        #region Operators
+
+        public static Point3D operator +(Point3D p, Vector3D v)
+        {
+            return new Point3D(p.X + v.X, p.Y + v.Y, p.Z + v.Z);
+        }
+
+        public static bool operator ==(Point3D a, Point3D b)
+        {
+            return Math.Abs(a.X - b.X) <= Double.Epsilon && Math.Abs(a.Y - b.Y) <= Double.Epsilon
+                   && Math.Abs(a.Z - b.Z) <= Double.Epsilon;
+        }
+
+        public static bool operator !=(Point3D a, Point3D b)
+        {
+            return !(a == b);
+        }
+
+        public override int GetHashCode()
+        {
+            return (int)((X + Y + Z) % int.MaxValue);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Point3D) return this == (Point3D)obj;
+            return false;
+        }
+
+        public override string ToString()
+        {
+            return String.Format("({0}, {1}, {2})", X, Y, Z);
+        }
+
+        #endregion
+    }
+
+    public class Line3D
+    {
+        #region Private Members
+
+        private Vector3D _vector;
+
+        private Point3D _point;
+
+        #endregion
+
+        #region Public Constructors
+
+        public Line3D()
+        {
+            _point = Point3D.Zero.Clone();
+            _vector = Vector3D.Zero.Clone();
+        }
+
+        public Line3D(Point3D p, Vector3D v)
+        {
+            _point = p.Clone();
+            _vector = v.Clone();
+        }
+
+        public Line3D(Line3D line)
+        {
+            _point = line.Point.Clone();
+            _vector = line.Vector.Clone();
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public Point3D Point
+        {
+            get
+            {
+                return _point;
+            }
+            set
+            {
+                _point = value;
+            }
+        }
+
+        public Vector3D Vector
+        {
+            get
+            {
+                return _vector;
+            }
+            set
+            {
+                _vector = value;
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        public Point3D ClosestPoint(Point3D point)
+        {
+            double n = (point.ToVector() - Point.ToVector()).DotProduct(Vector);
+            double d = Vector.Length();
+            return Point + (Vector * (n / d));
+        }
+
+        public bool ClosestPoints(Line3D b, out Point3D pa, out Point3D pb)
+        {
+            pa = null;
+            pb = null;
+
+            if (Vector == b.Vector || Vector == -b.Vector) return false;
+
+            Vector3D p0 = Point.ToVector();
+            Vector3D p1 = b.Point.ToVector();
+            Vector3D d0 = Vector;
+            Vector3D d1 = b.Vector;
+            Vector3D d0n = d0.Normalize();
+
+            Vector3D c = new Vector3D();
+            Vector3D d = new Vector3D();
+
+            d.X = d1.X - d0n.X * (d0.X * d1.X + d0.Y * d1.Y + d0.Z * d1.Z);
+            c.X = p1.X - p0.X + d0n.X * (d0.X * p0.X + d0.Y * p0.Y + d0.Z * p0.Z);
+
+            d.Y = d1.Y - d0n.Y * (d0.X * d1.X + d0.Y * d1.Y + d0.Z * d1.Z);
+            c.Y = p1.Y - p0.Y + d0n.Y * (d0.X * p0.X + d0.Y * p0.Y + d0.Z * p0.Z);
+
+            d.Z = d1.Z - d0n.Z * (d0.X * d1.X + d0.Y * d1.Y + d0.Z * d1.Z);
+            c.Z = p1.Z - p0.Z + d0n.Z * (d0.X * p0.X + d0.Y * p0.Y + d0.Z * p0.Z);
+
+            double t = -(c.X * d.X + c.Y * d.Y + c.Z * d.Z) / (d.X * d.X + d.Y * d.Y + d.Z * d.Z);
+
+            pb = b.Point + (b.Vector * t);
+            pa = ClosestPoint(pb);
+
+            return true;
+        }
+
+        #endregion
+    }
+
+    public class Segment3D
+    {
+        #region Private Members
+
+        private Point3D _a;
+
+        private Point3D _b;
+
+        #endregion
+
+        #region Public Constructors
+
+        public Segment3D()
+        {
+            _a = Point3D.Zero.Clone();
+            _b = Point3D.Zero.Clone();
+        }
+
+        public Segment3D(Point3D a, Point3D b)
+        {
+            _a = a.Clone();
+            _b = b.Clone();
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public Point3D A
+        {
+            get
+            {
+                return _a;
+            }
+            set
+            {
+                _a = value;
+            }
+        }
+
+        public Point3D B
+        {
+            get
+            {
+                return _b;
+            }
+            set
+            {
+                _b = value;
+            }
+        }
+
+        public double Length
+        {
+            get
+            {
+                return _a.Distance(_b);
+            }
+        }
+
+        public Vector3D Vector
+        {
+            get
+            {
+                return new Vector3D(_b.X - _a.X, _b.Y - _a.Y, _b.Z - _a.Z);
+            }
+        }
+
+        public Vector3D NormalVector
+        {
+            get
+            {
+                return Vector.Normalize();
+            }
+        }
+
+        #endregion
+    }
+
+    public class Plane3D
+    {
+        #region Private Members
+
+        private Vector3D _normal;
+
+        private Point3D _point;
+
+        #endregion
+
+        #region Public Constructors
+
+        public Plane3D(Vector3D normal, Point3D point)
+        {
+            _normal = normal;
+            _point = point;
+        }
+
+        public Plane3D(Point3D a, Point3D b, Point3D c)
+        {
+            Vector3D av = a.ToVector();
+            Vector3D bv = b.ToVector();
+            Vector3D cv = c.ToVector();
+
+            _normal = (bv - av).CrossProduct(cv - av).Normalize();
+            _point = a;
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public Vector3D Normal
+        {
+            get
+            {
+                return _normal;
+            }
+            set
+            {
+                _normal = value;
+            }
+        }
+
+        public Point3D Point
+        {
+            get
+            {
+                return _point;
+            }
+            set
+            {
+                _point = value;
+            }
+        }
+
+        public double Distance
+        {
+            get
+            {
+                return Point.Distance(Point3D.Zero);
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        public bool IsParallel(Line3D line)
+        {
+            return line.Vector.DotProduct(Normal) == 0.0;
+        }
+
+        public bool IsParallel(Plane3D plane)
+        {
+            return Normal == plane.Normal;
+        }
+
+        public bool Intersect(Line3D line, out Point3D intersection)
+        {
+            if (IsParallel(line))
+            {
+                intersection = null;
+                return false;
+            }
+            double t = (Distance - Normal.DotProduct(line.Point.ToVector())) / Normal.DotProduct(line.Vector);
+            intersection = line.Point + (t * line.Vector);
+            return true;
+        }
+
+        public bool Intersect(Plane3D b, out Line3D intersection)
+        {
+            intersection = null;
+
+            if (IsParallel(b)) return false;
+
+            Point3D p;
+            Vector3D v1 = Normal.CrossProduct(b.Normal);
+            Vector3D v2 = new Vector3D(v1.X * v1.X, v1.Y * v1.Y, v1.Z * v1.Z);
+            double w1 = -Distance;
+            double w2 = -b.Distance;
+            double id;
+
+            if ((v2.Z > v2.Y) && (v2.Z > v2.X) && (v2.Z > Double.Epsilon))
+            {
+                // point on XY plane
+                id = 1.0 / v1.Z;
+                p = new Point3D(Normal.Y * w2 - b.Normal.Y * w1, b.Normal.X * w1 - Normal.X * w2, 0.0);
+            }
+            else if ((v2.Y > v2.X) && (v2.Y > Double.Epsilon))
+            {
+                // point on XZ plane
+                id = -1.0 / v1.Y;
+                p = new Point3D(Normal.Z * w2 - b.Normal.Z * w1, 0.0, b.Normal.Y * w1 - Normal.Y * w2);
+            }
+            else if (v2.X > Double.Epsilon)
+            {
+                // point on YZ plane
+                id = 1.0 / v1.X;
+                p = new Point3D(0.0, Normal.Z * w2 - b.Normal.Z * w1, b.Normal.Y * w1 - Normal.Y * w2);
+            }
+            else return false;
+
+            p = (p.ToVector() * id).ToPoint();
+            id = 1.0 / Math.Sqrt(v2.X + v2.Y + v2.Z);
+            v1 *= id;
+
+            intersection = new Line3D(p, p.ToVector() + v1);
+
+            return true;
+        }
+
+        public Point3D ClosestPoint(Point3D point)
+        {
+            Vector3D pv = point.ToVector();
+            double d = Normal.DotProduct(pv - Point.ToVector());
+            return (pv - (Normal * d)).ToPoint();
+        }
+
+        #endregion
+    }
+
+    public class Slice3D
+    {
+        #region Private Members
+
+        private Vector3D _normal;
+
+        private Point3D _topLeft;
+
+        private Point3D _topRight;
+
+        private Point3D _bottomLeft;
+
+        private Point3D _bottomRight;
+
+        private double _width;
+
+        private double _height;
+
+        private Plane3D _plane;
+
+        #endregion
+
+        #region Public Constructors
+
+        public Slice3D(Vector3D normal, Point3D topLeft, double width, double height)
+        {
+            Vector3D right = normal.Rotate(Vector3D.AxisY, -90.0);
+            Vector3D down = normal.Rotate(Vector3D.AxisX, -90.0);
+
+            _topLeft = topLeft;
+            _topRight = _topLeft + (right * width);
+            _bottomLeft = _topLeft + (down * height);
+            _bottomRight = _bottomLeft + (right * width);
+
+            _normal = normal;
+            _width = width;
+            _height = height;
+            _plane = new Plane3D(normal, _topLeft);
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public Vector3D Normal
+        {
+            get
+            {
+                return _normal;
+            }
+        }
+
+        public Plane3D Plane
+        {
+            get
+            {
+                return _plane;
+            }
+        }
+
+        public Point3D TopLeft
+        {
+            get
+            {
+                return _topLeft;
+            }
+        }
+
+        public Point3D TopRight
+        {
+            get
+            {
+                return _topRight;
+            }
+        }
+
+        public Point3D BottomLeft
+        {
+            get
+            {
+                return _bottomLeft;
+            }
+        }
+
+        public Point3D BottomRight
+        {
+            get
+            {
+                return _bottomRight;
+            }
+        }
+
+        public double Width
+        {
+            get
+            {
+                return _width;
+            }
+        }
+
+        public double Height
+        {
+            get
+            {
+                return _height;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public Point3D Project(Point3D point)
+        {
+            Point3D p = Plane.ClosestPoint(point);
+            //normal vector?
+            throw new NotImplementedException();
+            return p;
+        }
+
+        public Segment3D Project(Segment3D segment)
+        {
+            return new Segment3D(Project(segment.A), Project(segment.B));
+        }
+
+        public bool Intersect(Slice3D b, out Segment3D intersection)
+        {
+            intersection = null;
+
+            Line3D line;
+            if (!Plane.Intersect(b.Plane, out line)) return false;
+
+            return false;
+        }
+
+        #endregion
+    }
+
+    public class Orientation3D
+    {
+        #region Private Members
+
+        private Vector3D _forward;
+
+        private Vector3D _down;
+
+        #endregion
+
+        #region Public Constructors
+
+        public Orientation3D()
+        {
+            _forward = new Vector3D(1.0, 0.0, 0.0);
+            _down = new Vector3D(0.0, 0.0, 1.0);
+        }
+
+        public Orientation3D(Vector3D forward, Vector3D down)
+        {
+            _forward = forward;
+            _down = down;
+        }
+
+        public Orientation3D(Orientation3D orientation)
+        {
+            _forward = orientation.Forward.Clone();
+            _down = orientation.Down.Clone();
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public Vector3D Forward
+        {
+            get
+            {
+                return _forward;
+            }
+        }
+
+        public Vector3D Backward
+        {
+            get
+            {
+                return -Forward;
+            }
+        }
+
+        public Vector3D Left
+        {
+            get
+            {
+                return -Right;
+            }
+        }
+
+        public Vector3D Right
+        {
+            get
+            {
+                return Down.CrossProduct(Forward);
+            }
+        }
+
+        public Vector3D Up
+        {
+            get
+            {
+                return -Down;
+            }
+        }
+
+        public Vector3D Down
+        {
+            get
+            {
+                return _down;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Pitch(double angle)
+        {
+            Vector3D right = Right;
+            _forward = _forward.Rotate(right, angle);
+            _down = _down.Rotate(right, angle);
+        }
+
+        public void Roll(double angle)
+        {
+            _down = _down.Rotate(_forward, angle);
+        }
+
+        public void Yaw(double angle)
+        {
+            _forward = _forward.Rotate(_down, angle);
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/Mathematics/Histogram.cs
+++ b/DICOM/Imaging/Mathematics/Histogram.cs
@@ -1,127 +1,145 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Mathematics {
-	public class Histogram {
-		private int[] _values;
-		private int _total;
-		private int _min;
-		private int _max;
-		private int _offset;
+namespace Dicom.Imaging.Mathematics
+{
+    public class Histogram
+    {
+        private int[] _values;
 
-		private int _window;
-		private int _wstart;
-		private int _wend;
-		private int _wtotal;
+        private int _total;
 
-		public Histogram(int min, int max) {
-			int range = max - min + 1;
-			_values = new int[range];
-			_min = min;
-			_max = max;
-			_offset = -_min;
-			_wstart = 0;
-			_wend = _values.Length - 1;
-			_window = -1;
-		}
+        private int _min;
 
-		public int WindowStart {
-			get { return _wstart - _offset; }
-		}
+        private int _max;
 
-		public int WindowEnd {
-			get { return _wend - _offset; }
-		}
+        private int _offset;
 
-		public int WindowTotal {
-			get {
-				if (_window == -1)
-					ApplyWindow(100);
-				return _wtotal;
-			}
-		}
+        private int _window;
 
-		public int this[int value] {
-			get {
-				int pos = value + _offset;
-				if (pos < 0 || pos >= _values.Length)
-					return 0;
-				return _values[pos];
-			}
-		}
+        private int _wstart;
 
-		public void Add(int value) {
-			int pos = value + _offset;
-			if (pos < 0 || pos >= _values.Length)
-				return;
+        private int _wend;
 
-			_values[pos]++;
-			_total++;
+        private int _wtotal;
 
-			if (pos >= _wstart && pos <= _wend)
-				_wtotal++;
-		}
+        public Histogram(int min, int max)
+        {
+            int range = max - min + 1;
+            _values = new int[range];
+            _min = min;
+            _max = max;
+            _offset = -_min;
+            _wstart = 0;
+            _wend = _values.Length - 1;
+            _window = -1;
+        }
 
-		public void Clear(int value) {
-			int pos = value + _offset - 1;
-			if (pos < 0 || pos >= _values.Length)
-				return;
+        public int WindowStart
+        {
+            get
+            {
+                return _wstart - _offset;
+            }
+        }
 
-			_total -= _values[pos];
-			if (pos >= _wstart && pos <= _wend)
-				_wtotal -= _values[pos];
+        public int WindowEnd
+        {
+            get
+            {
+                return _wend - _offset;
+            }
+        }
 
-			_values[pos] = 0;
-		}
+        public int WindowTotal
+        {
+            get
+            {
+                if (_window == -1) ApplyWindow(100);
+                return _wtotal;
+            }
+        }
 
-		public void ApplyWindow(int percent) {
-			_wstart = 0;
-			_wend = _values.Length - 1;
-			_window = percent;
-			_wtotal = _total;
+        public int this[int value]
+        {
+            get
+            {
+                int pos = value + _offset;
+                if (pos < 0 || pos >= _values.Length) return 0;
+                return _values[pos];
+            }
+        }
 
-			if (percent == 100 || _total == 0)
-				return;
+        public void Add(int value)
+        {
+            int pos = value + _offset;
+            if (pos < 0 || pos >= _values.Length) return;
 
-			var target = (int)(_total * (percent / 100.0));
+            _values[pos]++;
+            _total++;
 
-			while (_wtotal > target) {
-				var wtotal = _wtotal;
-				if (_values[_wstart] >= _values[_wend]) {
-					wtotal -= _values[_wstart];
-					if (wtotal < target)
-						break;
-					_wstart++;
-				} else {
-					wtotal -= _values[_wend];
-					if (wtotal < target)
-						break;
-					_wend--;
-				}
+            if (pos >= _wstart && pos <= _wend) _wtotal++;
+        }
 
-				_wtotal = wtotal;
+        public void Clear(int value)
+        {
+            int pos = value + _offset - 1;
+            if (pos < 0 || pos >= _values.Length) return;
 
-				if (_wstart == _wend)
-					break;
-			}
-		}
+            _total -= _values[pos];
+            if (pos >= _wstart && pos <= _wend) _wtotal -= _values[pos];
 
-		public void ApplyWindow(int start, int end) {
-			_wstart = start + _offset;
-			_wend = end + _offset;
+            _values[pos] = 0;
+        }
 
-			if (_wstart == 0 && _wend == _values.Length - 1) {
-				_window = 100;
-				_wtotal = _total;
-				return;
-			}
+        public void ApplyWindow(int percent)
+        {
+            _wstart = 0;
+            _wend = _values.Length - 1;
+            _window = percent;
+            _wtotal = _total;
 
-			for (int i = _wstart; i <= _wend; i++)
-				_wtotal += _values[i];
+            if (percent == 100 || _total == 0) return;
 
-			_window = (int)((double)_wtotal / (double)_total);
-		}
-	}
+            var target = (int)(_total * (percent / 100.0));
+
+            while (_wtotal > target)
+            {
+                var wtotal = _wtotal;
+                if (_values[_wstart] >= _values[_wend])
+                {
+                    wtotal -= _values[_wstart];
+                    if (wtotal < target) break;
+                    _wstart++;
+                }
+                else
+                {
+                    wtotal -= _values[_wend];
+                    if (wtotal < target) break;
+                    _wend--;
+                }
+
+                _wtotal = wtotal;
+
+                if (_wstart == _wend) break;
+            }
+        }
+
+        public void ApplyWindow(int start, int end)
+        {
+            _wstart = start + _offset;
+            _wend = end + _offset;
+
+            if (_wstart == 0 && _wend == _values.Length - 1)
+            {
+                _window = 100;
+                _wtotal = _total;
+                return;
+            }
+
+            for (int i = _wstart; i <= _wend; i++) _wtotal += _values[i];
+
+            _window = (int)((double)_wtotal / (double)_total);
+        }
+    }
 }

--- a/DICOM/Imaging/Mathematics/Matrix.cs
+++ b/DICOM/Imaging/Mathematics/Matrix.cs
@@ -1,1111 +1,1391 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom.Imaging.Mathematics {
-	public class Matrix {
-		#region Members
-		private int[,] _matrix;
-		#endregion
-
-		#region Constructors
-		public Matrix(int rows, int cols) {
-			_matrix = new int[rows, cols];
-		}
-
-		public Matrix(int[,] matrix) {
-			_matrix = (int[,])matrix.Clone();
-		}
-		#endregion
-
-		#region Properties
-		public int Rows { get { return _matrix.GetLength(0); } }
-		public int Columns { get { return _matrix.GetLength(1); } }
-		public bool IsSquare { get { return Rows == Columns; } }
-
-		public bool IsIdentity {
-			get {
-				if (!IsSquare)
-					return false;
-
-				for (int r = 0, rows = Rows; r < rows; r++) {
-					for (int c = 0, cols = Columns; c < cols; c++) {
-						if (_matrix[r, c] != ((r == c) ? 1.0 : 0.0))
-							return false;
-					}
-				}
-
-				return true;
-			}
-		}
-
-		public int this[int row, int col] {
-			get { return _matrix[row, col]; }
-			set { _matrix[row, col] = value; }
-		}
-
-		public int Determinant {
-			get {
-				if (!IsSquare)
-					throw new InvalidOperationException("Cannot calculate determinant of non-square matrix.");
-
-				int dimensions = Rows;
-
-				if (dimensions == 1)
-					return _matrix[0, 0];
-
-				if (dimensions == 2) {
-					return (_matrix[0, 0] * _matrix[1, 1]) - (_matrix[0, 1] * _matrix[1, 0]);
-				}
-
-				if (dimensions == 3) {
-					int aei = _matrix[0, 0] * _matrix[1, 1] * _matrix[2, 2];
-					int bfg = _matrix[0, 1] * _matrix[1, 2] * _matrix[2, 0];
-					int cdh = _matrix[0, 2] * _matrix[1, 0] * _matrix[2, 1];
-					int hfa = _matrix[2, 1] * _matrix[1, 2] * _matrix[0, 0];
-					int idb = _matrix[2, 2] * _matrix[1, 0] * _matrix[0, 1];
-					int gec = _matrix[2, 0] * _matrix[1, 1] * _matrix[0, 2];
-					return (aei + bfg + cdh) - (hfa + idb + gec);
-				}
-
-				int pos = 0;
-				for (int c = 0; c < dimensions; c++) {
-					int k = c;
-					int diag = 0;
-					for (int r = 0; r < dimensions; r++, k = ((k + 1) % dimensions)) {
-						diag *= _matrix[r, k];
-					}
-					pos += diag;
-				}
-
-				int neg = 0;
-				for (int c = 0; c < dimensions; c++) {
-					int k = (c + 1) % dimensions;
-					int diag = 0;
-					for (int r = dimensions - 1; r >= 0; r--, k = ((k + 1) % dimensions)) {
-						diag *= _matrix[r, k];
-					}
-					neg += diag;
-				}
-
-				return pos - neg;
-			}
-		}
-
-		public int Trace {
-			get {
-				if (!IsSquare)
-					throw new InvalidOperationException("Cannot calc trace of non-square matrix.");
-
-				int t = 0;
-
-				for (int x = 0, count = Rows; x < count; x++) {
-					t += _matrix[x, x];
-				}
-
-				return t;
-			}
-		}
-		#endregion
-
-		#region Methods
-		public void Row(int row, params int[] values) {
-			if (values.Length != Columns)
-				throw new ArgumentOutOfRangeException("values.Length");
-
-			for (int col = 0, cols = Columns; col < cols; col++) {
-				_matrix[row, col] = values[col];
-			}
-		}
-
-		public int[] Row(int row) {
-			int[] values = new int[Columns];
-
-			for (int col = 0, cols = Columns; col < cols; col++) {
-				values[col] = _matrix[row, col];
-			}
-
-			return values;
-		}
-
-		public void Column(int col, params int[] values) {
-			if (values.Length != Rows)
-				throw new ArgumentOutOfRangeException("values.Length");
-
-			for (int row = 0, rows = Rows; row < rows; row++) {
-				_matrix[row, col] = values[row];
-			}
-		}
-
-		public int[] Column(int col) {
-			int[] values = new int[Rows];
-
-			for (int row = 0, rows = Rows; row < rows; row++) {
-				values[row] = _matrix[row, col];
-			}
-
-			return values;
-		}
-
-		public Matrix Clone() {
-			return new Matrix(_matrix);
-		}
-
-		public Matrix Transpose() {
-			Matrix t = new Matrix(Columns, Rows);
-
-			for (int r = 0, rows = Rows; r < rows; r++) {
-				for (int c = 0, cols = Columns; c < cols; c++) {
-					t[c, r] = _matrix[r, c];
-				}
-			}
-
-			return t;
-		}
-
-		public Matrix Invert() {
-			int rows = Rows;
-			int cols = Columns;
-
-			if (rows != cols)
-				throw new InvalidOperationException("Unable to invert non-square matrix");
-
-			if (Determinant == 0.0)
-				throw new InvalidOperationException("Unable to invert matrix where determinant equals 0");
-
-			Matrix x = Clone();
-
-			int e;
-			for (int k = 0; k < rows; k++) {
-				e = x[k, k];
-				x[k, k] = 1;
-
-				for (int j = 0; j < cols; j++) {
-					x[k, j] = x[k, j] / e;
-				}
-
-				for (int i = 0; i < cols; i++) {
-					if (i != k) {
-						e = x[i, k];
-						x[i, k] = 0;
-
-						for (int j = 0; j < cols; j++) {
-							x[i, j] = x[i, j] - e * x[k, j];
-						}
-					}
-				}
-			}
-
-			return x;
-		}
-
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.Append("[");
-			for (int r = 0, rows = Rows; r < rows; r++) {
-				if (r > 0)
-					sb.Append("; ");
-				for (int c = 0, cols = Columns; c < cols; c++) {
-					if (c > 0)
-						sb.Append(",");
-					sb.Append(_matrix[r, c]);
-				}
-			}
-			sb.Append("]");
-			return sb.ToString();
-		}
-
-		public override bool Equals(object obj) {
-			if (obj is Matrix)
-				return (obj as Matrix) == this;
-			return false;
-		}
-
-		public override int GetHashCode() {
-			return _matrix.GetHashCode();
-		}
-		#endregion
-
-		#region Static
-		public static Matrix Zero(int rows, int columns) {
-			return new Matrix(rows, columns);
-		}
-
-		public static Matrix One(int rows, int columns) {
-			Matrix m = new Matrix(rows, columns);
-
-			for (int r = 0; r < rows; r++) {
-				for (int c = 0; c < columns; c++) {
-					m[r, c] = 1;
-				}
-			}
-
-			return m;
-		}
-
-		public static Matrix Identity(int dimensions) {
-			Matrix m = new Matrix(dimensions, dimensions);
-
-			for (int r = 0, rows = dimensions; r < rows; r++) {
-				for (int c = 0, cols = dimensions; c < cols; c++) {
-					m[r, c] = (r == c) ? 1 : 0;
-				}
-			}
-
-			return m;
-		}
-
-		public static bool operator ==(Matrix a, Matrix b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				return false;
-
-			for (int r = 0, rows = a.Rows; r < rows; r++) {
-				for (int c = 0, cols = a.Columns; c < cols; c++) {
-					if (a[r, c] != b[r, c])
-						return false;
-				}
-			}
-
-			return true;
-		}
-
-		public static bool operator !=(Matrix a, Matrix b) {
-			return !(a == b);
-		}
-
-		public static Matrix operator +(Matrix a, Matrix b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				throw new ArgumentException("Unable to add matrices of different dimensions");
-
-			Matrix x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] += b[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static Matrix operator -(Matrix a, Matrix b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				throw new ArgumentException("Unable to subtract matrices of different dimensions");
-
-			Matrix x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] -= b[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static Matrix operator -(Matrix a) {
-			Matrix x = a.Clone();
-
-			for (int r = 0, rows = a.Rows; r < rows; r++) {
-				for (int c = 0, cols = a.Columns; c < cols; c++) {
-					x[r, c] = -x[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static Matrix operator *(Matrix a, Matrix b) {
-			if (a.Columns != b.Rows)
-				throw new ArgumentException("Unable to multiply matrices of different inner dimensions");
-
-			Matrix x = new Matrix(a.Rows, b.Columns);
-
-			int inner = a.Columns;
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					int d = 0;
-					for (int i = 0; i < inner; i++)
-						d += a[r, i] * b[i, c];
-					x[r, c] = d;
-				}
-			}
-
-			return x;
-		}
-
-		public static Matrix operator *(Matrix a, int d) {
-			Matrix x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] *= d;
-				}
-			}
-
-			return x;
-		}
-
-		public static Matrix operator *(int d, Matrix a) {
-			Matrix x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] *= d;
-				}
-			}
-
-			return x;
-		}
-
-		public static Matrix operator /(Matrix a, int d) {
-			return a * (1 / d);
-		}
-
-		public static Matrix operator ^(Matrix a, int e) {
-			Matrix m = a.Clone();
-			for (int i = 1; i < e; i++) {
-				m *= a;
-			}
-			return m;
-		}
-		#endregion
-	}
-
-	public class MatrixF {
-		#region Members
-		private float[,] _matrix;
-		#endregion
-
-		#region Constructors
-		public MatrixF(int rows, int cols) {
-			_matrix = new float[rows, cols];
-		}
-
-		public MatrixF(float[,] matrix) {
-			_matrix = (float[,])matrix.Clone();
-		}
-		#endregion
-
-		#region Properties
-		public int Rows { get { return _matrix.GetLength(0); } }
-		public int Columns { get { return _matrix.GetLength(1); } }
-		public bool IsSquare { get { return Rows == Columns; } }
-
-		public bool IsIdentity {
-			get {
-				if (!IsSquare)
-					return false;
-
-				for (int r = 0, rows = Rows; r < rows; r++) {
-					for (int c = 0, cols = Columns; c < cols; c++) {
-						if (_matrix[r, c] != ((r == c) ? 1.0 : 0.0))
-							return false;
-					}
-				}
-
-				return true;
-			}
-		}
-
-		public float this[int row, int col] {
-			get { return _matrix[row, col]; }
-			set { _matrix[row, col] = value; }
-		}
-
-		public float Determinant {
-			get {
-				if (!IsSquare)
-					throw new InvalidOperationException("Cannot calculate determinant of non-square matrix.");
-
-				int dimensions = Rows;
-
-				if (dimensions == 1)
-					return _matrix[0, 0];
-
-				if (dimensions == 2) {
-					return (_matrix[0, 0] * _matrix[1, 1]) - (_matrix[0, 1] * _matrix[1, 0]);
-				}
-
-				if (dimensions == 3) {
-					float aei = _matrix[0, 0] * _matrix[1, 1] * _matrix[2, 2];
-					float bfg = _matrix[0, 1] * _matrix[1, 2] * _matrix[2, 0];
-					float cdh = _matrix[0, 2] * _matrix[1, 0] * _matrix[2, 1];
-					float hfa = _matrix[2, 1] * _matrix[1, 2] * _matrix[0, 0];
-					float idb = _matrix[2, 2] * _matrix[1, 0] * _matrix[0, 1];
-					float gec = _matrix[2, 0] * _matrix[1, 1] * _matrix[0, 2];
-					return (aei + bfg + cdh) - (hfa + idb + gec);
-				}
-
-				float pos = 0.0f;
-				for (int c = 0; c < dimensions; c++) {
-					int k = c;
-					float diag = 0.0f;
-					for (int r = 0; r < dimensions; r++, k = ((k + 1) % dimensions)) {
-						diag *= _matrix[r, k];
-					}
-					pos += diag;
-				}
-
-				float neg = 0.0f;
-				for (int c = 0; c < dimensions; c++) {
-					int k = (c + 1) % dimensions;
-					float diag = 0.0f;
-					for (int r = dimensions - 1; r >= 0; r--, k = ((k + 1) % dimensions)) {
-						diag *= _matrix[r, k];
-					}
-					neg += diag;
-				}
-
-				return pos - neg;
-			}
-		}
-
-		public float Trace {
-			get {
-				if (!IsSquare)
-					throw new InvalidOperationException("Cannot calc trace of non-square matrix.");
-
-				float t = 0.0f;
-
-				for (int x = 0, count = Rows; x < count; x++) {
-					t += _matrix[x, x];
-				}
-
-				return t;
-			}
-		}
-		#endregion
-
-		#region Methods
-		public void Row(int row, params float[] values) {
-			if (values.Length != Columns)
-				throw new ArgumentOutOfRangeException("values.Length");
-
-			for (int col = 0, cols = Columns; col < cols; col++) {
-				_matrix[row, col] = values[col];
-			}
-		}
-
-		public float[] Row(int row) {
-			float[] values = new float[Columns];
-
-			for (int col = 0, cols = Columns; col < cols; col++) {
-				values[col] = _matrix[row, col];
-			}
-
-			return values;
-		}
-
-		public void Column(int col, params float[] values) {
-			if (values.Length != Rows)
-				throw new ArgumentOutOfRangeException("values.Length");
-
-			for (int row = 0, rows = Rows; row < rows; row++) {
-				_matrix[row, col] = values[row];
-			}
-		}
-
-		public float[] Column(int col) {
-			float[] values = new float[Rows];
-
-			for (int row = 0, rows = Rows; row < rows; row++) {
-				values[row] = _matrix[row, col];
-			}
-
-			return values;
-		}
-
-		public MatrixF Clone() {
-			return new MatrixF(_matrix);
-		}
-
-		public MatrixF Transpose() {
-			MatrixF t = new MatrixF(Columns, Rows);
-
-			for (int r = 0, rows = Rows; r < rows; r++) {
-				for (int c = 0, cols = Columns; c < cols; c++) {
-					t[c, r] = _matrix[r, c];
-				}
-			}
-
-			return t;
-		}
-
-		public MatrixF Invert() {
-			int rows = Rows;
-			int cols = Columns;
-
-			if (rows != cols)
-				throw new InvalidOperationException("Unable to invert non-square matrix");
-
-			if (Determinant == 0.0f)
-				throw new InvalidOperationException("Unable to invert matrix where determinant equals 0");
-
-			MatrixF x = Clone();
-
-			float e;
-			for (int k = 0; k < rows; k++) {
-				e = x[k, k];
-				x[k, k] = 1.0f;
-
-				for (int j = 0; j < cols; j++) {
-					x[k, j] = x[k, j] / e;
-				}
-
-				for (int i = 0; i < cols; i++) {
-					if (i != k) {
-						e = x[i, k];
-						x[i, k] = 0.0f;
-
-						for (int j = 0; j < cols; j++) {
-							x[i, j] = x[i, j] - e * x[k, j];
-						}
-					}
-				}
-			}
-
-			return x;
-		}
-
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.Append("[");
-			for (int r = 0, rows = Rows; r < rows; r++) {
-				if (r > 0)
-					sb.Append("; ");
-				for (int c = 0, cols = Columns; c < cols; c++) {
-					if (c > 0)
-						sb.Append(",");
-					sb.Append(_matrix[r, c]);
-				}
-			}
-			sb.Append("]");
-			return sb.ToString();
-		}
-
-		public override bool Equals(object obj) {
-			if (obj is MatrixF)
-				return (obj as MatrixF) == this;
-			return false;
-		}
-
-		public override int GetHashCode() {
-			return _matrix.GetHashCode();
-		}
-		#endregion
-
-		#region Static
-		public static MatrixF Zero(int rows, int columns) {
-			return new MatrixF(rows, columns);
-		}
-
-		public static MatrixF One(int rows, int columns) {
-			MatrixF m = new MatrixF(rows, columns);
-
-			for (int r = 0; r < rows; r++) {
-				for (int c = 0; c < columns; c++) {
-					m[r, c] = 1.0f;
-				}
-			}
-
-			return m;
-		}
-
-		public static MatrixF Identity(int dimensions) {
-			MatrixF m = new MatrixF(dimensions, dimensions);
-
-			for (int r = 0, rows = dimensions; r < rows; r++) {
-				for (int c = 0, cols = dimensions; c < cols; c++) {
-					m[r, c] = (r == c) ? 1.0f : 0.0f;
-				}
-			}
-
-			return m;
-		}
-
-		public static bool operator ==(MatrixF a, MatrixF b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				return false;
-
-			for (int r = 0, rows = a.Rows; r < rows; r++) {
-				for (int c = 0, cols = a.Columns; c < cols; c++) {
-					if (a[r, c] != b[r, c])
-						return false;
-				}
-			}
-
-			return true;
-		}
-
-		public static bool operator !=(MatrixF a, MatrixF b) {
-			return !(a == b);
-		}
-
-		public static MatrixF operator +(MatrixF a, MatrixF b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				throw new ArgumentException("Unable to add matrices of different dimensions");
-
-			MatrixF x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] += b[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixF operator -(MatrixF a, MatrixF b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				throw new ArgumentException("Unable to subtract matrices of different dimensions");
-
-			MatrixF x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] -= b[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixF operator -(MatrixF a) {
-			MatrixF x = a.Clone();
-
-			for (int r = 0, rows = a.Rows; r < rows; r++) {
-				for (int c = 0, cols = a.Columns; c < cols; c++) {
-					x[r, c] = -x[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixF operator *(MatrixF a, MatrixF b) {
-			if (a.Columns != b.Rows)
-				throw new ArgumentException("Unable to multiply matrices of different inner dimensions");
-
-			MatrixF x = new MatrixF(a.Rows, b.Columns);
-
-			int inner = a.Columns;
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					float d = 0.0f;
-					for (int i = 0; i < inner; i++)
-						d += a[r, i] * b[i, c];
-					x[r, c] = d;
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixF operator *(MatrixF a, float d) {
-			MatrixF x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] *= d;
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixF operator *(float d, MatrixF a) {
-			MatrixF x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] *= d;
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixF operator /(MatrixF a, float d) {
-			return a * (1 / d);
-		}
-
-		public static MatrixF operator ^(MatrixF a, int e) {
-			MatrixF m = a.Clone();
-			for (int i = 1; i < e; i++) {
-				m *= a;
-			}
-			return m;
-		}
-		#endregion
-	}
-
-	public class MatrixD {
-		#region Members
-		private double[,] _matrix;
-		#endregion
-
-		#region Constructors
-		public MatrixD(int rows, int cols) {
-			_matrix = new double[rows, cols];
-		}
-
-		public MatrixD(double[,] matrix) {
-			_matrix = (double[,])matrix.Clone();
-		}
-		#endregion
-
-		#region Properties
-		public int Rows { get { return _matrix.GetLength(0); } }
-		public int Columns { get { return _matrix.GetLength(1); } }
-		public bool IsSquare { get { return Rows == Columns; } }
-
-		public bool IsIdentity {
-			get {
-				if (!IsSquare)
-					return false;
-
-				for (int r = 0, rows = Rows; r < rows; r++) {
-					for (int c = 0, cols = Columns; c < cols; c++) {
-						if (_matrix[r, c] != ((r == c) ? 1.0 : 0.0))
-							return false;
-					}
-				}
-
-				return true;
-			}
-		}
-
-		public double this[int row, int col] {
-			get { return _matrix[row, col]; }
-			set { _matrix[row, col] = value; }
-		}
-
-		public double Determinant {
-			get {
-				if (!IsSquare)
-					throw new InvalidOperationException("Cannot calculate determinant of non-square matrix.");
-
-				int dimensions = Rows;
-
-				if (dimensions == 1)
-					return _matrix[0, 0];
-
-				if (dimensions == 2) {
-					return (_matrix[0, 0] * _matrix[1, 1]) - (_matrix[0, 1] * _matrix[1, 0]);
-				}
-
-				if (dimensions == 3) {
-					double aei = _matrix[0, 0] * _matrix[1, 1] * _matrix[2, 2];
-					double bfg = _matrix[0, 1] * _matrix[1, 2] * _matrix[2, 0];
-					double cdh = _matrix[0, 2] * _matrix[1, 0] * _matrix[2, 1];
-					double hfa = _matrix[2, 1] * _matrix[1, 2] * _matrix[0, 0];
-					double idb = _matrix[2, 2] * _matrix[1, 0] * _matrix[0, 1];
-					double gec = _matrix[2, 0] * _matrix[1, 1] * _matrix[0, 2];
-					return (aei + bfg + cdh) - (hfa + idb + gec);
-				}
-
-				double pos = 0.0;
-				for (int c = 0; c < dimensions; c++) {
-					int k = c;
-					double diag = 0.0;
-					for (int r = 0; r < dimensions; r++, k = ((k + 1) % dimensions)) {
-						diag *= _matrix[r, k];
-					}
-					pos += diag;
-				}
-
-				double neg = 0.0;
-				for (int c = 0; c < dimensions; c++) {
-					int k = (c + 1) % dimensions;
-					double diag = 0.0;
-					for (int r = dimensions - 1; r >= 0; r--, k = ((k + 1) % dimensions)) {
-						diag *= _matrix[r, k];
-					}
-					neg += diag;
-				}
-
-				return pos - neg;
-			}
-		}
-
-		public double Trace {
-			get {
-				if (!IsSquare)
-					throw new InvalidOperationException("Cannot calc trace of non-square matrix.");
-
-				double t = 0.0;
-
-				for (int x = 0, count = Rows; x < count; x++) {
-					t += _matrix[x, x];
-				}
-
-				return t;
-			}
-		}
-		#endregion
-
-		#region Methods
-		public void Row(int row, params double[] values) {
-			if (values.Length != Columns)
-				throw new ArgumentOutOfRangeException("values.Length");
-
-			for (int col = 0, cols = Columns; col < cols; col++) {
-				_matrix[row, col] = values[col];
-			}
-		}
-
-		public double[] Row(int row) {
-			double[] values = new double[Columns];
-
-			for (int col = 0, cols = Columns; col < cols; col++) {
-				values[col] = _matrix[row, col];
-			}
-
-			return values;
-		}
-
-		public void Column(int col, params double[] values) {
-			if (values.Length != Rows)
-				throw new ArgumentOutOfRangeException("values.Length");
-
-			for (int row = 0, rows = Rows; row < rows; row++) {
-				_matrix[row, col] = values[row];
-			}
-		}
-
-		public double[] Column(int col) {
-			double[] values = new double[Rows];
-
-			for (int row = 0, rows = Rows; row < rows; row++) {
-				values[row] = _matrix[row, col];
-			}
-
-			return values;
-		}
-
-		public MatrixD Clone() {
-			return new MatrixD(_matrix);
-		}
-
-		public MatrixD Transpose() {
-			MatrixD t = new MatrixD(Columns, Rows);
-
-			for (int r = 0, rows = Rows; r < rows; r++) {
-				for (int c = 0, cols = Columns; c < cols; c++) {
-					t[c, r] = _matrix[r, c];
-				}
-			}
-
-			return t;
-		}
-
-		public MatrixD Invert() {
-			int rows = Rows;
-			int cols = Columns;
-
-			if (rows != cols)
-				throw new InvalidOperationException("Unable to invert non-square matrix");
-
-			if (Determinant == 0.0)
-				throw new InvalidOperationException("Unable to invert matrix where determinant equals 0");
-
-			MatrixD x = Clone();
-
-			double e;
-			for (int k = 0; k < rows; k++) {
-				e = x[k, k];
-				x[k, k] = 1.0;
-
-				for (int j = 0; j < cols; j++) {
-					x[k, j] = x[k, j] / e;
-				}
-
-				for (int i = 0; i < cols; i++) {
-					if (i != k) {
-						e = x[i, k];
-						x[i, k] = 0.0;
-
-						for (int j = 0; j < cols; j++) {
-							x[i, j] = x[i, j] - e * x[k, j];
-						}
-					}
-				}
-			}
-
-			return x;
-		}
-
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.Append("[");
-			for (int r = 0, rows = Rows; r < rows; r++) {
-				if (r > 0)
-					sb.Append("; ");
-				for (int c = 0, cols = Columns; c < cols; c++) {
-					if (c > 0)
-						sb.Append(",");
-					sb.Append(_matrix[r, c]);
-				}
-			}
-			sb.Append("]");
-			return sb.ToString();
-		}
-
-		public override bool Equals(object obj) {
-			if (obj is MatrixD)
-				return (obj as MatrixD) == this;
-			return false;
-		}
-
-		public override int GetHashCode() {
-			return _matrix.GetHashCode();
-		}
-		#endregion
-
-		#region Static
-		public static MatrixD Zero(int rows, int columns) {
-			return new MatrixD(rows, columns);
-		}
-
-		public static MatrixD One(int rows, int columns) {
-			MatrixD m = new MatrixD(rows, columns);
-
-			for (int r = 0; r < rows; r++) {
-				for (int c = 0; c < columns; c++) {
-					m[r, c] = 1.0;
-				}
-			}
-
-			return m;
-		}
-
-		public static MatrixD Identity(int dimensions) {
-			MatrixD m = new MatrixD(dimensions, dimensions);
-
-			for (int r = 0, rows = dimensions; r < rows; r++) {
-				for (int c = 0, cols = dimensions; c < cols; c++) {
-					m[r, c] = (r == c) ? 1.0 : 0.0;
-				}
-			}
-
-			return m;
-		}
-
-		public static bool operator ==(MatrixD a, MatrixD b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				return false;
-
-			for (int r = 0, rows = a.Rows; r < rows; r++) {
-				for (int c = 0, cols = a.Columns; c < cols; c++) {
-					if (a[r, c] != b[r, c])
-						return false;
-				}
-			}
-
-			return true;
-		}
-
-		public static bool operator !=(MatrixD a, MatrixD b) {
-			return !(a == b);
-		}
-
-		public static MatrixD operator +(MatrixD a, MatrixD b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				throw new ArgumentException("Unable to add matrices of different dimensions");
-
-			MatrixD x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] += b[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixD operator -(MatrixD a, MatrixD b) {
-			if (a.Rows != b.Rows || a.Columns != b.Columns)
-				throw new ArgumentException("Unable to subtract matrices of different dimensions");
-
-			MatrixD x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] -= b[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixD operator -(MatrixD a) {
-			MatrixD x = a.Clone();
-
-			for (int r = 0, rows = a.Rows; r < rows; r++) {
-				for (int c = 0, cols = a.Columns; c < cols; c++) {
-					x[r, c] = -x[r, c];
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixD operator *(MatrixD a, MatrixD b) {
-			if (a.Columns != b.Rows)
-				throw new ArgumentException("Unable to multiply matrices of different inner dimensions");
-
-			MatrixD x = new MatrixD(a.Rows, b.Columns);
-
-			int inner = a.Columns;
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					double d = 0.0;
-					for (int i = 0; i < inner; i++)
-						d += a[r, i] * b[i, c];
-					x[r, c] = d;
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixD operator *(MatrixD a, double d) {
-			MatrixD x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] *= d;
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixD operator *(double d, MatrixD a) {
-			MatrixD x = a.Clone();
-
-			for (int r = 0, rows = x.Rows; r < rows; r++) {
-				for (int c = 0, cols = x.Columns; c < cols; c++) {
-					x[r, c] *= d;
-				}
-			}
-
-			return x;
-		}
-
-		public static MatrixD operator /(MatrixD a, double d) {
-			return a * (1 / d);
-		}
-
-		public static MatrixD operator ^(MatrixD a, int e) {
-			MatrixD m = a.Clone();
-			for (int i = 1; i < e; i++) {
-				m *= a;
-			}
-			return m;
-		}
-		#endregion
-	}
+namespace Dicom.Imaging.Mathematics
+{
+    public class Matrix
+    {
+        #region Members
+
+        private int[,] _matrix;
+
+        #endregion
+
+        #region Constructors
+
+        public Matrix(int rows, int cols)
+        {
+            _matrix = new int[rows, cols];
+        }
+
+        public Matrix(int[,] matrix)
+        {
+            _matrix = (int[,])matrix.Clone();
+        }
+
+        #endregion
+
+        #region Properties
+
+        public int Rows
+        {
+            get
+            {
+                return _matrix.GetLength(0);
+            }
+        }
+
+        public int Columns
+        {
+            get
+            {
+                return _matrix.GetLength(1);
+            }
+        }
+
+        public bool IsSquare
+        {
+            get
+            {
+                return Rows == Columns;
+            }
+        }
+
+        public bool IsIdentity
+        {
+            get
+            {
+                if (!IsSquare) return false;
+
+                for (int r = 0, rows = Rows; r < rows; r++)
+                {
+                    for (int c = 0, cols = Columns; c < cols; c++)
+                    {
+                        if (_matrix[r, c] != ((r == c) ? 1.0 : 0.0)) return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        public int this[int row, int col]
+        {
+            get
+            {
+                return _matrix[row, col];
+            }
+            set
+            {
+                _matrix[row, col] = value;
+            }
+        }
+
+        public int Determinant
+        {
+            get
+            {
+                if (!IsSquare) throw new InvalidOperationException("Cannot calculate determinant of non-square matrix.");
+
+                int dimensions = Rows;
+
+                if (dimensions == 1) return _matrix[0, 0];
+
+                if (dimensions == 2)
+                {
+                    return (_matrix[0, 0] * _matrix[1, 1]) - (_matrix[0, 1] * _matrix[1, 0]);
+                }
+
+                if (dimensions == 3)
+                {
+                    int aei = _matrix[0, 0] * _matrix[1, 1] * _matrix[2, 2];
+                    int bfg = _matrix[0, 1] * _matrix[1, 2] * _matrix[2, 0];
+                    int cdh = _matrix[0, 2] * _matrix[1, 0] * _matrix[2, 1];
+                    int hfa = _matrix[2, 1] * _matrix[1, 2] * _matrix[0, 0];
+                    int idb = _matrix[2, 2] * _matrix[1, 0] * _matrix[0, 1];
+                    int gec = _matrix[2, 0] * _matrix[1, 1] * _matrix[0, 2];
+                    return (aei + bfg + cdh) - (hfa + idb + gec);
+                }
+
+                int pos = 0;
+                for (int c = 0; c < dimensions; c++)
+                {
+                    int k = c;
+                    int diag = 0;
+                    for (int r = 0; r < dimensions; r++, k = ((k + 1) % dimensions))
+                    {
+                        diag *= _matrix[r, k];
+                    }
+                    pos += diag;
+                }
+
+                int neg = 0;
+                for (int c = 0; c < dimensions; c++)
+                {
+                    int k = (c + 1) % dimensions;
+                    int diag = 0;
+                    for (int r = dimensions - 1; r >= 0; r--, k = ((k + 1) % dimensions))
+                    {
+                        diag *= _matrix[r, k];
+                    }
+                    neg += diag;
+                }
+
+                return pos - neg;
+            }
+        }
+
+        public int Trace
+        {
+            get
+            {
+                if (!IsSquare) throw new InvalidOperationException("Cannot calc trace of non-square matrix.");
+
+                int t = 0;
+
+                for (int x = 0, count = Rows; x < count; x++)
+                {
+                    t += _matrix[x, x];
+                }
+
+                return t;
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        public void Row(int row, params int[] values)
+        {
+            if (values.Length != Columns) throw new ArgumentOutOfRangeException("values.Length");
+
+            for (int col = 0, cols = Columns; col < cols; col++)
+            {
+                _matrix[row, col] = values[col];
+            }
+        }
+
+        public int[] Row(int row)
+        {
+            int[] values = new int[Columns];
+
+            for (int col = 0, cols = Columns; col < cols; col++)
+            {
+                values[col] = _matrix[row, col];
+            }
+
+            return values;
+        }
+
+        public void Column(int col, params int[] values)
+        {
+            if (values.Length != Rows) throw new ArgumentOutOfRangeException("values.Length");
+
+            for (int row = 0, rows = Rows; row < rows; row++)
+            {
+                _matrix[row, col] = values[row];
+            }
+        }
+
+        public int[] Column(int col)
+        {
+            int[] values = new int[Rows];
+
+            for (int row = 0, rows = Rows; row < rows; row++)
+            {
+                values[row] = _matrix[row, col];
+            }
+
+            return values;
+        }
+
+        public Matrix Clone()
+        {
+            return new Matrix(_matrix);
+        }
+
+        public Matrix Transpose()
+        {
+            Matrix t = new Matrix(Columns, Rows);
+
+            for (int r = 0, rows = Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = Columns; c < cols; c++)
+                {
+                    t[c, r] = _matrix[r, c];
+                }
+            }
+
+            return t;
+        }
+
+        public Matrix Invert()
+        {
+            int rows = Rows;
+            int cols = Columns;
+
+            if (rows != cols) throw new InvalidOperationException("Unable to invert non-square matrix");
+
+            if (Determinant == 0.0) throw new InvalidOperationException("Unable to invert matrix where determinant equals 0");
+
+            Matrix x = Clone();
+
+            int e;
+            for (int k = 0; k < rows; k++)
+            {
+                e = x[k, k];
+                x[k, k] = 1;
+
+                for (int j = 0; j < cols; j++)
+                {
+                    x[k, j] = x[k, j] / e;
+                }
+
+                for (int i = 0; i < cols; i++)
+                {
+                    if (i != k)
+                    {
+                        e = x[i, k];
+                        x[i, k] = 0;
+
+                        for (int j = 0; j < cols; j++)
+                        {
+                            x[i, j] = x[i, j] - e * x[k, j];
+                        }
+                    }
+                }
+            }
+
+            return x;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[");
+            for (int r = 0, rows = Rows; r < rows; r++)
+            {
+                if (r > 0) sb.Append("; ");
+                for (int c = 0, cols = Columns; c < cols; c++)
+                {
+                    if (c > 0) sb.Append(",");
+                    sb.Append(_matrix[r, c]);
+                }
+            }
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix) return (obj as Matrix) == this;
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _matrix.GetHashCode();
+        }
+
+        #endregion
+
+        #region Static
+
+        public static Matrix Zero(int rows, int columns)
+        {
+            return new Matrix(rows, columns);
+        }
+
+        public static Matrix One(int rows, int columns)
+        {
+            Matrix m = new Matrix(rows, columns);
+
+            for (int r = 0; r < rows; r++)
+            {
+                for (int c = 0; c < columns; c++)
+                {
+                    m[r, c] = 1;
+                }
+            }
+
+            return m;
+        }
+
+        public static Matrix Identity(int dimensions)
+        {
+            Matrix m = new Matrix(dimensions, dimensions);
+
+            for (int r = 0, rows = dimensions; r < rows; r++)
+            {
+                for (int c = 0, cols = dimensions; c < cols; c++)
+                {
+                    m[r, c] = (r == c) ? 1 : 0;
+                }
+            }
+
+            return m;
+        }
+
+        public static bool operator ==(Matrix a, Matrix b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) return false;
+
+            for (int r = 0, rows = a.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = a.Columns; c < cols; c++)
+                {
+                    if (a[r, c] != b[r, c]) return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool operator !=(Matrix a, Matrix b)
+        {
+            return !(a == b);
+        }
+
+        public static Matrix operator +(Matrix a, Matrix b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) throw new ArgumentException("Unable to add matrices of different dimensions");
+
+            Matrix x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] += b[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static Matrix operator -(Matrix a, Matrix b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) throw new ArgumentException("Unable to subtract matrices of different dimensions");
+
+            Matrix x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] -= b[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static Matrix operator -(Matrix a)
+        {
+            Matrix x = a.Clone();
+
+            for (int r = 0, rows = a.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = a.Columns; c < cols; c++)
+                {
+                    x[r, c] = -x[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static Matrix operator *(Matrix a, Matrix b)
+        {
+            if (a.Columns != b.Rows) throw new ArgumentException("Unable to multiply matrices of different inner dimensions");
+
+            Matrix x = new Matrix(a.Rows, b.Columns);
+
+            int inner = a.Columns;
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    int d = 0;
+                    for (int i = 0; i < inner; i++) d += a[r, i] * b[i, c];
+                    x[r, c] = d;
+                }
+            }
+
+            return x;
+        }
+
+        public static Matrix operator *(Matrix a, int d)
+        {
+            Matrix x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] *= d;
+                }
+            }
+
+            return x;
+        }
+
+        public static Matrix operator *(int d, Matrix a)
+        {
+            Matrix x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] *= d;
+                }
+            }
+
+            return x;
+        }
+
+        public static Matrix operator /(Matrix a, int d)
+        {
+            return a * (1 / d);
+        }
+
+        public static Matrix operator ^(Matrix a, int e)
+        {
+            Matrix m = a.Clone();
+            for (int i = 1; i < e; i++)
+            {
+                m *= a;
+            }
+            return m;
+        }
+
+        #endregion
+    }
+
+    public class MatrixF
+    {
+        #region Members
+
+        private float[,] _matrix;
+
+        #endregion
+
+        #region Constructors
+
+        public MatrixF(int rows, int cols)
+        {
+            _matrix = new float[rows, cols];
+        }
+
+        public MatrixF(float[,] matrix)
+        {
+            _matrix = (float[,])matrix.Clone();
+        }
+
+        #endregion
+
+        #region Properties
+
+        public int Rows
+        {
+            get
+            {
+                return _matrix.GetLength(0);
+            }
+        }
+
+        public int Columns
+        {
+            get
+            {
+                return _matrix.GetLength(1);
+            }
+        }
+
+        public bool IsSquare
+        {
+            get
+            {
+                return Rows == Columns;
+            }
+        }
+
+        public bool IsIdentity
+        {
+            get
+            {
+                if (!IsSquare) return false;
+
+                for (int r = 0, rows = Rows; r < rows; r++)
+                {
+                    for (int c = 0, cols = Columns; c < cols; c++)
+                    {
+                        if (_matrix[r, c] != ((r == c) ? 1.0 : 0.0)) return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        public float this[int row, int col]
+        {
+            get
+            {
+                return _matrix[row, col];
+            }
+            set
+            {
+                _matrix[row, col] = value;
+            }
+        }
+
+        public float Determinant
+        {
+            get
+            {
+                if (!IsSquare) throw new InvalidOperationException("Cannot calculate determinant of non-square matrix.");
+
+                int dimensions = Rows;
+
+                if (dimensions == 1) return _matrix[0, 0];
+
+                if (dimensions == 2)
+                {
+                    return (_matrix[0, 0] * _matrix[1, 1]) - (_matrix[0, 1] * _matrix[1, 0]);
+                }
+
+                if (dimensions == 3)
+                {
+                    float aei = _matrix[0, 0] * _matrix[1, 1] * _matrix[2, 2];
+                    float bfg = _matrix[0, 1] * _matrix[1, 2] * _matrix[2, 0];
+                    float cdh = _matrix[0, 2] * _matrix[1, 0] * _matrix[2, 1];
+                    float hfa = _matrix[2, 1] * _matrix[1, 2] * _matrix[0, 0];
+                    float idb = _matrix[2, 2] * _matrix[1, 0] * _matrix[0, 1];
+                    float gec = _matrix[2, 0] * _matrix[1, 1] * _matrix[0, 2];
+                    return (aei + bfg + cdh) - (hfa + idb + gec);
+                }
+
+                float pos = 0.0f;
+                for (int c = 0; c < dimensions; c++)
+                {
+                    int k = c;
+                    float diag = 0.0f;
+                    for (int r = 0; r < dimensions; r++, k = ((k + 1) % dimensions))
+                    {
+                        diag *= _matrix[r, k];
+                    }
+                    pos += diag;
+                }
+
+                float neg = 0.0f;
+                for (int c = 0; c < dimensions; c++)
+                {
+                    int k = (c + 1) % dimensions;
+                    float diag = 0.0f;
+                    for (int r = dimensions - 1; r >= 0; r--, k = ((k + 1) % dimensions))
+                    {
+                        diag *= _matrix[r, k];
+                    }
+                    neg += diag;
+                }
+
+                return pos - neg;
+            }
+        }
+
+        public float Trace
+        {
+            get
+            {
+                if (!IsSquare) throw new InvalidOperationException("Cannot calc trace of non-square matrix.");
+
+                float t = 0.0f;
+
+                for (int x = 0, count = Rows; x < count; x++)
+                {
+                    t += _matrix[x, x];
+                }
+
+                return t;
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        public void Row(int row, params float[] values)
+        {
+            if (values.Length != Columns) throw new ArgumentOutOfRangeException("values.Length");
+
+            for (int col = 0, cols = Columns; col < cols; col++)
+            {
+                _matrix[row, col] = values[col];
+            }
+        }
+
+        public float[] Row(int row)
+        {
+            float[] values = new float[Columns];
+
+            for (int col = 0, cols = Columns; col < cols; col++)
+            {
+                values[col] = _matrix[row, col];
+            }
+
+            return values;
+        }
+
+        public void Column(int col, params float[] values)
+        {
+            if (values.Length != Rows) throw new ArgumentOutOfRangeException("values.Length");
+
+            for (int row = 0, rows = Rows; row < rows; row++)
+            {
+                _matrix[row, col] = values[row];
+            }
+        }
+
+        public float[] Column(int col)
+        {
+            float[] values = new float[Rows];
+
+            for (int row = 0, rows = Rows; row < rows; row++)
+            {
+                values[row] = _matrix[row, col];
+            }
+
+            return values;
+        }
+
+        public MatrixF Clone()
+        {
+            return new MatrixF(_matrix);
+        }
+
+        public MatrixF Transpose()
+        {
+            MatrixF t = new MatrixF(Columns, Rows);
+
+            for (int r = 0, rows = Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = Columns; c < cols; c++)
+                {
+                    t[c, r] = _matrix[r, c];
+                }
+            }
+
+            return t;
+        }
+
+        public MatrixF Invert()
+        {
+            int rows = Rows;
+            int cols = Columns;
+
+            if (rows != cols) throw new InvalidOperationException("Unable to invert non-square matrix");
+
+            if (Determinant == 0.0f) throw new InvalidOperationException("Unable to invert matrix where determinant equals 0");
+
+            MatrixF x = Clone();
+
+            float e;
+            for (int k = 0; k < rows; k++)
+            {
+                e = x[k, k];
+                x[k, k] = 1.0f;
+
+                for (int j = 0; j < cols; j++)
+                {
+                    x[k, j] = x[k, j] / e;
+                }
+
+                for (int i = 0; i < cols; i++)
+                {
+                    if (i != k)
+                    {
+                        e = x[i, k];
+                        x[i, k] = 0.0f;
+
+                        for (int j = 0; j < cols; j++)
+                        {
+                            x[i, j] = x[i, j] - e * x[k, j];
+                        }
+                    }
+                }
+            }
+
+            return x;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[");
+            for (int r = 0, rows = Rows; r < rows; r++)
+            {
+                if (r > 0) sb.Append("; ");
+                for (int c = 0, cols = Columns; c < cols; c++)
+                {
+                    if (c > 0) sb.Append(",");
+                    sb.Append(_matrix[r, c]);
+                }
+            }
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MatrixF) return (obj as MatrixF) == this;
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _matrix.GetHashCode();
+        }
+
+        #endregion
+
+        #region Static
+
+        public static MatrixF Zero(int rows, int columns)
+        {
+            return new MatrixF(rows, columns);
+        }
+
+        public static MatrixF One(int rows, int columns)
+        {
+            MatrixF m = new MatrixF(rows, columns);
+
+            for (int r = 0; r < rows; r++)
+            {
+                for (int c = 0; c < columns; c++)
+                {
+                    m[r, c] = 1.0f;
+                }
+            }
+
+            return m;
+        }
+
+        public static MatrixF Identity(int dimensions)
+        {
+            MatrixF m = new MatrixF(dimensions, dimensions);
+
+            for (int r = 0, rows = dimensions; r < rows; r++)
+            {
+                for (int c = 0, cols = dimensions; c < cols; c++)
+                {
+                    m[r, c] = (r == c) ? 1.0f : 0.0f;
+                }
+            }
+
+            return m;
+        }
+
+        public static bool operator ==(MatrixF a, MatrixF b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) return false;
+
+            for (int r = 0, rows = a.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = a.Columns; c < cols; c++)
+                {
+                    if (a[r, c] != b[r, c]) return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool operator !=(MatrixF a, MatrixF b)
+        {
+            return !(a == b);
+        }
+
+        public static MatrixF operator +(MatrixF a, MatrixF b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) throw new ArgumentException("Unable to add matrices of different dimensions");
+
+            MatrixF x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] += b[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixF operator -(MatrixF a, MatrixF b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) throw new ArgumentException("Unable to subtract matrices of different dimensions");
+
+            MatrixF x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] -= b[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixF operator -(MatrixF a)
+        {
+            MatrixF x = a.Clone();
+
+            for (int r = 0, rows = a.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = a.Columns; c < cols; c++)
+                {
+                    x[r, c] = -x[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixF operator *(MatrixF a, MatrixF b)
+        {
+            if (a.Columns != b.Rows) throw new ArgumentException("Unable to multiply matrices of different inner dimensions");
+
+            MatrixF x = new MatrixF(a.Rows, b.Columns);
+
+            int inner = a.Columns;
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    float d = 0.0f;
+                    for (int i = 0; i < inner; i++) d += a[r, i] * b[i, c];
+                    x[r, c] = d;
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixF operator *(MatrixF a, float d)
+        {
+            MatrixF x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] *= d;
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixF operator *(float d, MatrixF a)
+        {
+            MatrixF x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] *= d;
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixF operator /(MatrixF a, float d)
+        {
+            return a * (1 / d);
+        }
+
+        public static MatrixF operator ^(MatrixF a, int e)
+        {
+            MatrixF m = a.Clone();
+            for (int i = 1; i < e; i++)
+            {
+                m *= a;
+            }
+            return m;
+        }
+
+        #endregion
+    }
+
+    public class MatrixD
+    {
+        #region Members
+
+        private double[,] _matrix;
+
+        #endregion
+
+        #region Constructors
+
+        public MatrixD(int rows, int cols)
+        {
+            _matrix = new double[rows, cols];
+        }
+
+        public MatrixD(double[,] matrix)
+        {
+            _matrix = (double[,])matrix.Clone();
+        }
+
+        #endregion
+
+        #region Properties
+
+        public int Rows
+        {
+            get
+            {
+                return _matrix.GetLength(0);
+            }
+        }
+
+        public int Columns
+        {
+            get
+            {
+                return _matrix.GetLength(1);
+            }
+        }
+
+        public bool IsSquare
+        {
+            get
+            {
+                return Rows == Columns;
+            }
+        }
+
+        public bool IsIdentity
+        {
+            get
+            {
+                if (!IsSquare) return false;
+
+                for (int r = 0, rows = Rows; r < rows; r++)
+                {
+                    for (int c = 0, cols = Columns; c < cols; c++)
+                    {
+                        if (_matrix[r, c] != ((r == c) ? 1.0 : 0.0)) return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        public double this[int row, int col]
+        {
+            get
+            {
+                return _matrix[row, col];
+            }
+            set
+            {
+                _matrix[row, col] = value;
+            }
+        }
+
+        public double Determinant
+        {
+            get
+            {
+                if (!IsSquare) throw new InvalidOperationException("Cannot calculate determinant of non-square matrix.");
+
+                int dimensions = Rows;
+
+                if (dimensions == 1) return _matrix[0, 0];
+
+                if (dimensions == 2)
+                {
+                    return (_matrix[0, 0] * _matrix[1, 1]) - (_matrix[0, 1] * _matrix[1, 0]);
+                }
+
+                if (dimensions == 3)
+                {
+                    double aei = _matrix[0, 0] * _matrix[1, 1] * _matrix[2, 2];
+                    double bfg = _matrix[0, 1] * _matrix[1, 2] * _matrix[2, 0];
+                    double cdh = _matrix[0, 2] * _matrix[1, 0] * _matrix[2, 1];
+                    double hfa = _matrix[2, 1] * _matrix[1, 2] * _matrix[0, 0];
+                    double idb = _matrix[2, 2] * _matrix[1, 0] * _matrix[0, 1];
+                    double gec = _matrix[2, 0] * _matrix[1, 1] * _matrix[0, 2];
+                    return (aei + bfg + cdh) - (hfa + idb + gec);
+                }
+
+                double pos = 0.0;
+                for (int c = 0; c < dimensions; c++)
+                {
+                    int k = c;
+                    double diag = 0.0;
+                    for (int r = 0; r < dimensions; r++, k = ((k + 1) % dimensions))
+                    {
+                        diag *= _matrix[r, k];
+                    }
+                    pos += diag;
+                }
+
+                double neg = 0.0;
+                for (int c = 0; c < dimensions; c++)
+                {
+                    int k = (c + 1) % dimensions;
+                    double diag = 0.0;
+                    for (int r = dimensions - 1; r >= 0; r--, k = ((k + 1) % dimensions))
+                    {
+                        diag *= _matrix[r, k];
+                    }
+                    neg += diag;
+                }
+
+                return pos - neg;
+            }
+        }
+
+        public double Trace
+        {
+            get
+            {
+                if (!IsSquare) throw new InvalidOperationException("Cannot calc trace of non-square matrix.");
+
+                double t = 0.0;
+
+                for (int x = 0, count = Rows; x < count; x++)
+                {
+                    t += _matrix[x, x];
+                }
+
+                return t;
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        public void Row(int row, params double[] values)
+        {
+            if (values.Length != Columns) throw new ArgumentOutOfRangeException("values.Length");
+
+            for (int col = 0, cols = Columns; col < cols; col++)
+            {
+                _matrix[row, col] = values[col];
+            }
+        }
+
+        public double[] Row(int row)
+        {
+            double[] values = new double[Columns];
+
+            for (int col = 0, cols = Columns; col < cols; col++)
+            {
+                values[col] = _matrix[row, col];
+            }
+
+            return values;
+        }
+
+        public void Column(int col, params double[] values)
+        {
+            if (values.Length != Rows) throw new ArgumentOutOfRangeException("values.Length");
+
+            for (int row = 0, rows = Rows; row < rows; row++)
+            {
+                _matrix[row, col] = values[row];
+            }
+        }
+
+        public double[] Column(int col)
+        {
+            double[] values = new double[Rows];
+
+            for (int row = 0, rows = Rows; row < rows; row++)
+            {
+                values[row] = _matrix[row, col];
+            }
+
+            return values;
+        }
+
+        public MatrixD Clone()
+        {
+            return new MatrixD(_matrix);
+        }
+
+        public MatrixD Transpose()
+        {
+            MatrixD t = new MatrixD(Columns, Rows);
+
+            for (int r = 0, rows = Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = Columns; c < cols; c++)
+                {
+                    t[c, r] = _matrix[r, c];
+                }
+            }
+
+            return t;
+        }
+
+        public MatrixD Invert()
+        {
+            int rows = Rows;
+            int cols = Columns;
+
+            if (rows != cols) throw new InvalidOperationException("Unable to invert non-square matrix");
+
+            if (Determinant == 0.0) throw new InvalidOperationException("Unable to invert matrix where determinant equals 0");
+
+            MatrixD x = Clone();
+
+            double e;
+            for (int k = 0; k < rows; k++)
+            {
+                e = x[k, k];
+                x[k, k] = 1.0;
+
+                for (int j = 0; j < cols; j++)
+                {
+                    x[k, j] = x[k, j] / e;
+                }
+
+                for (int i = 0; i < cols; i++)
+                {
+                    if (i != k)
+                    {
+                        e = x[i, k];
+                        x[i, k] = 0.0;
+
+                        for (int j = 0; j < cols; j++)
+                        {
+                            x[i, j] = x[i, j] - e * x[k, j];
+                        }
+                    }
+                }
+            }
+
+            return x;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[");
+            for (int r = 0, rows = Rows; r < rows; r++)
+            {
+                if (r > 0) sb.Append("; ");
+                for (int c = 0, cols = Columns; c < cols; c++)
+                {
+                    if (c > 0) sb.Append(",");
+                    sb.Append(_matrix[r, c]);
+                }
+            }
+            sb.Append("]");
+            return sb.ToString();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MatrixD) return (obj as MatrixD) == this;
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _matrix.GetHashCode();
+        }
+
+        #endregion
+
+        #region Static
+
+        public static MatrixD Zero(int rows, int columns)
+        {
+            return new MatrixD(rows, columns);
+        }
+
+        public static MatrixD One(int rows, int columns)
+        {
+            MatrixD m = new MatrixD(rows, columns);
+
+            for (int r = 0; r < rows; r++)
+            {
+                for (int c = 0; c < columns; c++)
+                {
+                    m[r, c] = 1.0;
+                }
+            }
+
+            return m;
+        }
+
+        public static MatrixD Identity(int dimensions)
+        {
+            MatrixD m = new MatrixD(dimensions, dimensions);
+
+            for (int r = 0, rows = dimensions; r < rows; r++)
+            {
+                for (int c = 0, cols = dimensions; c < cols; c++)
+                {
+                    m[r, c] = (r == c) ? 1.0 : 0.0;
+                }
+            }
+
+            return m;
+        }
+
+        public static bool operator ==(MatrixD a, MatrixD b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) return false;
+
+            for (int r = 0, rows = a.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = a.Columns; c < cols; c++)
+                {
+                    if (a[r, c] != b[r, c]) return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool operator !=(MatrixD a, MatrixD b)
+        {
+            return !(a == b);
+        }
+
+        public static MatrixD operator +(MatrixD a, MatrixD b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) throw new ArgumentException("Unable to add matrices of different dimensions");
+
+            MatrixD x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] += b[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixD operator -(MatrixD a, MatrixD b)
+        {
+            if (a.Rows != b.Rows || a.Columns != b.Columns) throw new ArgumentException("Unable to subtract matrices of different dimensions");
+
+            MatrixD x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] -= b[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixD operator -(MatrixD a)
+        {
+            MatrixD x = a.Clone();
+
+            for (int r = 0, rows = a.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = a.Columns; c < cols; c++)
+                {
+                    x[r, c] = -x[r, c];
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixD operator *(MatrixD a, MatrixD b)
+        {
+            if (a.Columns != b.Rows) throw new ArgumentException("Unable to multiply matrices of different inner dimensions");
+
+            MatrixD x = new MatrixD(a.Rows, b.Columns);
+
+            int inner = a.Columns;
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    double d = 0.0;
+                    for (int i = 0; i < inner; i++) d += a[r, i] * b[i, c];
+                    x[r, c] = d;
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixD operator *(MatrixD a, double d)
+        {
+            MatrixD x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] *= d;
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixD operator *(double d, MatrixD a)
+        {
+            MatrixD x = a.Clone();
+
+            for (int r = 0, rows = x.Rows; r < rows; r++)
+            {
+                for (int c = 0, cols = x.Columns; c < cols; c++)
+                {
+                    x[r, c] *= d;
+                }
+            }
+
+            return x;
+        }
+
+        public static MatrixD operator /(MatrixD a, double d)
+        {
+            return a * (1 / d);
+        }
+
+        public static MatrixD operator ^(MatrixD a, int e)
+        {
+            MatrixD m = a.Clone();
+            for (int i = 1; i < e; i++)
+            {
+                m *= a;
+            }
+            return m;
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/Mathematics/MovingAverage.cs
+++ b/DICOM/Imaging/Mathematics/MovingAverage.cs
@@ -1,84 +1,103 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Linq;
-using System.Text;
 
-namespace Dicom.Imaging.Mathematics {
-	public class MovingAverage {
-		private readonly int _window;
-		private readonly int[] _values;
-		private int _count;
+namespace Dicom.Imaging.Mathematics
+{
+    public class MovingAverage
+    {
+        private readonly int _window;
 
-		public MovingAverage(int window) {
-			_window = window;
-			_values = new int[_window];
-			_count = 0;
-		}
+        private readonly int[] _values;
 
-		public int Count {
-			get {
-				return _count;
-			}
-		}
+        private int _count;
 
-		public int Next(int value) {
-			_values[_count % _window] = value;
-			_count++;
-			if (_count < _window)
-				return _values.Sum() / _count;
-			return _values.Sum() / _window;
-		}
-	}
+        public MovingAverage(int window)
+        {
+            _window = window;
+            _values = new int[_window];
+            _count = 0;
+        }
 
-	public class MovingAverageF {
-		private readonly int _window;
-		private readonly float[] _values;
-		private int _count;
+        public int Count
+        {
+            get
+            {
+                return _count;
+            }
+        }
 
-		public MovingAverageF(int window) {
-			_window = window;
-			_values = new float[_window];
-			_count = 0;
-		}
+        public int Next(int value)
+        {
+            _values[_count % _window] = value;
+            _count++;
+            if (_count < _window) return _values.Sum() / _count;
+            return _values.Sum() / _window;
+        }
+    }
 
-		public int Count {
-			get {
-				return _count;
-			}
-		}
+    public class MovingAverageF
+    {
+        private readonly int _window;
 
-		public float Next(float value) {
-			_values[_count % _window] = value;
-			_count++;
-			if (_count < _window)
-				return _values.Sum() / _count;
-			return _values.Sum() / _window;
-		}
-	}
+        private readonly float[] _values;
 
-	public class MovingAverageD {
-		private readonly int _window;
-		private readonly double[] _values;
-		private int _count;
+        private int _count;
 
-		public MovingAverageD(int window) {
-			_window = window;
-			_values = new double[_window];
-			_count = 0;
-		}
+        public MovingAverageF(int window)
+        {
+            _window = window;
+            _values = new float[_window];
+            _count = 0;
+        }
 
-		public int Count {
-			get {
-				return _count;
-			}
-		}
+        public int Count
+        {
+            get
+            {
+                return _count;
+            }
+        }
 
-		public double Next(double value) {
-			_values[_count % _window] = value;
-			_count++;
-			if (_count < _window)
-				return _values.Sum() / _count;
-			return _values.Sum() / _window;
-		}
-	}
+        public float Next(float value)
+        {
+            _values[_count % _window] = value;
+            _count++;
+            if (_count < _window) return _values.Sum() / _count;
+            return _values.Sum() / _window;
+        }
+    }
+
+    public class MovingAverageD
+    {
+        private readonly int _window;
+
+        private readonly double[] _values;
+
+        private int _count;
+
+        public MovingAverageD(int window)
+        {
+            _window = window;
+            _values = new double[_window];
+            _count = 0;
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _count;
+            }
+        }
+
+        public double Next(double value)
+        {
+            _values[_count % _window] = value;
+            _count++;
+            if (_count < _window) return _values.Sum() / _count;
+            return _values.Sum() / _window;
+        }
+    }
 }

--- a/DICOM/Imaging/Mathematics/Point2.cs
+++ b/DICOM/Imaging/Mathematics/Point2.cs
@@ -1,66 +1,72 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Mathematics {
-	/// <summary>
-	/// Coordinate in 2D space
-	/// </summary>
-	public class Point2 : IComparable<Point2>, IEquatable<Point2> {
-		public static readonly Point2 Origin = new Point2();
+using System;
 
-		public Point2() {
-		}
+namespace Dicom.Imaging.Mathematics
+{
+    /// <summary>
+    /// Coordinate in 2D space
+    /// </summary>
+    public class Point2 : IComparable<Point2>, IEquatable<Point2>
+    {
+        public static readonly Point2 Origin = new Point2();
 
-		public Point2(int x, int y) {
-			X = x;
-			Y = y;
-		}
+        public Point2()
+        {
+        }
 
-		/// <summary>Position on X axis</summary>
-		public int X {
-			get;
-			set;
-		}
+        public Point2(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
 
-		/// <summary>Position on Y axis</summary>
-		public int Y {
-			get;
-			set;
-		}
+        /// <summary>Position on X axis</summary>
+        public int X { get; set; }
 
-		public override bool Equals(object obj) {
-			if (ReferenceEquals(this, obj)) return true;
-			if (obj is Point2) {
-				Point2 other = obj as Point2;
-				return X == other.X && Y == other.Y;
-			}
-			return false;
-		}
+        /// <summary>Position on Y axis</summary>
+        public int Y { get; set; }
 
-		public bool Equals(Point2 other) {
-			if (other == null)
-				return false;
-			return X == other.X && Y == other.Y;
-		}
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj is Point2)
+            {
+                Point2 other = obj as Point2;
+                return X == other.X && Y == other.Y;
+            }
+            return false;
+        }
 
-		public override int GetHashCode() {
-			return X ^ Y;
-		}
+        public bool Equals(Point2 other)
+        {
+            if (other == null) return false;
+            return X == other.X && Y == other.Y;
+        }
 
-		/// <summary>Gets a human-readable string representing this <see cref="Dicom.Imaging.Mathematics.Point2"/> object.</summary>
-		/// <returns>String representation</returns>
-		public override string ToString() {
-			return String.Format("({0},{1})", X, Y);
-		}
+        public override int GetHashCode()
+        {
+            return X ^ Y;
+        }
 
-		/// <summary>IComparable interface implementation</summary>
-		/// <param name="other">Point to compare</param>
-		/// <returns>Compare result</returns>
-		public int CompareTo(Point2 other) {
-			if (X < other.X) return -1;
-			if (X > other.X) return 1;
-			if (Y < other.Y) return -1;
-			if (Y > other.Y) return 1;
-			return 0;
-		}
-	}
+        /// <summary>Gets a human-readable string representing this <see cref="Dicom.Imaging.Mathematics.Point2"/> object.</summary>
+        /// <returns>String representation</returns>
+        public override string ToString()
+        {
+            return String.Format("({0},{1})", X, Y);
+        }
+
+        /// <summary>IComparable interface implementation</summary>
+        /// <param name="other">Point to compare</param>
+        /// <returns>Compare result</returns>
+        public int CompareTo(Point2 other)
+        {
+            if (X < other.X) return -1;
+            if (X > other.X) return 1;
+            if (Y < other.Y) return -1;
+            if (Y > other.Y) return 1;
+            return 0;
+        }
+    }
 }

--- a/DICOM/Imaging/PhotometricInterpretation.cs
+++ b/DICOM/Imaging/PhotometricInterpretation.cs
@@ -1,283 +1,339 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom;
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// Photometric Interpretation
+    /// </summary>
+    public class PhotometricInterpretation : DicomParseable
+    {
+        #region Constructor
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// Photometric Interpretation
-	/// </summary>
-	public class PhotometricInterpretation : DicomParseable {
-		#region Constructor
-		private PhotometricInterpretation() {
-		}
-		#endregion
+        private PhotometricInterpretation()
+        {
+        }
 
-		#region Public Properties
-		public string Value {
-			get;
-			private set;
-		}
+        #endregion
 
-		public string Description {
-			get;
-			private set;
-		}
+        #region Public Properties
 
-		public bool IsColor {
-			get;
-			private set;
-		}
+        public string Value { get; private set; }
 
-		public bool IsPalette {
-			get;
-			private set;
-		}
+        public string Description { get; private set; }
 
-		public bool IsYBR {
-			get;
-			private set;
-		}
+        public bool IsColor { get; private set; }
 
-		public ColorSpace ColorSpace {
-			get;
-			private set;
-		}
-		#endregion
+        public bool IsPalette { get; private set; }
 
-		#region Public Methods
-		public override bool Equals(object obj) {
-			if (ReferenceEquals(this, obj))
-				return true;
-			if (!(obj is PhotometricInterpretation))
-				return false;
-			return (obj as PhotometricInterpretation).Value == Value;
-		}
+        public bool IsYBR { get; private set; }
 
-		public override int GetHashCode() {
-			return Value.GetHashCode();
-		}
+        public ColorSpace ColorSpace { get; private set; }
 
-		public override string ToString() {
-			return Description;
-		}
-		#endregion
+        #endregion
 
-		#region Static Methods
-		public static PhotometricInterpretation Parse(string photometricInterpretation) {
-			switch (photometricInterpretation.Trim(' ', '\0')) {
-				case "MONOCHROME1": return Monochrome1;
-				case "MONOCHROME":
-				case "MONOCHROME2": return Monochrome2;
-				case "PALETTE COLOR": return PaletteColor;
-				case "RGB": return Rgb;
-				case "YBR_FULL": return YbrFull;
-				case "YBR_FULL_422": return YbrFull422;
-				case "YBR_PARTIAL_422": return YbrPartial422;
-				case "YBR_PARTIAL_420": return YbrPartial420;
-				case "YBR_ICT": return YbrIct;
-				case "YBR_RCT": return YbrRct;
-				default:
-					break;
-			}
-			throw new DicomImagingException("Unknown Photometric Interpretation [{0}]", photometricInterpretation);
-		}
+        #region Public Methods
 
-		public static bool operator ==(PhotometricInterpretation a, PhotometricInterpretation b) {
-			if (((object)a == null) && ((object)b == null))
-				return true;
-			if (((object)a == null) || ((object)b == null))
-				return false;
-			return a.Value == b.Value;
-		}
-		public static bool operator !=(PhotometricInterpretation a, PhotometricInterpretation b) {
-			return !(a == b);
-		}
-		#endregion
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(this, obj)) return true;
+            if (!(obj is PhotometricInterpretation)) return false;
+            return (obj as PhotometricInterpretation).Value == Value;
+        }
 
-		/// <summary>
-		/// Pixel data represent a single monochrome image plane. The minimum sample value is intended 
-		/// to be displayed as white after any VOI gray scale transformations have been performed. See 
-		/// PS 3.4. This value may be used only when Samples per Pixel (0028,0002) has a value of 1.
-		/// </summary>
-		public readonly static PhotometricInterpretation Monochrome1 = new PhotometricInterpretation() {
-			Value = "MONOCHROME1",
-			Description = "Monochrome 1",
-			IsColor = false,
-			IsPalette = false,
-			IsYBR = false,
-			ColorSpace = ColorSpace.Grayscale
-		};
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
 
-		/// <summary>
-		/// Pixel data represent a single monochrome image plane. The minimum sample value is intended 
-		/// to be displayed as black after any VOI gray scale transformations have been performed. See 
-		/// PS 3.4. This value may be used only when Samples per Pixel (0028,0002) has a value of 1.
-		/// </summary>
-		public readonly static PhotometricInterpretation Monochrome2 = new PhotometricInterpretation() {
-			Value = "MONOCHROME2",
-			Description = "Monochrome 2",
-			IsColor = false,
-			IsPalette = false,
-			IsYBR = false,
-			ColorSpace = ColorSpace.Grayscale
-		};
+        public override string ToString()
+        {
+            return Description;
+        }
 
-		/// <summary>
-		/// Pixel data describe a color image with a single sample per pixel (single image plane). The 
-		/// pixel value is used as an index into each of the Red, Blue, and Green Palette Color Lookup 
-		/// Tables (0028,1101-1103&1201-1203). This value may be used only when Samples per Pixel (0028,0002) 
-		/// has a value of 1. When the Photometric Interpretation is Palette Color; Red, Blue, and Green 
-		/// Palette Color Lookup Tables shall be present.
-		/// </summary>
-		public readonly static PhotometricInterpretation PaletteColor = new PhotometricInterpretation() {
-			Value = "PALETTE COLOR",
-			Description = "Palette Color",
-			IsColor = true,
-			IsPalette = true,
-			IsYBR = false,
-			ColorSpace = ColorSpace.Indexed
-		};
+        #endregion
 
-		/// <summary>
-		/// Pixel data represent a color image described by red, green, and blue image planes. The minimum 
-		/// sample value for each color plane represents minimum intensity of the color. This value may be 
-		/// used only when Samples per Pixel (0028,0002) has a value of 3.
-		/// </summary>
-		public readonly static PhotometricInterpretation Rgb = new PhotometricInterpretation() {
-			Value = "RGB",
-			Description = "RGB",
-			IsColor = true,
-			IsPalette = false,
-			IsYBR = false,
-			ColorSpace = ColorSpace.RGB
-		};
+        #region Static Methods
 
-		/// <summary>
-		/// Pixel data represent a color image described by one luminance (Y) and two chrominance planes 
-		/// (Cb and Cr). This photometric interpretation may be used only when Samples per Pixel (0028,0002) 
-		/// has a value of 3. Black is represented by Y equal to zero. The absence of color is represented 
-		/// by both Cb and Cr values equal to half full scale.
-		/// 
-		/// In the case where Bits Allocated (0028,0100) has a value of 8 then the following equations convert 
-		/// between RGB and YCBCR Photometric Interpretation:
-		/// Y  = + .2990R + .5870G + .1140B
-		/// Cb = - .1687R - .3313G + .5000B + 128
-		/// Cr = + .5000R - .4187G - .0813B + 128
-		/// </summary>
-		public readonly static PhotometricInterpretation YbrFull = new PhotometricInterpretation() {
-			Value = "YBR_FULL",
-			Description = "YBR Full",
-			IsColor = true,
-			IsPalette = false,
-			IsYBR = true,
-			ColorSpace = ColorSpace.YCbCrJPEG
-		};
+        public static PhotometricInterpretation Parse(string photometricInterpretation)
+        {
+            switch (photometricInterpretation.Trim(' ', '\0'))
+            {
+                case "MONOCHROME1":
+                    return Monochrome1;
+                case "MONOCHROME":
+                case "MONOCHROME2":
+                    return Monochrome2;
+                case "PALETTE COLOR":
+                    return PaletteColor;
+                case "RGB":
+                    return Rgb;
+                case "YBR_FULL":
+                    return YbrFull;
+                case "YBR_FULL_422":
+                    return YbrFull422;
+                case "YBR_PARTIAL_422":
+                    return YbrPartial422;
+                case "YBR_PARTIAL_420":
+                    return YbrPartial420;
+                case "YBR_ICT":
+                    return YbrIct;
+                case "YBR_RCT":
+                    return YbrRct;
+                default:
+                    break;
+            }
+            throw new DicomImagingException("Unknown Photometric Interpretation [{0}]", photometricInterpretation);
+        }
 
-		/// <summary>
-		/// The same as YBR_FULL except that the Cb and Cr values are sampled horizontally at half the Y rate 
-		/// and as a result there are half as many Cb and Cr values as Y values.
-		/// 
-		/// This Photometric Interpretation is only allowed with Planar Configuration (0028,0006) equal to 0.  
-		/// Two Y values shall be stored followed by one Cb and one Cr value. The Cb and Cr values shall be 
-		/// sampled at the location of the first of the two Y values. For each Row of Pixels, the first Cb and 
-		/// Cr samples shall be at the location of the first Y sample. The next Cb and Cr samples shall be 
-		/// at the location of the third Y sample etc.
-		/// </summary>
-		public readonly static PhotometricInterpretation YbrFull422 = new PhotometricInterpretation() {
-			Value = "YBR_FULL_422",
-			Description = "YBR Full 4:2:2",
-			IsColor = true,
-			IsPalette = false,
-			IsYBR = true
-		};
+        public static bool operator ==(PhotometricInterpretation a, PhotometricInterpretation b)
+        {
+            if (((object)a == null) && ((object)b == null)) return true;
+            if (((object)a == null) || ((object)b == null)) return false;
+            return a.Value == b.Value;
+        }
 
-		/// <summary>
-		/// The same as YBR_FULL_422 except that:
-		/// <list type="number">
-		/// <item>black corresponds to Y = 16</item>
-		/// <item>Y is restricted to 220 levels (i.e. the maximum value is 235)</item>
-		/// <item>Cb and Cr each has a minimum value of 16</item>
-		/// <item>Cb and Cr are restricted to 225 levels (i.e. the maximum value is 240)</item>
-		/// <item>lack of color is represented by Cb and Cr equal to 128</item>
-		/// </list>
-		/// 
-		/// In the case where Bits Allocated (0028,0100) has value of 8 then the following equations convert 
-		/// between RGB and YBR_PARTIAL_422 Photometric Interpretation:
-		/// Y  = + .2568R + .5041G + .0979B + 16
-		/// Cb = - .1482R - .2910G + .4392B + 128
-		/// Cr = + .4392R - .3678G - .0714B + 128
-		/// </summary>
-		public readonly static PhotometricInterpretation YbrPartial422 = new PhotometricInterpretation() {
-			Value = "YBR_PARTIAL_422",
-			Description = "YBR Partial 4:2:2",
-			IsColor = true,
-			IsPalette = false,
-			IsYBR = true
-		};
+        public static bool operator !=(PhotometricInterpretation a, PhotometricInterpretation b)
+        {
+            return !(a == b);
+        }
 
-		/// <summary>
-		/// The same as YBR_PARTIAL_422 except that the Cb and Cr values are sampled horizontally and vertically 
-		/// at half the Y rate and as a result there are four times less Cb and Cr values than Y values, versus 
-		/// twice less for YBR_PARTIAL_422.
-		/// 
-		/// This Photometric Interpretation is only allowed with Planar Configuration (0028,0006) equal to 0.  
-		/// The Cb and Cr values shall be sampled at the location of the first of the two Y values. For the first 
-		/// Row of Pixels (etc.), the first Cb and Cr samples shall be at the location of the first Y sample.  The 
-		/// next Cb and Cr samples shall be at the location of the third Y sample etc. The next Rows of Pixels 
-		/// containing Cb and Cr samples (at the same locations than for the first Row) will be the third etc.
-		/// </summary>
-		public readonly static PhotometricInterpretation YbrPartial420 = new PhotometricInterpretation() {
-			Value = "YBR_PARTIAL_420",
-			Description = "YBR Partial 4:2:0",
-			IsColor = true,
-			IsPalette = false,
-			IsYBR = true
-		};
+        #endregion
 
-		/// <summary>
-		/// Pixel data represent a color image described by one luminance (Y) and two chrominance planes 
-		/// (Cb and Cr). This photometric interpretation may be used only when Samples per Pixel (0028,0002) has 
-		/// a value of 3. Black is represented by Y equal to zero. The absence of color is represented by both 
-		/// Cb and Cr values equal to zero.
-		/// 
-		/// Regardless of the value of Bits Allocated (0028,0100), the following equations convert between RGB 
-		/// and YCbCr Photometric Interpretation:
-		/// Y  = + .29900R + .58700G + .11400B
-		/// Cb = - .16875R - .33126G + .50000B
-		/// Cr = + .50000R - .41869G - .08131B
-		/// </summary>
-		public readonly static PhotometricInterpretation YbrIct = new PhotometricInterpretation() {
-			Value = "YBR_ICT",
-			Description = "YBR Irreversible Color Transformation (JPEG 2000)",
-			IsColor = true,
-			IsPalette = false,
-			IsYBR = true
-		};
+        /// <summary>
+        /// Pixel data represent a single monochrome image plane. The minimum sample value is intended 
+        /// to be displayed as white after any VOI gray scale transformations have been performed. See 
+        /// PS 3.4. This value may be used only when Samples per Pixel (0028,0002) has a value of 1.
+        /// </summary>
+        public static readonly PhotometricInterpretation Monochrome1 = new PhotometricInterpretation()
+                                                                           {
+                                                                               Value =
+                                                                                   "MONOCHROME1",
+                                                                               Description =
+                                                                                   "Monochrome 1",
+                                                                               IsColor =
+                                                                                   false,
+                                                                               IsPalette =
+                                                                                   false,
+                                                                               IsYBR = false,
+                                                                               ColorSpace =
+                                                                                   ColorSpace
+                                                                                   .Grayscale
+                                                                           };
 
-		/// <summary>
-		/// Pixel data represent a color image described by one luminance (Y) and two chrominance planes 
-		/// (Cb and Cr). This photometric interpretation may be used only when Samples per Pixel (0028,0002) 
-		/// has a value of 3. Black is represented by Y equal to zero. The absence of color is represented 
-		/// by both Cb and Cr values equal to zero.
-		/// 
-		/// Regardless of the value of Bits Allocated (0028,0100), the following equations convert between 
-		/// RGB and YBR_RCT Photometric Interpretation:
-		/// Y  = floor((R + 2G +B) / 4)
-		/// Cb = B - G
-		/// Cr = R - G
-		/// 
-		/// The following equations convert between YBR_RCT and RGB Photometric Interpretation:
-		/// R = Cr + G
-		/// G = Y – floor((Cb + Cr) / 4)
-		/// B = Cb + G
-		/// </summary>
-		public readonly static PhotometricInterpretation YbrRct = new PhotometricInterpretation() {
-			Value = "YBR_RCT",
-			Description = "YBR Reversible Color Transformation (JPEG 2000)",
-			IsColor = true,
-			IsPalette = false,
-			IsYBR = true
-		};
-	}
+        /// <summary>
+        /// Pixel data represent a single monochrome image plane. The minimum sample value is intended 
+        /// to be displayed as black after any VOI gray scale transformations have been performed. See 
+        /// PS 3.4. This value may be used only when Samples per Pixel (0028,0002) has a value of 1.
+        /// </summary>
+        public static readonly PhotometricInterpretation Monochrome2 = new PhotometricInterpretation()
+                                                                           {
+                                                                               Value =
+                                                                                   "MONOCHROME2",
+                                                                               Description =
+                                                                                   "Monochrome 2",
+                                                                               IsColor =
+                                                                                   false,
+                                                                               IsPalette =
+                                                                                   false,
+                                                                               IsYBR = false,
+                                                                               ColorSpace =
+                                                                                   ColorSpace
+                                                                                   .Grayscale
+                                                                           };
+
+        /// <summary>
+        /// Pixel data describe a color image with a single sample per pixel (single image plane). The 
+        /// pixel value is used as an index into each of the Red, Blue, and Green Palette Color Lookup 
+        /// Tables (0028,1101-1103&1201-1203). This value may be used only when Samples per Pixel (0028,0002) 
+        /// has a value of 1. When the Photometric Interpretation is Palette Color; Red, Blue, and Green 
+        /// Palette Color Lookup Tables shall be present.
+        /// </summary>
+        public static readonly PhotometricInterpretation PaletteColor = new PhotometricInterpretation()
+                                                                            {
+                                                                                Value =
+                                                                                    "PALETTE COLOR",
+                                                                                Description
+                                                                                    =
+                                                                                    "Palette Color",
+                                                                                IsColor =
+                                                                                    true,
+                                                                                IsPalette =
+                                                                                    true,
+                                                                                IsYBR =
+                                                                                    false,
+                                                                                ColorSpace =
+                                                                                    ColorSpace
+                                                                                    .Indexed
+                                                                            };
+
+        /// <summary>
+        /// Pixel data represent a color image described by red, green, and blue image planes. The minimum 
+        /// sample value for each color plane represents minimum intensity of the color. This value may be 
+        /// used only when Samples per Pixel (0028,0002) has a value of 3.
+        /// </summary>
+        public static readonly PhotometricInterpretation Rgb = new PhotometricInterpretation()
+                                                                   {
+                                                                       Value = "RGB",
+                                                                       Description = "RGB",
+                                                                       IsColor = true,
+                                                                       IsPalette = false,
+                                                                       IsYBR = false,
+                                                                       ColorSpace =
+                                                                           ColorSpace.RGB
+                                                                   };
+
+        /// <summary>
+        /// Pixel data represent a color image described by one luminance (Y) and two chrominance planes 
+        /// (Cb and Cr). This photometric interpretation may be used only when Samples per Pixel (0028,0002) 
+        /// has a value of 3. Black is represented by Y equal to zero. The absence of color is represented 
+        /// by both Cb and Cr values equal to half full scale.
+        /// 
+        /// In the case where Bits Allocated (0028,0100) has a value of 8 then the following equations convert 
+        /// between RGB and YCBCR Photometric Interpretation:
+        /// Y  = + .2990R + .5870G + .1140B
+        /// Cb = - .1687R - .3313G + .5000B + 128
+        /// Cr = + .5000R - .4187G - .0813B + 128
+        /// </summary>
+        public static readonly PhotometricInterpretation YbrFull = new PhotometricInterpretation()
+                                                                       {
+                                                                           Value = "YBR_FULL",
+                                                                           Description =
+                                                                               "YBR Full",
+                                                                           IsColor = true,
+                                                                           IsPalette = false,
+                                                                           IsYBR = true,
+                                                                           ColorSpace =
+                                                                               ColorSpace
+                                                                               .YCbCrJPEG
+                                                                       };
+
+        /// <summary>
+        /// The same as YBR_FULL except that the Cb and Cr values are sampled horizontally at half the Y rate 
+        /// and as a result there are half as many Cb and Cr values as Y values.
+        /// 
+        /// This Photometric Interpretation is only allowed with Planar Configuration (0028,0006) equal to 0.  
+        /// Two Y values shall be stored followed by one Cb and one Cr value. The Cb and Cr values shall be 
+        /// sampled at the location of the first of the two Y values. For each Row of Pixels, the first Cb and 
+        /// Cr samples shall be at the location of the first Y sample. The next Cb and Cr samples shall be 
+        /// at the location of the third Y sample etc.
+        /// </summary>
+        public static readonly PhotometricInterpretation YbrFull422 = new PhotometricInterpretation()
+                                                                          {
+                                                                              Value =
+                                                                                  "YBR_FULL_422",
+                                                                              Description =
+                                                                                  "YBR Full 4:2:2",
+                                                                              IsColor = true,
+                                                                              IsPalette =
+                                                                                  false,
+                                                                              IsYBR = true
+                                                                          };
+
+        /// <summary>
+        /// The same as YBR_FULL_422 except that:
+        /// <list type="number">
+        /// <item>black corresponds to Y = 16</item>
+        /// <item>Y is restricted to 220 levels (i.e. the maximum value is 235)</item>
+        /// <item>Cb and Cr each has a minimum value of 16</item>
+        /// <item>Cb and Cr are restricted to 225 levels (i.e. the maximum value is 240)</item>
+        /// <item>lack of color is represented by Cb and Cr equal to 128</item>
+        /// </list>
+        /// 
+        /// In the case where Bits Allocated (0028,0100) has value of 8 then the following equations convert 
+        /// between RGB and YBR_PARTIAL_422 Photometric Interpretation:
+        /// Y  = + .2568R + .5041G + .0979B + 16
+        /// Cb = - .1482R - .2910G + .4392B + 128
+        /// Cr = + .4392R - .3678G - .0714B + 128
+        /// </summary>
+        public static readonly PhotometricInterpretation YbrPartial422 = new PhotometricInterpretation()
+                                                                             {
+                                                                                 Value =
+                                                                                     "YBR_PARTIAL_422",
+                                                                                 Description
+                                                                                     =
+                                                                                     "YBR Partial 4:2:2",
+                                                                                 IsColor =
+                                                                                     true,
+                                                                                 IsPalette =
+                                                                                     false,
+                                                                                 IsYBR =
+                                                                                     true
+                                                                             };
+
+        /// <summary>
+        /// The same as YBR_PARTIAL_422 except that the Cb and Cr values are sampled horizontally and vertically 
+        /// at half the Y rate and as a result there are four times less Cb and Cr values than Y values, versus 
+        /// twice less for YBR_PARTIAL_422.
+        /// 
+        /// This Photometric Interpretation is only allowed with Planar Configuration (0028,0006) equal to 0.  
+        /// The Cb and Cr values shall be sampled at the location of the first of the two Y values. For the first 
+        /// Row of Pixels (etc.), the first Cb and Cr samples shall be at the location of the first Y sample.  The 
+        /// next Cb and Cr samples shall be at the location of the third Y sample etc. The next Rows of Pixels 
+        /// containing Cb and Cr samples (at the same locations than for the first Row) will be the third etc.
+        /// </summary>
+        public static readonly PhotometricInterpretation YbrPartial420 = new PhotometricInterpretation()
+                                                                             {
+                                                                                 Value =
+                                                                                     "YBR_PARTIAL_420",
+                                                                                 Description
+                                                                                     =
+                                                                                     "YBR Partial 4:2:0",
+                                                                                 IsColor =
+                                                                                     true,
+                                                                                 IsPalette =
+                                                                                     false,
+                                                                                 IsYBR =
+                                                                                     true
+                                                                             };
+
+        /// <summary>
+        /// Pixel data represent a color image described by one luminance (Y) and two chrominance planes 
+        /// (Cb and Cr). This photometric interpretation may be used only when Samples per Pixel (0028,0002) has 
+        /// a value of 3. Black is represented by Y equal to zero. The absence of color is represented by both 
+        /// Cb and Cr values equal to zero.
+        /// 
+        /// Regardless of the value of Bits Allocated (0028,0100), the following equations convert between RGB 
+        /// and YCbCr Photometric Interpretation:
+        /// Y  = + .29900R + .58700G + .11400B
+        /// Cb = - .16875R - .33126G + .50000B
+        /// Cr = + .50000R - .41869G - .08131B
+        /// </summary>
+        public static readonly PhotometricInterpretation YbrIct = new PhotometricInterpretation()
+                                                                      {
+                                                                          Value = "YBR_ICT",
+                                                                          Description =
+                                                                              "YBR Irreversible Color Transformation (JPEG 2000)",
+                                                                          IsColor = true,
+                                                                          IsPalette = false,
+                                                                          IsYBR = true
+                                                                      };
+
+        /// <summary>
+        /// Pixel data represent a color image described by one luminance (Y) and two chrominance planes 
+        /// (Cb and Cr). This photometric interpretation may be used only when Samples per Pixel (0028,0002) 
+        /// has a value of 3. Black is represented by Y equal to zero. The absence of color is represented 
+        /// by both Cb and Cr values equal to zero.
+        /// 
+        /// Regardless of the value of Bits Allocated (0028,0100), the following equations convert between 
+        /// RGB and YBR_RCT Photometric Interpretation:
+        /// Y  = floor((R + 2G +B) / 4)
+        /// Cb = B - G
+        /// Cr = R - G
+        /// 
+        /// The following equations convert between YBR_RCT and RGB Photometric Interpretation:
+        /// R = Cr + G
+        /// G = Y – floor((Cb + Cr) / 4)
+        /// B = Cb + G
+        /// </summary>
+        public static readonly PhotometricInterpretation YbrRct = new PhotometricInterpretation()
+                                                                      {
+                                                                          Value = "YBR_RCT",
+                                                                          Description =
+                                                                              "YBR Reversible Color Transformation (JPEG 2000)",
+                                                                          IsColor = true,
+                                                                          IsPalette = false,
+                                                                          IsYBR = true
+                                                                      };
+    }
 }

--- a/DICOM/Imaging/PixelDataConverter.cs
+++ b/DICOM/Imaging/PixelDataConverter.cs
@@ -1,180 +1,191 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom.IO;
 using Dicom.IO.Buffer;
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// Convert pixels from presentation from interleaved to planar and from planar to interleaved
-	/// </summary>
-	public static class PixelDataConverter {
-		/// <summary>
-		/// Convert 24 bits pixels from interleaved (RGB) to planar (RRR...GGG...BBB...)
-		/// </summary>
-		/// <param name="data">Pixels data in interleaved format (RGB)</param>
-		/// <returns>Pixels data in planar format (RRR...GGG...BBB...)</returns>
-		public static IByteBuffer InterleavedToPlanar24(IByteBuffer data) {
-			byte[] oldPixels = data.Data;
-			byte[] newPixels = new byte[oldPixels.Length];
-			int pixelCount = newPixels.Length / 3;
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// Convert pixels from presentation from interleaved to planar and from planar to interleaved
+    /// </summary>
+    public static class PixelDataConverter
+    {
+        /// <summary>
+        /// Convert 24 bits pixels from interleaved (RGB) to planar (RRR...GGG...BBB...)
+        /// </summary>
+        /// <param name="data">Pixels data in interleaved format (RGB)</param>
+        /// <returns>Pixels data in planar format (RRR...GGG...BBB...)</returns>
+        public static IByteBuffer InterleavedToPlanar24(IByteBuffer data)
+        {
+            byte[] oldPixels = data.Data;
+            byte[] newPixels = new byte[oldPixels.Length];
+            int pixelCount = newPixels.Length / 3;
 
-			unchecked {
-				for (int n = 0; n < pixelCount; n++) {
-					newPixels[n + (pixelCount * 0)] = oldPixels[(n * 3) + 0];
-					newPixels[n + (pixelCount * 1)] = oldPixels[(n * 3) + 1];
-					newPixels[n + (pixelCount * 2)] = oldPixels[(n * 3) + 2];
-				}
-			}
+            unchecked
+            {
+                for (int n = 0; n < pixelCount; n++)
+                {
+                    newPixels[n + (pixelCount * 0)] = oldPixels[(n * 3) + 0];
+                    newPixels[n + (pixelCount * 1)] = oldPixels[(n * 3) + 1];
+                    newPixels[n + (pixelCount * 2)] = oldPixels[(n * 3) + 2];
+                }
+            }
 
-			return new MemoryByteBuffer(newPixels);
-		}
+            return new MemoryByteBuffer(newPixels);
+        }
 
-		/// <summary>
-		/// Convert 24 bits pixels from planar (RRR...GGG...BBB...) to interleaved (RGB)
-		/// </summary>
-		/// <param name="data">Pixels data in planar format (RRR...GGG...BBB...)</param>
-		/// <returns>Pixels data in interleaved format (RGB)</returns>
-		public static IByteBuffer PlanarToInterleaved24(IByteBuffer data) {
-			byte[] oldPixels = data.Data;
-			byte[] newPixels = new byte[oldPixels.Length];
-			int pixelCount = newPixels.Length / 3;
+        /// <summary>
+        /// Convert 24 bits pixels from planar (RRR...GGG...BBB...) to interleaved (RGB)
+        /// </summary>
+        /// <param name="data">Pixels data in planar format (RRR...GGG...BBB...)</param>
+        /// <returns>Pixels data in interleaved format (RGB)</returns>
+        public static IByteBuffer PlanarToInterleaved24(IByteBuffer data)
+        {
+            byte[] oldPixels = data.Data;
+            byte[] newPixels = new byte[oldPixels.Length];
+            int pixelCount = newPixels.Length / 3;
 
-			unchecked {
-				for (int n = 0; n < pixelCount; n++) {
-					newPixels[(n * 3) + 0] = oldPixels[n + (pixelCount * 0)];
-					newPixels[(n * 3) + 1] = oldPixels[n + (pixelCount * 1)];
-					newPixels[(n * 3) + 2] = oldPixels[n + (pixelCount * 2)];
-				}
-			}
-			
-			return new MemoryByteBuffer(newPixels);
-		}
+            unchecked
+            {
+                for (int n = 0; n < pixelCount; n++)
+                {
+                    newPixels[(n * 3) + 0] = oldPixels[n + (pixelCount * 0)];
+                    newPixels[(n * 3) + 1] = oldPixels[n + (pixelCount * 1)];
+                    newPixels[(n * 3) + 2] = oldPixels[n + (pixelCount * 2)];
+                }
+            }
 
-		public static IByteBuffer YbrFullToRgb(IByteBuffer data) {
-			byte[] oldPixels = data.Data;
-			byte[] newPixels = new byte[oldPixels.Length];
+            return new MemoryByteBuffer(newPixels);
+        }
 
-			unchecked {
-				int y, b, r;
-				for (int n = 0; n < newPixels.Length; n += 3) {
-					y = oldPixels[n + 0];
-					b = oldPixels[n + 1];
-					r = oldPixels[n + 2];
+        public static IByteBuffer YbrFullToRgb(IByteBuffer data)
+        {
+            byte[] oldPixels = data.Data;
+            byte[] newPixels = new byte[oldPixels.Length];
 
-					newPixels[n + 0] = (byte)(y + 1.4020 * (r - 128) + 0.5);
-					newPixels[n + 1] = (byte)(y - 0.3441 * (b - 128) - 0.7141 * (r - 128) + 0.5);
-					newPixels[n + 2] = (byte)(y + 1.7720 * (b - 128) + 0.5);
-				}
-			}
+            unchecked
+            {
+                int y, b, r;
+                for (int n = 0; n < newPixels.Length; n += 3)
+                {
+                    y = oldPixels[n + 0];
+                    b = oldPixels[n + 1];
+                    r = oldPixels[n + 2];
 
-			return new MemoryByteBuffer(newPixels);
-		}
+                    newPixels[n + 0] = (byte)(y + 1.4020 * (r - 128) + 0.5);
+                    newPixels[n + 1] = (byte)(y - 0.3441 * (b - 128) - 0.7141 * (r - 128) + 0.5);
+                    newPixels[n + 2] = (byte)(y + 1.7720 * (b - 128) + 0.5);
+                }
+            }
 
-		public static IByteBuffer YbrFull422ToRgb(IByteBuffer data) {
-			byte[] oldPixels = data.Data;
-			byte[] newPixels = new byte[(oldPixels.Length / 4) * 2 * 3];
+            return new MemoryByteBuffer(newPixels);
+        }
 
-			unchecked {
-				int y1, y2, cb, cr;
-				for (int n = 0, p = 0; n < oldPixels.Length; ) {
-					y1 = oldPixels[n++];
-					y2 = oldPixels[n++];
-					cb = oldPixels[n++];
-					cr = oldPixels[n++];
+        public static IByteBuffer YbrFull422ToRgb(IByteBuffer data)
+        {
+            byte[] oldPixels = data.Data;
+            byte[] newPixels = new byte[(oldPixels.Length / 4) * 2 * 3];
 
-					newPixels[p++] = (byte)(y1 + 1.4020 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(y1 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(y1 + 1.7720 * (cb - 128) + 0.5);
+            unchecked
+            {
+                int y1, y2, cb, cr;
+                for (int n = 0, p = 0; n < oldPixels.Length;)
+                {
+                    y1 = oldPixels[n++];
+                    y2 = oldPixels[n++];
+                    cb = oldPixels[n++];
+                    cr = oldPixels[n++];
 
-					newPixels[p++] = (byte)(y2 + 1.4020 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(y2 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(y2 + 1.7720 * (cb - 128) + 0.5);
-				}
-			}
+                    newPixels[p++] = (byte)(y1 + 1.4020 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(y1 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(y1 + 1.7720 * (cb - 128) + 0.5);
 
-			return new MemoryByteBuffer(newPixels);
-		}
+                    newPixels[p++] = (byte)(y2 + 1.4020 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(y2 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(y2 + 1.7720 * (cb - 128) + 0.5);
+                }
+            }
 
-		public static IByteBuffer YbrPartial422ToRgb(IByteBuffer data) {
-			byte[] oldPixels = data.Data;
-			byte[] newPixels = new byte[(oldPixels.Length / 4) * 2 * 3];
+            return new MemoryByteBuffer(newPixels);
+        }
 
-			unchecked {
-				int y1, y2, cb, cr;
-				for (int n = 0, p = 0; n < oldPixels.Length; ) {
-					y1 = oldPixels[n++];
-					y2 = oldPixels[n++];
-					cb = oldPixels[n++];
-					cr = oldPixels[n++];
+        public static IByteBuffer YbrPartial422ToRgb(IByteBuffer data)
+        {
+            byte[] oldPixels = data.Data;
+            byte[] newPixels = new byte[(oldPixels.Length / 4) * 2 * 3];
 
-					newPixels[p++] = (byte)(1.1644 * (y1 - 16) + 1.5960 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(1.1644 * (y1 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(1.1644 * (y1 - 16) + 2.0173 * (cb - 128) + 0.5);
+            unchecked
+            {
+                int y1, y2, cb, cr;
+                for (int n = 0, p = 0; n < oldPixels.Length;)
+                {
+                    y1 = oldPixels[n++];
+                    y2 = oldPixels[n++];
+                    cb = oldPixels[n++];
+                    cr = oldPixels[n++];
 
-					newPixels[p++] = (byte)(1.1644 * (y2 - 16) + 1.5960 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(1.1644 * (y2 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
-					newPixels[p++] = (byte)(1.1644 * (y2 - 16) + 2.0173 * (cb - 128) + 0.5);
-				}
-			}
+                    newPixels[p++] = (byte)(1.1644 * (y1 - 16) + 1.5960 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(1.1644 * (y1 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(1.1644 * (y1 - 16) + 2.0173 * (cb - 128) + 0.5);
 
-			return new MemoryByteBuffer(newPixels);
-		}
+                    newPixels[p++] = (byte)(1.1644 * (y2 - 16) + 1.5960 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(1.1644 * (y2 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
+                    newPixels[p++] = (byte)(1.1644 * (y2 - 16) + 2.0173 * (cb - 128) + 0.5);
+                }
+            }
 
-		private readonly static byte[] BitReverseTable =
-		{
-			0x00, 0x80, 0x40, 0xc0, 0x20, 0xa0, 0x60, 0xe0,
-			0x10, 0x90, 0x50, 0xd0, 0x30, 0xb0, 0x70, 0xf0,
-			0x08, 0x88, 0x48, 0xc8, 0x28, 0xa8, 0x68, 0xe8,
-			0x18, 0x98, 0x58, 0xd8, 0x38, 0xb8, 0x78, 0xf8,
-			0x04, 0x84, 0x44, 0xc4, 0x24, 0xa4, 0x64, 0xe4,
-			0x14, 0x94, 0x54, 0xd4, 0x34, 0xb4, 0x74, 0xf4,
-			0x0c, 0x8c, 0x4c, 0xcc, 0x2c, 0xac, 0x6c, 0xec,
-			0x1c, 0x9c, 0x5c, 0xdc, 0x3c, 0xbc, 0x7c, 0xfc,
-			0x02, 0x82, 0x42, 0xc2, 0x22, 0xa2, 0x62, 0xe2,
-			0x12, 0x92, 0x52, 0xd2, 0x32, 0xb2, 0x72, 0xf2,
-			0x0a, 0x8a, 0x4a, 0xca, 0x2a, 0xaa, 0x6a, 0xea,
-			0x1a, 0x9a, 0x5a, 0xda, 0x3a, 0xba, 0x7a, 0xfa,
-			0x06, 0x86, 0x46, 0xc6, 0x26, 0xa6, 0x66, 0xe6,
-			0x16, 0x96, 0x56, 0xd6, 0x36, 0xb6, 0x76, 0xf6,
-			0x0e, 0x8e, 0x4e, 0xce, 0x2e, 0xae, 0x6e, 0xee,
-			0x1e, 0x9e, 0x5e, 0xde, 0x3e, 0xbe, 0x7e, 0xfe,
-			0x01, 0x81, 0x41, 0xc1, 0x21, 0xa1, 0x61, 0xe1,
-			0x11, 0x91, 0x51, 0xd1, 0x31, 0xb1, 0x71, 0xf1,
-			0x09, 0x89, 0x49, 0xc9, 0x29, 0xa9, 0x69, 0xe9,
-			0x19, 0x99, 0x59, 0xd9, 0x39, 0xb9, 0x79, 0xf9,
-			0x05, 0x85, 0x45, 0xc5, 0x25, 0xa5, 0x65, 0xe5,
-			0x15, 0x95, 0x55, 0xd5, 0x35, 0xb5, 0x75, 0xf5,
-			0x0d, 0x8d, 0x4d, 0xcd, 0x2d, 0xad, 0x6d, 0xed,
-			0x1d, 0x9d, 0x5d, 0xdd, 0x3d, 0xbd, 0x7d, 0xfd,
-			0x03, 0x83, 0x43, 0xc3, 0x23, 0xa3, 0x63, 0xe3,
-			0x13, 0x93, 0x53, 0xd3, 0x33, 0xb3, 0x73, 0xf3,
-			0x0b, 0x8b, 0x4b, 0xcb, 0x2b, 0xab, 0x6b, 0xeb,
-			0x1b, 0x9b, 0x5b, 0xdb, 0x3b, 0xbb, 0x7b, 0xfb,
-			0x07, 0x87, 0x47, 0xc7, 0x27, 0xa7, 0x67, 0xe7,
-			0x17, 0x97, 0x57, 0xd7, 0x37, 0xb7, 0x77, 0xf7,
-			0x0f, 0x8f, 0x4f, 0xcf, 0x2f, 0xaf, 0x6f, 0xef,
-			0x1f, 0x9f, 0x5f, 0xdf, 0x3f, 0xbf, 0x7f, 0xff
-		};
+            return new MemoryByteBuffer(newPixels);
+        }
 
-		/// <summary>
-		/// Reverses bits for each byte in buffer.
-		/// </summary>
-		/// <param name="data"></param>
-		/// <returns></returns>
-		public static IByteBuffer ReverseBits(IByteBuffer data) {
-			byte[] oldPixels = data.Data;
-			byte[] newPixels = new byte[oldPixels.Length];
+        private static readonly byte[] BitReverseTable =
+            {
+                0x00, 0x80, 0x40, 0xc0, 0x20, 0xa0, 0x60, 0xe0, 0x10, 0x90,
+                0x50, 0xd0, 0x30, 0xb0, 0x70, 0xf0, 0x08, 0x88, 0x48, 0xc8,
+                0x28, 0xa8, 0x68, 0xe8, 0x18, 0x98, 0x58, 0xd8, 0x38, 0xb8,
+                0x78, 0xf8, 0x04, 0x84, 0x44, 0xc4, 0x24, 0xa4, 0x64, 0xe4,
+                0x14, 0x94, 0x54, 0xd4, 0x34, 0xb4, 0x74, 0xf4, 0x0c, 0x8c,
+                0x4c, 0xcc, 0x2c, 0xac, 0x6c, 0xec, 0x1c, 0x9c, 0x5c, 0xdc,
+                0x3c, 0xbc, 0x7c, 0xfc, 0x02, 0x82, 0x42, 0xc2, 0x22, 0xa2,
+                0x62, 0xe2, 0x12, 0x92, 0x52, 0xd2, 0x32, 0xb2, 0x72, 0xf2,
+                0x0a, 0x8a, 0x4a, 0xca, 0x2a, 0xaa, 0x6a, 0xea, 0x1a, 0x9a,
+                0x5a, 0xda, 0x3a, 0xba, 0x7a, 0xfa, 0x06, 0x86, 0x46, 0xc6,
+                0x26, 0xa6, 0x66, 0xe6, 0x16, 0x96, 0x56, 0xd6, 0x36, 0xb6,
+                0x76, 0xf6, 0x0e, 0x8e, 0x4e, 0xce, 0x2e, 0xae, 0x6e, 0xee,
+                0x1e, 0x9e, 0x5e, 0xde, 0x3e, 0xbe, 0x7e, 0xfe, 0x01, 0x81,
+                0x41, 0xc1, 0x21, 0xa1, 0x61, 0xe1, 0x11, 0x91, 0x51, 0xd1,
+                0x31, 0xb1, 0x71, 0xf1, 0x09, 0x89, 0x49, 0xc9, 0x29, 0xa9,
+                0x69, 0xe9, 0x19, 0x99, 0x59, 0xd9, 0x39, 0xb9, 0x79, 0xf9,
+                0x05, 0x85, 0x45, 0xc5, 0x25, 0xa5, 0x65, 0xe5, 0x15, 0x95,
+                0x55, 0xd5, 0x35, 0xb5, 0x75, 0xf5, 0x0d, 0x8d, 0x4d, 0xcd,
+                0x2d, 0xad, 0x6d, 0xed, 0x1d, 0x9d, 0x5d, 0xdd, 0x3d, 0xbd,
+                0x7d, 0xfd, 0x03, 0x83, 0x43, 0xc3, 0x23, 0xa3, 0x63, 0xe3,
+                0x13, 0x93, 0x53, 0xd3, 0x33, 0xb3, 0x73, 0xf3, 0x0b, 0x8b,
+                0x4b, 0xcb, 0x2b, 0xab, 0x6b, 0xeb, 0x1b, 0x9b, 0x5b, 0xdb,
+                0x3b, 0xbb, 0x7b, 0xfb, 0x07, 0x87, 0x47, 0xc7, 0x27, 0xa7,
+                0x67, 0xe7, 0x17, 0x97, 0x57, 0xd7, 0x37, 0xb7, 0x77, 0xf7,
+                0x0f, 0x8f, 0x4f, 0xcf, 0x2f, 0xaf, 0x6f, 0xef, 0x1f, 0x9f,
+                0x5f, 0xdf, 0x3f, 0xbf, 0x7f, 0xff
+            };
 
-			unchecked {
-				for (int n = 0; n < oldPixels.Length; n++) {
-					newPixels[n] = BitReverseTable[oldPixels[n]];
-				}
-			}
+        /// <summary>
+        /// Reverses bits for each byte in buffer.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static IByteBuffer ReverseBits(IByteBuffer data)
+        {
+            byte[] oldPixels = data.Data;
+            byte[] newPixels = new byte[oldPixels.Length];
 
-			return new MemoryByteBuffer(newPixels);
-		}
-	}
+            unchecked
+            {
+                for (int n = 0; n < oldPixels.Length; n++)
+                {
+                    newPixels[n] = BitReverseTable[oldPixels[n]];
+                }
+            }
+
+            return new MemoryByteBuffer(newPixels);
+        }
+    }
 }

--- a/DICOM/Imaging/PixelRepresentation.cs
+++ b/DICOM/Imaging/PixelRepresentation.cs
@@ -1,18 +1,22 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// Pixel Representation (0028,0103) represents signed/unsigned data of the pixel samples.
-	/// Each sample shall have the same pixel representation
-	/// </summary>
-	public enum PixelRepresentation {
-		/// <summary>
-		/// Unsigned integer
-		/// </summary>
-		Unsigned = 0,
-		/// <summary>
-		/// 2's complement (signed) integer
-		/// </summary>
-		Signed = 1
-	}
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// Pixel Representation (0028,0103) represents signed/unsigned data of the pixel samples.
+    /// Each sample shall have the same pixel representation
+    /// </summary>
+    public enum PixelRepresentation
+    {
+        /// <summary>
+        /// Unsigned integer
+        /// </summary>
+        Unsigned = 0,
+
+        /// <summary>
+        /// 2's complement (signed) integer
+        /// </summary>
+        Signed = 1
+    }
 }

--- a/DICOM/Imaging/PlanarConfiguration.cs
+++ b/DICOM/Imaging/PlanarConfiguration.cs
@@ -1,26 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging {
-	/// <summary>
-	/// Planar Configuration (0028,0006) indicates whether the color pixel data are sent color-by-plane
-	/// or color-by-pixel. This Attribute shall be present if Samples per Pixel (0028,0002) has a value
-	/// greater than 1. It shall not be present otherwise.
-	/// </summary>
-	public enum PlanarConfiguration {
-		/// <summary>
-		/// The sample values for the first pixel are followed by the sample values for the second 
-		/// pixel, etc. For RGB images, this means the order of the pixel values sent shall be R1, 
-		/// G1, B1, R2, G2, B2, ..., etc.
-		/// </summary>
-		Interleaved = 0,
+namespace Dicom.Imaging
+{
+    /// <summary>
+    /// Planar Configuration (0028,0006) indicates whether the color pixel data are sent color-by-plane
+    /// or color-by-pixel. This Attribute shall be present if Samples per Pixel (0028,0002) has a value
+    /// greater than 1. It shall not be present otherwise.
+    /// </summary>
+    public enum PlanarConfiguration
+    {
+        /// <summary>
+        /// The sample values for the first pixel are followed by the sample values for the second 
+        /// pixel, etc. For RGB images, this means the order of the pixel values sent shall be R1, 
+        /// G1, B1, R2, G2, B2, ..., etc.
+        /// </summary>
+        Interleaved = 0,
 
-		/// <summary>
-		/// Each color plane shall be sent contiguously. For RGB images, this means the order of 
-		/// the pixel values sent is R1, R2, R3, ..., G1, G2, G3, ..., B1, B2, B3, etc.
-		/// </summary>
-		Planar = 1
-	}
+        /// <summary>
+        /// Each color plane shall be sent contiguously. For RGB images, this means the order of 
+        /// the pixel values sent is R1, R2, R3, ..., G1, G2, G3, ..., B1, B2, B3, etc.
+        /// </summary>
+        Planar = 1
+    }
 }

--- a/DICOM/Imaging/Render/CompositeGraphic.cs
+++ b/DICOM/Imaging/Render/CompositeGraphic.cs
@@ -1,189 +1,253 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System;
 using System.Collections.Generic;
 #if !SILVERLIGHT
 using System.Drawing;
 #endif
 using System.Windows;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Text;
 using Dicom.Imaging.LUT;
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// The Composite Graphic implementation of <seealso cref="IGraphic"/> which layers graphics one over the other
-	/// </summary>
-	public class CompositeGraphic : IGraphic {
-		#region Private Members
-		private List<IGraphic> _layers = new List<IGraphic>();
-		#endregion
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// The Composite Graphic implementation of <seealso cref="IGraphic"/> which layers graphics one over the other
+    /// </summary>
+    public class CompositeGraphic : IGraphic
+    {
+        #region Private Members
 
-		#region Public Constructor
-		/// <summary>
-		/// Initialize new instance of <seealso cref="CompositeGraphic"/>
-		/// </summary>
-		/// <param name="bg">background (initial) graphic layer</param>
-		public CompositeGraphic(IGraphic bg) {
-			_layers.Add(bg);
-		}
-		#endregion
+        private List<IGraphic> _layers = new List<IGraphic>();
 
-		#region Public Properties
-		/// <summary>
-		/// The backgroun graphic layer
-		/// </summary>
-		public IGraphic BackgroundLayer {
-			get { return _layers[0]; }
-		}
+        #endregion
 
-		public int OriginalWidth {
-			get { return BackgroundLayer.OriginalWidth; }
-		}
+        #region Public Constructor
 
-		public int OriginalHeight {
-			get { return BackgroundLayer.OriginalHeight; }
-		}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="CompositeGraphic"/>
+        /// </summary>
+        /// <param name="bg">background (initial) graphic layer</param>
+        public CompositeGraphic(IGraphic bg)
+        {
+            _layers.Add(bg);
+        }
 
-		public int OriginalOffsetX {
-			get { return 0; }
-		}
+        #endregion
 
-		public int OriginalOffsetY {
-			get { return 0; }
-		}
+        #region Public Properties
 
-		public double ScaleFactor {
-			get { return BackgroundLayer.ScaleFactor; }
-		}
+        /// <summary>
+        /// The backgroun graphic layer
+        /// </summary>
+        public IGraphic BackgroundLayer
+        {
+            get
+            {
+                return _layers[0];
+            }
+        }
 
-		public int ScaledWidth {
-			get { return BackgroundLayer.ScaledWidth; }
-		}
+        public int OriginalWidth
+        {
+            get
+            {
+                return BackgroundLayer.OriginalWidth;
+            }
+        }
 
-		public int ScaledHeight {
-			get { return BackgroundLayer.ScaledHeight; }
-		}
+        public int OriginalHeight
+        {
+            get
+            {
+                return BackgroundLayer.OriginalHeight;
+            }
+        }
 
-		public int ScaledOffsetX {
-			get { return 0; }
-		}
+        public int OriginalOffsetX
+        {
+            get
+            {
+                return 0;
+            }
+        }
 
-		public int ScaledOffsetY {
-			get { return 0; }
-		}
+        public int OriginalOffsetY
+        {
+            get
+            {
+                return 0;
+            }
+        }
 
-		public int ZOrder {
-			get { return 0; }
-		}
-		#endregion
+        public double ScaleFactor
+        {
+            get
+            {
+                return BackgroundLayer.ScaleFactor;
+            }
+        }
 
-		#region Public Members
-		/// <summary>
-		/// Add new graphic layer to the existing layers according to its Z Order
-		/// </summary>
-		/// <param name="layer">The layer graphic instance</param>
-		public void AddLayer(IGraphic layer) {
-			_layers.Add(layer);
-			_layers.Sort(delegate(IGraphic a, IGraphic b) {
-				if (b.ZOrder > a.ZOrder)
-					return 1;
-				else if (a.ZOrder > b.ZOrder)
-					return -1;
-				else
-					return 0;
-			});
-		}
+        public int ScaledWidth
+        {
+            get
+            {
+                return BackgroundLayer.ScaledWidth;
+            }
+        }
 
-		public void Reset() {
-			foreach (IGraphic graphic in _layers)
-				graphic.Reset();
-		}
+        public int ScaledHeight
+        {
+            get
+            {
+                return BackgroundLayer.ScaledHeight;
+            }
+        }
 
-		public void Scale(double scale) {
-			foreach (IGraphic graphic in _layers)
-				graphic.Scale(scale);
-		}
+        public int ScaledOffsetX
+        {
+            get
+            {
+                return 0;
+            }
+        }
 
-		public void BestFit(int width, int height) {
-			foreach (IGraphic graphic in _layers)
-				graphic.BestFit(width, height);
-		}
+        public int ScaledOffsetY
+        {
+            get
+            {
+                return 0;
+            }
+        }
 
-		public void Rotate(int angle) {
-			foreach (IGraphic graphic in _layers)
-				graphic.Rotate(angle);
-		}
+        public int ZOrder
+        {
+            get
+            {
+                return 0;
+            }
+        }
 
-		public void FlipX() {
-			foreach (IGraphic graphic in _layers)
-				graphic.FlipX();
-		}
+        #endregion
 
-		public void FlipY() {
-			foreach (IGraphic graphic in _layers)
-				graphic.FlipY();
-		}
+        #region Public Members
 
-		public void Transform(double scale, int rotation, bool flipx, bool flipy) {
-			foreach (IGraphic graphic in _layers)
-				graphic.Transform(scale, rotation, flipx, flipy);
-		}
+        /// <summary>
+        /// Add new graphic layer to the existing layers according to its Z Order
+        /// </summary>
+        /// <param name="layer">The layer graphic instance</param>
+        public void AddLayer(IGraphic layer)
+        {
+            _layers.Add(layer);
+            _layers.Sort(
+                delegate(IGraphic a, IGraphic b)
+                    {
+                        if (b.ZOrder > a.ZOrder) return 1;
+                        else if (a.ZOrder > b.ZOrder) return -1;
+                        else return 0;
+                    });
+        }
+
+        public void Reset()
+        {
+            foreach (IGraphic graphic in _layers) graphic.Reset();
+        }
+
+        public void Scale(double scale)
+        {
+            foreach (IGraphic graphic in _layers) graphic.Scale(scale);
+        }
+
+        public void BestFit(int width, int height)
+        {
+            foreach (IGraphic graphic in _layers) graphic.BestFit(width, height);
+        }
+
+        public void Rotate(int angle)
+        {
+            foreach (IGraphic graphic in _layers) graphic.Rotate(angle);
+        }
+
+        public void FlipX()
+        {
+            foreach (IGraphic graphic in _layers) graphic.FlipX();
+        }
+
+        public void FlipY()
+        {
+            foreach (IGraphic graphic in _layers) graphic.FlipY();
+        }
+
+        public void Transform(double scale, int rotation, bool flipx, bool flipy)
+        {
+            foreach (IGraphic graphic in _layers) graphic.Transform(scale, rotation, flipx, flipy);
+        }
+
 #if SILVERLIGHT
-		public BitmapSource RenderImageSource(ILUT lut)
-		{
-			WriteableBitmap img = BackgroundLayer.RenderImageSource(lut) as WriteableBitmap;
-			if (img != null && _layers.Count > 1)
-			{
-				for (int i = 1; i < _layers.Count; ++i)
-				{
-					var g = _layers[i];
-					var layer = _layers[i].RenderImageSource(null) as WriteableBitmap;
+        public BitmapSource RenderImageSource(ILUT lut)
+        {
+            WriteableBitmap img = BackgroundLayer.RenderImageSource(lut) as WriteableBitmap;
+            if (img != null && _layers.Count > 1)
+            {
+                for (int i = 1; i < _layers.Count; ++i)
+                {
+                    var g = _layers[i];
+                    var layer = _layers[i].RenderImageSource(null) as WriteableBitmap;
 
-					if (layer != null)
-					{
-						var rect = new Rect(g.ScaledOffsetX, g.ScaledOffsetY, g.ScaledWidth, g.ScaledHeight);
-						img.Blit(rect, layer, rect);
-					}
-				}
-			}
-			return img;
-		}
+                    if (layer != null)
+                    {
+                        var rect = new Rect(g.ScaledOffsetX, g.ScaledOffsetY, g.ScaledWidth, g.ScaledHeight);
+                        img.Blit(rect, layer, rect);
+                    }
+                }
+            }
+            return img;
+        }
 #else
-		public BitmapSource RenderImageSource(ILUT lut)
-		{
-			WriteableBitmap img = BackgroundLayer.RenderImageSource(lut) as WriteableBitmap;
-			if (img != null && _layers.Count > 1)
-			{
-				for (int i = 1; i < _layers.Count; ++i)
-				{
-					var g = _layers[i];
-					var layer = _layers[i].RenderImageSource(null) as WriteableBitmap;
+        public BitmapSource RenderImageSource(ILUT lut)
+        {
+            WriteableBitmap img = BackgroundLayer.RenderImageSource(lut) as WriteableBitmap;
+            if (img != null && _layers.Count > 1)
+            {
+                for (int i = 1; i < _layers.Count; ++i)
+                {
+                    var g = _layers[i];
+                    var layer = _layers[i].RenderImageSource(null) as WriteableBitmap;
 
-					if (layer != null)
-					{
-						Array pixels = new int[g.ScaledWidth * g.ScaledHeight];
-						layer.CopyPixels(pixels, 4, 0);
-						img.WritePixels(new Int32Rect(g.ScaledOffsetX, g.ScaledOffsetY, g.ScaledWidth, g.ScaledHeight),
-										pixels, 4, 0);
-					}
-				}
-			}
-			return img;
-		}
+                    if (layer != null)
+                    {
+                        Array pixels = new int[g.ScaledWidth * g.ScaledHeight];
+                        layer.CopyPixels(pixels, 4, 0);
+                        img.WritePixels(
+                            new Int32Rect(g.ScaledOffsetX, g.ScaledOffsetY, g.ScaledWidth, g.ScaledHeight),
+                            pixels,
+                            4,
+                            0);
+                    }
+                }
+            }
+            return img;
+        }
 
-		public Image RenderImage(ILUT lut) {
-			Image img = BackgroundLayer.RenderImage(lut);
-			if (_layers.Count > 1) {
-				using (Graphics graphics = Graphics.FromImage(img)) {
-					for (int i = 1; i < _layers.Count; i++) {
-						Image layer = _layers[i].RenderImage(null);
-						graphics.DrawImage(layer, _layers[i].ScaledOffsetX, _layers[i].ScaledOffsetY);
-					}
-				}
-			}
-			return img;
-		}
+        public Image RenderImage(ILUT lut)
+        {
+            Image img = BackgroundLayer.RenderImage(lut);
+            if (_layers.Count > 1)
+            {
+                using (Graphics graphics = Graphics.FromImage(img))
+                {
+                    for (int i = 1; i < _layers.Count; i++)
+                    {
+                        Image layer = _layers[i].RenderImage(null);
+                        graphics.DrawImage(layer, _layers[i].ScaledOffsetX, _layers[i].ScaledOffsetY);
+                    }
+                }
+            }
+            return img;
+        }
 #endif
-		#endregion
-	}
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/Render/GenericGrayscalePipeline.cs
+++ b/DICOM/Imaging/Render/GenericGrayscalePipeline.cs
@@ -1,57 +1,71 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
 using Dicom.Imaging.LUT;
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// Grayscale color pipeline implementation of <seealso cref="IPipeline"/> interface
-	/// </summary>
-	public class GenericGrayscalePipeline : IPipeline {
-		#region Private Members
-		private CompositeLUT _lut;
-		private ModalityLUT _rescaleLut;
-		private VOILUT _voiLut;
-		private OutputLUT _outputLut;
-		private InvertLUT _invertLut;
-		private GrayscaleRenderOptions _options;
-		#endregion
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// Grayscale color pipeline implementation of <seealso cref="IPipeline"/> interface
+    /// </summary>
+    public class GenericGrayscalePipeline : IPipeline
+    {
+        #region Private Members
 
-		#region Public Constructor
-		/// <summary>
-		/// Initialize new instance of <seealso cref="GenericGrayscalePipeline"/> which consist of the following sequence
-		/// Rescale (Modality) LUT -> VOI LUT -> Output LUT and optionally Invert LUT if specified by grayscale options
-		/// </summary>
-		/// <param name="options">Grayscale options to use in the pipeline</param>
-		public GenericGrayscalePipeline(GrayscaleRenderOptions options) {
-			_options = options;
-			if (_options.RescaleSlope != 1.0 || _options.RescaleIntercept != 0.0)
-				_rescaleLut = new ModalityLUT(_options);
-			_voiLut = VOILUT.Create(_options);
-			_outputLut = new OutputLUT(_options.Monochrome1 ? ColorTable.Monochrome1 : ColorTable.Monochrome2);
-			if (_options.Invert)
-				_invertLut = new InvertLUT(_outputLut.MinimumOutputValue, _outputLut.MaximumOutputValue);
-		}
-		#endregion
+        private CompositeLUT _lut;
 
-		#region Public Properties
-		/// <summary>
-		/// Get <seealso cref="CompositeLUT"/> of avaliavble LUTs available in this pipeline instance
-		/// </summary>
-		public ILUT LUT {
-			get {
-				if (_lut == null) {
-					CompositeLUT composite = new CompositeLUT();
-					if (_rescaleLut != null)
-						composite.Add(_rescaleLut);
-					composite.Add(_voiLut);
-					composite.Add(_outputLut);
-					if (_invertLut != null)
-						composite.Add(_invertLut);
-					_lut = composite;
-				}
-				return new PrecalculatedLUT(_lut, _options.BitDepth.MinimumValue, _options.BitDepth.MaximumValue);
-			}
-		}
-		#endregion
-	}
+        private ModalityLUT _rescaleLut;
+
+        private VOILUT _voiLut;
+
+        private OutputLUT _outputLut;
+
+        private InvertLUT _invertLut;
+
+        private GrayscaleRenderOptions _options;
+
+        #endregion
+
+        #region Public Constructor
+
+        /// <summary>
+        /// Initialize new instance of <seealso cref="GenericGrayscalePipeline"/> which consist of the following sequence
+        /// Rescale (Modality) LUT -> VOI LUT -> Output LUT and optionally Invert LUT if specified by grayscale options
+        /// </summary>
+        /// <param name="options">Grayscale options to use in the pipeline</param>
+        public GenericGrayscalePipeline(GrayscaleRenderOptions options)
+        {
+            _options = options;
+            if (_options.RescaleSlope != 1.0 || _options.RescaleIntercept != 0.0) _rescaleLut = new ModalityLUT(_options);
+            _voiLut = VOILUT.Create(_options);
+            _outputLut = new OutputLUT(_options.Monochrome1 ? ColorTable.Monochrome1 : ColorTable.Monochrome2);
+            if (_options.Invert) _invertLut = new InvertLUT(_outputLut.MinimumOutputValue, _outputLut.MaximumOutputValue);
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Get <seealso cref="CompositeLUT"/> of avaliavble LUTs available in this pipeline instance
+        /// </summary>
+        public ILUT LUT
+        {
+            get
+            {
+                if (_lut == null)
+                {
+                    CompositeLUT composite = new CompositeLUT();
+                    if (_rescaleLut != null) composite.Add(_rescaleLut);
+                    composite.Add(_voiLut);
+                    composite.Add(_outputLut);
+                    if (_invertLut != null) composite.Add(_invertLut);
+                    _lut = composite;
+                }
+                return new PrecalculatedLUT(_lut, _options.BitDepth.MinimumValue, _options.BitDepth.MaximumValue);
+            }
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/Render/IGraphic.cs
+++ b/DICOM/Imaging/Render/IGraphic.cs
@@ -1,110 +1,126 @@
-using System;
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 #if !SILVERLIGHT
 using System.Drawing;
 #endif
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Dicom.Imaging.LUT;
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// Graphic interface
-	/// </summary>
-	public interface IGraphic {
-		/// <summary>
-		/// The original image width
-		/// </summary>
-		int OriginalWidth { get; }
-		/// <summary>
-		/// The original image height
-		/// </summary>
-		int OriginalHeight { get; }
-		/// <summary>
-		/// The original image offset in X direction
-		/// </summary>
-		int OriginalOffsetX { get; }
-		/// <summary>
-		/// The original image offset in Y direction
-		/// </summary>
-		int OriginalOffsetY { get; }
-		/// <summary>
-		/// The image scale factor
-		/// </summary>
-		double ScaleFactor { get; }
-		/// <summary>
-		/// The scaled image width
-		/// </summary>
-		int ScaledWidth { get; }
-		/// <summary>
-		/// The scaled image height
-		/// </summary>
-		int ScaledHeight { get; }
-		/// <summary>
-		/// The scaled image offset in X direction
-		/// </summary>
-		int ScaledOffsetX { get; }
-		/// <summary>
-		/// The scaled image offset in Y direction
-		/// </summary>
-		int ScaledOffsetY { get; }
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// Graphic interface
+    /// </summary>
+    public interface IGraphic
+    {
+        /// <summary>
+        /// The original image width
+        /// </summary>
+        int OriginalWidth { get; }
 
-		/// <summary>
-		/// The Z Order
-		/// </summary>
-		int ZOrder { get; }
+        /// <summary>
+        /// The original image height
+        /// </summary>
+        int OriginalHeight { get; }
 
-		/// <summary>
-		/// Reset the tranformation to default
-		/// </summary>
-		void Reset();
-		/// <summary>
-		/// Scale the image
-		/// </summary>
-		/// <param name="scale">scale factor</param>
-		void Scale(double scale);
+        /// <summary>
+        /// The original image offset in X direction
+        /// </summary>
+        int OriginalOffsetX { get; }
 
-		/// <summary>
-		/// Auto calculate the scale factor to fit the image in the specified width and height
-		/// </summary>
-		/// <param name="width">Destination width</param>
-		/// <param name="height">Destination height</param>
-		void BestFit(int width, int height);
+        /// <summary>
+        /// The original image offset in Y direction
+        /// </summary>
+        int OriginalOffsetY { get; }
 
-		/// <summary>
-		/// Rotate the image arround its center 
-		/// </summary>
-		/// <param name="angle">Rotation angle</param>
-		void Rotate(int angle);
-		/// <summary>
-		/// Flip the image vertically arround its X-Axis
-		/// </summary>
-		void FlipX();
-		/// <summary>
-		/// Flip the image horizontally arround its Y-Axis
-		/// </summary>
-		void FlipY();
+        /// <summary>
+        /// The image scale factor
+        /// </summary>
+        double ScaleFactor { get; }
 
-		/// <summary>
-		/// Transform the image 
-		/// </summary>
-		/// <param name="scale">Scale factor</param>
-		/// <param name="rotation">Rotation angle</param>
-		/// <param name="flipx">True to flip vertically</param>
-		/// <param name="flipy">True to flip horizontally</param>
-		void Transform(double scale, int rotation, bool flipx, bool flipy);
+        /// <summary>
+        /// The scaled image width
+        /// </summary>
+        int ScaledWidth { get; }
+
+        /// <summary>
+        /// The scaled image height
+        /// </summary>
+        int ScaledHeight { get; }
+
+        /// <summary>
+        /// The scaled image offset in X direction
+        /// </summary>
+        int ScaledOffsetX { get; }
+
+        /// <summary>
+        /// The scaled image offset in Y direction
+        /// </summary>
+        int ScaledOffsetY { get; }
+
+        /// <summary>
+        /// The Z Order
+        /// </summary>
+        int ZOrder { get; }
+
+        /// <summary>
+        /// Reset the tranformation to default
+        /// </summary>
+        void Reset();
+
+        /// <summary>
+        /// Scale the image
+        /// </summary>
+        /// <param name="scale">scale factor</param>
+        void Scale(double scale);
+
+        /// <summary>
+        /// Auto calculate the scale factor to fit the image in the specified width and height
+        /// </summary>
+        /// <param name="width">Destination width</param>
+        /// <param name="height">Destination height</param>
+        void BestFit(int width, int height);
+
+        /// <summary>
+        /// Rotate the image arround its center 
+        /// </summary>
+        /// <param name="angle">Rotation angle</param>
+        void Rotate(int angle);
+
+        /// <summary>
+        /// Flip the image vertically arround its X-Axis
+        /// </summary>
+        void FlipX();
+
+        /// <summary>
+        /// Flip the image horizontally arround its Y-Axis
+        /// </summary>
+        void FlipY();
+
+        /// <summary>
+        /// Transform the image 
+        /// </summary>
+        /// <param name="scale">Scale factor</param>
+        /// <param name="rotation">Rotation angle</param>
+        /// <param name="flipx">True to flip vertically</param>
+        /// <param name="flipy">True to flip horizontally</param>
+        void Transform(double scale, int rotation, bool flipx, bool flipy);
+
 #if !SILVERLIGHT
-		/// <summary>
-		/// Render the image and return the result as <seealso cref="Image"/>
-		/// </summary>
-		/// <param name="lut">The image LUT </param>
-		/// <returns>Image after applying LUT and transformation</returns>
-		Image RenderImage(ILUT lut);
+        /// <summary>
+        /// Render the image and return the result as <seealso cref="Image"/>
+        /// </summary>
+        /// <param name="lut">The image LUT </param>
+        /// <returns>Image after applying LUT and transformation</returns>
+        Image RenderImage(ILUT lut);
 #endif
-		/// <summary>
-		/// Render the image and return the result as <seealso cref="BitmapSource"/>
-		/// </summary>
-		/// <param name="lut">The image LUT </param>
-		/// <returns>Image after applying LUT and transformation</returns>
-		BitmapSource RenderImageSource(ILUT lut);
-	}
+
+        /// <summary>
+        /// Render the image and return the result as <seealso cref="BitmapSource"/>
+        /// </summary>
+        /// <param name="lut">The image LUT </param>
+        /// <returns>Image after applying LUT and transformation</returns>
+        BitmapSource RenderImageSource(ILUT lut);
+    }
 }

--- a/DICOM/Imaging/Render/IPipeline.cs
+++ b/DICOM/Imaging/Render/IPipeline.cs
@@ -1,16 +1,18 @@
-﻿using Dicom;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using Dicom.Imaging.LUT;
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// Pipeline interface
-	/// </summary>
-	public interface IPipeline {
-		/// <summary>
-		/// Get the LUT of the pipeline 
-		/// </summary>
-		ILUT LUT {
-			get;
-		}
-	}
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// Pipeline interface
+    /// </summary>
+    public interface IPipeline
+    {
+        /// <summary>
+        /// Get the LUT of the pipeline 
+        /// </summary>
+        ILUT LUT { get; }
+    }
 }

--- a/DICOM/Imaging/Render/ImageGraphic.cs
+++ b/DICOM/Imaging/Render/ImageGraphic.cs
@@ -1,18 +1,17 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System;
 using System.Collections.Generic;
 #if !SILVERLIGHT
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 #endif
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Threading;
 
-using Dicom.Imaging.Algorithms;
 using Dicom.Imaging.LUT;
-using Dicom.Imaging.Render;
 using Dicom.IO;
 
 namespace Dicom.Imaging.Render
@@ -23,38 +22,54 @@ namespace Dicom.Imaging.Render
     public class ImageGraphic : IGraphic, IDisposable
     {
         #region Protected Members
+
         protected IPixelData _originalData;
+
         protected IPixelData _scaledData;
 
         protected PinnedIntArray _pixels;
+
 #if SILVERLIGHT
 		protected WriteableBitmap _bitmap;
 #else
         private const int DPI = 96;
+
         protected BitmapSource _bitmapSource;
+
         protected Bitmap _bitmap;
 #endif
 
         protected double _scaleFactor;
+
         protected int _rotation;
+
         protected bool _flipX;
+
         protected bool _flipY;
+
         protected int _offsetX;
+
         protected int _offsetY;
 
         protected int _zorder;
+
         protected bool _applyLut;
 
         protected List<OverlayGraphic> _overlays;
+
         #endregion
 
         #region Public Properties
+
         /// <summary>
         /// Number of pixel componenets (samples)
         /// </summary>
         public int Components
         {
-            get { return OriginalData.Components; }
+            get
+            {
+                return OriginalData.Components;
+            }
         }
 
         /// <summary>
@@ -62,30 +77,50 @@ namespace Dicom.Imaging.Render
         /// </summary>
         public IPixelData OriginalData
         {
-            get { return _originalData; }
+            get
+            {
+                return _originalData;
+            }
         }
 
         public int OriginalWidth
         {
-            get { return _originalData.Width; }
+            get
+            {
+                return _originalData.Width;
+            }
         }
+
         public int OriginalHeight
         {
-            get { return _originalData.Height; }
+            get
+            {
+                return _originalData.Height;
+            }
         }
+
         public int OriginalOffsetX
         {
-            get { return _offsetX; }
+            get
+            {
+                return _offsetX;
+            }
         }
 
         public int OriginalOffsetY
         {
-            get { return _offsetY; }
+            get
+            {
+                return _offsetY;
+            }
         }
 
         public double ScaleFactor
         {
-            get { return _scaleFactor; }
+            get
+            {
+                return _scaleFactor;
+            }
         }
 
         /// <summary>
@@ -97,40 +132,61 @@ namespace Dicom.Imaging.Render
             {
                 if (_scaledData == null)
                 {
-                    if (Math.Abs(_scaleFactor - 1.0) <= Double.Epsilon)
-                        _scaledData = _originalData;
-                    else
-                        _scaledData = OriginalData.Rescale(_scaleFactor);
+                    if (Math.Abs(_scaleFactor - 1.0) <= Double.Epsilon) _scaledData = _originalData;
+                    else _scaledData = OriginalData.Rescale(_scaleFactor);
                 }
                 return _scaledData;
             }
         }
+
         public int ScaledWidth
         {
-            get { return ScaledData.Width; }
+            get
+            {
+                return ScaledData.Width;
+            }
         }
+
         public int ScaledHeight
         {
-            get { return ScaledData.Height; }
+            get
+            {
+                return ScaledData.Height;
+            }
         }
+
         public int ScaledOffsetX
         {
-            get { return (int)(_offsetX * _scaleFactor); }
+            get
+            {
+                return (int)(_offsetX * _scaleFactor);
+            }
         }
 
         public int ScaledOffsetY
         {
-            get { return (int)(_offsetY * _scaleFactor); }
+            get
+            {
+                return (int)(_offsetY * _scaleFactor);
+            }
         }
 
         public int ZOrder
         {
-            get { return _zorder; }
-            set { _zorder = value; }
+            get
+            {
+                return _zorder;
+            }
+            set
+            {
+                _zorder = value;
+            }
         }
+
         #endregion
 
         #region Public Constructors
+
         /// <summary>
         /// Initialize new instance of <seealso cref="ImageGraphic"/>
         /// </summary>
@@ -156,9 +212,11 @@ namespace Dicom.Imaging.Render
         {
             Dispose(false);
         }
+
         #endregion
 
         #region Public Members
+
         /// <summary>
         /// Add overlay to render over the resulted image 
         /// </summary>
@@ -179,8 +237,7 @@ namespace Dicom.Imaging.Render
 
         public void Scale(double scale)
         {
-            if (Math.Abs(scale - _scaleFactor) <= Double.Epsilon)
-                return;
+            if (Math.Abs(scale - _scaleFactor) <= Double.Epsilon) return;
 
             _scaleFactor = scale;
             if (_bitmap != null)
@@ -208,28 +265,20 @@ namespace Dicom.Imaging.Render
         {
             if (angle > 0)
             {
-                if (angle <= 90)
-                    _rotation += 90;
-                else if (angle <= 180)
-                    _rotation += 180;
-                else if (angle <= 270)
-                    _rotation += 270;
+                if (angle <= 90) _rotation += 90;
+                else if (angle <= 180) _rotation += 180;
+                else if (angle <= 270) _rotation += 270;
             }
             else if (angle < 0)
             {
-                if (angle >= -90)
-                    _rotation -= 90;
-                else if (angle >= -180)
-                    _rotation -= 180;
-                else if (angle >= -270)
-                    _rotation -= 270;
+                if (angle >= -90) _rotation -= 90;
+                else if (angle >= -180) _rotation -= 180;
+                else if (angle >= -270) _rotation -= 270;
             }
             if (angle != 0)
             {
-                if (_rotation >= 360)
-                    _rotation -= 360;
-                else if (_rotation < 0)
-                    _rotation += 360;
+                if (_rotation >= 360) _rotation -= 360;
+                else if (_rotation < 0) _rotation += 360;
             }
         }
 
@@ -347,10 +396,10 @@ namespace Dicom.Imaging.Render
             if (_bitmap == null)
             {
                 System.Drawing.Imaging.PixelFormat format = Components == 4
-                    ? System.Drawing.Imaging.PixelFormat.Format32bppArgb
-                    : System.Drawing.Imaging.PixelFormat.Format32bppRgb;
+                                                                ? System.Drawing.Imaging.PixelFormat.Format32bppArgb
+                                                                : System.Drawing.Imaging.PixelFormat.Format32bppRgb;
                 _pixels = new PinnedIntArray(ScaledData.Width * ScaledData.Height);
-                    _bitmap = new Bitmap(ScaledData.Width, ScaledData.Height, ScaledData.Width * 4, format, _pixels.Pointer);
+                _bitmap = new Bitmap(ScaledData.Width, ScaledData.Height, ScaledData.Width * 4, format, _pixels.Pointer);
                 render = true;
             }
 
@@ -383,44 +432,61 @@ namespace Dicom.Imaging.Render
             {
                 switch (_rotation)
                 {
-                    case 90: return RotateFlipType.Rotate90FlipXY;
-                    case 180: return RotateFlipType.Rotate180FlipXY;
-                    case 270: return RotateFlipType.Rotate270FlipXY;
-                    default: return RotateFlipType.RotateNoneFlipXY;
+                    case 90:
+                        return RotateFlipType.Rotate90FlipXY;
+                    case 180:
+                        return RotateFlipType.Rotate180FlipXY;
+                    case 270:
+                        return RotateFlipType.Rotate270FlipXY;
+                    default:
+                        return RotateFlipType.RotateNoneFlipXY;
                 }
             }
             else if (_flipX)
             {
                 switch (_rotation)
                 {
-                    case 90: return RotateFlipType.Rotate90FlipX;
-                    case 180: return RotateFlipType.Rotate180FlipX;
-                    case 270: return RotateFlipType.Rotate270FlipX;
-                    default: return RotateFlipType.RotateNoneFlipX;
+                    case 90:
+                        return RotateFlipType.Rotate90FlipX;
+                    case 180:
+                        return RotateFlipType.Rotate180FlipX;
+                    case 270:
+                        return RotateFlipType.Rotate270FlipX;
+                    default:
+                        return RotateFlipType.RotateNoneFlipX;
                 }
             }
             else if (_flipY)
             {
                 switch (_rotation)
                 {
-                    case 90: return RotateFlipType.Rotate90FlipY;
-                    case 180: return RotateFlipType.Rotate180FlipY;
-                    case 270: return RotateFlipType.Rotate270FlipY;
-                    default: return RotateFlipType.RotateNoneFlipY;
+                    case 90:
+                        return RotateFlipType.Rotate90FlipY;
+                    case 180:
+                        return RotateFlipType.Rotate180FlipY;
+                    case 270:
+                        return RotateFlipType.Rotate270FlipY;
+                    default:
+                        return RotateFlipType.RotateNoneFlipY;
                 }
             }
             else
             {
                 switch (_rotation)
                 {
-                    case 90: return RotateFlipType.Rotate90FlipNone;
-                    case 180: return RotateFlipType.Rotate180FlipNone;
-                    case 270: return RotateFlipType.Rotate270FlipNone;
-                    default: return RotateFlipType.RotateNoneFlipNone;
+                    case 90:
+                        return RotateFlipType.Rotate90FlipNone;
+                    case 180:
+                        return RotateFlipType.Rotate180FlipNone;
+                    case 270:
+                        return RotateFlipType.Rotate270FlipNone;
+                    default:
+                        return RotateFlipType.RotateNoneFlipNone;
                 }
             }
         }
 #endif
+
         #endregion
 
         #region IDisposable Members

--- a/DICOM/Imaging/Render/OverlayGraphic.cs
+++ b/DICOM/Imaging/Render/OverlayGraphic.cs
@@ -1,73 +1,92 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System;
 using System.Threading.Tasks;
 
-using Dicom.Imaging.Algorithms;
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// The Overlay Graphic which render overlay over pixel data
+    /// </summary>
+    public class OverlayGraphic
+    {
+        #region Private Members
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// The Overlay Graphic which render overlay over pixel data
-	/// </summary>
-	public class OverlayGraphic {
-		#region Private Members
-		private SingleBitPixelData _originalData;
-		private IPixelData _scaledData;
-		private int _offsetX;
-		private int _offsetY;
-		private int _color;
-		private double _scale;
-		#endregion
+        private SingleBitPixelData _originalData;
 
-		#region Public Constructors
-		/// <summary>
-		/// Initialize new instance of <seealso cref="OverlayGraphic"/>
-		/// </summary>
-		/// <param name="pixelData">Overlay pixel data</param>
-		/// <param name="offsetx">X offset</param>
-		/// <param name="offsety">Y offset</param>
-		/// <param name="color">The color of the resulting overlay</param>
-		public OverlayGraphic(SingleBitPixelData pixelData, int offsetx, int offsety, int color) {
-			_originalData = pixelData;
-			_scaledData = _originalData;
-			_offsetX = offsetx;
-			_offsetY = offsety;
-			_color = color;
-			_scale = 1.0;
-		}
-		#endregion
+        private IPixelData _scaledData;
 
-		#region Public Methods
-		public void Scale(double scale) {
-			if (Math.Abs(scale - _scale) <= Double.Epsilon)
-				return;
+        private int _offsetX;
 
-			_scale = scale;
-			_scaledData = null;
-		}
+        private int _offsetY;
 
-		public void Render(int[] pixels, int width, int height) {
-			byte[] data = null;
+        private int _color;
 
-			if (_scaledData == null)
-				_scaledData = _originalData.Rescale(_scale);
+        private double _scale;
 
-			data = (_scaledData as GrayscalePixelDataU8).Data;
+        #endregion
 
-			int ox = (int)(_offsetX * _scale);
-			int oy = (int)(_offsetY * _scale);
+        #region Public Constructors
 
-			Parallel.For(0, _scaledData.Height, y => {
-				if ((oy + y) >= height)
-					return;
-				for (int i = _scaledData.Width * y, e = i + _scaledData.Width, x = 0; i < e; i++, x++) {
-					if (data[i] > 0) {
-						if ((ox + x) >= width)
-							break;
-						int p = (oy * width) + ox + i;
-						pixels[p] = _color;
-					}
-				}
-			});
-		}
-		#endregion
-	}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="OverlayGraphic"/>
+        /// </summary>
+        /// <param name="pixelData">Overlay pixel data</param>
+        /// <param name="offsetx">X offset</param>
+        /// <param name="offsety">Y offset</param>
+        /// <param name="color">The color of the resulting overlay</param>
+        public OverlayGraphic(SingleBitPixelData pixelData, int offsetx, int offsety, int color)
+        {
+            _originalData = pixelData;
+            _scaledData = _originalData;
+            _offsetX = offsetx;
+            _offsetY = offsety;
+            _color = color;
+            _scale = 1.0;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Scale(double scale)
+        {
+            if (Math.Abs(scale - _scale) <= Double.Epsilon) return;
+
+            _scale = scale;
+            _scaledData = null;
+        }
+
+        public void Render(int[] pixels, int width, int height)
+        {
+            byte[] data = null;
+
+            if (_scaledData == null) _scaledData = _originalData.Rescale(_scale);
+
+            data = (_scaledData as GrayscalePixelDataU8).Data;
+
+            int ox = (int)(_offsetX * _scale);
+            int oy = (int)(_offsetY * _scale);
+
+            Parallel.For(
+                0,
+                _scaledData.Height,
+                y =>
+                    {
+                        if ((oy + y) >= height) return;
+                        for (int i = _scaledData.Width * y, e = i + _scaledData.Width, x = 0; i < e; i++, x++)
+                        {
+                            if (data[i] > 0)
+                            {
+                                if ((ox + x) >= width) break;
+                                int p = (oy * width) + ox + i;
+                                pixels[p] = _color;
+                            }
+                        }
+                    });
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/Render/PaletteColorPipeline.cs
+++ b/DICOM/Imaging/Render/PaletteColorPipeline.cs
@@ -1,28 +1,39 @@
-﻿using Dicom.Imaging.LUT;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// Palette color pipeline implementation of <seealso cref="IPipeline"/>
-	/// </summary>
-	public class PaletteColorPipeline : IPipeline {
-		private ILUT _lut;
+using Dicom.Imaging.LUT;
 
-		/// <summary>
-		/// Initialize new instance of <seealso cref="PaletteColorPipeline"/> containing palette color LUT extracted from
-		/// <paramref name="pixelData"/>
-		/// </summary>
-		/// <param name="pixelData">Dicom Pixel Data containing paletter color LUT</param>
-		public PaletteColorPipeline(DicomPixelData pixelData) {
-			var lut = pixelData.PaletteColorLUT;
-			var first = pixelData.Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 1);
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// Palette color pipeline implementation of <seealso cref="IPipeline"/>
+    /// </summary>
+    public class PaletteColorPipeline : IPipeline
+    {
+        private ILUT _lut;
 
-			_lut = new PaletteColorLUT(first, lut);
-		}
-		/// <summary>
-		/// Get the <seealso cref="PaletteColorLUT"/>
-		/// </summary>
-		public ILUT LUT {
-			get { return _lut; }
-		}
-	}
+        /// <summary>
+        /// Initialize new instance of <seealso cref="PaletteColorPipeline"/> containing palette color LUT extracted from
+        /// <paramref name="pixelData"/>
+        /// </summary>
+        /// <param name="pixelData">Dicom Pixel Data containing paletter color LUT</param>
+        public PaletteColorPipeline(DicomPixelData pixelData)
+        {
+            var lut = pixelData.PaletteColorLUT;
+            var first = pixelData.Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 1);
+
+            _lut = new PaletteColorLUT(first, lut);
+        }
+
+        /// <summary>
+        /// Get the <seealso cref="PaletteColorLUT"/>
+        /// </summary>
+        public ILUT LUT
+        {
+            get
+            {
+                return _lut;
+            }
+        }
+    }
 }

--- a/DICOM/Imaging/Render/PixelData.cs
+++ b/DICOM/Imaging/Render/PixelData.cs
@@ -1,690 +1,915 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections;
-using System.Linq;
 using System.Threading.Tasks;
 
-using Dicom;
 using Dicom.IO.Buffer;
 
 using Dicom.Imaging.Algorithms;
 using Dicom.Imaging.LUT;
 using Dicom.Imaging.Mathematics;
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// Pixel data interface implemented by various pixel format classes
-	/// </summary>
-	public interface IPixelData {
-		/// <summary>
-		/// Image width (columns) in pixels
-		/// </summary>
-		int Width { get; }
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// Pixel data interface implemented by various pixel format classes
+    /// </summary>
+    public interface IPixelData
+    {
+        /// <summary>
+        /// Image width (columns) in pixels
+        /// </summary>
+        int Width { get; }
 
-		/// <summary>
-		/// Image height (rows) in pixels
-		/// </summary>
-		int Height { get; }
+        /// <summary>
+        /// Image height (rows) in pixels
+        /// </summary>
+        int Height { get; }
 
-		/// <summary>
-		/// Number for pixel comopnents (normally 1 for grayscale, 1 for palette, and 3 for RGB and YBR
-		/// </summary>
-		int Components { get; }
+        /// <summary>
+        /// Number for pixel comopnents (normally 1 for grayscale, 1 for palette, and 3 for RGB and YBR
+        /// </summary>
+        int Components { get; }
 
-		/// <summary>
-		/// return the minimum and maximum pixel values from pixel data
-		/// </summary>
-		/// <param name="padding"></param>
-		/// <returns>Range of claculated minimum and max</returns>
-		DicomRange<double> GetMinMax(int padding);
+        /// <summary>
+        /// return the minimum and maximum pixel values from pixel data
+        /// </summary>
+        /// <param name="padding"></param>
+        /// <returns>Range of claculated minimum and max</returns>
+        DicomRange<double> GetMinMax(int padding);
 
-		/// <summary>
-		/// Gets the value of the pixel at the specified coordinates.
-		/// </summary>
-		/// <param name="x">X</param>
-		/// <param name="y">Y</param>
-		/// <returns>Pixel value</returns>
-		double GetPixel(int x, int y);
+        /// <summary>
+        /// Gets the value of the pixel at the specified coordinates.
+        /// </summary>
+        /// <param name="x">X</param>
+        /// <param name="y">Y</param>
+        /// <returns>Pixel value</returns>
+        double GetPixel(int x, int y);
 
-		IPixelData Rescale(double scale);
+        IPixelData Rescale(double scale);
 
-		/// <summary>
-		/// Render the pixel data after applying <paramref name="lut"/> to the output array (allocated by user)
-		/// </summary>
-		/// <param name="lut">Lookup table to render the pixels into output pixels</param>
-		/// <param name="output">The output array to store the result in</param>
-		void Render(ILUT lut, int[] output);
+        /// <summary>
+        /// Render the pixel data after applying <paramref name="lut"/> to the output array (allocated by user)
+        /// </summary>
+        /// <param name="lut">Lookup table to render the pixels into output pixels</param>
+        /// <param name="output">The output array to store the result in</param>
+        void Render(ILUT lut, int[] output);
 
-		Histogram GetHistogram(int channel);
-	}
+        Histogram GetHistogram(int channel);
+    }
 
-	/// <summary>
-	/// Pixel data factory to create <seealso cref="IPixelData"/> and <seealso cref="SingleBitPixelData"/> from 
-	/// <seealso cref="DicomPixelData"/>
-	/// </summary>
-	public static class PixelDataFactory {
-		/// <summary>
-		/// Create <see cref="IPixelData"/> form <see cref="DicomPixelData"/> 
-		/// according to the input <paramref name="pixelData"/> <seealso cref="PhotometricInterpretation"/>
-		/// </summary>
-		/// <param name="pixelData">Input pixel data</param>
-		/// <param name="frame">Frame number (0 based)</param>
-		/// <returns>Implementation of <seealso cref="IPixelData"/> according to <seealso cref="PhotometricInterpretation"/></returns>
-		public static IPixelData Create(DicomPixelData pixelData, int frame) {
-			PhotometricInterpretation pi = pixelData.PhotometricInterpretation;
+    /// <summary>
+    /// Pixel data factory to create <seealso cref="IPixelData"/> and <seealso cref="SingleBitPixelData"/> from 
+    /// <seealso cref="DicomPixelData"/>
+    /// </summary>
+    public static class PixelDataFactory
+    {
+        /// <summary>
+        /// Create <see cref="IPixelData"/> form <see cref="DicomPixelData"/> 
+        /// according to the input <paramref name="pixelData"/> <seealso cref="PhotometricInterpretation"/>
+        /// </summary>
+        /// <param name="pixelData">Input pixel data</param>
+        /// <param name="frame">Frame number (0 based)</param>
+        /// <returns>Implementation of <seealso cref="IPixelData"/> according to <seealso cref="PhotometricInterpretation"/></returns>
+        public static IPixelData Create(DicomPixelData pixelData, int frame)
+        {
+            PhotometricInterpretation pi = pixelData.PhotometricInterpretation;
 
-			if (pi == null) {
-				// generally ACR-NEMA
-				var samples = pixelData.SamplesPerPixel;
-				if (samples == 0 || samples == 1) {
-					if (pixelData.Dataset.Contains(DicomTag.RedPaletteColorLookupTableData))
-						pi = PhotometricInterpretation.PaletteColor;
-					else
-						pi = PhotometricInterpretation.Monochrome2;
-				} else {
-					// assume, probably incorrectly, that the image is RGB
-					pi = PhotometricInterpretation.Rgb;
-				}
-			}
+            if (pi == null)
+            {
+                // generally ACR-NEMA
+                var samples = pixelData.SamplesPerPixel;
+                if (samples == 0 || samples == 1)
+                {
+                    if (pixelData.Dataset.Contains(DicomTag.RedPaletteColorLookupTableData)) pi = PhotometricInterpretation.PaletteColor;
+                    else pi = PhotometricInterpretation.Monochrome2;
+                }
+                else
+                {
+                    // assume, probably incorrectly, that the image is RGB
+                    pi = PhotometricInterpretation.Rgb;
+                }
+            }
 
-			if (pixelData.BitsStored == 1) {
-				if (pixelData.Dataset.Get<DicomUID>(DicomTag.SOPClassUID) == DicomUID.MultiFrameSingleBitSecondaryCaptureImageStorage)
-					// Multi-frame Single Bit Secondary Capture is stored LSB -> MSB
-					return new SingleBitPixelData(pixelData.Width, pixelData.Height, PixelDataConverter.ReverseBits(pixelData.GetFrame(frame)));
-				else
-					// Need sample images to verify that this is correct
-					return new SingleBitPixelData(pixelData.Width, pixelData.Height, pixelData.GetFrame(frame));
-			} else if (pi == PhotometricInterpretation.Monochrome1 || pi == PhotometricInterpretation.Monochrome2 || pi == PhotometricInterpretation.PaletteColor) {
-				if (pixelData.BitsAllocated <= 8)
-					return new GrayscalePixelDataU8(pixelData.Width, pixelData.Height, pixelData.GetFrame(frame));
-				else if (pixelData.BitsAllocated <= 16) {
-					if (pixelData.PixelRepresentation == PixelRepresentation.Signed)
-						return new GrayscalePixelDataS16(pixelData.Width, pixelData.Height, pixelData.BitDepth, pixelData.GetFrame(frame));
-					else
-						return new GrayscalePixelDataU16(pixelData.Width, pixelData.Height, pixelData.BitDepth, pixelData.GetFrame(frame));
-				} else if (pixelData.BitsAllocated <= 32) {
+            if (pixelData.BitsStored == 1)
+            {
+                if (pixelData.Dataset.Get<DicomUID>(DicomTag.SOPClassUID)
+                    == DicomUID.MultiFrameSingleBitSecondaryCaptureImageStorage)
+                    // Multi-frame Single Bit Secondary Capture is stored LSB -> MSB
+                    return new SingleBitPixelData(
+                        pixelData.Width,
+                        pixelData.Height,
+                        PixelDataConverter.ReverseBits(pixelData.GetFrame(frame)));
+                else
+                // Need sample images to verify that this is correct
+                    return new SingleBitPixelData(pixelData.Width, pixelData.Height, pixelData.GetFrame(frame));
+            }
+            else if (pi == PhotometricInterpretation.Monochrome1 || pi == PhotometricInterpretation.Monochrome2
+                     || pi == PhotometricInterpretation.PaletteColor)
+            {
+                if (pixelData.BitsAllocated <= 8) return new GrayscalePixelDataU8(pixelData.Width, pixelData.Height, pixelData.GetFrame(frame));
+                else if (pixelData.BitsAllocated <= 16)
+                {
                     if (pixelData.PixelRepresentation == PixelRepresentation.Signed)
-						return new GrayscalePixelDataS32(pixelData.Width, pixelData.Height, pixelData.BitDepth, pixelData.GetFrame(frame));
+                        return new GrayscalePixelDataS16(
+                            pixelData.Width,
+                            pixelData.Height,
+                            pixelData.BitDepth,
+                            pixelData.GetFrame(frame));
                     else
-						return new GrayscalePixelDataU32(pixelData.Width, pixelData.Height, pixelData.BitDepth, pixelData.GetFrame(frame));
-				} else
-					throw new DicomImagingException("Unsupported pixel data value for bits stored: {0}", pixelData.BitsStored);
-			} else if (pi == PhotometricInterpretation.Rgb || pi == PhotometricInterpretation.YbrFull || pi == PhotometricInterpretation.YbrFull422 || pi == PhotometricInterpretation.YbrPartial422) {
-				var buffer = pixelData.GetFrame(frame);
-
-				if (pixelData.PlanarConfiguration == PlanarConfiguration.Planar)
-					buffer = PixelDataConverter.PlanarToInterleaved24(buffer);
-
-				if (pi == PhotometricInterpretation.YbrFull)
-					buffer = PixelDataConverter.YbrFullToRgb(buffer);
-				else if (pi == PhotometricInterpretation.YbrFull422)
-					buffer = PixelDataConverter.YbrFull422ToRgb(buffer);
-				else if (pi == PhotometricInterpretation.YbrPartial422)
-					buffer = PixelDataConverter.YbrPartial422ToRgb(buffer);
-
-				return new ColorPixelData24(pixelData.Width, pixelData.Height, buffer);
-            } else if (pi == PhotometricInterpretation.YbrFull422) {
+                        return new GrayscalePixelDataU16(
+                            pixelData.Width,
+                            pixelData.Height,
+                            pixelData.BitDepth,
+                            pixelData.GetFrame(frame));
+                }
+                else if (pixelData.BitsAllocated <= 32)
+                {
+                    if (pixelData.PixelRepresentation == PixelRepresentation.Signed)
+                        return new GrayscalePixelDataS32(
+                            pixelData.Width,
+                            pixelData.Height,
+                            pixelData.BitDepth,
+                            pixelData.GetFrame(frame));
+                    else
+                        return new GrayscalePixelDataU32(
+                            pixelData.Width,
+                            pixelData.Height,
+                            pixelData.BitDepth,
+                            pixelData.GetFrame(frame));
+                }
+                else
+                    throw new DicomImagingException(
+                        "Unsupported pixel data value for bits stored: {0}",
+                        pixelData.BitsStored);
+            }
+            else if (pi == PhotometricInterpretation.Rgb || pi == PhotometricInterpretation.YbrFull
+                     || pi == PhotometricInterpretation.YbrFull422 || pi == PhotometricInterpretation.YbrPartial422)
+            {
                 var buffer = pixelData.GetFrame(frame);
-                if (pixelData.PlanarConfiguration == PlanarConfiguration.Planar)
-                    throw new DicomImagingException("Unsupported planar configuration for YBR_FULL_422");
+
+                if (pixelData.PlanarConfiguration == PlanarConfiguration.Planar) buffer = PixelDataConverter.PlanarToInterleaved24(buffer);
+
+                if (pi == PhotometricInterpretation.YbrFull) buffer = PixelDataConverter.YbrFullToRgb(buffer);
+                else if (pi == PhotometricInterpretation.YbrFull422) buffer = PixelDataConverter.YbrFull422ToRgb(buffer);
+                else if (pi == PhotometricInterpretation.YbrPartial422) buffer = PixelDataConverter.YbrPartial422ToRgb(buffer);
+
                 return new ColorPixelData24(pixelData.Width, pixelData.Height, buffer);
-            } else {
-				throw new DicomImagingException("Unsupported pixel data photometric interpretation: {0}", pi.Value);
-			}
-		}
-
-		/// <summary>
-		/// Create <see cref="SingleBitPixelData"/> form <see cref="DicomOverlayData"/> 
-		/// according to the input <paramref name="overlayData"/>
-		/// </summary>
-		/// <param name="overlayData">The input overlay data</param>
-		/// <returns>The result overlay stored in <seealso cref="SingleBitPixelData"/></returns>
-		public static SingleBitPixelData Create(DicomOverlayData overlayData) {
-			return new SingleBitPixelData(overlayData.Columns, overlayData.Rows, overlayData.Data);
-		}
-	}
-
-	/// <summary>
-	/// Grayscale unsigned 8 bits <seealso cref="IPixelData"/> implementation
-	/// </summary>
-	public class GrayscalePixelDataU8 : IPixelData {
-		#region Private Members
-		int _width;
-		int _height;
-        MappedFileBuffer _buffer;
-		#endregion
-
-		#region Public Constructor
-		public GrayscalePixelDataU8(int width, int height, IByteBuffer data) {
-			_width = width;
-			_height = height;
-
-            _buffer = new MappedFileBuffer(data.Data);
-		}
-
-		private GrayscalePixelDataU8(int width, int height, byte[] data) {
-			_width = width;
-			_height = height;
-
-            _buffer = new MappedFileBuffer(data);
-            //_data = data;
-		}
-
-
-		#endregion
-
-		#region Public Properties
-		public int Width {
-			get { return _width; }
-		}
-
-		public int Height {
-			get { return _height; }
-		}
-
-		public int Components {
-			get { return 1; }
-		}
-
-		public byte[] Data {
-            get { return _buffer.Data; }
-		}
-		#endregion
-
-		#region Public Methods
-
-		public DicomRange<double> GetMinMax(int padding) {
-			var min = Double.MaxValue;
-			var max = Double.MinValue;
-
-            var data = Data;
-            for (int i = 0; i < data.Length; i++) {
-                if (data[i] == padding)
-					continue;
-                else if (data[i] > max)
-                    max = data[i];
-                else if (data[i] < min)
-                    min = data[i];
-			}
-
-			return new DicomRange<double>(min, max);
-		}
-
-		public double GetPixel(int x, int y) {
-            var data = Data;
-            return (double)data[(y * Width) + x];
-		}
-
-		public IPixelData Rescale(double scale) {
-			if (scale == 1.0)
-				return this;
-			int w = (int)(Width * scale);
-			int h = (int)(Height * scale);
-            byte[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
-			return new GrayscalePixelDataU8(w, h, data);
-		}
-
-		public void Render(ILUT lut, int[] output) {
-            var data = Data;
-			if (lut == null) {
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = data[i];
-					}
-				});
-			} else {
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = lut[data[i]];
-					}
-				});
-			}
-		}
-
-		public virtual Histogram GetHistogram(int channel) {
-			if (channel != 0)
-				throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
-
-			var histogram = new Histogram(Byte.MinValue, Byte.MaxValue);
-
-            var data = Data;
-            for (int i = 0; i < data.Length; i++)
-                histogram.Add(data[i]);
-
-			return histogram;
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Single bit pixel <seealso cref="IPixelData"/> implementation(for binary pixels) usually used for overlay pixel data
-	/// </summary>
-	public class SingleBitPixelData : GrayscalePixelDataU8 {
-		#region Public Constructor
-        public SingleBitPixelData(int width, int height, IByteBuffer data)
-            : base(width, height, new MemoryByteBuffer(ExpandBits(width, height, data.Data))) {
-		}
-		#endregion
-
-		#region Static Methods
-		private const byte One = 1;
-		private const byte Zero = 0;
-
-		private static byte[] ExpandBits(int width, int height, byte[] input) {
-			BitArray bits = new BitArray(input);
-			byte[] output = new byte[width * height];
-			for (int i = 0, l = width * height; i < l; i++) {
-				output[i] = bits[i] ? One : Zero;
-			}
-			return output;
-		}
-		#endregion
-
-		#region Public Methods
-		public override Histogram GetHistogram(int channel) {
-			if (channel != 0)
-				throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
-
-			var histogram = new Histogram(0, 1);
-
-            var data = Data;
-            for (int i = 0; i < data.Length; i++)
-                histogram.Add(data[i]);
-
-			return histogram;
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Grayscale signed 16 bits <seealso cref="IPixelData"/> implementation
-	/// </summary>
-	public class GrayscalePixelDataS16 : IPixelData {
-		#region Private Members
-		BitDepth _bits;
-		int _width;
-		int _height;
-
-        MappedFileBuffer _buffer;
-		#endregion
-
-		#region Public Constructor
-		public GrayscalePixelDataS16(int width, int height, BitDepth bitDepth, IByteBuffer data) {
-			_bits = bitDepth;
-			_width = width;
-			_height = height;
-
-            var shortData = Dicom.IO.ByteConverter.ToArray<short>(data);
-
-			if (bitDepth.BitsStored != 16) {
-				int sign = 1 << bitDepth.HighBit;
-				int mask = (UInt16.MaxValue >> (bitDepth.BitsAllocated - bitDepth.BitsStored));
-
-                Parallel.For(0, shortData.Length, (int i) => {
-                    short d = shortData[i];
-					if ((d & sign) != 0)
-                        shortData[i] = (short)-(((-d) & mask) + 1);
-					else
-                        shortData[i] = (short)(d & mask);
-				});
-			}
-
-            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<short>(shortData).Data);
-		}
-
-		private GrayscalePixelDataS16(int width, int height, short[] data) {
-			_width = width;
-			_height = height;
-            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<short>(data).Data);
-		}
-		#endregion
-
-		#region Public Properties
-		public int Width {
-			get { return _width; }
-		}
-
-		public int Height {
-			get { return _height; }
-		}
-
-		public int Components {
-			get { return 1; }
-		}
-
-		public short[] Data {
-            get {
-                return Dicom.IO.ByteConverter.ToArray<short>(_buffer);
             }
-		}
-		#endregion
-
-		#region Public Methods
-		public DicomRange<double> GetMinMax(int padding) {
-			var min = Double.MaxValue;
-			var max = Double.MinValue;
-
-            var data = Data;
-            for (int i = 0; i < data.Length; i++) {
-                if (data[i] == padding)
-					continue;
-                else if (data[i] > max)
-                    max = data[i];
-                else if (data[i] < min)
-                    min = data[i];
-			}
-
-			return new DicomRange<double>(min, max);
-		}
-
-		public double GetPixel(int x, int y) {
-            var data = Data;
-            return (double)data[(y * Width) + x];
-		}
-
-		public IPixelData Rescale(double scale) {
-			if (scale == 1.0)
-				return this;
-			int w = (int)(Width * scale);
-			int h = (int)(Height * scale);
-
-            short[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
-			return new GrayscalePixelDataS16(w, h, data);
-		}
-
-		public void Render(ILUT lut, int[] output) {
-            var data = Data;
-			if (lut == null) {
-
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = data[i];
-					}
-				});
-			} else {
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = lut[data[i]];
-					}
-				});
-			}
-		}
-
-		public Histogram GetHistogram(int channel) {
-			if (channel != 0)
-				throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
-
-			var histogram = new Histogram(_bits.MinimumValue, _bits.MaximumValue);
-
-            var data = Data;
-
-            for (int i = 0; i < data.Length; i++)
-                histogram.Add(data[i]);
-
-			return histogram;
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Grayscale unsigned 16 bits <seealso cref="IPixelData"/> implementation
-	/// </summary>
-	public class GrayscalePixelDataU16 : IPixelData {
-		#region Private Members
-		BitDepth _bits;
-		int _width;
-		int _height;
-        MappedFileBuffer _buffer;
-
-		#endregion
-
-		#region Public Constructor
-		public GrayscalePixelDataU16(int width, int height, BitDepth bitDepth, IByteBuffer data) {
-			_bits = bitDepth;
-			_width = width;
-			_height = height;
-
-            var ushortData = Dicom.IO.ByteConverter.ToArray<ushort>(data);
-
-			if (bitDepth.BitsStored != 16) {
-				int mask = (1 << (bitDepth.HighBit + 1)) - 1;
-
-                Parallel.For(0, ushortData.Length, (int i) => {
-                    ushortData[i] = (ushort)(ushortData[i] & mask);
-				});
-			}
-
-            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<ushort>(ushortData).Data);
-		}
-
-		private GrayscalePixelDataU16(int width, int height, ushort[] data) {
-			_width = width;
-			_height = height;
-
-            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<ushort>(data).Data);
-		}
-		#endregion
-
-		#region Public Properties
-		public int Width {
-			get { return _width; }
-		}
-
-		public int Height {
-			get { return _height; }
-		}
-
-		public int Components {
-			get { return 1; }
-		}
-
-		public ushort[] Data {
-            get {
-                return Dicom.IO.ByteConverter.ToArray<ushort>(_buffer);
+            else if (pi == PhotometricInterpretation.YbrFull422)
+            {
+                var buffer = pixelData.GetFrame(frame);
+                if (pixelData.PlanarConfiguration == PlanarConfiguration.Planar) throw new DicomImagingException("Unsupported planar configuration for YBR_FULL_422");
+                return new ColorPixelData24(pixelData.Width, pixelData.Height, buffer);
             }
-		}
-		#endregion
+            else
+            {
+                throw new DicomImagingException(
+                    "Unsupported pixel data photometric interpretation: {0}",
+                    pi.Value);
+            }
+        }
 
-		#region Public Methods
-		public DicomRange<double> GetMinMax(int padding) {
-			var min = Double.MaxValue;
-			var max = Double.MinValue;
+        /// <summary>
+        /// Create <see cref="SingleBitPixelData"/> form <see cref="DicomOverlayData"/> 
+        /// according to the input <paramref name="overlayData"/>
+        /// </summary>
+        /// <param name="overlayData">The input overlay data</param>
+        /// <returns>The result overlay stored in <seealso cref="SingleBitPixelData"/></returns>
+        public static SingleBitPixelData Create(DicomOverlayData overlayData)
+        {
+            return new SingleBitPixelData(overlayData.Columns, overlayData.Rows, overlayData.Data);
+        }
+    }
 
-            var data = Data;
-            for (int i = 0; i < data.Length; i++) {
-                if (data[i] == padding)
-					continue;
-                else if (data[i] > max)
-                    max = data[i];
-                else if (data[i] < min)
-                    min = data[i];
-			}
-
-			return new DicomRange<double>(min, max);
-		}
-
-		public double GetPixel(int x, int y) {
-            var data = Data;
-            return (double)data[(y * Width) + x];
-		}
-
-		public IPixelData Rescale(double scale) {
-			if (scale == 1.0)
-				return this;
-
-
-			int w = (int)(Width * scale);
-			int h = (int)(Height * scale);
-            ushort[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
-			return new GrayscalePixelDataU16(w, h, data);
-		}
-
-		public void Render(ILUT lut, int[] output) {
-            var data = Data;
-			if (lut == null) {
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = data[i];
-					}
-				});
-			} else {
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = lut[data[i]];
-					}
-				});
-			}
-		}
-
-		public Histogram GetHistogram(int channel) {
-			if (channel != 0)
-				throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
-
-			var histogram = new Histogram(_bits.MinimumValue, _bits.MaximumValue);
-
-            var data = Data;
-            for (int i = 0; i < data.Length; i++)
-                histogram.Add(data[i]);
-
-			return histogram;
-		}
-		#endregion
-	}
-
-	/// <summary>
-	/// Grayscale signed 32 bits <seealso cref="IPixelData"/> implementation
-	/// </summary>
-    public class GrayscalePixelDataS32 : IPixelData {
+    /// <summary>
+    /// Grayscale unsigned 8 bits <seealso cref="IPixelData"/> implementation
+    /// </summary>
+    public class GrayscalePixelDataU8 : IPixelData
+    {
         #region Private Members
-        int _width;
-        int _height;
 
-        MappedFileBuffer _buffer;
+        private int _width;
+
+        private int _height;
+
+        private MappedFileBuffer _buffer;
+
         #endregion
 
         #region Public Constructor
-        public GrayscalePixelDataS32(int width, int height, BitDepth bitDepth, IByteBuffer data) {
+
+        public GrayscalePixelDataU8(int width, int height, IByteBuffer data)
+        {
+            _width = width;
+            _height = height;
+
+            _buffer = new MappedFileBuffer(data.Data);
+        }
+
+        private GrayscalePixelDataU8(int width, int height, byte[] data)
+        {
+            _width = width;
+            _height = height;
+
+            _buffer = new MappedFileBuffer(data);
+            //_data = data;
+        }
+
+
+        #endregion
+
+        #region Public Properties
+
+        public int Width
+        {
+            get
+            {
+                return _width;
+            }
+        }
+
+        public int Height
+        {
+            get
+            {
+                return _height;
+            }
+        }
+
+        public int Components
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        public byte[] Data
+        {
+            get
+            {
+                return _buffer.Data;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public DicomRange<double> GetMinMax(int padding)
+        {
+            var min = Double.MaxValue;
+            var max = Double.MinValue;
+
+            var data = Data;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] == padding) continue;
+                else if (data[i] > max) max = data[i];
+                else if (data[i] < min) min = data[i];
+            }
+
+            return new DicomRange<double>(min, max);
+        }
+
+        public double GetPixel(int x, int y)
+        {
+            var data = Data;
+            return (double)data[(y * Width) + x];
+        }
+
+        public IPixelData Rescale(double scale)
+        {
+            if (scale == 1.0) return this;
+            int w = (int)(Width * scale);
+            int h = (int)(Height * scale);
+            byte[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
+            return new GrayscalePixelDataU8(w, h, data);
+        }
+
+        public void Render(ILUT lut, int[] output)
+        {
+            var data = Data;
+            if (lut == null)
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = data[i];
+                            }
+                        });
+            }
+            else
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = lut[data[i]];
+                            }
+                        });
+            }
+        }
+
+        public virtual Histogram GetHistogram(int channel)
+        {
+            if (channel != 0) throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
+
+            var histogram = new Histogram(Byte.MinValue, Byte.MaxValue);
+
+            var data = Data;
+            for (int i = 0; i < data.Length; i++) histogram.Add(data[i]);
+
+            return histogram;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Single bit pixel <seealso cref="IPixelData"/> implementation(for binary pixels) usually used for overlay pixel data
+    /// </summary>
+    public class SingleBitPixelData : GrayscalePixelDataU8
+    {
+        #region Public Constructor
+
+        public SingleBitPixelData(int width, int height, IByteBuffer data)
+            : base(width, height, new MemoryByteBuffer(ExpandBits(width, height, data.Data)))
+        {
+        }
+
+        #endregion
+
+        #region Static Methods
+
+        private const byte One = 1;
+
+        private const byte Zero = 0;
+
+        private static byte[] ExpandBits(int width, int height, byte[] input)
+        {
+            BitArray bits = new BitArray(input);
+            byte[] output = new byte[width * height];
+            for (int i = 0, l = width * height; i < l; i++)
+            {
+                output[i] = bits[i] ? One : Zero;
+            }
+            return output;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public override Histogram GetHistogram(int channel)
+        {
+            if (channel != 0) throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
+
+            var histogram = new Histogram(0, 1);
+
+            var data = Data;
+            for (int i = 0; i < data.Length; i++) histogram.Add(data[i]);
+
+            return histogram;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Grayscale signed 16 bits <seealso cref="IPixelData"/> implementation
+    /// </summary>
+    public class GrayscalePixelDataS16 : IPixelData
+    {
+        #region Private Members
+
+        private BitDepth _bits;
+
+        private int _width;
+
+        private int _height;
+
+        private MappedFileBuffer _buffer;
+
+        #endregion
+
+        #region Public Constructor
+
+        public GrayscalePixelDataS16(int width, int height, BitDepth bitDepth, IByteBuffer data)
+        {
+            _bits = bitDepth;
+            _width = width;
+            _height = height;
+
+            var shortData = Dicom.IO.ByteConverter.ToArray<short>(data);
+
+            if (bitDepth.BitsStored != 16)
+            {
+                int sign = 1 << bitDepth.HighBit;
+                int mask = (UInt16.MaxValue >> (bitDepth.BitsAllocated - bitDepth.BitsStored));
+
+                Parallel.For(
+                    0,
+                    shortData.Length,
+                    (int i) =>
+                        {
+                            short d = shortData[i];
+                            if ((d & sign) != 0) shortData[i] = (short)-(((-d) & mask) + 1);
+                            else shortData[i] = (short)(d & mask);
+                        });
+            }
+
+            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<short>(shortData).Data);
+        }
+
+        private GrayscalePixelDataS16(int width, int height, short[] data)
+        {
+            _width = width;
+            _height = height;
+            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<short>(data).Data);
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public int Width
+        {
+            get
+            {
+                return _width;
+            }
+        }
+
+        public int Height
+        {
+            get
+            {
+                return _height;
+            }
+        }
+
+        public int Components
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        public short[] Data
+        {
+            get
+            {
+                return Dicom.IO.ByteConverter.ToArray<short>(_buffer);
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public DicomRange<double> GetMinMax(int padding)
+        {
+            var min = Double.MaxValue;
+            var max = Double.MinValue;
+
+            var data = Data;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] == padding) continue;
+                else if (data[i] > max) max = data[i];
+                else if (data[i] < min) min = data[i];
+            }
+
+            return new DicomRange<double>(min, max);
+        }
+
+        public double GetPixel(int x, int y)
+        {
+            var data = Data;
+            return (double)data[(y * Width) + x];
+        }
+
+        public IPixelData Rescale(double scale)
+        {
+            if (scale == 1.0) return this;
+            int w = (int)(Width * scale);
+            int h = (int)(Height * scale);
+
+            short[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
+            return new GrayscalePixelDataS16(w, h, data);
+        }
+
+        public void Render(ILUT lut, int[] output)
+        {
+            var data = Data;
+            if (lut == null)
+            {
+
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = data[i];
+                            }
+                        });
+            }
+            else
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = lut[data[i]];
+                            }
+                        });
+            }
+        }
+
+        public Histogram GetHistogram(int channel)
+        {
+            if (channel != 0) throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
+
+            var histogram = new Histogram(_bits.MinimumValue, _bits.MaximumValue);
+
+            var data = Data;
+
+            for (int i = 0; i < data.Length; i++) histogram.Add(data[i]);
+
+            return histogram;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Grayscale unsigned 16 bits <seealso cref="IPixelData"/> implementation
+    /// </summary>
+    public class GrayscalePixelDataU16 : IPixelData
+    {
+        #region Private Members
+
+        private BitDepth _bits;
+
+        private int _width;
+
+        private int _height;
+
+        private MappedFileBuffer _buffer;
+
+        #endregion
+
+        #region Public Constructor
+
+        public GrayscalePixelDataU16(int width, int height, BitDepth bitDepth, IByteBuffer data)
+        {
+            _bits = bitDepth;
+            _width = width;
+            _height = height;
+
+            var ushortData = Dicom.IO.ByteConverter.ToArray<ushort>(data);
+
+            if (bitDepth.BitsStored != 16)
+            {
+                int mask = (1 << (bitDepth.HighBit + 1)) - 1;
+
+                Parallel.For(0, ushortData.Length, (int i) => { ushortData[i] = (ushort)(ushortData[i] & mask); });
+            }
+
+            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<ushort>(ushortData).Data);
+        }
+
+        private GrayscalePixelDataU16(int width, int height, ushort[] data)
+        {
+            _width = width;
+            _height = height;
+
+            _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<ushort>(data).Data);
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public int Width
+        {
+            get
+            {
+                return _width;
+            }
+        }
+
+        public int Height
+        {
+            get
+            {
+                return _height;
+            }
+        }
+
+        public int Components
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        public ushort[] Data
+        {
+            get
+            {
+                return Dicom.IO.ByteConverter.ToArray<ushort>(_buffer);
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public DicomRange<double> GetMinMax(int padding)
+        {
+            var min = Double.MaxValue;
+            var max = Double.MinValue;
+
+            var data = Data;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] == padding) continue;
+                else if (data[i] > max) max = data[i];
+                else if (data[i] < min) min = data[i];
+            }
+
+            return new DicomRange<double>(min, max);
+        }
+
+        public double GetPixel(int x, int y)
+        {
+            var data = Data;
+            return (double)data[(y * Width) + x];
+        }
+
+        public IPixelData Rescale(double scale)
+        {
+            if (scale == 1.0) return this;
+
+
+            int w = (int)(Width * scale);
+            int h = (int)(Height * scale);
+            ushort[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
+            return new GrayscalePixelDataU16(w, h, data);
+        }
+
+        public void Render(ILUT lut, int[] output)
+        {
+            var data = Data;
+            if (lut == null)
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = data[i];
+                            }
+                        });
+            }
+            else
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = lut[data[i]];
+                            }
+                        });
+            }
+        }
+
+        public Histogram GetHistogram(int channel)
+        {
+            if (channel != 0) throw new ArgumentOutOfRangeException("channel", channel, "Expected channel 0 for grayscale image.");
+
+            var histogram = new Histogram(_bits.MinimumValue, _bits.MaximumValue);
+
+            var data = Data;
+            for (int i = 0; i < data.Length; i++) histogram.Add(data[i]);
+
+            return histogram;
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Grayscale signed 32 bits <seealso cref="IPixelData"/> implementation
+    /// </summary>
+    public class GrayscalePixelDataS32 : IPixelData
+    {
+        #region Private Members
+
+        private int _width;
+
+        private int _height;
+
+        private MappedFileBuffer _buffer;
+
+        #endregion
+
+        #region Public Constructor
+
+        public GrayscalePixelDataS32(int width, int height, BitDepth bitDepth, IByteBuffer data)
+        {
             _width = width;
             _height = height;
 
             var intData = Dicom.IO.ByteConverter.ToArray<int>(data);
 
             int sign = 1 << bitDepth.HighBit;
-			uint mask = (UInt32.MaxValue >> (bitDepth.BitsAllocated - bitDepth.BitsStored));
+            uint mask = (UInt32.MaxValue >> (bitDepth.BitsAllocated - bitDepth.BitsStored));
 
-            Parallel.For(0, intData.Length, (int i) => {
-                int d = intData[i];
-                if ((d & sign) != 0)
-                    intData[i] = (int)-(((-d) & mask) + 1);
-                else
-                    intData[i] = (int)(d & mask);
-            });
+            Parallel.For(
+                0,
+                intData.Length,
+                (int i) =>
+                    {
+                        int d = intData[i];
+                        if ((d & sign) != 0) intData[i] = (int)-(((-d) & mask) + 1);
+                        else intData[i] = (int)(d & mask);
+                    });
 
             _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<int>(intData).Data);
         }
 
-        private GrayscalePixelDataS32(int width, int height, int[] data) {
+        private GrayscalePixelDataS32(int width, int height, int[] data)
+        {
             _width = width;
             _height = height;
             _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<int>(data).Data);
         }
+
         #endregion
 
         #region Public Properties
-        public int Width {
-            get { return _width; }
+
+        public int Width
+        {
+            get
+            {
+                return _width;
+            }
         }
 
-        public int Height {
-            get { return _height; }
+        public int Height
+        {
+            get
+            {
+                return _height;
+            }
         }
 
-        public int Components {
-            get { return 1; }
+        public int Components
+        {
+            get
+            {
+                return 1;
+            }
         }
 
-        public int[] Data {
-            get { return Dicom.IO.ByteConverter.ToArray<int>(_buffer); ; }
+        public int[] Data
+        {
+            get
+            {
+                return Dicom.IO.ByteConverter.ToArray<int>(_buffer);
+                ;
+            }
         }
+
         #endregion
 
         #region Public Methods
-		public DicomRange<double> GetMinMax(int padding) {
-			var min = Double.MaxValue;
-			var max = Double.MinValue;
+
+        public DicomRange<double> GetMinMax(int padding)
+        {
+            var min = Double.MaxValue;
+            var max = Double.MinValue;
 
             var data = Data;
-            for (int i = 0; i < data.Length; i++) {
-                if (data[i] > max)
-                    max = data[i];
-                else if (data[i] < min)
-                    min = data[i];
-			}
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] > max) max = data[i];
+                else if (data[i] < min) min = data[i];
+            }
 
-			return new DicomRange<double>(min, max);
-		}
+            return new DicomRange<double>(min, max);
+        }
 
-		public double GetPixel(int x, int y) {
+        public double GetPixel(int x, int y)
+        {
             return (double)Data[(y * Width) + x];
-		}
+        }
 
-        public IPixelData Rescale(double scale) {
-            if (scale == 1.0)
-                return this;
+        public IPixelData Rescale(double scale)
+        {
+            if (scale == 1.0) return this;
             int w = (int)(Width * scale);
             int h = (int)(Height * scale);
             int[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
             return new GrayscalePixelDataS32(w, h, data);
         }
 
-        public void Render(ILUT lut, int[] output) {
+        public void Render(ILUT lut, int[] output)
+        {
             var data = Data;
 
-            if (lut == null) {
+            if (lut == null)
+            {
 
-                Parallel.For(0, Height, y => {
-                    for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = data[i];
-                    }
-                });
-            } else {
-                Parallel.For(0, Height, y => {
-                    for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = lut[data[i]];
-                    }
-                });
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = data[i];
+                            }
+                        });
+            }
+            else
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = lut[data[i]];
+                            }
+                        });
             }
         }
 
-		public Histogram GetHistogram(int channel) {
-			throw new NotSupportedException("Histograms are not supported for signed 32-bit images.");
-		}
+        public Histogram GetHistogram(int channel)
+        {
+            throw new NotSupportedException("Histograms are not supported for signed 32-bit images.");
+        }
+
         #endregion
     }
 
-	/// <summary>
-	/// Grayscale unsgiend 32 bits <seealso cref="IPixelData"/> implementation
-	/// </summary>
-    public class GrayscalePixelDataU32 : IPixelData {
+    /// <summary>
+    /// Grayscale unsgiend 32 bits <seealso cref="IPixelData"/> implementation
+    /// </summary>
+    public class GrayscalePixelDataU32 : IPixelData
+    {
         #region Private Members
-        int _width;
-        int _height;
 
-        MappedFileBuffer _buffer;
+        private int _width;
+
+        private int _height;
+
+        private MappedFileBuffer _buffer;
+
         #endregion
 
         #region Public Constructor
-        public GrayscalePixelDataU32(int width, int height, BitDepth bitDepth, IByteBuffer data) {
+
+        public GrayscalePixelDataU32(int width, int height, BitDepth bitDepth, IByteBuffer data)
+        {
             _width = width;
             _height = height;
 
             var uintData = Dicom.IO.ByteConverter.ToArray<uint>(data);
 
-            if (bitDepth.BitsStored != 32) {
+            if (bitDepth.BitsStored != 32)
+            {
                 int mask = (1 << (bitDepth.HighBit + 1)) - 1;
 
-                Parallel.For(0, uintData.Length, (int i) => {
-                    uintData[i] = (uint)(uintData[i] & mask);
-                });
+                Parallel.For(0, uintData.Length, (int i) => { uintData[i] = (uint)(uintData[i] & mask); });
             }
 
 
@@ -692,174 +917,261 @@ namespace Dicom.Imaging.Render {
             _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<uint>(uintData).Data);
         }
 
-        private GrayscalePixelDataU32(int width, int height, uint[] data) {
+        private GrayscalePixelDataU32(int width, int height, uint[] data)
+        {
             _width = width;
             _height = height;
             _buffer = new MappedFileBuffer(Dicom.IO.ByteConverter.ToByteBuffer<uint>(data).Data);
         }
+
         #endregion
 
         #region Public Properties
-        public int Width {
-            get { return _width; }
+
+        public int Width
+        {
+            get
+            {
+                return _width;
+            }
         }
 
-        public int Height {
-            get { return _height; }
+        public int Height
+        {
+            get
+            {
+                return _height;
+            }
         }
 
-        public int Components {
-            get { return 1; }
+        public int Components
+        {
+            get
+            {
+                return 1;
+            }
         }
 
-        public uint[] Data {
-            get { return Dicom.IO.ByteConverter.ToArray<uint>(_buffer); }
+        public uint[] Data
+        {
+            get
+            {
+                return Dicom.IO.ByteConverter.ToArray<uint>(_buffer);
+            }
         }
+
         #endregion
 
         #region Public Methods
-		public DicomRange<double> GetMinMax(int padding) {
-			var min = Double.MaxValue;
-			var max = Double.MinValue;
+
+        public DicomRange<double> GetMinMax(int padding)
+        {
+            var min = Double.MaxValue;
+            var max = Double.MinValue;
 
             var data = Data;
-            for (int i = 0; i < data.Length; i++) {
-                if (data[i] > max)
-                    max = data[i];
-                else if (data[i] < min)
-                    min = data[i];
-			}
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] > max) max = data[i];
+                else if (data[i] < min) min = data[i];
+            }
 
-			return new DicomRange<double>(min, max);
-		}
+            return new DicomRange<double>(min, max);
+        }
 
-		public double GetPixel(int x, int y) {
+        public double GetPixel(int x, int y)
+        {
             return (double)Data[(y * Width) + x];
-		}
+        }
 
-        public IPixelData Rescale(double scale) {
-            if (scale == 1.0)
-                return this;
+        public IPixelData Rescale(double scale)
+        {
+            if (scale == 1.0) return this;
             int w = (int)(Width * scale);
             int h = (int)(Height * scale);
             uint[] data = BilinearInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
             return new GrayscalePixelDataU32(w, h, data);
         }
 
-        public void Render(ILUT lut, int[] output) {
+        public void Render(ILUT lut, int[] output)
+        {
             var data = Data;
-            if (lut == null) {
-                Parallel.For(0, Height, y => {
-                    for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = (int)data[i];
-                    }
-                });
-            } else {
-                Parallel.For(0, Height, y => {
-                    for (int i = Width * y, e = i + Width; i < e; i++) {
-                        output[i] = lut[(int)data[i]];
-                    }
-                });
+            if (lut == null)
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = (int)data[i];
+                            }
+                        });
+            }
+            else
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width; i < e; i++)
+                            {
+                                output[i] = lut[(int)data[i]];
+                            }
+                        });
             }
         }
 
-		public Histogram GetHistogram(int channel) {
-			throw new NotSupportedException("Histograms are not supported for unsigned 32-bit images.");
-		}
+        public Histogram GetHistogram(int channel)
+        {
+            throw new NotSupportedException("Histograms are not supported for unsigned 32-bit images.");
+        }
+
         #endregion
     }
 
-	/// <summary>
-	/// Color 24 bits <seealso cref="IPixelData"/> implementation used for RGB
-	/// </summary>
-    public class ColorPixelData24 : IPixelData {
-		#region Private Members
-		int _width;
-		int _height;
-        MappedFileBuffer _buffer;
-		#endregion
+    /// <summary>
+    /// Color 24 bits <seealso cref="IPixelData"/> implementation used for RGB
+    /// </summary>
+    public class ColorPixelData24 : IPixelData
+    {
+        #region Private Members
 
-		#region Public Constructor
-		public ColorPixelData24(int width, int height, IByteBuffer data) {
-			_width = width;
-			_height = height;
+        private int _width;
+
+        private int _height;
+
+        private MappedFileBuffer _buffer;
+
+        #endregion
+
+        #region Public Constructor
+
+        public ColorPixelData24(int width, int height, IByteBuffer data)
+        {
+            _width = width;
+            _height = height;
             _buffer = new MappedFileBuffer(data.Data);
-		}
+        }
 
-		private ColorPixelData24(int width, int height, byte[] data) {
-			_width = width;
-			_height = height;
+        private ColorPixelData24(int width, int height, byte[] data)
+        {
+            _width = width;
+            _height = height;
             _buffer = new MappedFileBuffer(data);
-		}
-		#endregion
+        }
 
-		#region Public Properties
-		public int Width {
-			get { return _width; }
-		}
+        #endregion
 
-		public int Height {
-			get { return _height; }
-		}
+        #region Public Properties
 
-		public int Components {
-			get { return 3; }
-		}
+        public int Width
+        {
+            get
+            {
+                return _width;
+            }
+        }
 
-		public byte[] Data {
-            get { return _buffer.Data; }
-		}
-		#endregion
+        public int Height
+        {
+            get
+            {
+                return _height;
+            }
+        }
 
-		#region Public Methods
-		public DicomRange<double> GetMinMax(int padding) {
-			throw new InvalidOperationException("Calculation of min/max pixel values is not supported for 24-bit color pixel data.");
-		}
+        public int Components
+        {
+            get
+            {
+                return 3;
+            }
+        }
 
-		public double GetPixel(int x, int y) {
+        public byte[] Data
+        {
+            get
+            {
+                return _buffer.Data;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public DicomRange<double> GetMinMax(int padding)
+        {
+            throw new InvalidOperationException(
+                "Calculation of min/max pixel values is not supported for 24-bit color pixel data.");
+        }
+
+        public double GetPixel(int x, int y)
+        {
             var data = Data;
-			var p = ((y * Width) + x) * 3;
+            var p = ((y * Width) + x) * 3;
             return (double)((data[p++] << 16) | (data[p++] << 8) | data[p++]);
-		}
+        }
 
-		public IPixelData Rescale(double scale) {
-			if (scale == 1.0)
-				return this;
-			int w = (int)(Width * scale);
-			int h = (int)(Height * scale);
+        public IPixelData Rescale(double scale)
+        {
+            if (scale == 1.0) return this;
+            int w = (int)(Width * scale);
+            int h = (int)(Height * scale);
             byte[] data = BilinearInterpolation.RescaleColor24(Data, Width, Height, w, h);
-			return new ColorPixelData24(w, h, data);
-		}
+            return new ColorPixelData24(w, h, data);
+        }
 
-		public void Render(ILUT lut, int[] output) {
+        public void Render(ILUT lut, int[] output)
+        {
             var data = Data;
-			if (lut == null) {
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width, p = i * 3; i < e; i++) {
-                        output[i] = (data[p++] << 16) | (data[p++] << 8) | data[p++];
-					}
-				});
-			} else {
-				Parallel.For(0, Height, y => {
-					for (int i = Width * y, e = i + Width, p = i * 3; i < e; i++) {
-                        output[i] = (lut[data[p++]] << 16) | (lut[data[p++]] << 8) | lut[data[p++]];
-					}
-				});
-			}
-		}
+            if (lut == null)
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width, p = i * 3; i < e; i++)
+                            {
+                                output[i] = (data[p++] << 16) | (data[p++] << 8) | data[p++];
+                            }
+                        });
+            }
+            else
+            {
+                Parallel.For(
+                    0,
+                    Height,
+                    y =>
+                        {
+                            for (int i = Width * y, e = i + Width, p = i * 3; i < e; i++)
+                            {
+                                output[i] = (lut[data[p++]] << 16) | (lut[data[p++]] << 8) | lut[data[p++]];
+                            }
+                        });
+            }
+        }
 
-		public Histogram GetHistogram(int channel) {
-			if (channel < 0 || channel > 2)
-				throw new ArgumentOutOfRangeException("channel", channel, "Expected channel between 0 and 2 for 24-bit color image.");
+        public Histogram GetHistogram(int channel)
+        {
+            if (channel < 0 || channel > 2)
+                throw new ArgumentOutOfRangeException(
+                    "channel",
+                    channel,
+                    "Expected channel between 0 and 2 for 24-bit color image.");
 
-			var histogram = new Histogram(Byte.MinValue, Byte.MaxValue);
+            var histogram = new Histogram(Byte.MinValue, Byte.MaxValue);
 
             var data = Data;
-            for (int i = channel; i < data.Length; i += 3)
-                histogram.Add(data[i]);
+            for (int i = channel; i < data.Length; i += 3) histogram.Add(data[i]);
 
-			return histogram;
-		}
-		#endregion
-	}
+            return histogram;
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Imaging/Render/RgbColorPipeline.cs
+++ b/DICOM/Imaging/Render/RgbColorPipeline.cs
@@ -1,12 +1,21 @@
-﻿using Dicom.Imaging.LUT;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Imaging.Render {
-	/// <summary>
-	/// RGB color pipeline implementation of <seealso cref="IPipeline"/> interface
-	/// </summary>
-	public class RgbColorPipeline : IPipeline {
-		public ILUT LUT {
-			get { return null; }
-		}
-	}
+using Dicom.Imaging.LUT;
+
+namespace Dicom.Imaging.Render
+{
+    /// <summary>
+    /// RGB color pipeline implementation of <seealso cref="IPipeline"/> interface
+    /// </summary>
+    public class RgbColorPipeline : IPipeline
+    {
+        public ILUT LUT
+        {
+            get
+            {
+                return null;
+            }
+        }
+    }
 }

--- a/DICOM/Imaging/SpatialTransform.cs
+++ b/DICOM/Imaging/SpatialTransform.cs
@@ -1,71 +1,125 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Drawing;
 
-namespace Dicom.Imaging {
-	public class SpatialTransform {
-		#region Private Members
-		private double _scale;
-		private int _rotate;
-		private bool _flipx;
-		private bool _flipy;
-		private Point _pan;
-		#endregion
+namespace Dicom.Imaging
+{
+    public class SpatialTransform
+    {
+        #region Private Members
 
-		#region Public Constructors
-		public SpatialTransform() {
-			_pan = new Point(0, 0);
-			Reset();
-		}
-		#endregion
+        private double _scale;
 
-		#region Public Properties
-		public double Scale {
-			get { return _scale; }
-			set { _scale = value; }
-		}
+        private int _rotate;
 
-		public int Rotation {
-			get { return _rotate; }
-			set { _rotate = value; }
-		}
+        private bool _flipx;
 
-		public bool FlipX {
-			get { return _flipx; }
-			set { _flipx = value; }
-		}
+        private bool _flipy;
 
-		public bool FlipY {
-			get { return _flipy; }
-			set { _flipy = value; }
-		}
+        private Point _pan;
 
-		public Point Pan {
-			get { return _pan; }
-			set { _pan = value; }
-		}
+        #endregion
 
-		public bool IsTransformed {
-			get {
-				return _scale != 1.0f ||
-					_rotate != 0.0f ||
-					_pan == Point.Empty;
-			}
-		}
-		#endregion
+        #region Public Constructors
 
-		#region Public Members
-		public void Rotate(int angle) {
-			_rotate += angle;
-		}
+        public SpatialTransform()
+        {
+            _pan = new Point(0, 0);
+            Reset();
+        }
 
-		public void Reset() {
-			_scale = 1.0;
-			_rotate = 0;
-			_flipx = false;
-			_flipy = false;
-			_pan.X = 0;
-			_pan.Y = 0;
-		}
-		#endregion
-	}
+        #endregion
+
+        #region Public Properties
+
+        public double Scale
+        {
+            get
+            {
+                return _scale;
+            }
+            set
+            {
+                _scale = value;
+            }
+        }
+
+        public int Rotation
+        {
+            get
+            {
+                return _rotate;
+            }
+            set
+            {
+                _rotate = value;
+            }
+        }
+
+        public bool FlipX
+        {
+            get
+            {
+                return _flipx;
+            }
+            set
+            {
+                _flipx = value;
+            }
+        }
+
+        public bool FlipY
+        {
+            get
+            {
+                return _flipy;
+            }
+            set
+            {
+                _flipy = value;
+            }
+        }
+
+        public Point Pan
+        {
+            get
+            {
+                return _pan;
+            }
+            set
+            {
+                _pan = value;
+            }
+        }
+
+        public bool IsTransformed
+        {
+            get
+            {
+                return _scale != 1.0f || _rotate != 0.0f || _pan == Point.Empty;
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        public void Rotate(int angle)
+        {
+            _rotate += angle;
+        }
+
+        public void Reset()
+        {
+            _scale = 1.0;
+            _rotate = 0;
+            _flipx = false;
+            _flipy = false;
+            _pan.X = 0;
+            _pan.Y = 0;
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Log/ConsoleLogger.cs
+++ b/DICOM/Log/ConsoleLogger.cs
@@ -1,44 +1,56 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Log {
-	public class ConsoleLogger : Logger {
-		public readonly static Logger Instance = new ConsoleLogger();
-		private object _lock = new object();
+using System;
 
-		private ConsoleLogger() {
-		}
+namespace Dicom.Log
+{
+    public class ConsoleLogger : Logger
+    {
+        public static readonly Logger Instance = new ConsoleLogger();
 
-		public override void Log(LogLevel level, string msg, params object[] args) {
-			lock (_lock) {
-				var previous = Console.ForegroundColor;
-				switch (level) {
-				case LogLevel.Debug:
-					Console.ForegroundColor = ConsoleColor.Blue;
-					break;
-				case LogLevel.Info:
-					Console.ForegroundColor = ConsoleColor.White;
-					break;
-				case LogLevel.Warning:
-					Console.ForegroundColor = ConsoleColor.Yellow;
-					break;
-				case LogLevel.Error:
-					Console.ForegroundColor = ConsoleColor.Red;
-					break;
-				case LogLevel.Fatal:
-					Console.ForegroundColor = ConsoleColor.Magenta;
-					break;
-				default:
-					break;
-				}
+        private object _lock = new object();
+
+        private ConsoleLogger()
+        {
+        }
+
+        public override void Log(LogLevel level, string msg, params object[] args)
+        {
+            lock (_lock)
+            {
+                var previous = Console.ForegroundColor;
+                switch (level)
+                {
+                    case LogLevel.Debug:
+                        Console.ForegroundColor = ConsoleColor.Blue;
+                        break;
+                    case LogLevel.Info:
+                        Console.ForegroundColor = ConsoleColor.White;
+                        break;
+                    case LogLevel.Warning:
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        break;
+                    case LogLevel.Error:
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        break;
+                    case LogLevel.Fatal:
+                        Console.ForegroundColor = ConsoleColor.Magenta;
+                        break;
+                    default:
+                        break;
+                }
                 Console.WriteLine(NameFormatToPositionalFormat(msg), args);
-				Console.ForegroundColor = previous;
-			}
-		}
-	}
+                Console.ForegroundColor = previous;
+            }
+        }
+    }
 
-	public class ConsoleLogManager : LogManager {
-		public override Logger GetLogger(string name) {
-			return ConsoleLogger.Instance;
-		}
-	}
+    public class ConsoleLogManager : LogManager
+    {
+        public override Logger GetLogger(string name)
+        {
+            return ConsoleLogger.Instance;
+        }
+    }
 }

--- a/DICOM/Log/DicomDatasetDumper.cs
+++ b/DICOM/Log/DicomDatasetDumper.cs
@@ -1,118 +1,161 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
 using Dicom.IO.Buffer;
 
-namespace Dicom.Log {
-	public class DicomDatasetDumper : IDicomDatasetWalker {
-		private StringBuilder _log;
-		private int _width = 128;
-		private int _value = 64;
-		private int _depth = 0;
-		private string _pad = String.Empty;
+namespace Dicom.Log
+{
+    public class DicomDatasetDumper : IDicomDatasetWalker
+    {
+        private StringBuilder _log;
 
-		public DicomDatasetDumper(StringBuilder log, int width = 128, int valueLength = 64) {
-			_log = log;
-			_width = width;
-			_value = valueLength;
-		}
+        private int _width = 128;
 
-		public void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback) {
-		}
+        private int _value = 64;
 
-		public bool OnElement(DicomElement element) {
-			StringBuilder sb = new StringBuilder();
-			if (_depth > 0)
-				sb.Append(_pad).Append("> ");
-			sb.Append(element.Tag);
-			sb.Append(' ');
-			sb.Append(element.ValueRepresentation.Code);
-			sb.Append(' ');
-			if (element.Length == 0) {
-				sb.Append("(no value available)");
-			} else if (element.ValueRepresentation.IsString) {
-				sb.Append('[');
-				string val = element.Get<string>();
-				if (val.Length > (_value - 2 - sb.Length)) {
-					sb.Append(val.Substring(0, _value - 2 - sb.Length));
-					sb.Append(')');
-				} else {
-					sb.Append(val);
-					sb.Append(']');
-				}
-			} else if (element.Length >= 1024) {
-				sb.Append("<skipping large element>");
-			} else {
-				var val = String.Join("/", element.Get<string[]>());
-				if (val.Length > (_value - sb.Length)) {
-					sb.Append(val.Substring(0, _value - sb.Length));
-				} else {
-					sb.Append(val);
-				}
-			}
-			while (sb.Length < _value)
-				sb.Append(' ');
-			sb.Append('#');
-			string name = element.Tag.DictionaryEntry.Keyword;
-			sb.AppendFormat("{0,6}, {1}", element.Length, name.Substring(0, System.Math.Min(_width - sb.Length - 9, name.Length)));
-			_log.AppendLine(sb.ToString());
-			return true;
-		}
+        private int _depth = 0;
 
-		public bool OnBeginSequence(DicomSequence sequence) {
-			_log.AppendFormat("{0}{1} SQ {2}", (_depth > 0) ? _pad + "> " : "", sequence.Tag, sequence.Tag.DictionaryEntry.Name).AppendLine();
-			IncreaseDepth();
-			return true;
-		}
+        private string _pad = String.Empty;
 
-		public bool OnBeginSequenceItem(DicomDataset dataset) {
-			_log.AppendLine(_pad + "Item:");
-			IncreaseDepth();
-			return true;
-		}
+        public DicomDatasetDumper(StringBuilder log, int width = 128, int valueLength = 64)
+        {
+            _log = log;
+            _width = width;
+            _value = valueLength;
+        }
 
-		public bool OnEndSequenceItem() {
-			DecreaseDepth();
-			return true;
-		}
+        public void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback)
+        {
+        }
 
-		public bool OnEndSequence() {
-			DecreaseDepth();
-			return true;
-		}
+        public bool OnElement(DicomElement element)
+        {
+            StringBuilder sb = new StringBuilder();
+            if (_depth > 0) sb.Append(_pad).Append("> ");
+            sb.Append(element.Tag);
+            sb.Append(' ');
+            sb.Append(element.ValueRepresentation.Code);
+            sb.Append(' ');
+            if (element.Length == 0)
+            {
+                sb.Append("(no value available)");
+            }
+            else if (element.ValueRepresentation.IsString)
+            {
+                sb.Append('[');
+                string val = element.Get<string>();
+                if (val.Length > (_value - 2 - sb.Length))
+                {
+                    sb.Append(val.Substring(0, _value - 2 - sb.Length));
+                    sb.Append(')');
+                }
+                else
+                {
+                    sb.Append(val);
+                    sb.Append(']');
+                }
+            }
+            else if (element.Length >= 1024)
+            {
+                sb.Append("<skipping large element>");
+            }
+            else
+            {
+                var val = String.Join("/", element.Get<string[]>());
+                if (val.Length > (_value - sb.Length))
+                {
+                    sb.Append(val.Substring(0, _value - sb.Length));
+                }
+                else
+                {
+                    sb.Append(val);
+                }
+            }
+            while (sb.Length < _value) sb.Append(' ');
+            sb.Append('#');
+            string name = element.Tag.DictionaryEntry.Keyword;
+            sb.AppendFormat(
+                "{0,6}, {1}",
+                element.Length,
+                name.Substring(0, System.Math.Min(_width - sb.Length - 9, name.Length)));
+            _log.AppendLine(sb.ToString());
+            return true;
+        }
 
-		public bool OnBeginFragment(DicomFragmentSequence fragment) {
-			_log.AppendFormat("{0}{1} {2} {3} [{4} offsets, {5} fragments]", (_depth > 0) ? _pad + "> " : "",
-				fragment.Tag, fragment.ValueRepresentation.Code, fragment.Tag.DictionaryEntry.Name,
-				fragment.OffsetTable.Count, fragment.Fragments.Count).AppendLine();
-			return true;
-		}
+        public bool OnBeginSequence(DicomSequence sequence)
+        {
+            _log.AppendFormat(
+                "{0}{1} SQ {2}",
+                (_depth > 0) ? _pad + "> " : "",
+                sequence.Tag,
+                sequence.Tag.DictionaryEntry.Name).AppendLine();
+            IncreaseDepth();
+            return true;
+        }
 
-		public bool OnFragmentItem(IByteBuffer item) {
-			return true;
-		}
+        public bool OnBeginSequenceItem(DicomDataset dataset)
+        {
+            _log.AppendLine(_pad + "Item:");
+            IncreaseDepth();
+            return true;
+        }
 
-		public bool OnEndFragment() {
-			return true;
-		}
+        public bool OnEndSequenceItem()
+        {
+            DecreaseDepth();
+            return true;
+        }
 
-		public void OnEndWalk() {
-		}
+        public bool OnEndSequence()
+        {
+            DecreaseDepth();
+            return true;
+        }
 
-		private void IncreaseDepth() {
-			_depth++;
+        public bool OnBeginFragment(DicomFragmentSequence fragment)
+        {
+            _log.AppendFormat(
+                "{0}{1} {2} {3} [{4} offsets, {5} fragments]",
+                (_depth > 0) ? _pad + "> " : "",
+                fragment.Tag,
+                fragment.ValueRepresentation.Code,
+                fragment.Tag.DictionaryEntry.Name,
+                fragment.OffsetTable.Count,
+                fragment.Fragments.Count).AppendLine();
+            return true;
+        }
 
-			_pad = String.Empty;
-			for (int i = 0; i < _depth; i++)
-				_pad += "  ";
-		}
+        public bool OnFragmentItem(IByteBuffer item)
+        {
+            return true;
+        }
 
-		private void DecreaseDepth() {
-			_depth--;
+        public bool OnEndFragment()
+        {
+            return true;
+        }
 
-			_pad = String.Empty;
-			for (int i = 0; i < _depth; i++)
-				_pad += "  ";
-		}
-	}
+        public void OnEndWalk()
+        {
+        }
+
+        private void IncreaseDepth()
+        {
+            _depth++;
+
+            _pad = String.Empty;
+            for (int i = 0; i < _depth; i++) _pad += "  ";
+        }
+
+        private void DecreaseDepth()
+        {
+            _depth--;
+
+            _pad = String.Empty;
+            for (int i = 0; i < _depth; i++) _pad += "  ";
+        }
+    }
 }

--- a/DICOM/Log/DicomDatasetLogger.cs
+++ b/DICOM/Log/DicomDatasetLogger.cs
@@ -1,121 +1,166 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
 using Dicom.IO.Buffer;
-using Dicom.Log;
 
-namespace Dicom.Log {
-	public class DicomDatasetLogger : IDicomDatasetWalker {
-		private Logger _log;
-		private LogLevel _level;
-		private int _width = 128;
-		private int _value = 64;
-		private int _depth = 0;
-		private string _pad = String.Empty;
+namespace Dicom.Log
+{
+    public class DicomDatasetLogger : IDicomDatasetWalker
+    {
+        private Logger _log;
 
-		public DicomDatasetLogger(Logger logger, LogLevel level, int width = 128, int valueLength = 64) {
-			_log = logger;
-			_level = level;
-			_width = width;
-			_value = valueLength;
-		}
+        private LogLevel _level;
 
-		public void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback) {
-		}
+        private int _width = 128;
 
-		public bool OnElement(DicomElement element) {
-			StringBuilder sb = new StringBuilder();
-			if (_depth > 0)
-				sb.Append(_pad).Append("> ");
-			sb.Append(element.Tag);
-			sb.Append(' ');
-			sb.Append(element.ValueRepresentation.Code);
-			sb.Append(' ');
-			if (element.Length == 0) {
-				sb.Append("(no value available)");
-			} else if (element.ValueRepresentation.IsString) {
-				sb.Append('[');
-				string val = element.Get<string>();
-				if (val.Length > (_value - 2 - sb.Length)) {
-					sb.Append(val.Substring(0, _value - 2 - sb.Length));
-					sb.Append(')');
-				} else {
-					sb.Append(val);
-					sb.Append(']');
-				}
-			} else if (element.Length >= 1024) {
-				sb.Append("<skipping large element>");
-			} else {
-				var val = String.Join("/", element.Get<string[]>());
-				if (val.Length > (_value - sb.Length)) {
-					sb.Append(val.Substring(0, _value - sb.Length));
-				} else {
-					sb.Append(val);
-				}
-			}
-			while (sb.Length < _value)
-				sb.Append(' ');
-			sb.Append('#');
-			string name = element.Tag.DictionaryEntry.Keyword;
-			sb.AppendFormat("{0,6}, {1}", element.Length, name.Substring(0, System.Math.Min(_width - sb.Length - 9, name.Length)));
-			_log.Log(_level, sb.ToString());
-			return true;
-		}
+        private int _value = 64;
 
-		public bool OnBeginSequence(DicomSequence sequence) {
-			_log.Log(_level, "{padding}{tag} SQ {tagDictionaryEntryName}", (_depth > 0) ? _pad + "> " : "", sequence.Tag, sequence.Tag.DictionaryEntry.Name);
-			IncreaseDepth();
-			return true;
-		}
+        private int _depth = 0;
 
-		public bool OnBeginSequenceItem(DicomDataset dataset) {
-			_log.Log(_level, _pad + "Item:");
-			IncreaseDepth();
-			return true;
-		}
+        private string _pad = String.Empty;
 
-		public bool OnEndSequenceItem() {
-			DecreaseDepth();
-			return true;
-		}
+        public DicomDatasetLogger(Logger logger, LogLevel level, int width = 128, int valueLength = 64)
+        {
+            _log = logger;
+            _level = level;
+            _width = width;
+            _value = valueLength;
+        }
 
-		public bool OnEndSequence() {
-			DecreaseDepth();
-			return true;
-		}
+        public void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback)
+        {
+        }
 
-		public bool OnBeginFragment(DicomFragmentSequence fragment) {
-			_log.Log(_level, "{padding}{tag} {vrCode} {tagDictionaryEntryName} [{offsets} offsets, {fragments} fragments]", (_depth > 0) ? _pad + "> " : "", 
-				fragment.Tag, fragment.ValueRepresentation.Code, fragment.Tag.DictionaryEntry.Name, 
-				fragment.OffsetTable.Count, fragment.Fragments.Count);
-			return true;
-		}
+        public bool OnElement(DicomElement element)
+        {
+            StringBuilder sb = new StringBuilder();
+            if (_depth > 0) sb.Append(_pad).Append("> ");
+            sb.Append(element.Tag);
+            sb.Append(' ');
+            sb.Append(element.ValueRepresentation.Code);
+            sb.Append(' ');
+            if (element.Length == 0)
+            {
+                sb.Append("(no value available)");
+            }
+            else if (element.ValueRepresentation.IsString)
+            {
+                sb.Append('[');
+                string val = element.Get<string>();
+                if (val.Length > (_value - 2 - sb.Length))
+                {
+                    sb.Append(val.Substring(0, _value - 2 - sb.Length));
+                    sb.Append(')');
+                }
+                else
+                {
+                    sb.Append(val);
+                    sb.Append(']');
+                }
+            }
+            else if (element.Length >= 1024)
+            {
+                sb.Append("<skipping large element>");
+            }
+            else
+            {
+                var val = String.Join("/", element.Get<string[]>());
+                if (val.Length > (_value - sb.Length))
+                {
+                    sb.Append(val.Substring(0, _value - sb.Length));
+                }
+                else
+                {
+                    sb.Append(val);
+                }
+            }
+            while (sb.Length < _value) sb.Append(' ');
+            sb.Append('#');
+            string name = element.Tag.DictionaryEntry.Keyword;
+            sb.AppendFormat(
+                "{0,6}, {1}",
+                element.Length,
+                name.Substring(0, System.Math.Min(_width - sb.Length - 9, name.Length)));
+            _log.Log(_level, sb.ToString());
+            return true;
+        }
 
-		public bool OnFragmentItem(IByteBuffer item) {
-			return true;
-		}
+        public bool OnBeginSequence(DicomSequence sequence)
+        {
+            _log.Log(
+                _level,
+                "{padding}{tag} SQ {tagDictionaryEntryName}",
+                (_depth > 0) ? _pad + "> " : "",
+                sequence.Tag,
+                sequence.Tag.DictionaryEntry.Name);
+            IncreaseDepth();
+            return true;
+        }
 
-		public bool OnEndFragment() {
-			return true;
-		}
+        public bool OnBeginSequenceItem(DicomDataset dataset)
+        {
+            _log.Log(_level, _pad + "Item:");
+            IncreaseDepth();
+            return true;
+        }
 
-		public void OnEndWalk() {
-		}
+        public bool OnEndSequenceItem()
+        {
+            DecreaseDepth();
+            return true;
+        }
 
-		private void IncreaseDepth() {
-			_depth++;
+        public bool OnEndSequence()
+        {
+            DecreaseDepth();
+            return true;
+        }
 
-			_pad = String.Empty;
-			for (int i = 0; i < _depth; i++)
-				_pad += "  ";
-		}
+        public bool OnBeginFragment(DicomFragmentSequence fragment)
+        {
+            _log.Log(
+                _level,
+                "{padding}{tag} {vrCode} {tagDictionaryEntryName} [{offsets} offsets, {fragments} fragments]",
+                (_depth > 0) ? _pad + "> " : "",
+                fragment.Tag,
+                fragment.ValueRepresentation.Code,
+                fragment.Tag.DictionaryEntry.Name,
+                fragment.OffsetTable.Count,
+                fragment.Fragments.Count);
+            return true;
+        }
 
-		private void DecreaseDepth() {
-			_depth--;
+        public bool OnFragmentItem(IByteBuffer item)
+        {
+            return true;
+        }
 
-			_pad = String.Empty;
-			for (int i = 0; i < _depth; i++)
-				_pad += "  ";
-		}
-	}
+        public bool OnEndFragment()
+        {
+            return true;
+        }
+
+        public void OnEndWalk()
+        {
+        }
+
+        private void IncreaseDepth()
+        {
+            _depth++;
+
+            _pad = String.Empty;
+            for (int i = 0; i < _depth; i++) _pad += "  ";
+        }
+
+        private void DecreaseDepth()
+        {
+            _depth--;
+
+            _pad = String.Empty;
+            for (int i = 0; i < _depth; i++) _pad += "  ";
+        }
+    }
 }

--- a/DICOM/Log/DicomParserLogger.cs
+++ b/DICOM/Log/DicomParserLogger.cs
@@ -1,68 +1,105 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 
 using Dicom.IO;
 using Dicom.IO.Buffer;
 using Dicom.IO.Reader;
-using Dicom.Log;
 
-namespace Dicom.Log {
-	public class DicomParserLogger : IDicomReaderObserver {
-		private Logger _log;
-		private LogLevel _level;
-		private int _depth;
-		private string _pad;
+namespace Dicom.Log
+{
+    public class DicomParserLogger : IDicomReaderObserver
+    {
+        private Logger _log;
 
-		public DicomParserLogger(Logger log, LogLevel level) {
-			_log = log;
-			_level = level;
-			_depth = 0;
-			_pad = String.Empty;
-		}
+        private LogLevel _level;
 
-		public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data) {
-			_log.Log(_level, "{marker:x8}: {padding}{tag} {vrCode} {tagDictionaryEntryName} [{size}]", source.Marker, _pad, tag, vr.Code, tag.DictionaryEntry.Name, data.Size);
-		}
+        private int _depth;
 
-		public void OnBeginSequence(IByteSource source, DicomTag tag, uint length) {
-			_log.Log(_level, "{marker:x8}: {padding}{tag} SQ {length}", source.Marker, _pad, tag, tag.DictionaryEntry.Name, length);
-			IncreaseDepth();
-		}
+        private string _pad;
 
-		public void OnBeginSequenceItem(IByteSource source, uint length) {
-			_log.Log(_level, "{marker:x8}: {padding}Item:", source.Marker, _pad);
-			IncreaseDepth();
-		}
+        public DicomParserLogger(Logger log, LogLevel level)
+        {
+            _log = log;
+            _level = level;
+            _depth = 0;
+            _pad = String.Empty;
+        }
 
-		public void OnEndSequenceItem() {
-			DecreaseDepth();
-		}
+        public void OnElement(IByteSource source, DicomTag tag, DicomVR vr, IByteBuffer data)
+        {
+            _log.Log(
+                _level,
+                "{marker:x8}: {padding}{tag} {vrCode} {tagDictionaryEntryName} [{size}]",
+                source.Marker,
+                _pad,
+                tag,
+                vr.Code,
+                tag.DictionaryEntry.Name,
+                data.Size);
+        }
 
-		public void OnEndSequence() {
-			DecreaseDepth();
-		}
+        public void OnBeginSequence(IByteSource source, DicomTag tag, uint length)
+        {
+            _log.Log(
+                _level,
+                "{marker:x8}: {padding}{tag} SQ {length}",
+                source.Marker,
+                _pad,
+                tag,
+                tag.DictionaryEntry.Name,
+                length);
+            IncreaseDepth();
+        }
 
-		public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr) {
-			_log.Log(_level, "{marker:x8}: {padding}{tag} {vrCode} {tagDictionaryEntryName}", source.Marker, _pad, tag, vr.Code, tag.DictionaryEntry.Name);
-			IncreaseDepth();
-		}
+        public void OnBeginSequenceItem(IByteSource source, uint length)
+        {
+            _log.Log(_level, "{marker:x8}: {padding}Item:", source.Marker, _pad);
+            IncreaseDepth();
+        }
 
-		public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data) {
-			_log.Log(_level, "{marker:x8}: {padding}Fragment [{size}]", source.Marker, _pad, data.Size);
-		}
+        public void OnEndSequenceItem()
+        {
+            DecreaseDepth();
+        }
 
-		public void OnEndFragmentSequence() {
-			DecreaseDepth();
-		}
+        public void OnEndSequence()
+        {
+            DecreaseDepth();
+        }
 
-		private void IncreaseDepth() {
-			_depth++;
-		}
+        public void OnBeginFragmentSequence(IByteSource source, DicomTag tag, DicomVR vr)
+        {
+            _log.Log(
+                _level,
+                "{marker:x8}: {padding}{tag} {vrCode} {tagDictionaryEntryName}",
+                source.Marker,
+                _pad,
+                tag,
+                vr.Code,
+                tag.DictionaryEntry.Name);
+            IncreaseDepth();
+        }
 
-		private void DecreaseDepth() {
-			_depth--;
-		}
-	}
+        public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data)
+        {
+            _log.Log(_level, "{marker:x8}: {padding}Fragment [{size}]", source.Marker, _pad, data.Size);
+        }
+
+        public void OnEndFragmentSequence()
+        {
+            DecreaseDepth();
+        }
+
+        private void IncreaseDepth()
+        {
+            _depth++;
+        }
+
+        private void DecreaseDepth()
+        {
+            _depth--;
+        }
+    }
 }

--- a/DICOM/Log/Extensions.cs
+++ b/DICOM/Log/Extensions.cs
@@ -1,49 +1,59 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
-namespace Dicom.Log {
-	public static class Extensions {
-		public static void WriteToLog(this IEnumerable<DicomItem> dataset, Logger log, LogLevel level) {
-			var logger = new DicomDatasetLogger(log, level);
-			new DicomDatasetWalker(dataset).Walk(logger);
-		}
+namespace Dicom.Log
+{
+    public static class Extensions
+    {
+        public static void WriteToLog(this IEnumerable<DicomItem> dataset, Logger log, LogLevel level)
+        {
+            var logger = new DicomDatasetLogger(log, level);
+            new DicomDatasetWalker(dataset).Walk(logger);
+        }
 
-		public static void WriteToLog(this DicomFile file, Logger log, LogLevel level) {
-			var logger = new DicomDatasetLogger(log, level);
-			new DicomDatasetWalker(file.FileMetaInfo).Walk(logger);
-			new DicomDatasetWalker(file.Dataset).Walk(logger);
-		}
+        public static void WriteToLog(this DicomFile file, Logger log, LogLevel level)
+        {
+            var logger = new DicomDatasetLogger(log, level);
+            new DicomDatasetWalker(file.FileMetaInfo).Walk(logger);
+            new DicomDatasetWalker(file.Dataset).Walk(logger);
+        }
 
-		public static void WriteToConsole(this IEnumerable<DicomItem> dataset) {
-			var log = new StringBuilder();
-			var dumper = new DicomDatasetDumper(log, 80, 60);
-			new DicomDatasetWalker(dataset).Walk(dumper);
-			Console.WriteLine(log);
-		}
+        public static void WriteToConsole(this IEnumerable<DicomItem> dataset)
+        {
+            var log = new StringBuilder();
+            var dumper = new DicomDatasetDumper(log, 80, 60);
+            new DicomDatasetWalker(dataset).Walk(dumper);
+            Console.WriteLine(log);
+        }
 
-		public static void WriteToConsole(this DicomFile file) {
-			var log = new StringBuilder();
-			var dumper = new DicomDatasetDumper(log, 80, 60);
-			new DicomDatasetWalker(file.FileMetaInfo).Walk(dumper);
-			new DicomDatasetWalker(file.Dataset).Walk(dumper);
-			Console.WriteLine(log);
-		}
+        public static void WriteToConsole(this DicomFile file)
+        {
+            var log = new StringBuilder();
+            var dumper = new DicomDatasetDumper(log, 80, 60);
+            new DicomDatasetWalker(file.FileMetaInfo).Walk(dumper);
+            new DicomDatasetWalker(file.Dataset).Walk(dumper);
+            Console.WriteLine(log);
+        }
 
-		public static string WriteToString(this IEnumerable<DicomItem> dataset) {
-			var log = new StringBuilder();
-			var dumper = new DicomDatasetDumper(log);
-			new DicomDatasetWalker(dataset).Walk(dumper);
-			return log.ToString();
-		}
+        public static string WriteToString(this IEnumerable<DicomItem> dataset)
+        {
+            var log = new StringBuilder();
+            var dumper = new DicomDatasetDumper(log);
+            new DicomDatasetWalker(dataset).Walk(dumper);
+            return log.ToString();
+        }
 
-		public static string WriteToString(this DicomFile file) {
-			var log = new StringBuilder();
-			var dumper = new DicomDatasetDumper(log);
-			new DicomDatasetWalker(file.FileMetaInfo).Walk(dumper);
-			new DicomDatasetWalker(file.Dataset).Walk(dumper);
-			return log.ToString();
-		}
-	}
+        public static string WriteToString(this DicomFile file)
+        {
+            var log = new StringBuilder();
+            var dumper = new DicomDatasetDumper(log);
+            new DicomDatasetWalker(file.FileMetaInfo).Walk(dumper);
+            new DicomDatasetWalker(file.Dataset).Walk(dumper);
+            return log.ToString();
+        }
+    }
 }

--- a/DICOM/Log/HexWriter.cs
+++ b/DICOM/Log/HexWriter.cs
@@ -1,125 +1,125 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.IO;
 using System.Text;
 
-namespace Dicom.Log {
-	public class HexWriter {
-		public HexWriter(byte[] data) {
-			Data = data;
-			Start = 0;
-			End = Data.Length;
-			Offset = 0;
-		}
+namespace Dicom.Log
+{
+    public class HexWriter
+    {
+        public HexWriter(byte[] data)
+        {
+            Data = data;
+            Start = 0;
+            End = Data.Length;
+            Offset = 0;
+        }
 
-		/// <summary>Bytes to be displayed</summary>
-		public byte[] Data {
-			get;
-			private set;
-		}
+        /// <summary>Bytes to be displayed</summary>
+        public byte[] Data { get; private set; }
 
-		/// <summary>First byte to be displayed</summary>
-		public int Start {
-			get;
-			set;
-		}
+        /// <summary>First byte to be displayed</summary>
+        public int Start { get; set; }
 
-		/// <summary>Last byte to be displayed</summary>
-		public int End {
-			get;
-			set;
-		}
+        /// <summary>Last byte to be displayed</summary>
+        public int End { get; set; }
 
-		/// <summary>Offset to be added to the printed position</summary>
-		public int Offset {
-			get;
-			set;
-		}
+        /// <summary>Offset to be added to the printed position</summary>
+        public int Offset { get; set; }
 
-		public static string ToString(byte[] data) {
-			return new HexWriter(data).ToString();
-		}
+        public static string ToString(byte[] data)
+        {
+            return new HexWriter(data).ToString();
+        }
 
-		public static string ToString(byte[] data, int start, int length) {
-			HexWriter hw = new HexWriter(data);
-			hw.Start = start;
-			hw.End = start + length;
-			return hw.ToString();
-		}
+        public static string ToString(byte[] data, int start, int length)
+        {
+            HexWriter hw = new HexWriter(data);
+            hw.Start = start;
+            hw.End = start + length;
+            return hw.ToString();
+        }
 
-		public static string ToString(Stream stream, int start, int length) {
-			byte[] data = new byte[length];
-			stream.Position = start;
-			stream.Read(data, 0, length);
+        public static string ToString(Stream stream, int start, int length)
+        {
+            byte[] data = new byte[length];
+            stream.Position = start;
+            stream.Read(data, 0, length);
 
-			HexWriter hw = new HexWriter(data);
-			hw.Start = 0;
-			hw.End = length;
-			hw.Offset = start;
-			return hw.ToString();
-		}
+            HexWriter hw = new HexWriter(data);
+            hw.Start = 0;
+            hw.End = length;
+            hw.Offset = start;
+            return hw.ToString();
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
 
-			for (int b = Start; b < End;) {
-				b += WriteLine(sb, b);
-			}
+            for (int b = Start; b < End;)
+            {
+                b += WriteLine(sb, b);
+            }
 
-			return sb.ToString();
-		}
+            return sb.ToString();
+        }
 
-		private int WriteLine(StringBuilder sb, int start) {
-			int b = start;
-			int end = start + (16 - ((Offset + b) % 16));
-			int start_offset = start + Offset;
+        private int WriteLine(StringBuilder sb, int start)
+        {
+            int b = start;
+            int end = start + (16 - ((Offset + b) % 16));
+            int start_offset = start + Offset;
 
-			sb.AppendFormat("{0:x8}  ", start_offset - (start_offset % 16));
+            sb.AppendFormat("{0:x8}  ", start_offset - (start_offset % 16));
 
-			// blanks up to starting point
-			for (int i = 0, c = ((Offset + b) % 16); i < c; i++) {
-				if ((i % 16) == 8)
-					sb.Append(' ');
-				sb.Append("   ");
-			}
+            // blanks up to starting point
+            for (int i = 0, c = ((Offset + b) % 16); i < c; i++)
+            {
+                if ((i % 16) == 8) sb.Append(' ');
+                sb.Append("   ");
+            }
 
-			// write bytes
-			for (; b < end && b < End; b++) {
-				if (((Offset + b) % 16) == 8)
-					sb.Append(' ');
-				sb.AppendFormat("{0:x2} ", Data[b]);
-			}
+            // write bytes
+            for (; b < end && b < End; b++)
+            {
+                if (((Offset + b) % 16) == 8) sb.Append(' ');
+                sb.AppendFormat("{0:x2} ", Data[b]);
+            }
 
-			// blanks to finish line past end point
-			for (; b < end; b++) {
-				if (((Offset + b) % 16) == 8)
-					sb.Append(' ');
-				sb.Append("   ");
-			}
+            // blanks to finish line past end point
+            for (; b < end; b++)
+            {
+                if (((Offset + b) % 16) == 8) sb.Append(' ');
+                sb.Append("   ");
+            }
 
-			sb.Append(' ');
-			b = start;
+            sb.Append(' ');
+            b = start;
 
-			// blanks up to starting point
-			for (int i = (start_offset % 16); i > 0; i--) {
-				sb.Append(' ');
-			}
+            // blanks up to starting point
+            for (int i = (start_offset % 16); i > 0; i--)
+            {
+                sb.Append(' ');
+            }
 
-			// convert bytes to characters
-			for (; b < end && b < End; b++) {
-				if (Data[b] < 32 || Data[b] > 128)
-					sb.Append('.');
-				else
-					sb.Append((char)Data[b]);
-			}
+            // convert bytes to characters
+            for (; b < end && b < End; b++)
+            {
+                if (Data[b] < 32 || Data[b] > 128) sb.Append('.');
+                else sb.Append((char)Data[b]);
+            }
 
-			// blanks past end point
-			for (; b < end; b++) {
-				sb.Append(' ');
-			}
+            // blanks past end point
+            for (; b < end; b++)
+            {
+                sb.Append(' ');
+            }
 
-			sb.AppendLine();
+            sb.AppendLine();
 
-			return b - start;
-		}
-	}
+            return b - start;
+        }
+    }
 }

--- a/DICOM/Log/LogLevel.cs
+++ b/DICOM/Log/LogLevel.cs
@@ -1,14 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Log {
-	public enum LogLevel {
-		Debug,
-		Info,
-		Warning,
-		Error,
-		Fatal
-	}
+namespace Dicom.Log
+{
+    public enum LogLevel
+    {
+        Debug,
+
+        Info,
+
+        Warning,
+
+        Error,
+
+        Fatal
+    }
 }

--- a/DICOM/Log/LogManager.cs
+++ b/DICOM/Log/LogManager.cs
@@ -1,16 +1,17 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Log {
-	public abstract class LogManager {
-		static LogManager() {
-			Default = new ConsoleLogManager();
-		}
+namespace Dicom.Log
+{
+    public abstract class LogManager
+    {
+        static LogManager()
+        {
+            Default = new ConsoleLogManager();
+        }
 
-		public static LogManager Default {
-			get;
-			set;
-		}
+        public static LogManager Default { get; set; }
 
-		public abstract Logger GetLogger(string name);
-	}
+        public abstract Logger GetLogger(string name);
+    }
 }

--- a/DICOM/Log/Logger.cs
+++ b/DICOM/Log/Logger.cs
@@ -1,30 +1,39 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Dicom.Log {
-    public abstract class Logger {
+namespace Dicom.Log
+{
+    public abstract class Logger
+    {
         public abstract void Log(LogLevel level, string msg, params object[] args);
 
-        public void Debug(string msg, params object[] args) {
+        public void Debug(string msg, params object[] args)
+        {
             Log(LogLevel.Debug, msg, args);
         }
 
-        public void Info(string msg, params object[] args) {
+        public void Info(string msg, params object[] args)
+        {
             Log(LogLevel.Info, msg, args);
         }
 
-        public void Warn(string msg, params object[] args) {
+        public void Warn(string msg, params object[] args)
+        {
             Log(LogLevel.Warning, msg, args);
         }
 
-        public void Error(string msg, params object[] args) {
+        public void Error(string msg, params object[] args)
+        {
             Log(LogLevel.Error, msg, args);
         }
 
-        public void Fatal(string msg, params object[] args) {
+        public void Fatal(string msg, params object[] args)
+        {
             Log(LogLevel.Fatal, msg, args);
         }
 
@@ -42,7 +51,8 @@ namespace Dicom.Log {
         /// </summary>
         /// <param name="message"></param>
         /// <returns></returns>
-        protected static string NameFormatToPositionalFormat(string message) {
+        protected static string NameFormatToPositionalFormat(string message)
+        {
             var matches = _curlyBracePairRegex.Matches(message).Cast<Match>();
 
             var handledMatchNames = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
@@ -54,33 +64,37 @@ namespace Dicom.Log {
             //Is every encountered match a number?  If so, we've been given a string already in positional format so it should not be amended
             bool everyMatchIsANumber = true; //until proven otherwise
 
-            foreach (var match in matches) {
+            foreach (var match in matches)
+            {
                 //Remove the braces
                 var matchNameFormattingNoBraces = match.Value.Substring(1, match.Value.Length - 2);
 
                 //Split into the name and the formatting
                 var colonIndex = matchNameFormattingNoBraces.IndexOf(':');
                 var matchName = colonIndex < 0
-                    ? matchNameFormattingNoBraces
-                    : matchNameFormattingNoBraces.Substring(0, colonIndex);
+                                    ? matchNameFormattingNoBraces
+                                    : matchNameFormattingNoBraces.Substring(0, colonIndex);
                 var formattingIncludingColon = colonIndex < 0 ? "" : matchNameFormattingNoBraces.Substring(colonIndex);
 
                 everyMatchIsANumber = everyMatchIsANumber && IsNumber(matchName);
 
                 //Remove leading "@" sign (indicates destructuring was desired)
                 var destructured = matchName.StartsWith("@");
-                if (destructured) {
+                if (destructured)
+                {
                     matchName = matchName.Substring(1);
                 }
 
                 int ordinalOutputPosition;
                 //Already seen the match?
-                if (!handledMatchNames.ContainsKey(matchName)) {
+                if (!handledMatchNames.ContainsKey(matchName))
+                {
                     //first time
                     ordinalOutputPosition = handledMatchNames.Count;
                     handledMatchNames.Add(matchName, ordinalOutputPosition);
                 }
-                else {
+                else
+                {
                     //resuse previous number
                     ordinalOutputPosition = handledMatchNames[matchName];
                 }
@@ -88,21 +102,23 @@ namespace Dicom.Log {
                 var replacement = "{" + ordinalOutputPosition + formattingIncludingColon + "}";
 
                 //Substitute the new text in place in the message
-                updatedMessage = updatedMessage.Substring(0, match.Index + positionDelta) + replacement +
-                                 updatedMessage.Substring(match.Index + match.Length + positionDelta);
+                updatedMessage = updatedMessage.Substring(0, match.Index + positionDelta) + replacement
+                                 + updatedMessage.Substring(match.Index + match.Length + positionDelta);
                 //Update positionDelta to account for differing lengths of substitution
                 positionDelta = positionDelta + (replacement.Length - match.Length);
             }
 
 
-            if (everyMatchIsANumber) {
+            if (everyMatchIsANumber)
+            {
                 return message;
             }
 
             return updatedMessage;
         }
 
-        internal static bool IsNumber(string s) {
+        internal static bool IsNumber(string s)
+        {
             int dummy;
             return int.TryParse(s, out dummy);
         }

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Linq;
 using System.Text;
 
@@ -8,443 +9,556 @@ using Dicom.IO;
 using Dicom.IO.Reader;
 using Dicom.IO.Writer;
 
-namespace Dicom.Media {
-    public class DicomDirectory : DicomFile {
-		#region Properties and Attributes
+namespace Dicom.Media
+{
+    public class DicomDirectory : DicomFile
+    {
+        #region Properties and Attributes
 
-		private DicomSequence _directoryRecordSequence;
+        private DicomSequence _directoryRecordSequence;
 
-		private uint _fileOffset;
+        private uint _fileOffset;
 
-		public DicomDirectoryRecord RootDirectoryRecord { get; private set; }
+        public DicomDirectoryRecord RootDirectoryRecord { get; private set; }
 
-		public DicomDirectoryRecordCollection RootDirectoryRecordCollection {
-			get { return new DicomDirectoryRecordCollection(RootDirectoryRecord); }
-		}
+        public DicomDirectoryRecordCollection RootDirectoryRecordCollection
+        {
+            get
+            {
+                return new DicomDirectoryRecordCollection(RootDirectoryRecord);
+            }
+        }
 
-		public string FileSetID {
-			get { return Dataset.Get<string>(DicomTag.FileSetID); }
-			set {
-				if (!string.IsNullOrWhiteSpace(value)) {
-					Dataset.Add<string>(DicomTag.FileSetID, value);
-				} else {
-					throw new ArgumentException("FileSetId can only be a maxmimum of 16 characters", "value");
-				}
-			}
-		}
+        public string FileSetID
+        {
+            get
+            {
+                return Dataset.Get<string>(DicomTag.FileSetID);
+            }
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    Dataset.Add<string>(DicomTag.FileSetID, value);
+                }
+                else
+                {
+                    throw new ArgumentException("FileSetId can only be a maxmimum of 16 characters", "value");
+                }
+            }
+        }
 
-		public string SourceApplicationEntityTitle {
-			get { return FileMetaInfo.SourceApplicationEntityTitle; }
-			set { FileMetaInfo.SourceApplicationEntityTitle = value; }
-		}
+        public string SourceApplicationEntityTitle
+        {
+            get
+            {
+                return FileMetaInfo.SourceApplicationEntityTitle;
+            }
+            set
+            {
+                FileMetaInfo.SourceApplicationEntityTitle = value;
+            }
+        }
 
-		public DicomUID MediaStorageSOPInstanceUID {
-			get { return FileMetaInfo.MediaStorageSOPInstanceUID; }
-			set { FileMetaInfo.MediaStorageSOPInstanceUID = value; }
-		}
+        public DicomUID MediaStorageSOPInstanceUID
+        {
+            get
+            {
+                return FileMetaInfo.MediaStorageSOPInstanceUID;
+            }
+            set
+            {
+                FileMetaInfo.MediaStorageSOPInstanceUID = value;
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region Constructors
+        #region Constructors
 
-        public DicomDirectory(Boolean explicitVr = true) : base(){
-			FileMetaInfo.Add<byte>(DicomTag.FileMetaInformationVersion, new byte[] { 0x00, 0x01 });
-			FileMetaInfo.MediaStorageSOPClassUID = DicomUID.MediaStorageDirectoryStorage;
-			FileMetaInfo.MediaStorageSOPInstanceUID = DicomUID.Generate();
-			FileMetaInfo.SourceApplicationEntityTitle = string.Empty;
-            FileMetaInfo.TransferSyntax = explicitVr 
-                                                ? DicomTransferSyntax.ExplicitVRLittleEndian 
-                                                : DicomTransferSyntax.ImplicitVRLittleEndian;
-			FileMetaInfo.ImplementationClassUID = DicomImplementation.ClassUID;
-			FileMetaInfo.ImplementationVersionName = DicomImplementation.Version;
+        public DicomDirectory(Boolean explicitVr = true)
+            : base()
+        {
+            FileMetaInfo.Add<byte>(DicomTag.FileMetaInformationVersion, new byte[] { 0x00, 0x01 });
+            FileMetaInfo.MediaStorageSOPClassUID = DicomUID.MediaStorageDirectoryStorage;
+            FileMetaInfo.MediaStorageSOPInstanceUID = DicomUID.Generate();
+            FileMetaInfo.SourceApplicationEntityTitle = string.Empty;
+            FileMetaInfo.TransferSyntax = explicitVr
+                                              ? DicomTransferSyntax.ExplicitVRLittleEndian
+                                              : DicomTransferSyntax.ImplicitVRLittleEndian;
+            FileMetaInfo.ImplementationClassUID = DicomImplementation.ClassUID;
+            FileMetaInfo.ImplementationVersionName = DicomImplementation.Version;
 
-			_directoryRecordSequence = new DicomSequence(DicomTag.DirectoryRecordSequence);
+            _directoryRecordSequence = new DicomSequence(DicomTag.DirectoryRecordSequence);
 
-			Dataset.Add<string>(DicomTag.FileSetID, string.Empty)
-				   .Add<ushort>(DicomTag.FileSetConsistencyFlag, 0)
-				   .Add<uint>(DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity, 0)
-				   .Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, 0)
-				   .Add(_directoryRecordSequence);
-		}
+            Dataset.Add<string>(DicomTag.FileSetID, string.Empty)
+                .Add<ushort>(DicomTag.FileSetConsistencyFlag, 0)
+                .Add<uint>(DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity, 0)
+                .Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, 0)
+                .Add(_directoryRecordSequence);
+        }
 
-		#endregion
+        #endregion
 
-		#region Save/Load Methods
+        #region Save/Load Methods
 
-		protected override void OnSave() {
-			if (RootDirectoryRecord == null)
-				throw new InvalidOperationException("No DICOM files added, cannot save DICOM directory");
+        protected override void OnSave()
+        {
+            if (RootDirectoryRecord == null) throw new InvalidOperationException("No DICOM files added, cannot save DICOM directory");
 
-			_directoryRecordSequence.Items.Clear();
-			var calculator = new DicomWriteLengthCalculator(FileMetaInfo.TransferSyntax, DicomWriteOptions.Default);
+            _directoryRecordSequence.Items.Clear();
+            var calculator = new DicomWriteLengthCalculator(FileMetaInfo.TransferSyntax, DicomWriteOptions.Default);
 
-			// ensure write length calculator does not include end of sequence item
+            // ensure write length calculator does not include end of sequence item
             //Dataset.Remove(DicomTag.DirectoryRecordSequence);
 
             //_fileOffset = 128 + calculator.Calculate(FileMetaInfo) + calculator.Calculate(Dataset);
 
-			//Add the offset for the Directory Record sequence tag itself
+            //Add the offset for the Directory Record sequence tag itself
             //_fileOffset += 4;//sequence element tag
             if (FileMetaInfo.TransferSyntax.IsExplicitVR)
             {
                 _fileOffset = 128 + calculator.Calculate(FileMetaInfo) + calculator.Calculate(Dataset);
-				_fileOffset += 2; // vr
-				_fileOffset += 2; // padding
-				_fileOffset += 4; // length
+                _fileOffset += 2; // vr
+                _fileOffset += 2; // padding
+                _fileOffset += 4; // length
             }
             else
             {
                 _fileOffset = 128 + 4 + calculator.Calculate(FileMetaInfo) + calculator.Calculate(Dataset);
-                
-                _fileOffset += 4;//sequence element tag
-				_fileOffset += 4; //length
-			}
 
-			AddDirectoryRecordsToSequenceItem(RootDirectoryRecord);
+                _fileOffset += 4; //sequence element tag
+                _fileOffset += 4; //length
+            }
 
-			if (RootDirectoryRecord != null) {
-				CalculateOffsets(calculator);
+            AddDirectoryRecordsToSequenceItem(RootDirectoryRecord);
 
-				SetOffsets(RootDirectoryRecord);
+            if (RootDirectoryRecord != null)
+            {
+                CalculateOffsets(calculator);
 
-				Dataset.Add<uint>(DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity, RootDirectoryRecord.Offset);
+                SetOffsets(RootDirectoryRecord);
 
-				var lastRoot = RootDirectoryRecord;
+                Dataset.Add<uint>(
+                    DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity,
+                    RootDirectoryRecord.Offset);
 
-				while (lastRoot.NextDirectoryRecord != null)
-					lastRoot = lastRoot.NextDirectoryRecord;
+                var lastRoot = RootDirectoryRecord;
 
-				Dataset.Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, lastRoot.Offset);
-			} else {
-				Dataset.Add<uint>(DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity, 0);
-				Dataset.Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, 0);
-			}
-		}
+                while (lastRoot.NextDirectoryRecord != null) lastRoot = lastRoot.NextDirectoryRecord;
 
-	    public static new DicomDirectory Open(string fileName)
-	    {
-	        return Open(fileName, DicomEncoding.Default);
-	    }
+                Dataset.Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, lastRoot.Offset);
+            }
+            else
+            {
+                Dataset.Add<uint>(DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity, 0);
+                Dataset.Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, 0);
+            }
+        }
 
-	    public new static DicomDirectory Open(string fileName, Encoding fallbackEncoding) {
-	        if (fallbackEncoding == null)
-	        {
-	            throw new ArgumentNullException("fallbackEncoding");
-	        }
-	        var df = new DicomDirectory();
+        public static new DicomDirectory Open(string fileName)
+        {
+            return Open(fileName, DicomEncoding.Default);
+        }
 
-			// reset datasets
-			df.FileMetaInfo.Clear();
-			df.Dataset.Clear();
+        public static new DicomDirectory Open(string fileName, Encoding fallbackEncoding)
+        {
+            if (fallbackEncoding == null)
+            {
+                throw new ArgumentNullException("fallbackEncoding");
+            }
+            var df = new DicomDirectory();
 
-			try {
-				df.File = new FileReference(fileName);
+            // reset datasets
+            df.FileMetaInfo.Clear();
+            df.Dataset.Clear();
 
-				using (var source = new FileByteSource(df.File)) {
-					DicomFileReader reader = new DicomFileReader();
+            try
+            {
+                df.File = new FileReference(fileName);
 
-					var datasetObserver = new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding);
-					var dirObserver = new DicomDirectoryReaderObserver(df.Dataset);
+                using (var source = new FileByteSource(df.File))
+                {
+                    DicomFileReader reader = new DicomFileReader();
 
-					reader.Read(source,
-						new DicomDatasetReaderObserver(df.FileMetaInfo),
-						new DicomReaderMultiObserver(datasetObserver, dirObserver));
+                    var datasetObserver = new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding);
+                    var dirObserver = new DicomDirectoryReaderObserver(df.Dataset);
 
-					df.Format = reader.FileFormat;
+                    reader.Read(
+                        source,
+                        new DicomDatasetReaderObserver(df.FileMetaInfo),
+                        new DicomReaderMultiObserver(datasetObserver, dirObserver));
 
-					df.Dataset.InternalTransferSyntax = reader.Syntax;
+                    df.Format = reader.FileFormat;
 
-					df._directoryRecordSequence = df.Dataset.Get<DicomSequence>(DicomTag.DirectoryRecordSequence);
-					df.RootDirectoryRecord = dirObserver.BuildDirectoryRecords();
+                    df.Dataset.InternalTransferSyntax = reader.Syntax;
 
-					return df;
-				}
-			} catch (Exception e) {
-				throw new DicomFileException(df, e.Message, e);
-			}
-		}
+                    df._directoryRecordSequence = df.Dataset.Get<DicomSequence>(DicomTag.DirectoryRecordSequence);
+                    df.RootDirectoryRecord = dirObserver.BuildDirectoryRecords();
 
-        public static new IAsyncResult BeginOpen(string fileName, AsyncCallback callback, object state) {
+                    return df;
+                }
+            }
+            catch (Exception e)
+            {
+                throw new DicomFileException(df, e.Message, e);
+            }
+        }
+
+        public static new IAsyncResult BeginOpen(string fileName, AsyncCallback callback, object state)
+        {
             return BeginOpen(fileName, DicomEncoding.Default, callback, state);
         }
 
-        public new static IAsyncResult BeginOpen(string fileName, Encoding fallbackEncoding, AsyncCallback callback, object state) {
-			var df = new DicomDirectory();
+        public static new IAsyncResult BeginOpen(
+            string fileName,
+            Encoding fallbackEncoding,
+            AsyncCallback callback,
+            object state)
+        {
+            var df = new DicomDirectory();
 
-			// reset datasets
-			df.FileMetaInfo.Clear();
-			df.Dataset.Clear();
+            // reset datasets
+            df.FileMetaInfo.Clear();
+            df.Dataset.Clear();
 
-			df.File = new FileReference(fileName);
+            df.File = new FileReference(fileName);
 
-			FileByteSource source = new FileByteSource(df.File);
+            FileByteSource source = new FileByteSource(df.File);
 
-			EventAsyncResult result = new EventAsyncResult(callback, state);
+            EventAsyncResult result = new EventAsyncResult(callback, state);
 
-			DicomFileReader reader = new DicomFileReader();
+            DicomFileReader reader = new DicomFileReader();
 
-			var datasetObserver = new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding);
-			var dirObserver = new DicomDirectoryReaderObserver(df.Dataset);
+            var datasetObserver = new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding);
+            var dirObserver = new DicomDirectoryReaderObserver(df.Dataset);
 
-			reader.BeginRead(source,
-				new DicomDatasetReaderObserver(df.FileMetaInfo),
-				new DicomReaderMultiObserver(datasetObserver, dirObserver),
-				OnReadComplete, new Tuple<DicomFileReader, DicomDirectory, DicomDirectoryReaderObserver, EventAsyncResult>(reader, df, dirObserver, result));
+            reader.BeginRead(
+                source,
+                new DicomDatasetReaderObserver(df.FileMetaInfo),
+                new DicomReaderMultiObserver(datasetObserver, dirObserver),
+                OnReadComplete,
+                new Tuple<DicomFileReader, DicomDirectory, DicomDirectoryReaderObserver, EventAsyncResult>(
+                    reader,
+                    df,
+                    dirObserver,
+                    result));
 
-			return result;
-		}
-		private static void OnReadComplete(IAsyncResult result) {
-			var state = result.AsyncState as Tuple<DicomFileReader, DicomDirectory, DicomDirectoryReaderObserver, EventAsyncResult>;
+            return result;
+        }
 
-			Exception e = null;
-			try {
-				state.Item1.EndRead(result);
+        private static void OnReadComplete(IAsyncResult result)
+        {
+            var state =
+                result.AsyncState as
+                Tuple<DicomFileReader, DicomDirectory, DicomDirectoryReaderObserver, EventAsyncResult>;
 
-				// ensure that file handles are closed
-				var source = (FileByteSource)state.Item1.Source;
-				source.Dispose();
+            Exception e = null;
+            try
+            {
+                state.Item1.EndRead(result);
 
-				state.Item2.Format = state.Item1.FileFormat;
-				state.Item2.Dataset.InternalTransferSyntax = state.Item1.Syntax;
+                // ensure that file handles are closed
+                var source = (FileByteSource)state.Item1.Source;
+                source.Dispose();
 
-				state.Item2._directoryRecordSequence = state.Item2.Dataset.Get<DicomSequence>(DicomTag.DirectoryRecordSequence);
-				state.Item2.RootDirectoryRecord = state.Item3.BuildDirectoryRecords();
-			} catch (Exception ex) {
-				state.Item2.Format = state.Item1.FileFormat;
-				e = ex;
-			}
+                state.Item2.Format = state.Item1.FileFormat;
+                state.Item2.Dataset.InternalTransferSyntax = state.Item1.Syntax;
 
-			state.Item4.InternalState = new Tuple<DicomDirectory, Exception>(state.Item2, e);
-			state.Item4.Set();
-		}
+                state.Item2._directoryRecordSequence =
+                    state.Item2.Dataset.Get<DicomSequence>(DicomTag.DirectoryRecordSequence);
+                state.Item2.RootDirectoryRecord = state.Item3.BuildDirectoryRecords();
+            }
+            catch (Exception ex)
+            {
+                state.Item2.Format = state.Item1.FileFormat;
+                e = ex;
+            }
 
-		public new static DicomDirectory EndOpen(IAsyncResult result) {
-			result.AsyncWaitHandle.WaitOne();
+            state.Item4.InternalState = new Tuple<DicomDirectory, Exception>(state.Item2, e);
+            state.Item4.Set();
+        }
 
-			EventAsyncResult eventResult = result as EventAsyncResult;
-			var state = eventResult.InternalState as Tuple<DicomDirectory, Exception>;
+        public static new DicomDirectory EndOpen(IAsyncResult result)
+        {
+            result.AsyncWaitHandle.WaitOne();
 
-			if (state.Item2 != null)
-				throw new DicomFileException(state.Item1, state.Item2.Message, state.Item2);
+            EventAsyncResult eventResult = result as EventAsyncResult;
+            var state = eventResult.InternalState as Tuple<DicomDirectory, Exception>;
 
-			return state.Item1;
-		}
+            if (state.Item2 != null) throw new DicomFileException(state.Item1, state.Item2.Message, state.Item2);
 
-		private void AddDirectoryRecordsToSequenceItem(DicomDirectoryRecord recordItem) {
-			if (recordItem == null)
-				return;
+            return state.Item1;
+        }
 
-			_directoryRecordSequence.Items.Add(recordItem);
-			if (recordItem.LowerLevelDirectoryRecord != null)
-				AddDirectoryRecordsToSequenceItem(recordItem.LowerLevelDirectoryRecord);
+        private void AddDirectoryRecordsToSequenceItem(DicomDirectoryRecord recordItem)
+        {
+            if (recordItem == null) return;
 
-			if (recordItem.NextDirectoryRecord != null)
-				AddDirectoryRecordsToSequenceItem(recordItem.NextDirectoryRecord);
-		}
+            _directoryRecordSequence.Items.Add(recordItem);
+            if (recordItem.LowerLevelDirectoryRecord != null) AddDirectoryRecordsToSequenceItem(recordItem.LowerLevelDirectoryRecord);
 
-		#endregion
+            if (recordItem.NextDirectoryRecord != null) AddDirectoryRecordsToSequenceItem(recordItem.NextDirectoryRecord);
+        }
 
-		#region Calculation Methods
+        #endregion
 
-		private void CalculateOffsets(DicomWriteLengthCalculator calculator) {
-			foreach (var item in Dataset.Get<DicomSequence>(DicomTag.DirectoryRecordSequence)) {
-				var record = item as DicomDirectoryRecord;
-				if (record == null)
-					throw new InvalidOperationException("Unexpected type for directory record: " + item.GetType());
+        #region Calculation Methods
 
-				record.Offset = _fileOffset;
+        private void CalculateOffsets(DicomWriteLengthCalculator calculator)
+        {
+            foreach (var item in Dataset.Get<DicomSequence>(DicomTag.DirectoryRecordSequence))
+            {
+                var record = item as DicomDirectoryRecord;
+                if (record == null) throw new InvalidOperationException("Unexpected type for directory record: " + item.GetType());
 
-				_fileOffset += 4 + 4;//Sequence item tag;
+                record.Offset = _fileOffset;
 
-				_fileOffset += calculator.Calculate(record);
+                _fileOffset += 4 + 4; //Sequence item tag;
 
-				_fileOffset += 4 + 4; // Sequence Item Delimitation Item
-			}
+                _fileOffset += calculator.Calculate(record);
 
-			_fileOffset += 4 + 4; // Sequence Delimitation Item
-		}
+                _fileOffset += 4 + 4; // Sequence Item Delimitation Item
+            }
 
-		private void SetOffsets(DicomDirectoryRecord record) {
-			if (record.NextDirectoryRecord != null) {
-				record.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, record.NextDirectoryRecord.Offset);
-				SetOffsets(record.NextDirectoryRecord);
-			} else {
-				record.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, 0);
-			}
+            _fileOffset += 4 + 4; // Sequence Delimitation Item
+        }
 
-			if (record.LowerLevelDirectoryRecord != null) {
-				record.Add<uint>(DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity, record.LowerLevelDirectoryRecord.Offset);
-				SetOffsets(record.LowerLevelDirectoryRecord);
-			} else {
-				record.Add<uint>(DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity, 0);
-			}
-		}
+        private void SetOffsets(DicomDirectoryRecord record)
+        {
+            if (record.NextDirectoryRecord != null)
+            {
+                record.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, record.NextDirectoryRecord.Offset);
+                SetOffsets(record.NextDirectoryRecord);
+            }
+            else
+            {
+                record.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, 0);
+            }
 
-		#endregion
+            if (record.LowerLevelDirectoryRecord != null)
+            {
+                record.Add<uint>(
+                    DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity,
+                    record.LowerLevelDirectoryRecord.Offset);
+                SetOffsets(record.LowerLevelDirectoryRecord);
+            }
+            else
+            {
+                record.Add<uint>(DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity, 0);
+            }
+        }
 
-		#region File system creator Methods
+        #endregion
 
-		public void AddFile(DicomFile dicomFile, string referencedFileId = "") {
-			if (dicomFile == null)
-				throw new ArgumentNullException("dicomFile");
+        #region File system creator Methods
 
-			AddNewRcord(dicomFile.FileMetaInfo, dicomFile.Dataset, referencedFileId);
-		}
+        public void AddFile(DicomFile dicomFile, string referencedFileId = "")
+        {
+            if (dicomFile == null) throw new ArgumentNullException("dicomFile");
 
-		private void AddNewRcord(DicomFileMetaInformation metaFileInfo, DicomDataset dataset, string referencedFileId) {
-			DicomDirectoryRecord patientRecord, studyRecord, seriesRecord;
+            AddNewRcord(dicomFile.FileMetaInfo, dicomFile.Dataset, referencedFileId);
+        }
 
-			patientRecord = CreatePatientRecord(dataset);
-			studyRecord = CreateStudyRecord(dataset, patientRecord);
-			seriesRecord = CreateSeriesRecord(dataset, studyRecord);
-			CreateImageRecord(metaFileInfo, dataset, seriesRecord, referencedFileId);
-		}
+        private void AddNewRcord(DicomFileMetaInformation metaFileInfo, DicomDataset dataset, string referencedFileId)
+        {
+            DicomDirectoryRecord patientRecord, studyRecord, seriesRecord;
 
-		private void CreateImageRecord(DicomFileMetaInformation metaFileInfo, DicomDataset dataset, DicomDirectoryRecord seriesRecord, string referencedFileId) {
-			var currentImage = seriesRecord.LowerLevelDirectoryRecord;
-			var imageInstanceUid = dataset.Get<string>(DicomTag.SOPInstanceUID);
+            patientRecord = CreatePatientRecord(dataset);
+            studyRecord = CreateStudyRecord(dataset, patientRecord);
+            seriesRecord = CreateSeriesRecord(dataset, studyRecord);
+            CreateImageRecord(metaFileInfo, dataset, seriesRecord, referencedFileId);
+        }
 
-
-			while (currentImage != null) {
-				if (currentImage.Get<string>(DicomTag.ReferencedSOPInstanceUIDInFile) == imageInstanceUid) {
-					return;
-				}
-
-				if (currentImage.NextDirectoryRecord != null) {
-					currentImage = currentImage.NextDirectoryRecord;
-				} else {
-					//no more patient records, break the loop
-					break;
-				}
-			}
-			var newImage = CreateRecordSequenceItem(DicomDirectoryRecordType.Image, dataset);
-			newImage.Add(DicomTag.ReferencedFileID, referencedFileId);
-			newImage.Add(DicomTag.ReferencedSOPClassUIDInFile, metaFileInfo.MediaStorageSOPClassUID.UID);
-			newImage.Add(DicomTag.ReferencedSOPInstanceUIDInFile, metaFileInfo.MediaStorageSOPInstanceUID.UID);
-			newImage.Add(DicomTag.ReferencedTransferSyntaxUIDInFile, metaFileInfo.TransferSyntax.UID);
-
-			if (currentImage != null) {
-				//study not found under patient record
-				currentImage.NextDirectoryRecord = newImage;
-			} else {
-				//no studies record found under patient record
-				seriesRecord.LowerLevelDirectoryRecord = newImage;
-			}
-		}
-
-		private DicomDirectoryRecord CreateSeriesRecord(DicomDataset dataset, DicomDirectoryRecord studyRecord) {
-			var currentSeries = studyRecord.LowerLevelDirectoryRecord;
-			var seriesInstanceUid = dataset.Get<string>(DicomTag.SeriesInstanceUID);
-
-
-			while (currentSeries != null) {
-				if (currentSeries.Get<string>(DicomTag.SeriesInstanceUID) == seriesInstanceUid) {
-					return currentSeries;
-				}
-
-				if (currentSeries.NextDirectoryRecord != null) {
-					currentSeries = currentSeries.NextDirectoryRecord;
-				} else {
-					//no more patient records, break the loop
-					break;
-				}
-			}
-
-			var newSeries = CreateRecordSequenceItem(DicomDirectoryRecordType.Series, dataset);
-			if (currentSeries != null) {
-				//series not found under study record
-				currentSeries.NextDirectoryRecord = newSeries;
-			} else {
-				//no series record found under study record
-				studyRecord.LowerLevelDirectoryRecord = newSeries;
-			}
-			return newSeries;
-		}
-
-		private DicomDirectoryRecord CreateStudyRecord(DicomDataset dataset, DicomDirectoryRecord patientRecord) {
-			var currentStudy = patientRecord.LowerLevelDirectoryRecord;
-			var studyInstanceUid = dataset.Get<string>(DicomTag.StudyInstanceUID);
+        private void CreateImageRecord(
+            DicomFileMetaInformation metaFileInfo,
+            DicomDataset dataset,
+            DicomDirectoryRecord seriesRecord,
+            string referencedFileId)
+        {
+            var currentImage = seriesRecord.LowerLevelDirectoryRecord;
+            var imageInstanceUid = dataset.Get<string>(DicomTag.SOPInstanceUID);
 
 
-			while (currentStudy != null) {
-				if (currentStudy.Get<string>(DicomTag.StudyInstanceUID) == studyInstanceUid) {
-					return currentStudy;
-				}
+            while (currentImage != null)
+            {
+                if (currentImage.Get<string>(DicomTag.ReferencedSOPInstanceUIDInFile) == imageInstanceUid)
+                {
+                    return;
+                }
 
-				if (currentStudy.NextDirectoryRecord != null) {
-					currentStudy = currentStudy.NextDirectoryRecord;
-				} else {
-					//no more patient records, break the loop
-					break;
-				}
-			}
-			var newStudy = CreateRecordSequenceItem(DicomDirectoryRecordType.Study, dataset);
-			if (currentStudy != null) {
-				//study not found under patient record
-				currentStudy.NextDirectoryRecord = newStudy;
-			} else {
-				//no studies record found under patient record
-				patientRecord.LowerLevelDirectoryRecord = newStudy;
-			}
-			return newStudy;
-		}
+                if (currentImage.NextDirectoryRecord != null)
+                {
+                    currentImage = currentImage.NextDirectoryRecord;
+                }
+                else
+                {
+                    //no more patient records, break the loop
+                    break;
+                }
+            }
+            var newImage = CreateRecordSequenceItem(DicomDirectoryRecordType.Image, dataset);
+            newImage.Add(DicomTag.ReferencedFileID, referencedFileId);
+            newImage.Add(DicomTag.ReferencedSOPClassUIDInFile, metaFileInfo.MediaStorageSOPClassUID.UID);
+            newImage.Add(DicomTag.ReferencedSOPInstanceUIDInFile, metaFileInfo.MediaStorageSOPInstanceUID.UID);
+            newImage.Add(DicomTag.ReferencedTransferSyntaxUIDInFile, metaFileInfo.TransferSyntax.UID);
 
-		private DicomDirectoryRecord CreatePatientRecord(DicomDataset dataset) {
-			var currentPatient = RootDirectoryRecord;
-			var patientId = dataset.Get<string>(DicomTag.PatientID);
-			var patientName = dataset.Get<string>(DicomTag.PatientName);
+            if (currentImage != null)
+            {
+                //study not found under patient record
+                currentImage.NextDirectoryRecord = newImage;
+            }
+            else
+            {
+                //no studies record found under patient record
+                seriesRecord.LowerLevelDirectoryRecord = newImage;
+            }
+        }
 
-			while (currentPatient != null) {
-				if (currentPatient.Get<string>(DicomTag.PatientID) == patientId
-					&& currentPatient.Get<string>(DicomTag.PatientName) == patientName) {
-					return currentPatient;
-				}
+        private DicomDirectoryRecord CreateSeriesRecord(DicomDataset dataset, DicomDirectoryRecord studyRecord)
+        {
+            var currentSeries = studyRecord.LowerLevelDirectoryRecord;
+            var seriesInstanceUid = dataset.Get<string>(DicomTag.SeriesInstanceUID);
 
-				if (currentPatient.NextDirectoryRecord != null) {
-					currentPatient = currentPatient.NextDirectoryRecord;
-				} else {
-					//no more patient records, break the loop
-					break;
-				}
-			}
-			var newPatient = CreateRecordSequenceItem(DicomDirectoryRecordType.Patient, dataset);
-			if (currentPatient != null) {
-				//patient not found under root record
-				currentPatient.NextDirectoryRecord = newPatient;
-			} else {
-				//no patients record found under root record
-				RootDirectoryRecord = newPatient;
-			}
-			return newPatient;
-		}
 
-		private DicomDirectoryRecord CreateRecordSequenceItem(DicomDirectoryRecordType recordType, DicomDataset dataset) {
-			if (recordType == null)
-				throw new ArgumentNullException("recordType");
-			if (dataset == null)
-				throw new ArgumentNullException("dataset");
+            while (currentSeries != null)
+            {
+                if (currentSeries.Get<string>(DicomTag.SeriesInstanceUID) == seriesInstanceUid)
+                {
+                    return currentSeries;
+                }
 
-			var sequenceItem = new DicomDirectoryRecord();
+                if (currentSeries.NextDirectoryRecord != null)
+                {
+                    currentSeries = currentSeries.NextDirectoryRecord;
+                }
+                else
+                {
+                    //no more patient records, break the loop
+                    break;
+                }
+            }
 
-			//add record item attributes
-			sequenceItem.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, 0);
-			sequenceItem.Add<ushort>(DicomTag.RecordInUseFlag, 0xFFFF);
-			sequenceItem.Add<uint>(DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity, 0);
-			sequenceItem.Add<string>(DicomTag.DirectoryRecordType, recordType.ToString());
+            var newSeries = CreateRecordSequenceItem(DicomDirectoryRecordType.Series, dataset);
+            if (currentSeries != null)
+            {
+                //series not found under study record
+                currentSeries.NextDirectoryRecord = newSeries;
+            }
+            else
+            {
+                //no series record found under study record
+                studyRecord.LowerLevelDirectoryRecord = newSeries;
+            }
+            return newSeries;
+        }
 
-			//copy the current dataset character set
-			sequenceItem.Add(dataset.FirstOrDefault(d => d.Tag == DicomTag.SpecificCharacterSet));
+        private DicomDirectoryRecord CreateStudyRecord(DicomDataset dataset, DicomDirectoryRecord patientRecord)
+        {
+            var currentStudy = patientRecord.LowerLevelDirectoryRecord;
+            var studyInstanceUid = dataset.Get<string>(DicomTag.StudyInstanceUID);
 
-			foreach (var tag in recordType.Tags) {
-				if (dataset.Contains(tag)) {
-					sequenceItem.Add(dataset.Get<DicomItem>(tag));
-				} else {
-					System.Diagnostics.Debug.WriteLine("Cannot find tag {0} for record type {1}", tag, recordType);
-				}
-			}
 
-			return sequenceItem;
-		}
-		#endregion
-	}
+            while (currentStudy != null)
+            {
+                if (currentStudy.Get<string>(DicomTag.StudyInstanceUID) == studyInstanceUid)
+                {
+                    return currentStudy;
+                }
+
+                if (currentStudy.NextDirectoryRecord != null)
+                {
+                    currentStudy = currentStudy.NextDirectoryRecord;
+                }
+                else
+                {
+                    //no more patient records, break the loop
+                    break;
+                }
+            }
+            var newStudy = CreateRecordSequenceItem(DicomDirectoryRecordType.Study, dataset);
+            if (currentStudy != null)
+            {
+                //study not found under patient record
+                currentStudy.NextDirectoryRecord = newStudy;
+            }
+            else
+            {
+                //no studies record found under patient record
+                patientRecord.LowerLevelDirectoryRecord = newStudy;
+            }
+            return newStudy;
+        }
+
+        private DicomDirectoryRecord CreatePatientRecord(DicomDataset dataset)
+        {
+            var currentPatient = RootDirectoryRecord;
+            var patientId = dataset.Get<string>(DicomTag.PatientID);
+            var patientName = dataset.Get<string>(DicomTag.PatientName);
+
+            while (currentPatient != null)
+            {
+                if (currentPatient.Get<string>(DicomTag.PatientID) == patientId
+                    && currentPatient.Get<string>(DicomTag.PatientName) == patientName)
+                {
+                    return currentPatient;
+                }
+
+                if (currentPatient.NextDirectoryRecord != null)
+                {
+                    currentPatient = currentPatient.NextDirectoryRecord;
+                }
+                else
+                {
+                    //no more patient records, break the loop
+                    break;
+                }
+            }
+            var newPatient = CreateRecordSequenceItem(DicomDirectoryRecordType.Patient, dataset);
+            if (currentPatient != null)
+            {
+                //patient not found under root record
+                currentPatient.NextDirectoryRecord = newPatient;
+            }
+            else
+            {
+                //no patients record found under root record
+                RootDirectoryRecord = newPatient;
+            }
+            return newPatient;
+        }
+
+        private DicomDirectoryRecord CreateRecordSequenceItem(DicomDirectoryRecordType recordType, DicomDataset dataset)
+        {
+            if (recordType == null) throw new ArgumentNullException("recordType");
+            if (dataset == null) throw new ArgumentNullException("dataset");
+
+            var sequenceItem = new DicomDirectoryRecord();
+
+            //add record item attributes
+            sequenceItem.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, 0);
+            sequenceItem.Add<ushort>(DicomTag.RecordInUseFlag, 0xFFFF);
+            sequenceItem.Add<uint>(DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity, 0);
+            sequenceItem.Add<string>(DicomTag.DirectoryRecordType, recordType.ToString());
+
+            //copy the current dataset character set
+            sequenceItem.Add(dataset.FirstOrDefault(d => d.Tag == DicomTag.SpecificCharacterSet));
+
+            foreach (var tag in recordType.Tags)
+            {
+                if (dataset.Contains(tag))
+                {
+                    sequenceItem.Add(dataset.Get<DicomItem>(tag));
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine("Cannot find tag {0} for record type {1}", tag, recordType);
+                }
+            }
+
+            return sequenceItem;
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Media/DicomDirectoryRecord.cs
+++ b/DICOM/Media/DicomDirectoryRecord.cs
@@ -1,39 +1,58 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Dicom.Media {
-	public class DicomDirectoryRecord : DicomDataset {
-		#region Properties
+namespace Dicom.Media
+{
+    public class DicomDirectoryRecord : DicomDataset
+    {
+        #region Properties
 
-		public DicomDirectoryRecord LowerLevelDirectoryRecord { get; set; }
+        public DicomDirectoryRecord LowerLevelDirectoryRecord { get; set; }
 
-		public DicomDirectoryRecord NextDirectoryRecord { get; set; }
+        public DicomDirectoryRecord NextDirectoryRecord { get; set; }
 
-		public DicomDirectoryRecordCollection LowerLevelDirectoryRecordCollection {
-			get { return new DicomDirectoryRecordCollection(LowerLevelDirectoryRecord); }
-		}
+        public DicomDirectoryRecordCollection LowerLevelDirectoryRecordCollection
+        {
+            get
+            {
+                return new DicomDirectoryRecordCollection(LowerLevelDirectoryRecord);
+            }
+        }
 
-		public uint Offset { get; internal set; }
+        public uint Offset { get; internal set; }
 
-		public string DirectoryRecordType {
-			get { return Get<string>(DicomTag.DirectoryRecordType); }
-		}
+        public string DirectoryRecordType
+        {
+            get
+            {
+                return Get<string>(DicomTag.DirectoryRecordType);
+            }
+        }
 
-		#endregion
+        #endregion
 
-		public DicomDirectoryRecord() {
-		}
+        public DicomDirectoryRecord()
+        {
+        }
 
-		public DicomDirectoryRecord(IEnumerable<DicomItem> items) : base(items) {
-		}
+        public DicomDirectoryRecord(IEnumerable<DicomItem> items)
+            : base(items)
+        {
+        }
 
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("Directory Record Type: {0}, Lower level items:", DirectoryRecordType, LowerLevelDirectoryRecordCollection.Count());
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat(
+                "Directory Record Type: {0}, Lower level items:",
+                DirectoryRecordType,
+                LowerLevelDirectoryRecordCollection.Count());
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Media/DicomDirectoryRecordCollection.cs
+++ b/DICOM/Media/DicomDirectoryRecordCollection.cs
@@ -1,107 +1,131 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace Dicom.Media {
-	public class DicomDirectoryRecordCollection : IEnumerable<DicomDirectoryRecord> {
-		#region Properties and Attributes
-		private DicomDirectoryRecord _firstRecord;
-		#endregion
+namespace Dicom.Media
+{
+    public class DicomDirectoryRecordCollection : IEnumerable<DicomDirectoryRecord>
+    {
+        #region Properties and Attributes
 
-		#region Constructors
-		internal DicomDirectoryRecordCollection(DicomDirectoryRecord firstRecord) {
-			_firstRecord = firstRecord;
-		}
-		#endregion
+        private DicomDirectoryRecord _firstRecord;
 
-		#region Enumerator Class
+        #endregion
 
-		internal class DicomDirectoryRecordEnumerator : IEnumerator<DicomDirectoryRecord> {
-			#region Properties and Attributes
+        #region Constructors
 
-			private readonly DicomDirectoryRecord _head;
-			private DicomDirectoryRecord _current;
-			private bool _atEnd;
+        internal DicomDirectoryRecordCollection(DicomDirectoryRecord firstRecord)
+        {
+            _firstRecord = firstRecord;
+        }
 
-			#endregion
+        #endregion
 
-			#region Constructors
+        #region Enumerator Class
 
-			internal DicomDirectoryRecordEnumerator(DicomDirectoryRecord head) {
-				_head = head;
-			}
+        internal class DicomDirectoryRecordEnumerator : IEnumerator<DicomDirectoryRecord>
+        {
+            #region Properties and Attributes
 
-			#endregion
+            private readonly DicomDirectoryRecord _head;
 
-			#region IEnumerator<DirectoryRecordSequenceItem> Members
+            private DicomDirectoryRecord _current;
 
-			public DicomDirectoryRecord Current {
-				get { return _current; }
-			}
+            private bool _atEnd;
 
-			#endregion
+            #endregion
 
-			#region IDisposable Members
+            #region Constructors
 
-			public void Dispose() {
-				_current = null;
-			}
+            internal DicomDirectoryRecordEnumerator(DicomDirectoryRecord head)
+            {
+                _head = head;
+            }
 
-			#endregion
+            #endregion
 
-			#region IEnumerator Members
+            #region IEnumerator<DirectoryRecordSequenceItem> Members
 
-			object System.Collections.IEnumerator.Current {
-				get { return _current; }
-			}
+            public DicomDirectoryRecord Current
+            {
+                get
+                {
+                    return _current;
+                }
+            }
 
-			public bool MoveNext() {
-				if (_head == null)
-					return false;
+            #endregion
 
-				if (_atEnd)
-					return false;
+            #region IDisposable Members
 
-				if (_current == null) {
-					_current = _head;
-					return true;
-				}
+            public void Dispose()
+            {
+                _current = null;
+            }
 
-				if (_current.NextDirectoryRecord == null) {
-					_atEnd = true;
-					return false;
-				}
+            #endregion
 
-				_current = _current.NextDirectoryRecord;
+            #region IEnumerator Members
 
-				return true;
-			}
+            object System.Collections.IEnumerator.Current
+            {
+                get
+                {
+                    return _current;
+                }
+            }
 
-			public void Reset() {
-				_current = null;
-				_atEnd = false;
-			}
+            public bool MoveNext()
+            {
+                if (_head == null) return false;
 
-			#endregion
-		}
+                if (_atEnd) return false;
 
-		#endregion
+                if (_current == null)
+                {
+                    _current = _head;
+                    return true;
+                }
 
-		#region IEnumerable<DirectoryRecordSequenceItem> Members
+                if (_current.NextDirectoryRecord == null)
+                {
+                    _atEnd = true;
+                    return false;
+                }
 
-		public IEnumerator<DicomDirectoryRecord> GetEnumerator() {
-			return new DicomDirectoryRecordEnumerator(_firstRecord);
-		}
+                _current = _current.NextDirectoryRecord;
 
-		#endregion
+                return true;
+            }
 
-		#region IEnumerable Members
+            public void Reset()
+            {
+                _current = null;
+                _atEnd = false;
+            }
 
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
+            #endregion
+        }
 
-		#endregion
-	}
+        #endregion
+
+        #region IEnumerable<DirectoryRecordSequenceItem> Members
+
+        public IEnumerator<DicomDirectoryRecord> GetEnumerator()
+        {
+            return new DicomDirectoryRecordEnumerator(_firstRecord);
+        }
+
+        #endregion
+
+        #region IEnumerable Members
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Media/DicomDirectoryRecordType.cs
+++ b/DICOM/Media/DicomDirectoryRecordType.cs
@@ -1,61 +1,79 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace Dicom.Media {
-	public class DicomDirectoryRecordType {
-		#region Properties and Attributes
-		private readonly string _recordName;
-		private readonly ICollection<DicomTag> _tags = new HashSet<DicomTag>();
+namespace Dicom.Media
+{
+    public class DicomDirectoryRecordType
+    {
+        #region Properties and Attributes
 
-		public ICollection<DicomTag> Tags { get { return _tags; } }
+        private readonly string _recordName;
 
-		public readonly static DicomDirectoryRecordType Patient = new DicomDirectoryRecordType("PATIENT");
-		public readonly static DicomDirectoryRecordType Study = new DicomDirectoryRecordType("STUDY");
-		public readonly static DicomDirectoryRecordType Series = new DicomDirectoryRecordType("SERIES");
-		public readonly static DicomDirectoryRecordType Image = new DicomDirectoryRecordType("IMAGE");
+        private readonly ICollection<DicomTag> _tags = new HashSet<DicomTag>();
 
-		#endregion
+        public ICollection<DicomTag> Tags
+        {
+            get
+            {
+                return _tags;
+            }
+        }
 
-		#region Initialization
-		public DicomDirectoryRecordType(string recordName) {
-			_recordName = recordName;
+        public static readonly DicomDirectoryRecordType Patient = new DicomDirectoryRecordType("PATIENT");
 
-			switch (recordName) {
-			case "PATIENT":
-				_tags.Add(DicomTag.PatientID);
-				_tags.Add(DicomTag.PatientName);
-				_tags.Add(DicomTag.PatientBirthDate);
-				_tags.Add(DicomTag.PatientSex);
-				break;
-			case "STUDY":
-				_tags.Add(DicomTag.StudyInstanceUID);
-				_tags.Add(DicomTag.StudyID);
-				_tags.Add(DicomTag.StudyDate);
-				_tags.Add(DicomTag.StudyTime);
-				_tags.Add(DicomTag.AccessionNumber);
-				_tags.Add(DicomTag.StudyDescription);
-				break;
-			case "SERIES":
-				_tags.Add(DicomTag.SeriesInstanceUID);
-				_tags.Add(DicomTag.Modality);
-				_tags.Add(DicomTag.SeriesDate);
-				_tags.Add(DicomTag.SeriesTime);
-				_tags.Add(DicomTag.SeriesNumber);
-				_tags.Add(DicomTag.SeriesDescription);
-				break;
-			case "IMAGE":
-				_tags.Add(DicomTag.InstanceNumber);
-				break;
-			default:
-				break;
-			}
-		}
-		#endregion
+        public static readonly DicomDirectoryRecordType Study = new DicomDirectoryRecordType("STUDY");
 
-		public override string ToString() {
-			return _recordName;
-		}
-	}
+        public static readonly DicomDirectoryRecordType Series = new DicomDirectoryRecordType("SERIES");
+
+        public static readonly DicomDirectoryRecordType Image = new DicomDirectoryRecordType("IMAGE");
+
+        #endregion
+
+        #region Initialization
+
+        public DicomDirectoryRecordType(string recordName)
+        {
+            _recordName = recordName;
+
+            switch (recordName)
+            {
+                case "PATIENT":
+                    _tags.Add(DicomTag.PatientID);
+                    _tags.Add(DicomTag.PatientName);
+                    _tags.Add(DicomTag.PatientBirthDate);
+                    _tags.Add(DicomTag.PatientSex);
+                    break;
+                case "STUDY":
+                    _tags.Add(DicomTag.StudyInstanceUID);
+                    _tags.Add(DicomTag.StudyID);
+                    _tags.Add(DicomTag.StudyDate);
+                    _tags.Add(DicomTag.StudyTime);
+                    _tags.Add(DicomTag.AccessionNumber);
+                    _tags.Add(DicomTag.StudyDescription);
+                    break;
+                case "SERIES":
+                    _tags.Add(DicomTag.SeriesInstanceUID);
+                    _tags.Add(DicomTag.Modality);
+                    _tags.Add(DicomTag.SeriesDate);
+                    _tags.Add(DicomTag.SeriesTime);
+                    _tags.Add(DicomTag.SeriesNumber);
+                    _tags.Add(DicomTag.SeriesDescription);
+                    break;
+                case "IMAGE":
+                    _tags.Add(DicomTag.InstanceNumber);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        #endregion
+
+        public override string ToString()
+        {
+            return _recordName;
+        }
+    }
 }

--- a/DICOM/Media/DicomFileScanner.cs
+++ b/DICOM/Media/DicomFileScanner.cs
@@ -1,127 +1,173 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 using System.Threading;
 
-namespace Dicom.Media {
-	public delegate void DicomScanProgressCallback(DicomFileScanner scanner, string directory, int count);
-	public delegate void DicomScanFileFoundCallback(DicomFileScanner scanner, DicomFile file, string fileName);
-	public delegate void DicomScanCompleteCallback(DicomFileScanner scanner);
+namespace Dicom.Media
+{
+    public delegate void DicomScanProgressCallback(DicomFileScanner scanner, string directory, int count);
 
-	public class DicomFileScanner {
-		#region Private Members
-		private string _pattern;
-		private bool _recursive;
-		private bool _stop;
-		private bool _progressOnDirectory;
-		private int _progressAfterCount;
-		private bool _checkForValidHeader;
-		private int _count;
-		#endregion
+    public delegate void DicomScanFileFoundCallback(DicomFileScanner scanner, DicomFile file, string fileName);
 
-		#region Public Constructor
-		public DicomFileScanner() {
-			_pattern = null;
-			_recursive = true;
-			_progressOnDirectory = true;
-			_progressAfterCount = 10;
-		}
-		#endregion
+    public delegate void DicomScanCompleteCallback(DicomFileScanner scanner);
 
-		public event DicomScanProgressCallback Progress;
-		public event DicomScanFileFoundCallback FileFound;
-		public event DicomScanCompleteCallback Complete;
+    public class DicomFileScanner
+    {
+        #region Private Members
 
-		#region Public Properties
-		public bool ProgressOnDirectoryChange {
-			get { return _progressOnDirectory; }
-			set { _progressOnDirectory = value; }
-		}
+        private string _pattern;
 
-		public int ProgressFilesCount {
-			get { return _progressAfterCount; }
-			set { _progressAfterCount = value; }
-		}
+        private bool _recursive;
 
-		public bool CheckForValidHeader {
-			get { return _checkForValidHeader; }
-			set { _checkForValidHeader = value; }
-		}
-		#endregion
+        private bool _stop;
 
-		#region Public Methods
-		public void Start(string directory) {
-			_stop = false;
-			_count = 0;
-			new Thread(ScanProc).Start(directory);
-		}
+        private bool _progressOnDirectory;
 
-		public void Stop() {
-			_stop = true;
-		}
-		#endregion
+        private int _progressAfterCount;
 
-		#region Private Methods
-		private void ScanProc(object state) {
-			string directory = (string)state;
-			ScanDirectory(directory);
+        private bool _checkForValidHeader;
 
-			if (Complete != null)
-				Complete(this);
-		}
+        private int _count;
 
-		private void ScanDirectory(string directory) {
-			if (_stop)
-				return;
+        #endregion
 
-			if (Progress != null && _progressOnDirectory)
-				Progress(this, directory, _count);
+        #region Public Constructor
 
-			try {
-				string[] files;
-				if (!String.IsNullOrEmpty(_pattern))
-					files = Directory.GetFiles(directory, _pattern);
-				else
-					files = Directory.GetFiles(directory);
+        public DicomFileScanner()
+        {
+            _pattern = null;
+            _recursive = true;
+            _progressOnDirectory = true;
+            _progressAfterCount = 10;
+        }
 
-				foreach (string file in files) {
-					if (_stop)
-						return;
+        #endregion
 
-					ScanFile(file);
+        public event DicomScanProgressCallback Progress;
+        public event DicomScanFileFoundCallback FileFound;
+        public event DicomScanCompleteCallback Complete;
 
-					_count++;
-					if ((_count % _progressAfterCount) == 0 && Progress != null)
-						Progress(this, directory, _count);
-				}
+        #region Public Properties
 
-				if (!_recursive)
-					return;
+        public bool ProgressOnDirectoryChange
+        {
+            get
+            {
+                return _progressOnDirectory;
+            }
+            set
+            {
+                _progressOnDirectory = value;
+            }
+        }
 
-				string[] dirs = Directory.GetDirectories(directory);
-				foreach (string dir in dirs) {
-					if (_stop)
-						return;
+        public int ProgressFilesCount
+        {
+            get
+            {
+                return _progressAfterCount;
+            }
+            set
+            {
+                _progressAfterCount = value;
+            }
+        }
 
-					ScanDirectory(dir);
-				}
-			} catch {
-			}
-		}
+        public bool CheckForValidHeader
+        {
+            get
+            {
+                return _checkForValidHeader;
+            }
+            set
+            {
+                _checkForValidHeader = value;
+            }
+        }
 
-		private void ScanFile(string file) {
-			try {
-				if (CheckForValidHeader && !DicomFile.HasValidHeader(file))
-					return;
+        #endregion
 
-				var df = DicomFile.Open(file);
+        #region Public Methods
 
-				if (FileFound != null)
-					FileFound(this, df, file);
-			} catch {
-				// ignore exceptions?
-			}
-		}
-		#endregion
-	}
+        public void Start(string directory)
+        {
+            _stop = false;
+            _count = 0;
+            new Thread(ScanProc).Start(directory);
+        }
+
+        public void Stop()
+        {
+            _stop = true;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void ScanProc(object state)
+        {
+            string directory = (string)state;
+            ScanDirectory(directory);
+
+            if (Complete != null) Complete(this);
+        }
+
+        private void ScanDirectory(string directory)
+        {
+            if (_stop) return;
+
+            if (Progress != null && _progressOnDirectory) Progress(this, directory, _count);
+
+            try
+            {
+                string[] files;
+                if (!String.IsNullOrEmpty(_pattern)) files = Directory.GetFiles(directory, _pattern);
+                else files = Directory.GetFiles(directory);
+
+                foreach (string file in files)
+                {
+                    if (_stop) return;
+
+                    ScanFile(file);
+
+                    _count++;
+                    if ((_count % _progressAfterCount) == 0 && Progress != null) Progress(this, directory, _count);
+                }
+
+                if (!_recursive) return;
+
+                string[] dirs = Directory.GetDirectories(directory);
+                foreach (string dir in dirs)
+                {
+                    if (_stop) return;
+
+                    ScanDirectory(dir);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void ScanFile(string file)
+        {
+            try
+            {
+                if (CheckForValidHeader && !DicomFile.HasValidHeader(file)) return;
+
+                var df = DicomFile.Open(file);
+
+                if (FileFound != null) FileFound(this, df, file);
+            }
+            catch
+            {
+                // ignore exceptions?
+            }
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Network/DicomAssociation.cs
+++ b/DICOM/Network/DicomAssociation.cs
@@ -1,83 +1,72 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Text;
 
-namespace Dicom.Network {
-	public sealed class DicomAssociation {
-		public DicomAssociation() {
-			PresentationContexts = new DicomPresentationContextCollection();
-			MaxAsyncOpsInvoked = 1;
-			MaxAsyncOpsPerformed = 1;
-		}
+namespace Dicom.Network
+{
+    public sealed class DicomAssociation
+    {
+        public DicomAssociation()
+        {
+            PresentationContexts = new DicomPresentationContextCollection();
+            MaxAsyncOpsInvoked = 1;
+            MaxAsyncOpsPerformed = 1;
+        }
 
-		public DicomAssociation(string callingAe, string calledAe, uint maxPduLength = 16384) : this() {
-			CallingAE = callingAe;
-			CalledAE = calledAe;
-			MaximumPDULength = maxPduLength;
-		}
+        public DicomAssociation(string callingAe, string calledAe, uint maxPduLength = 16384)
+            : this()
+        {
+            CallingAE = callingAe;
+            CalledAE = calledAe;
+            MaximumPDULength = maxPduLength;
+        }
 
-		public string CallingAE {
-			get;
-			internal set;
-		}
+        public string CallingAE { get; internal set; }
 
-		public string CalledAE {
-			get;
-			internal set;
-		}
+        public string CalledAE { get; internal set; }
 
-		public int MaxAsyncOpsInvoked {
-			get;
-			set;
-		}
+        public int MaxAsyncOpsInvoked { get; set; }
 
-		public int MaxAsyncOpsPerformed {
-			get;
-			set;
-		}
+        public int MaxAsyncOpsPerformed { get; set; }
 
-		public DicomUID RemoteImplemetationClassUID {
-			get;
-			internal set;
-		}
+        public DicomUID RemoteImplemetationClassUID { get; internal set; }
 
-		public string RemoteImplementationVersion {
-			get;
-			internal set;
-		}
+        public string RemoteImplementationVersion { get; internal set; }
 
-		public uint MaximumPDULength {
-			get;
-			internal set;
-		}
+        public uint MaximumPDULength { get; internal set; }
 
-		public DicomPresentationContextCollection PresentationContexts {
-			get;
-			private set;
-		}
+        public DicomPresentationContextCollection PresentationContexts { get; private set; }
 
-		public override string ToString() {
-			var sb = new StringBuilder();
-			sb.AppendFormat("Calling AE Title:       {0}\n", CallingAE);
-			sb.AppendFormat("Called AE Title:        {0}\n", CalledAE);
-			sb.AppendFormat("Implementation Class:   {0}\n", RemoteImplemetationClassUID ?? DicomImplementation.ClassUID);
-			sb.AppendFormat("Implementation Version: {0}\n", RemoteImplementationVersion ?? DicomImplementation.Version);
-			sb.AppendFormat("Maximum PDU Length:     {0}\n", MaximumPDULength);
-			sb.AppendFormat("Async Ops Invoked:      {0}\n", MaxAsyncOpsInvoked);
-			sb.AppendFormat("Async Ops Performed:    {0}\n", MaxAsyncOpsPerformed);
-			sb.AppendFormat("Presentation Contexts:  {0}\n", PresentationContexts.Count);
-			foreach (var pc in PresentationContexts) {
-				sb.AppendFormat("  Presentation Context:  {0} [{1}]\n", pc.ID, pc.Result);
-				if (pc.AbstractSyntax.Name != "Unknown")
-					sb.AppendFormat("       Abstract Syntax:  {0}\n", pc.AbstractSyntax.Name);
-				else
-					sb.AppendFormat("       Abstract Syntax:  {0} [{1}]\n", pc.AbstractSyntax.Name, pc.AbstractSyntax.UID);
-				foreach (var tx in pc.GetTransferSyntaxes()) {
-					sb.AppendFormat("       Transfer Syntax:  {0}\n", tx.UID.Name);
-				}
-			}
-			sb.Length = sb.Length - 1;
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendFormat("Calling AE Title:       {0}\n", CallingAE);
+            sb.AppendFormat("Called AE Title:        {0}\n", CalledAE);
+            sb.AppendFormat(
+                "Implementation Class:   {0}\n",
+                RemoteImplemetationClassUID ?? DicomImplementation.ClassUID);
+            sb.AppendFormat("Implementation Version: {0}\n", RemoteImplementationVersion ?? DicomImplementation.Version);
+            sb.AppendFormat("Maximum PDU Length:     {0}\n", MaximumPDULength);
+            sb.AppendFormat("Async Ops Invoked:      {0}\n", MaxAsyncOpsInvoked);
+            sb.AppendFormat("Async Ops Performed:    {0}\n", MaxAsyncOpsPerformed);
+            sb.AppendFormat("Presentation Contexts:  {0}\n", PresentationContexts.Count);
+            foreach (var pc in PresentationContexts)
+            {
+                sb.AppendFormat("  Presentation Context:  {0} [{1}]\n", pc.ID, pc.Result);
+                if (pc.AbstractSyntax.Name != "Unknown") sb.AppendFormat("       Abstract Syntax:  {0}\n", pc.AbstractSyntax.Name);
+                else
+                    sb.AppendFormat(
+                        "       Abstract Syntax:  {0} [{1}]\n",
+                        pc.AbstractSyntax.Name,
+                        pc.AbstractSyntax.UID);
+                foreach (var tx in pc.GetTransferSyntaxes())
+                {
+                    sb.AppendFormat("       Transfer Syntax:  {0}\n", tx.UID.Name);
+                }
+            }
+            sb.Length = sb.Length - 1;
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomAssociationAbortedException.cs
+++ b/DICOM/Network/DicomAssociationAbortedException.cs
@@ -1,20 +1,19 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomAssociationAbortedException : DicomNetworkException {
-		public DicomAssociationAbortedException(DicomAbortSource source, DicomAbortReason reason) : base("Association Abort [source: {0}; reason: {1}]", source, reason) {
-			AbortSource = source;
-			AbortReason = reason;
-		}
+namespace Dicom.Network
+{
+    public class DicomAssociationAbortedException : DicomNetworkException
+    {
+        public DicomAssociationAbortedException(DicomAbortSource source, DicomAbortReason reason)
+            : base("Association Abort [source: {0}; reason: {1}]", source, reason)
+        {
+            AbortSource = source;
+            AbortReason = reason;
+        }
 
-		public DicomAbortSource AbortSource {
-			get;
-			private set;
-		}
+        public DicomAbortSource AbortSource { get; private set; }
 
-		public DicomAbortReason AbortReason {
-			get;
-			private set;
-		}
-	}
+        public DicomAbortReason AbortReason { get; private set; }
+    }
 }

--- a/DICOM/Network/DicomAssociationRejectedException.cs
+++ b/DICOM/Network/DicomAssociationRejectedException.cs
@@ -1,26 +1,25 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomAssociationRejectedException : DicomNetworkException {
-		public DicomAssociationRejectedException(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason) : base("Association rejected [result: {0}; source: {1}; reason: {2}]", result, source, reason) {
-			RejectResult = result;
-			RejectSource = source;
-			RejectReason = reason;
-		}
+namespace Dicom.Network
+{
+    public class DicomAssociationRejectedException : DicomNetworkException
+    {
+        public DicomAssociationRejectedException(
+            DicomRejectResult result,
+            DicomRejectSource source,
+            DicomRejectReason reason)
+            : base("Association rejected [result: {0}; source: {1}; reason: {2}]", result, source, reason)
+        {
+            RejectResult = result;
+            RejectSource = source;
+            RejectReason = reason;
+        }
 
-		public DicomRejectResult RejectResult {
-			get;
-			private set;
-		}
+        public DicomRejectResult RejectResult { get; private set; }
 
-		public DicomRejectSource RejectSource {
-			get;
-			private set;
-		}
+        public DicomRejectSource RejectSource { get; private set; }
 
-		public DicomRejectReason RejectReason {
-			get;
-			private set;
-		}
-	}
+        public DicomRejectReason RejectReason { get; private set; }
+    }
 }

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -1,35 +1,46 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
 
 using Dicom.Log;
 
-namespace Dicom.Network {
-	public class DicomCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider {
-		public DicomCEchoProvider(Stream stream, Logger log) : base(stream, log) {
-		}
+namespace Dicom.Network
+{
+    public class DicomCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
+    {
+        public DicomCEchoProvider(Stream stream, Logger log)
+            : base(stream, log)
+        {
+        }
 
-		public void OnReceiveAssociationRequest(DicomAssociation association) {
-			foreach (var pc in association.PresentationContexts) {
-				if (pc.AbstractSyntax == DicomUID.Verification)
-					pc.SetResult(DicomPresentationContextResult.Accept);
-				else
-					pc.SetResult(DicomPresentationContextResult.RejectAbstractSyntaxNotSupported);
-			}
-			SendAssociationAccept(association);
-		}
+        public void OnReceiveAssociationRequest(DicomAssociation association)
+        {
+            foreach (var pc in association.PresentationContexts)
+            {
+                if (pc.AbstractSyntax == DicomUID.Verification) pc.SetResult(DicomPresentationContextResult.Accept);
+                else pc.SetResult(DicomPresentationContextResult.RejectAbstractSyntaxNotSupported);
+            }
+            SendAssociationAccept(association);
+        }
 
-		public void OnReceiveAssociationReleaseRequest() {
-			SendAssociationReleaseResponse();
-		}
+        public void OnReceiveAssociationReleaseRequest()
+        {
+            SendAssociationReleaseResponse();
+        }
 
-		public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason) {
-		}
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
 
-		public void OnConnectionClosed(Exception exception) {
-		}
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
 
-		public DicomCEchoResponse OnCEchoRequest(DicomCEchoRequest request) {
-			return new DicomCEchoResponse(request, DicomStatus.Success);
-		}
-	}
+        public DicomCEchoResponse OnCEchoRequest(DicomCEchoRequest request)
+        {
+            return new DicomCEchoResponse(request, DicomStatus.Success);
+        }
+    }
 }

--- a/DICOM/Network/DicomCEchoRequest.cs
+++ b/DICOM/Network/DicomCEchoRequest.cs
@@ -1,26 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomCEchoRequest : DicomRequest {
-		public DicomCEchoRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomCEchoRequest : DicomRequest
+    {
+        public DicomCEchoRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomCEchoRequest(DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.CEchoRequest, DicomUID.Verification, priority) {
-		}
+        public DicomCEchoRequest(DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CEchoRequest, DicomUID.Verification, priority)
+        {
+        }
 
-		public delegate void ResponseDelegate(DicomCEchoRequest request, DicomCEchoResponse response);
+        public delegate void ResponseDelegate(DicomCEchoRequest request, DicomCEchoResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomCEchoResponse)response);
-			} catch {
-			}
-		}
-	}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomCEchoResponse)response);
+            }
+            catch
+            {
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomCEchoResponse.cs
+++ b/DICOM/Network/DicomCEchoResponse.cs
@@ -1,14 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomCEchoResponse : DicomResponse {
-		public DicomCEchoResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomCEchoResponse : DicomResponse
+    {
+        public DicomCEchoResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomCEchoResponse(DicomCEchoRequest request, DicomStatus status) : base(request, status) {
-		}
-	}
+        public DicomCEchoResponse(DicomCEchoRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
+    }
 }

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -1,148 +1,172 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomCFindRequest : DicomRequest {
-		public DicomCFindRequest(DicomDataset command) : base(command) {
-		}
+using System;
 
-		public DicomCFindRequest(DicomQueryRetrieveLevel level, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.CFindRequest, DicomUID.StudyRootQueryRetrieveInformationModelFIND, priority) {
-			Dataset = new DicomDataset();
-			Level = level;
-		}
+namespace Dicom.Network
+{
+    public class DicomCFindRequest : DicomRequest
+    {
+        public DicomCFindRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomQueryRetrieveLevel Level {
-			get { return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel); }
-			set {
-				Dataset.Remove(DicomTag.QueryRetrieveLevel);
-				if (value != DicomQueryRetrieveLevel.Worklist)
-					Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
-			}
-		}
+        public DicomCFindRequest(DicomQueryRetrieveLevel level, DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CFindRequest, DicomUID.StudyRootQueryRetrieveInformationModelFIND, priority)
+        {
+            Dataset = new DicomDataset();
+            Level = level;
+        }
 
-		public delegate void ResponseDelegate(DicomCFindRequest request, DicomCFindResponse response);
+        public DicomQueryRetrieveLevel Level
+        {
+            get
+            {
+                return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
+            }
+            set
+            {
+                Dataset.Remove(DicomTag.QueryRetrieveLevel);
+                if (value != DicomQueryRetrieveLevel.Worklist) Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+            }
+        }
 
-		public ResponseDelegate OnResponseReceived;
+        public delegate void ResponseDelegate(DicomCFindRequest request, DicomCFindResponse response);
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomCFindResponse)response);
-			} catch {
-			}
-		}
+        public ResponseDelegate OnResponseReceived;
 
-		public static DicomCFindRequest CreatePatientQuery(string patientId = null, string patientName = null) {
-			var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Patient);
-			dimse.SOPClassUID = DicomUID.PatientRootQueryRetrieveInformationModelFIND;
-			dimse.Dataset.Add(DicomTag.PatientID, patientId);
-			dimse.Dataset.Add(DicomTag.PatientName, patientName);
-			dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
-			dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
-			return dimse;
-		}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomCFindResponse)response);
+            }
+            catch
+            {
+            }
+        }
 
-		public static DicomCFindRequest CreateStudyQuery(string patientId = null, string patientName = null, 
-														 DicomDateRange studyDateTime = null, string accession = null, string studyId = null, 
-														 string modalitiesInStudy = null, string studyInstanceUid = null)
-		{
-			var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Study);
-			dimse.SOPClassUID = DicomUID.StudyRootQueryRetrieveInformationModelFIND;
-			dimse.Dataset.Add(DicomTag.PatientID, patientId);
-			dimse.Dataset.Add(DicomTag.PatientName, patientName);
-			dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
-			dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
-			dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
-			dimse.Dataset.Add(DicomTag.ModalitiesInStudy, modalitiesInStudy);
-			dimse.Dataset.Add(DicomTag.Modality, modalitiesInStudy);
-			dimse.Dataset.Add(DicomTag.StudyID, studyId);
-			dimse.Dataset.Add(DicomTag.AccessionNumber, accession);
-			dimse.Dataset.Add(DicomTag.StudyDate, studyDateTime);
-			dimse.Dataset.Add(DicomTag.StudyTime, studyDateTime);
-			dimse.Dataset.Add(DicomTag.StudyDescription, String.Empty);
-			dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedSeries, String.Empty);
-			dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedInstances, String.Empty);
-			return dimse;
-		}
+        public static DicomCFindRequest CreatePatientQuery(string patientId = null, string patientName = null)
+        {
+            var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Patient);
+            dimse.SOPClassUID = DicomUID.PatientRootQueryRetrieveInformationModelFIND;
+            dimse.Dataset.Add(DicomTag.PatientID, patientId);
+            dimse.Dataset.Add(DicomTag.PatientName, patientName);
+            dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
+            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
+            return dimse;
+        }
 
-		public static DicomCFindRequest CreateSeriesQuery(string studyInstanceUid, string modality = null) {
-			var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
-			dimse.SOPClassUID = DicomUID.StudyRootQueryRetrieveInformationModelFIND;
-			dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
-			dimse.Dataset.Add(DicomTag.SeriesInstanceUID, String.Empty);
-			dimse.Dataset.Add(DicomTag.SeriesNumber, String.Empty);
-			dimse.Dataset.Add(DicomTag.SeriesDescription, String.Empty);
-			dimse.Dataset.Add(DicomTag.Modality, modality);
-			dimse.Dataset.Add(DicomTag.SeriesDate, String.Empty);
-			dimse.Dataset.Add(DicomTag.SeriesTime, String.Empty);
-			dimse.Dataset.Add(DicomTag.NumberOfSeriesRelatedInstances, String.Empty);
-			return dimse;
-		}
+        public static DicomCFindRequest CreateStudyQuery(
+            string patientId = null,
+            string patientName = null,
+            DicomDateRange studyDateTime = null,
+            string accession = null,
+            string studyId = null,
+            string modalitiesInStudy = null,
+            string studyInstanceUid = null)
+        {
+            var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Study);
+            dimse.SOPClassUID = DicomUID.StudyRootQueryRetrieveInformationModelFIND;
+            dimse.Dataset.Add(DicomTag.PatientID, patientId);
+            dimse.Dataset.Add(DicomTag.PatientName, patientName);
+            dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
+            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
+            dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+            dimse.Dataset.Add(DicomTag.ModalitiesInStudy, modalitiesInStudy);
+            dimse.Dataset.Add(DicomTag.Modality, modalitiesInStudy);
+            dimse.Dataset.Add(DicomTag.StudyID, studyId);
+            dimse.Dataset.Add(DicomTag.AccessionNumber, accession);
+            dimse.Dataset.Add(DicomTag.StudyDate, studyDateTime);
+            dimse.Dataset.Add(DicomTag.StudyTime, studyDateTime);
+            dimse.Dataset.Add(DicomTag.StudyDescription, String.Empty);
+            dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedSeries, String.Empty);
+            dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedInstances, String.Empty);
+            return dimse;
+        }
 
-		public static DicomCFindRequest CreateWorklistQuery(string patientId = null, string patientName = null,
-															string stationAE = null, string stationName = null, string modality = null,
-															DicomDateRange scheduledDateTime = null)
-		{
-			var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Worklist);
-			dimse.SOPClassUID = DicomUID.ModalityWorklistInformationModelFIND;
-			dimse.Dataset.Add(DicomTag.PatientID, patientId);
-			dimse.Dataset.Add(DicomTag.PatientName, patientName);
-			dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
-			dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientWeight, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
-			dimse.Dataset.Add(DicomTag.MedicalAlerts, String.Empty);
-			dimse.Dataset.Add(DicomTag.PregnancyStatus, new ushort[0]);
-			dimse.Dataset.Add(DicomTag.Allergies, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientComments, String.Empty);
-			dimse.Dataset.Add(DicomTag.SpecialNeeds, String.Empty);
-			dimse.Dataset.Add(DicomTag.PatientState, String.Empty);
-			dimse.Dataset.Add(DicomTag.CurrentPatientLocation, String.Empty);
-			dimse.Dataset.Add(DicomTag.InstitutionName, String.Empty);
-			dimse.Dataset.Add(DicomTag.AdmissionID, String.Empty);
-			dimse.Dataset.Add(DicomTag.AccessionNumber, String.Empty);
-			dimse.Dataset.Add(DicomTag.ReferringPhysicianName, String.Empty);
-			dimse.Dataset.Add(DicomTag.AdmittingDiagnosesDescription, String.Empty);
-			dimse.Dataset.Add(DicomTag.RequestingPhysician, String.Empty);
-			dimse.Dataset.Add(DicomTag.StudyInstanceUID, String.Empty);
-			dimse.Dataset.Add(DicomTag.StudyDescription, String.Empty);
-			dimse.Dataset.Add(DicomTag.StudyID, String.Empty);
-			dimse.Dataset.Add(DicomTag.ReasonForTheRequestedProcedure, String.Empty);
-			dimse.Dataset.Add(DicomTag.StudyDate, String.Empty);
-			dimse.Dataset.Add(DicomTag.StudyTime, String.Empty);
+        public static DicomCFindRequest CreateSeriesQuery(string studyInstanceUid, string modality = null)
+        {
+            var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+            dimse.SOPClassUID = DicomUID.StudyRootQueryRetrieveInformationModelFIND;
+            dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+            dimse.Dataset.Add(DicomTag.SeriesInstanceUID, String.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesNumber, String.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesDescription, String.Empty);
+            dimse.Dataset.Add(DicomTag.Modality, modality);
+            dimse.Dataset.Add(DicomTag.SeriesDate, String.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesTime, String.Empty);
+            dimse.Dataset.Add(DicomTag.NumberOfSeriesRelatedInstances, String.Empty);
+            return dimse;
+        }
 
-			dimse.Dataset.Add(DicomTag.RequestedProcedureID, String.Empty);
-			dimse.Dataset.Add(DicomTag.RequestedProcedureDescription, String.Empty);
-			dimse.Dataset.Add(DicomTag.RequestedProcedurePriority, String.Empty);
-			dimse.Dataset.Add(new DicomSequence(DicomTag.RequestedProcedureCodeSequence));
-			dimse.Dataset.Add(new DicomSequence(DicomTag.ReferencedStudySequence));
+        public static DicomCFindRequest CreateWorklistQuery(
+            string patientId = null,
+            string patientName = null,
+            string stationAE = null,
+            string stationName = null,
+            string modality = null,
+            DicomDateRange scheduledDateTime = null)
+        {
+            var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Worklist);
+            dimse.SOPClassUID = DicomUID.ModalityWorklistInformationModelFIND;
+            dimse.Dataset.Add(DicomTag.PatientID, patientId);
+            dimse.Dataset.Add(DicomTag.PatientName, patientName);
+            dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
+            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientWeight, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
+            dimse.Dataset.Add(DicomTag.MedicalAlerts, String.Empty);
+            dimse.Dataset.Add(DicomTag.PregnancyStatus, new ushort[0]);
+            dimse.Dataset.Add(DicomTag.Allergies, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientComments, String.Empty);
+            dimse.Dataset.Add(DicomTag.SpecialNeeds, String.Empty);
+            dimse.Dataset.Add(DicomTag.PatientState, String.Empty);
+            dimse.Dataset.Add(DicomTag.CurrentPatientLocation, String.Empty);
+            dimse.Dataset.Add(DicomTag.InstitutionName, String.Empty);
+            dimse.Dataset.Add(DicomTag.AdmissionID, String.Empty);
+            dimse.Dataset.Add(DicomTag.AccessionNumber, String.Empty);
+            dimse.Dataset.Add(DicomTag.ReferringPhysicianName, String.Empty);
+            dimse.Dataset.Add(DicomTag.AdmittingDiagnosesDescription, String.Empty);
+            dimse.Dataset.Add(DicomTag.RequestingPhysician, String.Empty);
+            dimse.Dataset.Add(DicomTag.StudyInstanceUID, String.Empty);
+            dimse.Dataset.Add(DicomTag.StudyDescription, String.Empty);
+            dimse.Dataset.Add(DicomTag.StudyID, String.Empty);
+            dimse.Dataset.Add(DicomTag.ReasonForTheRequestedProcedure, String.Empty);
+            dimse.Dataset.Add(DicomTag.StudyDate, String.Empty);
+            dimse.Dataset.Add(DicomTag.StudyTime, String.Empty);
 
-			dimse.Dataset.Add(new DicomSequence(DicomTag.ProcedureCodeSequence));
+            dimse.Dataset.Add(DicomTag.RequestedProcedureID, String.Empty);
+            dimse.Dataset.Add(DicomTag.RequestedProcedureDescription, String.Empty);
+            dimse.Dataset.Add(DicomTag.RequestedProcedurePriority, String.Empty);
+            dimse.Dataset.Add(new DicomSequence(DicomTag.RequestedProcedureCodeSequence));
+            dimse.Dataset.Add(new DicomSequence(DicomTag.ReferencedStudySequence));
 
-			var sps = new DicomDataset();
-			sps.Add(DicomTag.ScheduledStationAETitle, stationAE);
-			sps.Add(DicomTag.ScheduledStationName, stationName);
-			sps.Add(DicomTag.ScheduledProcedureStepStartDate, scheduledDateTime);
-			sps.Add(DicomTag.ScheduledProcedureStepStartTime, scheduledDateTime);
-			sps.Add(DicomTag.Modality, modality);
-			sps.Add(DicomTag.ScheduledPerformingPhysicianName, String.Empty);
-			sps.Add(DicomTag.ScheduledProcedureStepDescription, String.Empty);
-			sps.Add(new DicomSequence(DicomTag.ScheduledProtocolCodeSequence));
-			sps.Add(DicomTag.ScheduledProcedureStepLocation, String.Empty);
-			sps.Add(DicomTag.ScheduledProcedureStepID, String.Empty);
-			sps.Add(DicomTag.RequestedContrastAgent, String.Empty);
-			sps.Add(DicomTag.PreMedication, String.Empty);
-			sps.Add(DicomTag.AnatomicalOrientationType, String.Empty);
-			dimse.Dataset.Add(new DicomSequence(DicomTag.ScheduledProcedureStepSequence, sps));
+            dimse.Dataset.Add(new DicomSequence(DicomTag.ProcedureCodeSequence));
 
-			return dimse;
-		}
-	}
+            var sps = new DicomDataset();
+            sps.Add(DicomTag.ScheduledStationAETitle, stationAE);
+            sps.Add(DicomTag.ScheduledStationName, stationName);
+            sps.Add(DicomTag.ScheduledProcedureStepStartDate, scheduledDateTime);
+            sps.Add(DicomTag.ScheduledProcedureStepStartTime, scheduledDateTime);
+            sps.Add(DicomTag.Modality, modality);
+            sps.Add(DicomTag.ScheduledPerformingPhysicianName, String.Empty);
+            sps.Add(DicomTag.ScheduledProcedureStepDescription, String.Empty);
+            sps.Add(new DicomSequence(DicomTag.ScheduledProtocolCodeSequence));
+            sps.Add(DicomTag.ScheduledProcedureStepLocation, String.Empty);
+            sps.Add(DicomTag.ScheduledProcedureStepID, String.Empty);
+            sps.Add(DicomTag.RequestedContrastAgent, String.Empty);
+            sps.Add(DicomTag.PreMedication, String.Empty);
+            sps.Add(DicomTag.AnatomicalOrientationType, String.Empty);
+            dimse.Dataset.Add(new DicomSequence(DicomTag.ScheduledProcedureStepSequence, sps));
+
+            return dimse;
+        }
+    }
 }

--- a/DICOM/Network/DicomCFindResponse.cs
+++ b/DICOM/Network/DicomCFindResponse.cs
@@ -1,52 +1,84 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom.Network {
-	public class DicomCFindResponse : DicomResponse {
-		public DicomCFindResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomCFindResponse : DicomResponse
+    {
+        public DicomCFindResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomCFindResponse(DicomCFindRequest request, DicomStatus status) : base(request, status) {
-		}
+        public DicomCFindResponse(DicomCFindRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
 
-		public int Remaining {
-			get { return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value); }
-		}
+        public int Remaining
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
+            }
+        }
 
-		public int Completed {
-			get { return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value); }
-		}
+        public int Completed
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
+            }
+        }
 
-		public int Warnings {
-			get { return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value); }
-		}
+        public int Warnings
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value);
+            }
+        }
 
-		public int Failures {
-			get { return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value); }
-		}
+        public int Failures
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value);
+            }
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-			if (Completed != 0)
-				sb.AppendFormat("\n\t\tCompleted:	{0}", Completed);
-			if (Remaining != 0)
-				sb.AppendFormat("\n\t\tRemaining:	{0}", Remaining);
-			if (Warnings != 0)
-				sb.AppendFormat("\n\t\tWarnings:	{0}", Warnings);
-			if (Failures != 0)
-				sb.AppendFormat("\n\t\tFailures:	{0}", Failures);
-			if (Status.State != DicomState.Pending && Status.State != DicomState.Success) {
-				if (!String.IsNullOrEmpty(Status.ErrorComment))
-					sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
-			}
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
+            if (Completed != 0) sb.AppendFormat("\n\t\tCompleted:	{0}", Completed);
+            if (Remaining != 0) sb.AppendFormat("\n\t\tRemaining:	{0}", Remaining);
+            if (Warnings != 0) sb.AppendFormat("\n\t\tWarnings:	{0}", Warnings);
+            if (Failures != 0) sb.AppendFormat("\n\t\tFailures:	{0}", Failures);
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            {
+                if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+            }
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -1,61 +1,95 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomCMoveRequest : DicomRequest {
-		public DicomCMoveRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomCMoveRequest : DicomRequest
+    {
+        public DicomCMoveRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomCMoveRequest(string destinationAe, string studyInstanceUid, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority) {
-			DestinationAE = destinationAe;
-			Dataset = new DicomDataset();
-			Level = DicomQueryRetrieveLevel.Study;
-			Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
-		}
+        public DicomCMoveRequest(
+            string destinationAe,
+            string studyInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
+        {
+            DestinationAE = destinationAe;
+            Dataset = new DicomDataset();
+            Level = DicomQueryRetrieveLevel.Study;
+            Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+        }
 
-		public DicomCMoveRequest(string destinationAe, string studyInstanceUid, string seriesInstanceUid, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority) {
-			DestinationAE = destinationAe;
-			Dataset = new DicomDataset();
-			Level = DicomQueryRetrieveLevel.Series;
-			Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
-			Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
-		}
+        public DicomCMoveRequest(
+            string destinationAe,
+            string studyInstanceUid,
+            string seriesInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
+        {
+            DestinationAE = destinationAe;
+            Dataset = new DicomDataset();
+            Level = DicomQueryRetrieveLevel.Series;
+            Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+            Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
+        }
 
-		public DicomCMoveRequest(string destinationAe, string studyInstanceUid, string seriesInstanceUid, string sopInstanceUid, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority) {
-			DestinationAE = destinationAe;
-			Dataset = new DicomDataset();
-			Level = DicomQueryRetrieveLevel.Image;
-			Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
-			Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
-			Dataset.Add(DicomTag.SOPInstanceUID, sopInstanceUid);
-		}
+        public DicomCMoveRequest(
+            string destinationAe,
+            string studyInstanceUid,
+            string seriesInstanceUid,
+            string sopInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
+        {
+            DestinationAE = destinationAe;
+            Dataset = new DicomDataset();
+            Level = DicomQueryRetrieveLevel.Image;
+            Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+            Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
+            Dataset.Add(DicomTag.SOPInstanceUID, sopInstanceUid);
+        }
 
-		public DicomQueryRetrieveLevel Level {
-			get { return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel); }
-			set {
-				Dataset.Remove(DicomTag.QueryRetrieveLevel);
-				if (value != DicomQueryRetrieveLevel.Worklist)
-					Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
-			}
-		}
+        public DicomQueryRetrieveLevel Level
+        {
+            get
+            {
+                return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
+            }
+            set
+            {
+                Dataset.Remove(DicomTag.QueryRetrieveLevel);
+                if (value != DicomQueryRetrieveLevel.Worklist) Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+            }
+        }
 
-		public string DestinationAE {
-			get { return Command.Get<string>(DicomTag.MoveDestination); }
-			set { Command.Add(DicomTag.MoveDestination, value); }
-		}
+        public string DestinationAE
+        {
+            get
+            {
+                return Command.Get<string>(DicomTag.MoveDestination);
+            }
+            set
+            {
+                Command.Add(DicomTag.MoveDestination, value);
+            }
+        }
 
-		public delegate void ResponseDelegate(DicomCMoveRequest request, DicomCMoveResponse response);
+        public delegate void ResponseDelegate(DicomCMoveRequest request, DicomCMoveResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomCMoveResponse)response);
-			} catch {
-			}
-		}
-	}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomCMoveResponse)response);
+            }
+            catch
+            {
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomCMoveResponse.cs
+++ b/DICOM/Network/DicomCMoveResponse.cs
@@ -1,60 +1,93 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom.Network {
-	public class DicomCMoveResponse : DicomResponse {
-		public DicomCMoveResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomCMoveResponse : DicomResponse
+    {
+        public DicomCMoveResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomCMoveResponse(DicomCMoveRequest request, DicomStatus status) : base(request, status) {
-		}
+        public DicomCMoveResponse(DicomCMoveRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
 
-		public int Remaining {
-			get { return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value); }
-		}
+        public int Remaining
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
+            }
+        }
 
-		public int Completed {
-			get { return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value); }
-		}
+        public int Completed
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
+            }
+        }
 
-		public int Warnings {
-			get { return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value); }
-		}
+        public int Warnings
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value);
+            }
+        }
 
-		public int Failures {
-			get { return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, 0); }
-			set { Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value); }
-		}
+        public int Failures
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, 0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value);
+            }
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-			if (Completed != 0)
-				sb.AppendFormat("\n\t\tCompleted:	{0}", Completed);
-			if (Remaining != 0)
-				sb.AppendFormat("\n\t\tRemaining:	{0}", Remaining);
-			if (Warnings != 0)
-				sb.AppendFormat("\n\t\tWarnings:	{0}", Warnings);
-			if (Failures != 0)
-				sb.AppendFormat("\n\t\tFailures:	{0}", Failures);
-			if (Status.State != DicomState.Pending && Status.State != DicomState.Success) {
-				if (!String.IsNullOrEmpty(Status.ErrorComment))
-					sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
-				if (Command.Contains(DicomTag.OffendingElement)) {
-					string[] tags = Command.Get<string[]>(DicomTag.OffendingElement);
-					if (tags.Length > 0) {
-						sb.Append("\n\t\tTags:		");
-						foreach (var tag in tags)
-							sb.AppendFormat(" {0}", tag);
-					}
-				}
-			}
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
+            if (Completed != 0) sb.AppendFormat("\n\t\tCompleted:	{0}", Completed);
+            if (Remaining != 0) sb.AppendFormat("\n\t\tRemaining:	{0}", Remaining);
+            if (Warnings != 0) sb.AppendFormat("\n\t\tWarnings:	{0}", Warnings);
+            if (Failures != 0) sb.AppendFormat("\n\t\tFailures:	{0}", Failures);
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            {
+                if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+                if (Command.Contains(DicomTag.OffendingElement))
+                {
+                    string[] tags = Command.Get<string[]>(DicomTag.OffendingElement);
+                    if (tags.Length > 0)
+                    {
+                        sb.Append("\n\t\tTags:		");
+                        foreach (var tag in tags) sb.AppendFormat(" {0}", tag);
+                    }
+                }
+            }
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomCStoreRequest.cs
+++ b/DICOM/Network/DicomCStoreRequest.cs
@@ -1,111 +1,128 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	/// <summary>
-	/// Represents a DICOM C-Store request to be sent to a C-Store SCP or a C-Store request that has been received from a C-Store SCU.
-	/// </summary>
-	/// <example>
-	/// The following example shows how to use the <see cref="DicomClient"/> class to send DICOM C-Store requests to a DICOM C-Store SCP.
-	/// <code>
-	/// var client = new DicomClient();
-	/// 
-	/// // queue C-Store request to send DICOM file
-	/// client.Add(new DicomCStoreRequest(@"test1.dcm") {
-	///		OnResponseReceived = (DicomCStoreRequest req, DicomCStoreResponse rsp) => {
-	///			Console.WriteLine("{0}: {1}", req.SOPInstanceUID, rsp.Status);
-	///		}
-	/// });
-	/// 
-	/// // queue C-Store request with additional proposed transfer syntaxes
-	/// client.Add(new DicomCStoreRequest(@"test2.dcm") {
-	///		AdditionalTransferSyntaxes = new DicomTransferSyntax[] {
-	///			DicomTransferSyntax.JPEGLSLossless,
-	///			DicomTransferSyntax.JPEG2000Lossless
-	///		}
-	/// });
-	/// 
-	/// // connect and send queued requests
-	/// client.Send("127.0.0.1", 12345, false, "SCU", "ANY-SCP");
-	/// </code>
-	/// </example>
-	public class DicomCStoreRequest : DicomRequest {
-		/// <summary>
-		/// Constructor for DICOM C-Store request received from SCU.
-		/// </summary>
-		/// <remarks>
-		/// In most use cases this constructor will only be called by the library.
-		/// </remarks>
-		/// <param name="command">DICOM Command Dataset</param>
-		public DicomCStoreRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Represents a DICOM C-Store request to be sent to a C-Store SCP or a C-Store request that has been received from a C-Store SCU.
+    /// </summary>
+    /// <example>
+    /// The following example shows how to use the <see cref="DicomClient"/> class to send DICOM C-Store requests to a DICOM C-Store SCP.
+    /// <code>
+    /// var client = new DicomClient();
+    /// 
+    /// // queue C-Store request to send DICOM file
+    /// client.Add(new DicomCStoreRequest(@"test1.dcm") {
+    ///		OnResponseReceived = (DicomCStoreRequest req, DicomCStoreResponse rsp) => {
+    ///			Console.WriteLine("{0}: {1}", req.SOPInstanceUID, rsp.Status);
+    ///		}
+    /// });
+    /// 
+    /// // queue C-Store request with additional proposed transfer syntaxes
+    /// client.Add(new DicomCStoreRequest(@"test2.dcm") {
+    ///		AdditionalTransferSyntaxes = new DicomTransferSyntax[] {
+    ///			DicomTransferSyntax.JPEGLSLossless,
+    ///			DicomTransferSyntax.JPEG2000Lossless
+    ///		}
+    /// });
+    /// 
+    /// // connect and send queued requests
+    /// client.Send("127.0.0.1", 12345, false, "SCU", "ANY-SCP");
+    /// </code>
+    /// </example>
+    public class DicomCStoreRequest : DicomRequest
+    {
+        /// <summary>
+        /// Constructor for DICOM C-Store request received from SCU.
+        /// </summary>
+        /// <remarks>
+        /// In most use cases this constructor will only be called by the library.
+        /// </remarks>
+        /// <param name="command">DICOM Command Dataset</param>
+        public DicomCStoreRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		/// <summary>
-		/// Initializes DICOM C-Store request to be sent to SCP.
-		/// </summary>
-		/// <param name="file">DICOM file to be sent</param>
-		/// <param name="priority">Priority of request</param>
-		public DicomCStoreRequest(DicomFile file, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.CStoreRequest, file.Dataset.Get<DicomUID>(DicomTag.SOPClassUID), priority) {
-			File = file;
-			Dataset = file.Dataset;
-			SOPInstanceUID = File.Dataset.Get<DicomUID>(DicomTag.SOPInstanceUID);
-		}
+        /// <summary>
+        /// Initializes DICOM C-Store request to be sent to SCP.
+        /// </summary>
+        /// <param name="file">DICOM file to be sent</param>
+        /// <param name="priority">Priority of request</param>
+        public DicomCStoreRequest(DicomFile file, DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CStoreRequest, file.Dataset.Get<DicomUID>(DicomTag.SOPClassUID), priority)
+        {
+            File = file;
+            Dataset = file.Dataset;
+            SOPInstanceUID = File.Dataset.Get<DicomUID>(DicomTag.SOPInstanceUID);
+        }
 
-		/// <summary>
-		/// Initializes DICOM C-Store request to be sent to SCP.
-		/// </summary>
-		/// <param name="file">DICOM file to be sent</param>
-		/// <param name="priority">Priority of request</param>
-		public DicomCStoreRequest(string fileName, DicomPriority priority = DicomPriority.Medium) : this(DicomFile.Open(fileName), priority) {
-		}
+        /// <summary>
+        /// Initializes DICOM C-Store request to be sent to SCP.
+        /// </summary>
+        /// <param name="file">DICOM file to be sent</param>
+        /// <param name="priority">Priority of request</param>
+        public DicomCStoreRequest(string fileName, DicomPriority priority = DicomPriority.Medium)
+            : this(DicomFile.Open(fileName), priority)
+        {
+        }
 
-		/// <summary>Gets the DICOM file associated with this DICOM C-Store request.</summary>
-		public DicomFile File {
-			get;
-			internal set;
-		}
+        /// <summary>Gets the DICOM file associated with this DICOM C-Store request.</summary>
+        public DicomFile File { get; internal set; }
 
-		/// <summary>Gets the SOP Instance UID of the DICOM file associated with this DICOM C-Store request.</summary>
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
+        /// <summary>Gets the SOP Instance UID of the DICOM file associated with this DICOM C-Store request.</summary>
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
 
-		/// <summary>Gets the transfer syntax of the DICOM file associated with this DICOM C-Store request.</summary>
-		public DicomTransferSyntax TransferSyntax {
-			get { return File.FileMetaInfo.TransferSyntax; }
-		}
+        /// <summary>Gets the transfer syntax of the DICOM file associated with this DICOM C-Store request.</summary>
+        public DicomTransferSyntax TransferSyntax
+        {
+            get
+            {
+                return File.FileMetaInfo.TransferSyntax;
+            }
+        }
 
-		/// <summary>
-		/// Additional transfer syntaxes to propose in the association request.
-		/// 
-		/// DICOM dataset will be transcoded on the fly if necessary.
-		/// </summary>
-		public DicomTransferSyntax[] AdditionalTransferSyntaxes {
-			get;
-			set;
-		}
+        /// <summary>
+        /// Additional transfer syntaxes to propose in the association request.
+        /// 
+        /// DICOM dataset will be transcoded on the fly if necessary.
+        /// </summary>
+        public DicomTransferSyntax[] AdditionalTransferSyntaxes { get; set; }
 
-		/// <summary>
-		/// Represents a callback method to be executed when the response for the DICOM C-Store request is received.
-		/// </summary>
-		/// <param name="request">Sent DICOM C-Store request</param>
-		/// <param name="response">Received DICOM C-Store response</param>
-		public delegate void ResponseDelegate(DicomCStoreRequest request, DicomCStoreResponse response);
+        /// <summary>
+        /// Represents a callback method to be executed when the response for the DICOM C-Store request is received.
+        /// </summary>
+        /// <param name="request">Sent DICOM C-Store request</param>
+        /// <param name="response">Received DICOM C-Store response</param>
+        public delegate void ResponseDelegate(DicomCStoreRequest request, DicomCStoreResponse response);
 
-		/// <summary>Delegate to be executed when the response for the DICOM C-Store request is received.</summary>
-		public ResponseDelegate OnResponseReceived;
+        /// <summary>Delegate to be executed when the response for the DICOM C-Store request is received.</summary>
+        public ResponseDelegate OnResponseReceived;
 
-		/// <summary>
-		/// Internal. Executes the DICOM C-Store response callback.
-		/// </summary>
-		/// <param name="service">DICOM SCP implementation</param>
-		/// <param name="response">Received DICOM response</param>
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomCStoreResponse)response);
-			} catch {
-			}
-		}
-	}
+        /// <summary>
+        /// Internal. Executes the DICOM C-Store response callback.
+        /// </summary>
+        /// <param name="service">DICOM SCP implementation</param>
+        /// <param name="response">Received DICOM response</param>
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomCStoreResponse)response);
+            }
+            catch
+            {
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomCStoreResponse.cs
+++ b/DICOM/Network/DicomCStoreResponse.cs
@@ -1,29 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	/// <summary>
-	/// Represents a DICOM C-Store response to be returned to a C-Store SCU or a C-Store response that has been received from a C-Store SCP.
-	/// </summary>
-	public class DicomCStoreResponse : DicomResponse {
-		/// <summary>
-		/// Constructor for DICOM C-Store response received from SCP.
-		/// </summary>
-		/// <remarks>
-		/// In most use cases this constructor will only be called by the library.
-		/// </remarks>
-		/// <param name="command">DICOM Command Dataset</param>
-		public DicomCStoreResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Represents a DICOM C-Store response to be returned to a C-Store SCU or a C-Store response that has been received from a C-Store SCP.
+    /// </summary>
+    public class DicomCStoreResponse : DicomResponse
+    {
+        /// <summary>
+        /// Constructor for DICOM C-Store response received from SCP.
+        /// </summary>
+        /// <remarks>
+        /// In most use cases this constructor will only be called by the library.
+        /// </remarks>
+        /// <param name="command">DICOM Command Dataset</param>
+        public DicomCStoreResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		/// <summary>
-		/// Initializes DICOM C-Store response to be returned to SCU.
-		/// </summary>
-		/// <param name="request">DICOM C-Store request being responded to</param>
-		/// <param name="status">Status result of the C-Store operation</param>
-		public DicomCStoreResponse(DicomCStoreRequest request, DicomStatus status) : base(request, status) {
-		}
-	}
+        /// <summary>
+        /// Initializes DICOM C-Store response to be returned to SCU.
+        /// </summary>
+        /// <param name="request">DICOM C-Store request being responded to</param>
+        /// <param name="status">Status result of the C-Store operation</param>
+        public DicomCStoreResponse(DicomCStoreRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
+    }
 }

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -1,299 +1,360 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Sockets;
 using System.Net.Security;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 
 using Dicom.Log;
 
-namespace Dicom.Network {
-	public class DicomClient {
-		private EventAsyncResult _async;
-		private ManualResetEventSlim _assoc;
-		private Exception _exception;
-		private List<DicomRequest> _requests;
-		private List<DicomPresentationContext> _contexts;
-		private DicomServiceUser _service;
-		private int _asyncInvoked;
-		private int _asyncPerformed;
-		private TcpClient _client;
-		private bool _abort;
+namespace Dicom.Network
+{
+    public class DicomClient
+    {
+        private EventAsyncResult _async;
 
-		public DicomClient() {
-			_requests = new List<DicomRequest>();
-			_contexts = new List<DicomPresentationContext>();
-			_asyncInvoked = 1;
-			_asyncPerformed = 1;
-			Linger = 50;
-		}
+        private ManualResetEventSlim _assoc;
 
-		public void NegotiateAsyncOps(int invoked = 0, int performed = 0) {
-			_asyncInvoked = invoked;
-			_asyncPerformed = performed;
-		}
+        private Exception _exception;
 
-		/// <summary>
-		/// Time in milliseconds to keep connection alive for additional requests.
-		/// </summary>
-		public int Linger {
-			get;
-			set;
-		}
+        private List<DicomRequest> _requests;
 
-		/// <summary>
-		/// Logger that is passed to the underlying DicomService implementation.
-		/// </summary>
-		public Logger Logger {
-			get;
-			set;
-		}
+        private List<DicomPresentationContext> _contexts;
 
-		/// <summary>
-		/// Options to control behavior of <see cref="DicomService"/> base class.
-		/// </summary>
-		public DicomServiceOptions Options {
-			get;
-			set;
-		}
+        private DicomServiceUser _service;
 
-		/// <summary>
-		/// Additional presentation contexts to negotiate with association.
-		/// </summary>
-		public List<DicomPresentationContext> AdditionalPresentationContexts {
-			get { return _contexts; }
-			set { _contexts = value; }
-		}
+        private int _asyncInvoked;
 
-		public object UserState {
-			get;
-			set;
-		}
+        private int _asyncPerformed;
 
-		public void AddRequest(DicomRequest request) {
-			if (_service != null && _service.IsConnected) {
-				_service.SendRequest(request);
-				if (_service._timer != null)
-					_service._timer.Change(Timeout.Infinite, Timeout.Infinite);
-			} else
-				_requests.Add(request);
-		}
+        private TcpClient _client;
 
-		public void Send(string host, int port, bool useTls, string callingAe, string calledAe) {
-			EndSend(BeginSend(host, port, useTls, callingAe, calledAe, null, null));
-		}
+        private bool _abort;
 
-		public IAsyncResult BeginSend(string host, int port, bool useTls, string callingAe, string calledAe, AsyncCallback callback, object state) {
-			_client = new TcpClient(host, port);
+        public DicomClient()
+        {
+            _requests = new List<DicomRequest>();
+            _contexts = new List<DicomPresentationContext>();
+            _asyncInvoked = 1;
+            _asyncPerformed = 1;
+            Linger = 50;
+        }
 
-			if (Options != null)
-				_client.NoDelay = Options.TcpNoDelay;
-			else
-				_client.NoDelay = DicomServiceOptions.Default.TcpNoDelay;
+        public void NegotiateAsyncOps(int invoked = 0, int performed = 0)
+        {
+            _asyncInvoked = invoked;
+            _asyncPerformed = performed;
+        }
 
-			Stream stream = _client.GetStream();
+        /// <summary>
+        /// Time in milliseconds to keep connection alive for additional requests.
+        /// </summary>
+        public int Linger { get; set; }
 
-			if (useTls) {
-				var ssl = new SslStream(stream, false, ValidateServerCertificate);
-				ssl.AuthenticateAsClient(host);
-				stream = ssl;
-			}
+        /// <summary>
+        /// Logger that is passed to the underlying DicomService implementation.
+        /// </summary>
+        public Logger Logger { get; set; }
 
-			return BeginSend(stream, callingAe, calledAe, callback, state);
-		}
+        /// <summary>
+        /// Options to control behavior of <see cref="DicomService"/> base class.
+        /// </summary>
+        public DicomServiceOptions Options { get; set; }
 
-		public void Send(Stream stream, string callingAe, string calledAe) {
-			EndSend(BeginSend(stream, callingAe, calledAe, null, null));
-		}
+        /// <summary>
+        /// Additional presentation contexts to negotiate with association.
+        /// </summary>
+        public List<DicomPresentationContext> AdditionalPresentationContexts
+        {
+            get
+            {
+                return _contexts;
+            }
+            set
+            {
+                _contexts = value;
+            }
+        }
 
-		public IAsyncResult BeginSend(Stream stream, string callingAe, string calledAe, AsyncCallback callback, object state) {
-			var assoc = new DicomAssociation(callingAe, calledAe);
-			assoc.MaxAsyncOpsInvoked = _asyncInvoked;
-			assoc.MaxAsyncOpsPerformed = _asyncPerformed;
-			foreach (var request in _requests)
-				assoc.PresentationContexts.AddFromRequest(request);
-			foreach (var context in _contexts)
-				assoc.PresentationContexts.Add(context.AbstractSyntax, context.GetTransferSyntaxes().ToArray());
+        public object UserState { get; set; }
 
-			_service = new DicomServiceUser(this, stream, assoc, Logger);
+        public void AddRequest(DicomRequest request)
+        {
+            if (_service != null && _service.IsConnected)
+            {
+                _service.SendRequest(request);
+                if (_service._timer != null) _service._timer.Change(Timeout.Infinite, Timeout.Infinite);
+            }
+            else _requests.Add(request);
+        }
 
-			_assoc = new ManualResetEventSlim(false);
+        public void Send(string host, int port, bool useTls, string callingAe, string calledAe)
+        {
+            EndSend(BeginSend(host, port, useTls, callingAe, calledAe, null, null));
+        }
 
-			_async = new EventAsyncResult(callback, state);
-			return _async;
-		}
+        public IAsyncResult BeginSend(
+            string host,
+            int port,
+            bool useTls,
+            string callingAe,
+            string calledAe,
+            AsyncCallback callback,
+            object state)
+        {
+            _client = new TcpClient(host, port);
 
-		private bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) {
-			if (sslPolicyErrors == SslPolicyErrors.None)
-				return true;
+            if (Options != null) _client.NoDelay = Options.TcpNoDelay;
+            else _client.NoDelay = DicomServiceOptions.Default.TcpNoDelay;
 
-			if (Options != null) {
-				if (Options.IgnoreSslPolicyErrors)
-					return true;
-			} else if (DicomServiceOptions.Default.IgnoreSslPolicyErrors)
-				return true;
+            Stream stream = _client.GetStream();
 
-			return false;
-		}
+            if (useTls)
+            {
+                var ssl = new SslStream(stream, false, ValidateServerCertificate);
+                ssl.AuthenticateAsClient(host);
+                stream = ssl;
+            }
 
-		public void EndSend(IAsyncResult result) {
-			if (_async != null)
-				_async.AsyncWaitHandle.WaitOne();
+            return BeginSend(stream, callingAe, calledAe, callback, state);
+        }
 
-			if (_assoc != null)
-				_assoc.Set();
+        public void Send(Stream stream, string callingAe, string calledAe)
+        {
+            EndSend(BeginSend(stream, callingAe, calledAe, null, null));
+        }
 
-			if (_client != null) {
-				try {
-					_client.Close();
-				} catch {
-				}
-			}
+        public IAsyncResult BeginSend(
+            Stream stream,
+            string callingAe,
+            string calledAe,
+            AsyncCallback callback,
+            object state)
+        {
+            var assoc = new DicomAssociation(callingAe, calledAe);
+            assoc.MaxAsyncOpsInvoked = _asyncInvoked;
+            assoc.MaxAsyncOpsPerformed = _asyncPerformed;
+            foreach (var request in _requests) assoc.PresentationContexts.AddFromRequest(request);
+            foreach (var context in _contexts) assoc.PresentationContexts.Add(context.AbstractSyntax, context.GetTransferSyntaxes().ToArray());
 
-			_service = null;
-			_client = null;
-			_async = null;
-			_assoc = null;
+            _service = new DicomServiceUser(this, stream, assoc, Logger);
 
-			if (_exception != null && !_abort)
-				throw _exception;
-		}
+            _assoc = new ManualResetEventSlim(false);
 
-		public void WaitForAssociation(int millisecondsTimeout = 5000) {
-			if (_assoc == null)
-				return;
+            _async = new EventAsyncResult(callback, state);
+            return _async;
+        }
 
-			_assoc.Wait(millisecondsTimeout);
-		}
+        private bool ValidateServerCertificate(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (sslPolicyErrors == SslPolicyErrors.None) return true;
 
-		public void Release() {
-			try {
-				_service._SendAssociationReleaseRequest();
+            if (Options != null)
+            {
+                if (Options.IgnoreSslPolicyErrors) return true;
+            }
+            else if (DicomServiceOptions.Default.IgnoreSslPolicyErrors) return true;
 
-				_async.AsyncWaitHandle.WaitOne(10000);
-			} catch {
-			} finally {
-				Abort();
-			}
-		}
+            return false;
+        }
 
-		public void Abort() {
-			try {
-				_abort = true;
-				_client.Close();
-			} catch {
-			} finally {
-				_client = null;
-				try {
-					_async.Set();
-				} catch {
-				}
-				_async = null;
-			}
-		}
+        public void EndSend(IAsyncResult result)
+        {
+            if (_async != null) _async.AsyncWaitHandle.WaitOne();
 
-		private class DicomServiceUser : DicomService, IDicomServiceUser {
-			public DicomClient _client;
-			public Timer _timer;
+            if (_assoc != null) _assoc.Set();
 
-			public DicomServiceUser(DicomClient client, Stream stream, DicomAssociation association, Logger log) : base(stream, log) {
-				_client = client;
-				if (_client.Options != null)
-					Options = _client.Options;
-				SendAssociationRequest(association);
-			}
+            if (_client != null)
+            {
+                try
+                {
+                    _client.Close();
+                }
+                catch
+                {
+                }
+            }
 
-			public void _SendAssociationReleaseRequest() {
-				try {
-					SendAssociationReleaseRequest();
-				} catch {
-					// may have already disconnected
-					_client._async.Set();
-					return;
-				}
+            _service = null;
+            _client = null;
+            _async = null;
+            _assoc = null;
 
-				_timer = new Timer(OnReleaseTimeout);
-				_timer.Change(2500, Timeout.Infinite);
-			}
+            if (_exception != null && !_abort) throw _exception;
+        }
 
-			public void OnReceiveAssociationAccept(DicomAssociation association) {
-				_client._assoc.Set();
-				_client._assoc = null;
+        public void WaitForAssociation(int millisecondsTimeout = 5000)
+        {
+            if (_assoc == null) return;
 
-				foreach (var request in _client._requests)
-					SendRequest(request);
-				_client._requests.Clear();
-			}
+            _assoc.Wait(millisecondsTimeout);
+        }
 
-			protected override void OnSendQueueEmpty() {
-				if (_client.Linger == Timeout.Infinite) {
-					OnLingerTimeout(null);
-				} else {
-					_timer = new Timer(OnLingerTimeout);
-					_timer.Change(_client.Linger, Timeout.Infinite);
-				}
-			}
+        public void Release()
+        {
+            try
+            {
+                _service._SendAssociationReleaseRequest();
 
-			private void OnLingerTimeout(object state) {
-				if (!IsSendQueueEmpty)
-					return;
+                _async.AsyncWaitHandle.WaitOne(10000);
+            }
+            catch
+            {
+            }
+            finally
+            {
+                Abort();
+            }
+        }
 
-				if (IsConnected)
-					_SendAssociationReleaseRequest();
-			}
+        public void Abort()
+        {
+            try
+            {
+                _abort = true;
+                _client.Close();
+            }
+            catch
+            {
+            }
+            finally
+            {
+                _client = null;
+                try
+                {
+                    _async.Set();
+                }
+                catch
+                {
+                }
+                _async = null;
+            }
+        }
 
-			private void OnReleaseTimeout(object state) {
-				if (_timer != null)
-					_timer.Change(Timeout.Infinite, Timeout.Infinite);
+        private class DicomServiceUser : DicomService, IDicomServiceUser
+        {
+            public DicomClient _client;
 
-				try {
-					if (_client._async != null)
-						_client._async.Set();
-				} catch {
-					// event handler has already fired
-				}
-			}
+            public Timer _timer;
 
-			public void OnReceiveAssociationReject(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason) {
-				if (_timer != null)
-					_timer.Change(Timeout.Infinite, Timeout.Infinite);
+            public DicomServiceUser(DicomClient client, Stream stream, DicomAssociation association, Logger log)
+                : base(stream, log)
+            {
+                _client = client;
+                if (_client.Options != null) Options = _client.Options;
+                SendAssociationRequest(association);
+            }
 
-				_client._exception = new DicomAssociationRejectedException(result, source, reason);
-				_client._async.Set();
-			}
+            public void _SendAssociationReleaseRequest()
+            {
+                try
+                {
+                    SendAssociationReleaseRequest();
+                }
+                catch
+                {
+                    // may have already disconnected
+                    _client._async.Set();
+                    return;
+                }
 
-			public void OnReceiveAssociationReleaseResponse() {
-				if (_timer != null)
-					_timer.Change(Timeout.Infinite, Timeout.Infinite);
+                _timer = new Timer(OnReleaseTimeout);
+                _timer.Change(2500, Timeout.Infinite);
+            }
 
-				_client._async.Set();
-			}
+            public void OnReceiveAssociationAccept(DicomAssociation association)
+            {
+                _client._assoc.Set();
+                _client._assoc = null;
 
-			public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason) {
-				if (_timer != null)
-					_timer.Change(Timeout.Infinite, Timeout.Infinite);
+                foreach (var request in _client._requests) SendRequest(request);
+                _client._requests.Clear();
+            }
 
-				_client._exception = new DicomAssociationAbortedException(source, reason);
-				_client._async.Set();
-			}
+            protected override void OnSendQueueEmpty()
+            {
+                if (_client.Linger == Timeout.Infinite)
+                {
+                    OnLingerTimeout(null);
+                }
+                else
+                {
+                    _timer = new Timer(OnLingerTimeout);
+                    _timer.Change(_client.Linger, Timeout.Infinite);
+                }
+            }
 
-			public void OnConnectionClosed(Exception exception) {
-				if (_timer != null)
-					_timer.Change(Timeout.Infinite, Timeout.Infinite);
+            private void OnLingerTimeout(object state)
+            {
+                if (!IsSendQueueEmpty) return;
 
-				_client._exception = exception;
+                if (IsConnected) _SendAssociationReleaseRequest();
+            }
 
-				try {
-					if (_client._async != null)
-						_client._async.Set();
-				} catch {
-					// event handler has already fired
-				}
-			}
-		}
-	}
+            private void OnReleaseTimeout(object state)
+            {
+                if (_timer != null) _timer.Change(Timeout.Infinite, Timeout.Infinite);
+
+                try
+                {
+                    if (_client._async != null) _client._async.Set();
+                }
+                catch
+                {
+                    // event handler has already fired
+                }
+            }
+
+            public void OnReceiveAssociationReject(
+                DicomRejectResult result,
+                DicomRejectSource source,
+                DicomRejectReason reason)
+            {
+                if (_timer != null) _timer.Change(Timeout.Infinite, Timeout.Infinite);
+
+                _client._exception = new DicomAssociationRejectedException(result, source, reason);
+                _client._async.Set();
+            }
+
+            public void OnReceiveAssociationReleaseResponse()
+            {
+                if (_timer != null) _timer.Change(Timeout.Infinite, Timeout.Infinite);
+
+                _client._async.Set();
+            }
+
+            public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+            {
+                if (_timer != null) _timer.Change(Timeout.Infinite, Timeout.Infinite);
+
+                _client._exception = new DicomAssociationAbortedException(source, reason);
+                _client._async.Set();
+            }
+
+            public void OnConnectionClosed(Exception exception)
+            {
+                if (_timer != null) _timer.Change(Timeout.Infinite, Timeout.Infinite);
+
+                _client._exception = exception;
+
+                try
+                {
+                    if (_client._async != null) _client._async.Set();
+                }
+                catch
+                {
+                    // event handler has already fired
+                }
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomCommandField.cs
+++ b/DICOM/Network/DicomCommandField.cs
@@ -1,32 +1,54 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public enum DicomCommandField : ushort {
-		CStoreRequest = 0x0001,
-		CStoreResponse = 0x8001,
-		CGetRequest = 0x0010,
-		CGetResponse = 0x8010,
-		CFindRequest = 0x0020,
-		CFindResponse = 0x8020,
-		CMoveRequest = 0x0021,
-		CMoveResponse = 0x8021,
-		CEchoRequest = 0x0030,
-		CEchoResponse = 0x8030,
-		NEventReportRequest = 0x0100,
-		NEventReportResponse = 0x8100,
-		NGetRequest = 0x0110,
-		NGetResponse = 0x8110,
-		NSetRequest = 0x0120,
-		NSetResponse = 0x8120,
-		NActionRequest = 0x0130,
-		NActionResponse = 0x8130,
-		NCreateRequest = 0x0140,
-		NCreateResponse = 0x8140,
-		NDeleteRequest = 0x0150,
-		NDeleteResponse = 0x8150,
-		CCancelRequest = 0x0FFF
-	}
+namespace Dicom.Network
+{
+    public enum DicomCommandField : ushort
+    {
+        CStoreRequest = 0x0001,
+
+        CStoreResponse = 0x8001,
+
+        CGetRequest = 0x0010,
+
+        CGetResponse = 0x8010,
+
+        CFindRequest = 0x0020,
+
+        CFindResponse = 0x8020,
+
+        CMoveRequest = 0x0021,
+
+        CMoveResponse = 0x8021,
+
+        CEchoRequest = 0x0030,
+
+        CEchoResponse = 0x8030,
+
+        NEventReportRequest = 0x0100,
+
+        NEventReportResponse = 0x8100,
+
+        NGetRequest = 0x0110,
+
+        NGetResponse = 0x8110,
+
+        NSetRequest = 0x0120,
+
+        NSetResponse = 0x8120,
+
+        NActionRequest = 0x0130,
+
+        NActionResponse = 0x8130,
+
+        NCreateRequest = 0x0140,
+
+        NCreateResponse = 0x8140,
+
+        NDeleteRequest = 0x0150,
+
+        NDeleteResponse = 0x8150,
+
+        CCancelRequest = 0x0FFF
+    }
 }

--- a/DICOM/Network/DicomMessage.cs
+++ b/DICOM/Network/DicomMessage.cs
@@ -1,62 +1,90 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
 using Dicom.Log;
 
-namespace Dicom.Network {
-	public class DicomMessage {
-		public DicomMessage() {
-			Command = new DicomDataset();
-			Dataset = null;
-		}
+namespace Dicom.Network
+{
+    public class DicomMessage
+    {
+        public DicomMessage()
+        {
+            Command = new DicomDataset();
+            Dataset = null;
+        }
 
-		public DicomMessage(DicomDataset command) {
-			Command = command;
-		}
+        public DicomMessage(DicomDataset command)
+        {
+            Command = command;
+        }
 
-		public DicomCommandField Type {
-			get { return Command.Get<DicomCommandField>(DicomTag.CommandField); }
-			set { Command.Add(DicomTag.CommandField, (ushort)value); }
-		}
+        public DicomCommandField Type
+        {
+            get
+            {
+                return Command.Get<DicomCommandField>(DicomTag.CommandField);
+            }
+            set
+            {
+                Command.Add(DicomTag.CommandField, (ushort)value);
+            }
+        }
 
-		/// <summary>Affected or requested SOP Class UID</summary>
-		public DicomUID SOPClassUID {
-			get {
-				switch (Type) {
-				case DicomCommandField.NGetRequest:
-				case DicomCommandField.NSetRequest:
-				case DicomCommandField.NActionRequest:
-				case DicomCommandField.NDeleteRequest:
-					return Command.Get<DicomUID>(DicomTag.RequestedSOPClassUID);
-				default:
-					return Command.Get<DicomUID>(DicomTag.AffectedSOPClassUID);
-				}
-			}
-			set {
-				switch (Type) {
-				case DicomCommandField.NGetRequest:
-				case DicomCommandField.NSetRequest:
-				case DicomCommandField.NActionRequest:
-				case DicomCommandField.NDeleteRequest:
-					Command.Add(DicomTag.RequestedSOPClassUID, value);
-					break;
-				default:
-					Command.Add(DicomTag.AffectedSOPClassUID, value);
-					break;
-				}
-			}
-		}
+        /// <summary>Affected or requested SOP Class UID</summary>
+        public DicomUID SOPClassUID
+        {
+            get
+            {
+                switch (Type)
+                {
+                    case DicomCommandField.NGetRequest:
+                    case DicomCommandField.NSetRequest:
+                    case DicomCommandField.NActionRequest:
+                    case DicomCommandField.NDeleteRequest:
+                        return Command.Get<DicomUID>(DicomTag.RequestedSOPClassUID);
+                    default:
+                        return Command.Get<DicomUID>(DicomTag.AffectedSOPClassUID);
+                }
+            }
+            set
+            {
+                switch (Type)
+                {
+                    case DicomCommandField.NGetRequest:
+                    case DicomCommandField.NSetRequest:
+                    case DicomCommandField.NActionRequest:
+                    case DicomCommandField.NDeleteRequest:
+                        Command.Add(DicomTag.RequestedSOPClassUID, value);
+                        break;
+                    default:
+                        Command.Add(DicomTag.AffectedSOPClassUID, value);
+                        break;
+                }
+            }
+        }
 
-		public ushort MessageID {
-			get { return Command.Get<ushort>(DicomTag.MessageID); }
-			set { Command.Add(DicomTag.MessageID, value); }
-		}
+        public ushort MessageID
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.MessageID);
+            }
+            set
+            {
+                Command.Add(DicomTag.MessageID, value);
+            }
+        }
 
-		public bool HasDataset {
-			get { return Command.Get<ushort>(DicomTag.CommandDataSetType, 0, 0x0101) != 0x0101; }
-		}
+        public bool HasDataset
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.CommandDataSetType, 0, 0x0101) != 0x0101;
+            }
+        }
 
 
         /// <summary>
@@ -64,110 +92,117 @@ namespace Dicom.Network {
         /// </summary>
         public DicomPresentationContext PresentationContext { get; set; }
 
-		public DicomDataset Command {
-			get;
-			set;
-		}
+        public DicomDataset Command { get; set; }
 
-		private DicomDataset _dataset;
-		public DicomDataset Dataset {
-			get { return _dataset; }
-			set {
-				_dataset = value;
-				Command.Add(DicomTag.CommandDataSetType,
-					(_dataset != null) ? (ushort)0x0202 : (ushort)0x0101);
-			}
-		}
+        private DicomDataset _dataset;
 
-		/// <summary>State object that will be passed from request to response objects.</summary>
-		public object UserState {
-			get;
-			set;
-		}
+        public DicomDataset Dataset
+        {
+            get
+            {
+                return _dataset;
+            }
+            set
+            {
+                _dataset = value;
+                Command.Add(DicomTag.CommandDataSetType, (_dataset != null) ? (ushort)0x0202 : (ushort)0x0101);
+            }
+        }
 
-		public override string ToString() {
-			return String.Format("{0} [{1}]", ToString(Type), IsRequest(Type) ? MessageID : Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo));
-		}
+        /// <summary>State object that will be passed from request to response objects.</summary>
+        public object UserState { get; set; }
 
-		public string ToString(bool printDatasets) {
-			var output = new StringBuilder(ToString());
+        public override string ToString()
+        {
+            return String.Format(
+                "{0} [{1}]",
+                ToString(Type),
+                IsRequest(Type) ? MessageID : Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo));
+        }
 
-			if (!printDatasets)
-				return output.ToString();
+        public string ToString(bool printDatasets)
+        {
+            var output = new StringBuilder(ToString());
 
-			output.AppendLine();
-			output.AppendLine("--------------------------------------------------------------------------------");
-			output.AppendLine(" DIMSE Command:");
-			output.AppendLine("--------------------------------------------------------------------------------");
-			output.AppendLine(Command.WriteToString());
+            if (!printDatasets) return output.ToString();
 
-			if (HasDataset) {
-				output.AppendLine("--------------------------------------------------------------------------------");
-				output.AppendLine(" DIMSE Dataset:");
-				output.AppendLine("--------------------------------------------------------------------------------");
-				output.AppendLine(Dataset.WriteToString());
-			}
+            output.AppendLine();
+            output.AppendLine("--------------------------------------------------------------------------------");
+            output.AppendLine(" DIMSE Command:");
+            output.AppendLine("--------------------------------------------------------------------------------");
+            output.AppendLine(Command.WriteToString());
 
-			output.AppendLine("--------------------------------------------------------------------------------");
+            if (HasDataset)
+            {
+                output.AppendLine("--------------------------------------------------------------------------------");
+                output.AppendLine(" DIMSE Dataset:");
+                output.AppendLine("--------------------------------------------------------------------------------");
+                output.AppendLine(Dataset.WriteToString());
+            }
 
-			return output.ToString();
-		}
+            output.AppendLine("--------------------------------------------------------------------------------");
 
-		public static string ToString(DicomCommandField type) {
-			switch (type) {
-			case DicomCommandField.CCancelRequest:
-				return "C-Cancel request";
-			case DicomCommandField.CEchoRequest:
-				return "C-Echo request";
-			case DicomCommandField.CEchoResponse:
-				return "C-Echo response";
-			case DicomCommandField.CFindRequest:
-				return "C-Find request";
-			case DicomCommandField.CFindResponse:
-				return "C-Find response";
-			case DicomCommandField.CGetRequest:
-				return "C-Get request";
-			case DicomCommandField.CGetResponse:
-				return "C-Get response";
-			case DicomCommandField.CMoveRequest:
-				return "C-Move request";
-			case DicomCommandField.CMoveResponse:
-				return "C-Move response";
-			case DicomCommandField.CStoreRequest:
-				return "C-Store request";
-			case DicomCommandField.CStoreResponse:
-				return "C-Store response";
-			case DicomCommandField.NActionRequest:
-				return "N-Action request";
-			case DicomCommandField.NActionResponse:
-				return "N-Action response";
-			case DicomCommandField.NCreateRequest:
-				return "N-Create request";
-			case DicomCommandField.NCreateResponse:
-				return "N-Create response";
-			case DicomCommandField.NDeleteRequest:
-				return "N-Delete request";
-			case DicomCommandField.NDeleteResponse:
-				return "N-Delete response";
-			case DicomCommandField.NEventReportRequest:
-				return "N-EventReport request";
-			case DicomCommandField.NEventReportResponse:
-				return "N-EventReport response";
-			case DicomCommandField.NGetRequest:
-				return "N-Get request";
-			case DicomCommandField.NGetResponse:
-				return "N-Get response";
-			case DicomCommandField.NSetRequest:
-				return "N-Set request";
-			case DicomCommandField.NSetResponse:
-				return "N-Set response";
-			default:
-				return "DIMSE";
-			}
-		}
+            return output.ToString();
+        }
 
-		public static bool IsRequest(DicomCommandField type) {
-			return ((int)type & 0x8000) == 0;
-		}
-	}
+        public static string ToString(DicomCommandField type)
+        {
+            switch (type)
+            {
+                case DicomCommandField.CCancelRequest:
+                    return "C-Cancel request";
+                case DicomCommandField.CEchoRequest:
+                    return "C-Echo request";
+                case DicomCommandField.CEchoResponse:
+                    return "C-Echo response";
+                case DicomCommandField.CFindRequest:
+                    return "C-Find request";
+                case DicomCommandField.CFindResponse:
+                    return "C-Find response";
+                case DicomCommandField.CGetRequest:
+                    return "C-Get request";
+                case DicomCommandField.CGetResponse:
+                    return "C-Get response";
+                case DicomCommandField.CMoveRequest:
+                    return "C-Move request";
+                case DicomCommandField.CMoveResponse:
+                    return "C-Move response";
+                case DicomCommandField.CStoreRequest:
+                    return "C-Store request";
+                case DicomCommandField.CStoreResponse:
+                    return "C-Store response";
+                case DicomCommandField.NActionRequest:
+                    return "N-Action request";
+                case DicomCommandField.NActionResponse:
+                    return "N-Action response";
+                case DicomCommandField.NCreateRequest:
+                    return "N-Create request";
+                case DicomCommandField.NCreateResponse:
+                    return "N-Create response";
+                case DicomCommandField.NDeleteRequest:
+                    return "N-Delete request";
+                case DicomCommandField.NDeleteResponse:
+                    return "N-Delete response";
+                case DicomCommandField.NEventReportRequest:
+                    return "N-EventReport request";
+                case DicomCommandField.NEventReportResponse:
+                    return "N-EventReport response";
+                case DicomCommandField.NGetRequest:
+                    return "N-Get request";
+                case DicomCommandField.NGetResponse:
+                    return "N-Get response";
+                case DicomCommandField.NSetRequest:
+                    return "N-Set request";
+                case DicomCommandField.NSetResponse:
+                    return "N-Set response";
+                default:
+                    return "DIMSE";
+            }
+        }
+
+        public static bool IsRequest(DicomCommandField type)
+        {
+            return ((int)type & 0x8000) == 0;
+        }
+    }
 }

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -1,45 +1,73 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Text;
 
-namespace Dicom.Network {
-	public class DicomNActionRequest : DicomRequest {
-		public DicomNActionRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNActionRequest : DicomRequest
+    {
+        public DicomNActionRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNActionRequest(DicomUID requestedClassUid, DicomUID requestedInstanceUid, ushort actionTypeId, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.NActionRequest, requestedClassUid, priority) {
-			SOPInstanceUID = requestedInstanceUid;
-			ActionTypeID = actionTypeId;
-		}
+        public DicomNActionRequest(
+            DicomUID requestedClassUid,
+            DicomUID requestedInstanceUid,
+            ushort actionTypeId,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.NActionRequest, requestedClassUid, priority)
+        {
+            SOPInstanceUID = requestedInstanceUid;
+            ActionTypeID = actionTypeId;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.RequestedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+            }
+        }
 
-		public ushort ActionTypeID {
-			get { return Command.Get<ushort>(DicomTag.ActionTypeID); }
-			private set { Command.Add(DicomTag.ActionTypeID, value); }
-		}
+        public ushort ActionTypeID
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.ActionTypeID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.ActionTypeID, value);
+            }
+        }
 
-		public delegate void ResponseDelegate(DicomNActionRequest request, DicomNActionResponse response);
+        public delegate void ResponseDelegate(DicomNActionRequest request, DicomNActionResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomNActionResponse)response);
-			} catch {
-			}
-		}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomNActionResponse)response);
+            }
+            catch
+            {
+            }
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} [{1}]", ToString(Type), MessageID);
-			sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]", ToString(Type), MessageID);
+            sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -1,35 +1,57 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom.Network {
-	public class DicomNActionResponse : DicomResponse {
-		public DicomNActionResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNActionResponse : DicomResponse
+    {
+        public DicomNActionResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNActionResponse(DicomNActionRequest request, DicomStatus status) : base(request, status) {
-		}
+        public DicomNActionResponse(DicomNActionRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
 
-		public ushort ActionTypeID {
-			get { return Command.Get<ushort>(DicomTag.ActionTypeID); }
-			private set { Command.Add(DicomTag.ActionTypeID, value); }
-		}
+        public ushort ActionTypeID
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.ActionTypeID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.ActionTypeID, value);
+            }
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-			sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
-			if (Status.State != DicomState.Pending && Status.State != DicomState.Success) {
-				if (!String.IsNullOrEmpty(Status.ErrorComment))
-					sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
-			}
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
+            sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            {
+                if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+            }
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -1,32 +1,50 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNCreateRequest : DicomRequest {
-		public DicomNCreateRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNCreateRequest : DicomRequest
+    {
+        public DicomNCreateRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNCreateRequest(DicomUID affectedClassUid, DicomUID affectedInstanceUid, ushort eventTypeId, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.NCreateRequest, affectedClassUid, priority) {
-			SOPInstanceUID = affectedInstanceUid;
-		}
+        public DicomNCreateRequest(
+            DicomUID affectedClassUid,
+            DicomUID affectedInstanceUid,
+            ushort eventTypeId,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.NCreateRequest, affectedClassUid, priority)
+        {
+            SOPInstanceUID = affectedInstanceUid;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
 
-		public delegate void ResponseDelegate(DicomNCreateRequest request, DicomNCreateResponse response);
+        public delegate void ResponseDelegate(DicomNCreateRequest request, DicomNCreateResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomNCreateResponse)response);
-			} catch {
-			}
-		}
-	}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomNCreateResponse)response);
+            }
+            catch
+            {
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNCreateResponse.cs
+++ b/DICOM/Network/DicomNCreateResponse.cs
@@ -1,19 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNCreateResponse : DicomResponse {
-		public DicomNCreateResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNCreateResponse : DicomResponse
+    {
+        public DicomNCreateResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNCreateResponse(DicomNCreateRequest request, DicomStatus status) : base(request, status) {
-		}
+        public DicomNCreateResponse(DicomNCreateRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
-	}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNDeleteRequest.cs
+++ b/DICOM/Network/DicomNDeleteRequest.cs
@@ -1,32 +1,49 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNDeleteRequest : DicomRequest {
-		public DicomNDeleteRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNDeleteRequest : DicomRequest
+    {
+        public DicomNDeleteRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNDeleteRequest(DicomUID requestedClassUid, DicomUID requestedInstanceUid, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.NDeleteRequest, requestedClassUid, priority) {
-			SOPInstanceUID = requestedInstanceUid;
-		}
+        public DicomNDeleteRequest(
+            DicomUID requestedClassUid,
+            DicomUID requestedInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.NDeleteRequest, requestedClassUid, priority)
+        {
+            SOPInstanceUID = requestedInstanceUid;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.RequestedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+            }
+        }
 
-		public delegate void ResponseDelegate(DicomNDeleteRequest request, DicomNDeleteResponse response);
+        public delegate void ResponseDelegate(DicomNDeleteRequest request, DicomNDeleteResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomNDeleteResponse)response);
-			} catch {
-			}
-		}
-	}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomNDeleteResponse)response);
+            }
+            catch
+            {
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNDeleteResponse.cs
+++ b/DICOM/Network/DicomNDeleteResponse.cs
@@ -1,19 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNDeleteResponse : DicomResponse {
-		public DicomNDeleteResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNDeleteResponse : DicomResponse
+    {
+        public DicomNDeleteResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNDeleteResponse(DicomNDeleteRequest request, DicomStatus status) : base(request, status) {
-		}
+        public DicomNDeleteResponse(DicomNDeleteRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
-	}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -1,45 +1,73 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Text;
 
-namespace Dicom.Network {
-	public class DicomNEventReportRequest : DicomRequest {
-		public DicomNEventReportRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNEventReportRequest : DicomRequest
+    {
+        public DicomNEventReportRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNEventReportRequest(DicomUID affectedClassUid, DicomUID affectedInstanceUid, ushort eventTypeId, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.NEventReportRequest, affectedClassUid, priority) {
-			SOPInstanceUID = affectedInstanceUid;
-			EventTypeID = eventTypeId;
-		}
+        public DicomNEventReportRequest(
+            DicomUID affectedClassUid,
+            DicomUID affectedInstanceUid,
+            ushort eventTypeId,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.NEventReportRequest, affectedClassUid, priority)
+        {
+            SOPInstanceUID = affectedInstanceUid;
+            EventTypeID = eventTypeId;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
 
-		public ushort EventTypeID {
-			get { return Command.Get<ushort>(DicomTag.EventTypeID); }
-			private set { Command.Add(DicomTag.EventTypeID, value); }
-		}
+        public ushort EventTypeID
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.EventTypeID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.EventTypeID, value);
+            }
+        }
 
-		public delegate void ResponseDelegate(DicomNEventReportRequest request, DicomNEventReportResponse response);
+        public delegate void ResponseDelegate(DicomNEventReportRequest request, DicomNEventReportResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomNEventReportResponse)response);
-			} catch {
-			}
-		}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomNEventReportResponse)response);
+            }
+            catch
+            {
+            }
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} [{1}]", ToString(Type), MessageID);
-			sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]", ToString(Type), MessageID);
+            sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomNEventReportResponse.cs
+++ b/DICOM/Network/DicomNEventReportResponse.cs
@@ -1,35 +1,57 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom.Network {
-	public class DicomNEventReportResponse : DicomResponse {
-		public DicomNEventReportResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNEventReportResponse : DicomResponse
+    {
+        public DicomNEventReportResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNEventReportResponse(DicomNEventReportRequest request, DicomStatus status) : base(request, status) {
-		}
+        public DicomNEventReportResponse(DicomNEventReportRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
 
-		public ushort EventTypeID {
-			get { return Command.Get<ushort>(DicomTag.EventTypeID); }
-			private set { Command.Add(DicomTag.EventTypeID, value); }
-		}
+        public ushort EventTypeID
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.EventTypeID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.EventTypeID, value);
+            }
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-			sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
-			if (Status.State != DicomState.Pending && Status.State != DicomState.Success) {
-				if (!String.IsNullOrEmpty(Status.ErrorComment))
-					sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
-			}
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
+            sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            {
+                if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+            }
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomNGetRequest.cs
+++ b/DICOM/Network/DicomNGetRequest.cs
@@ -1,37 +1,62 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNGetRequest : DicomRequest {
-		public DicomNGetRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNGetRequest : DicomRequest
+    {
+        public DicomNGetRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNGetRequest(DicomUID requestedClassUid, DicomUID requestedInstanceUid, DicomTag[] attributes, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.NGetRequest, requestedClassUid, priority) {
-			SOPInstanceUID = requestedInstanceUid;
-		}
+        public DicomNGetRequest(
+            DicomUID requestedClassUid,
+            DicomUID requestedInstanceUid,
+            DicomTag[] attributes,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.NGetRequest, requestedClassUid, priority)
+        {
+            SOPInstanceUID = requestedInstanceUid;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.RequestedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+            }
+        }
 
-		public DicomTag[] Attributes {
-			get { return Command.Get<DicomTag[]>(DicomTag.AttributeIdentifierList); }
-			private set { Command.Add(DicomTag.AttributeIdentifierList, value); }
-		}
+        public DicomTag[] Attributes
+        {
+            get
+            {
+                return Command.Get<DicomTag[]>(DicomTag.AttributeIdentifierList);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AttributeIdentifierList, value);
+            }
+        }
 
-		public delegate void ResponseDelegate(DicomNGetRequest request, DicomNGetResponse response);
+        public delegate void ResponseDelegate(DicomNGetRequest request, DicomNGetResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomNGetResponse)response);
-			} catch {
-			}
-		}
-	}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomNGetResponse)response);
+            }
+            catch
+            {
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNGetResponse.cs
+++ b/DICOM/Network/DicomNGetResponse.cs
@@ -1,20 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNGetResponse : DicomResponse {
-		public DicomNGetResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNGetResponse : DicomResponse
+    {
+        public DicomNGetResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNGetResponse(DicomNGetRequest request, DicomStatus status) : base(request, status) {
-			SOPInstanceUID = request.SOPInstanceUID;
-		}
+        public DicomNGetResponse(DicomNGetRequest request, DicomStatus status)
+            : base(request, status)
+        {
+            SOPInstanceUID = request.SOPInstanceUID;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
-	}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNSetRequest.cs
+++ b/DICOM/Network/DicomNSetRequest.cs
@@ -1,32 +1,49 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNSetRequest : DicomRequest {
-		public DicomNSetRequest(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNSetRequest : DicomRequest
+    {
+        public DicomNSetRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNSetRequest(DicomUID requestedClassUid, DicomUID requestedInstanceUid, DicomPriority priority = DicomPriority.Medium) : base(DicomCommandField.NSetRequest, requestedClassUid, priority) {
-			SOPInstanceUID = requestedInstanceUid;
-		}
+        public DicomNSetRequest(
+            DicomUID requestedClassUid,
+            DicomUID requestedInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.NSetRequest, requestedClassUid, priority)
+        {
+            SOPInstanceUID = requestedInstanceUid;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.RequestedSOPInstanceUID, value); }
-		}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+            }
+        }
 
-		public delegate void ResponseDelegate(DicomNSetRequest request, DicomNSetResponse response);
+        public delegate void ResponseDelegate(DicomNSetRequest request, DicomNSetResponse response);
 
-		public ResponseDelegate OnResponseReceived;
+        public ResponseDelegate OnResponseReceived;
 
-		internal override void PostResponse(DicomService service, DicomResponse response) {
-			try {
-				if (OnResponseReceived != null)
-					OnResponseReceived(this, (DicomNSetResponse)response);
-			} catch {
-			}
-		}
-	}
+        internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomNSetResponse)response);
+            }
+            catch
+            {
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNSetResponse.cs
+++ b/DICOM/Network/DicomNSetResponse.cs
@@ -1,20 +1,31 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNSetResponse : DicomResponse {
-		public DicomNSetResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNSetResponse : DicomResponse
+    {
+        public DicomNSetResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomNSetResponse(DicomNSetRequest request, DicomStatus status) : base(request, status) {
-			SOPInstanceUID = request.SOPInstanceUID;
-		}
+        public DicomNSetResponse(DicomNSetRequest request, DicomStatus status)
+            : base(request, status)
+        {
+            SOPInstanceUID = request.SOPInstanceUID;
+        }
 
-		public DicomUID SOPInstanceUID {
-			get { return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID); }
-			private set { Command.Add(DicomTag.AffectedSOPInstanceUID, value); }
-		}
-	}
+        public DicomUID SOPInstanceUID
+        {
+            get
+            {
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+            }
+            private set
+            {
+                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomNetworkException.cs
+++ b/DICOM/Network/DicomNetworkException.cs
@@ -1,17 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public class DicomNetworkException : DicomException {
-		public DicomNetworkException(string message) : base(message) {
-		}
+using System;
 
-		public DicomNetworkException(string format, params object[] args) : base(format, args) {
-		}
+namespace Dicom.Network
+{
+    public class DicomNetworkException : DicomException
+    {
+        public DicomNetworkException(string message)
+            : base(message)
+        {
+        }
 
-		public DicomNetworkException(string message, Exception innerException) : base(message, innerException) {
-		}
-	}
+        public DicomNetworkException(string format, params object[] args)
+            : base(format, args)
+        {
+        }
+
+        public DicomNetworkException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/DICOM/Network/DicomPresentationContext.cs
+++ b/DICOM/Network/DicomPresentationContext.cs
@@ -1,175 +1,229 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Dicom.Network {
-	public enum DicomPresentationContextResult : byte {
-		Proposed = 255,
-		Accept = 0,
-		RejectUser = 1,
-		RejectNoReason = 2,
-		RejectAbstractSyntaxNotSupported = 3,
-		RejectTransferSyntaxesNotSupported = 4
-	}
+namespace Dicom.Network
+{
+    public enum DicomPresentationContextResult : byte
+    {
+        Proposed = 255,
 
-	public class DicomPresentationContext {
-		#region Private Members
-		private byte _pcid;
-		private DicomPresentationContextResult _result;
-		private DicomUID _abstract;
-		private List<DicomTransferSyntax> _transferSyntaxes;
-		#endregion
+        Accept = 0,
 
-		#region Public Constructor
-		public DicomPresentationContext(byte pcid, DicomUID abstractSyntax) {
-			_pcid = pcid;
-			_result = DicomPresentationContextResult.Proposed;
-			_abstract = abstractSyntax;
-			_transferSyntaxes = new List<DicomTransferSyntax>();
-		}
+        RejectUser = 1,
 
-		internal DicomPresentationContext(byte pcid, DicomUID abstractSyntax, DicomTransferSyntax transferSyntax, DicomPresentationContextResult result) {
-			_pcid = pcid;
-			_result = result;
-			_abstract = abstractSyntax;
-			_transferSyntaxes = new List<DicomTransferSyntax>();
-			_transferSyntaxes.Add(transferSyntax);
-		}
-		#endregion
+        RejectNoReason = 2,
 
-		#region Public Properties
-		public byte ID {
-			get { return _pcid; }
-		}
+        RejectAbstractSyntaxNotSupported = 3,
 
-		public DicomPresentationContextResult Result {
-			get { return _result; }
-		}
+        RejectTransferSyntaxesNotSupported = 4
+    }
 
-		public DicomUID AbstractSyntax {
-			get { return _abstract; }
-		}
+    public class DicomPresentationContext
+    {
+        #region Private Members
 
-		public DicomTransferSyntax AcceptedTransferSyntax {
-			get {
-				if (_transferSyntaxes.Count > 0)
-					return _transferSyntaxes[0];
-				return null;
-			}
-		}
-		#endregion
+        private byte _pcid;
 
-		#region Public Members
-		/// <summary>
-		/// Sets the <c>Result</c> of this presentation context.
-		/// 
-		/// The preferred method of accepting presentation contexts is to call one of the <c>AcceptTransferSyntaxes</c> methods.
-		/// </summary>
-		/// <param name="result">Result status to return for this proposed presentation context.</param>
-		public void SetResult(DicomPresentationContextResult result) {
-			SetResult(result, _transferSyntaxes[0]);
-		}
+        private DicomPresentationContextResult _result;
 
-		/// <summary>
-		/// Sets the <c>Result</c> and <c>AcceptedTransferSyntax</c> of this presentation context.
-		/// 
-		/// The preferred method of accepting presentation contexts is to call one of the <c>AcceptTransferSyntaxes</c> methods.
-		/// </summary>
-		/// <param name="result">Result status to return for this proposed presentation context.</param>
-		/// <param name="acceptedTransferSyntax">Accepted transfer syntax for this proposed presentation context.</param>
-		public void SetResult(DicomPresentationContextResult result, DicomTransferSyntax acceptedTransferSyntax) {
-			_transferSyntaxes.Clear();
-			_transferSyntaxes.Add(acceptedTransferSyntax);
-			_result = result;
-		}
+        private DicomUID _abstract;
 
-		/// <summary>
-		/// Compares a list of transfer syntaxes accepted by the SCP against the list of transfer syntaxes proposed by the SCU. Sets the presentation 
-		/// context <c>Result</c> to <c>DicomPresentationContextResult.Accept</c> if an accepted transfer syntax is found. If no accepted transfer
-		/// syntax is found, the presentation context <c>Result</c> is set to <c>DicomPresentationContextResult.RejectTransferSyntaxesNotSupported</c>.
-		/// </summary>
-		/// <param name="acceptedTransferSyntaxes">Transfer syntaxes that the SCP accepts for the proposed abstract syntax.</param>
-		/// <returns>Returns <c>true</c> if an accepted transfer syntax was found. Returns <c>false</c> if no accepted transfer syntax was found.</returns>
-		public bool AcceptTransferSyntaxes(params DicomTransferSyntax[] acceptedTransferSyntaxes) {
-			return AcceptTransferSyntaxes(acceptedTransferSyntaxes, false);
-		}
+        private List<DicomTransferSyntax> _transferSyntaxes;
 
-		/// <summary>
-		/// Compares a list of transfer syntaxes accepted by the SCP against the list of transfer syntaxes proposed by the SCU. Sets the presentation 
-		/// context <c>Result</c> to <c>DicomPresentationContextResult.Accept</c> if an accepted transfer syntax is found. If no accepted transfer
-		/// syntax is found, the presentation context <c>Result</c> is set to <c>DicomPresentationContextResult.RejectTransferSyntaxesNotSupported</c>.
-		/// </summary>
-		/// <param name="acceptedTransferSyntaxes">Transfer syntaxes that the SCP accepts for the proposed abstract syntax.</param>
-		/// <param name="scpPriority">If set to <c>true</c>, transfer syntaxes will be accepted in the order specified by <paramref name="acceptedTransferSyntaxes"/>. If set to <c>false</c>, transfer syntaxes will be accepted in the order proposed by the SCU.</param>
-		/// <returns>Returns <c>true</c> if an accepted transfer syntax was found. Returns <c>false</c> if no accepted transfer syntax was found.</returns>
-		public bool AcceptTransferSyntaxes(DicomTransferSyntax[] acceptedTransferSyntaxes, bool scpPriority = false) {
-			if (Result == DicomPresentationContextResult.Accept)
-				return true;
+        #endregion
 
-			if (scpPriority) {
-				// let the SCP decide which syntax that it would prefer
-				foreach (DicomTransferSyntax ts in acceptedTransferSyntaxes) {
-					if (ts != null && HasTransferSyntax(ts)) {
-						SetResult(DicomPresentationContextResult.Accept, ts);
-						return true;
-					}
-				}
-			} else {
-				// accept syntaxes in the order that the SCU proposed them
-				foreach (DicomTransferSyntax ts in _transferSyntaxes) {
-					if (acceptedTransferSyntaxes.Contains(ts)) {
-						SetResult(DicomPresentationContextResult.Accept, ts);
-						return true;
-					}
-				}
-			}
+        #region Public Constructor
 
-			SetResult(DicomPresentationContextResult.RejectTransferSyntaxesNotSupported);
+        public DicomPresentationContext(byte pcid, DicomUID abstractSyntax)
+        {
+            _pcid = pcid;
+            _result = DicomPresentationContextResult.Proposed;
+            _abstract = abstractSyntax;
+            _transferSyntaxes = new List<DicomTransferSyntax>();
+        }
 
-			return false;
-		}
+        internal DicomPresentationContext(
+            byte pcid,
+            DicomUID abstractSyntax,
+            DicomTransferSyntax transferSyntax,
+            DicomPresentationContextResult result)
+        {
+            _pcid = pcid;
+            _result = result;
+            _abstract = abstractSyntax;
+            _transferSyntaxes = new List<DicomTransferSyntax>();
+            _transferSyntaxes.Add(transferSyntax);
+        }
 
-		public void AddTransferSyntax(DicomTransferSyntax ts) {
-			if (ts != null && !_transferSyntaxes.Contains(ts))
-				_transferSyntaxes.Add(ts);
-		}
+        #endregion
 
-		public void RemoveTransferSyntax(DicomTransferSyntax ts) {
-			if (ts != null && _transferSyntaxes.Contains(ts))
-				_transferSyntaxes.Remove(ts);
-		}
+        #region Public Properties
 
-		public void ClearTransferSyntaxes() {
-			_transferSyntaxes.Clear();
-		}
+        public byte ID
+        {
+            get
+            {
+                return _pcid;
+            }
+        }
 
-		public IList<DicomTransferSyntax> GetTransferSyntaxes() {
-			return _transferSyntaxes.AsReadOnly();
-		}
+        public DicomPresentationContextResult Result
+        {
+            get
+            {
+                return _result;
+            }
+        }
 
-		public bool HasTransferSyntax(DicomTransferSyntax ts) {
-			return _transferSyntaxes.Contains(ts);
-		}
+        public DicomUID AbstractSyntax
+        {
+            get
+            {
+                return _abstract;
+            }
+        }
 
-		public string GetResultDescription() {
-			switch (_result) {
-			case DicomPresentationContextResult.Accept:
-				return "Accept";
-			case DicomPresentationContextResult.Proposed:
-				return "Proposed";
-			case DicomPresentationContextResult.RejectAbstractSyntaxNotSupported:
-				return "Reject - Abstract Syntax Not Supported";
-			case DicomPresentationContextResult.RejectNoReason:
-				return "Reject - No Reason";
-			case DicomPresentationContextResult.RejectTransferSyntaxesNotSupported:
-				return "Reject - Transfer Syntaxes Not Supported";
-			case DicomPresentationContextResult.RejectUser:
-				return "Reject - User";
-			default:
-				return "Unknown";
-			}
-		}
-		#endregion
-	}
+        public DicomTransferSyntax AcceptedTransferSyntax
+        {
+            get
+            {
+                if (_transferSyntaxes.Count > 0) return _transferSyntaxes[0];
+                return null;
+            }
+        }
+
+        #endregion
+
+        #region Public Members
+
+        /// <summary>
+        /// Sets the <c>Result</c> of this presentation context.
+        /// 
+        /// The preferred method of accepting presentation contexts is to call one of the <c>AcceptTransferSyntaxes</c> methods.
+        /// </summary>
+        /// <param name="result">Result status to return for this proposed presentation context.</param>
+        public void SetResult(DicomPresentationContextResult result)
+        {
+            SetResult(result, _transferSyntaxes[0]);
+        }
+
+        /// <summary>
+        /// Sets the <c>Result</c> and <c>AcceptedTransferSyntax</c> of this presentation context.
+        /// 
+        /// The preferred method of accepting presentation contexts is to call one of the <c>AcceptTransferSyntaxes</c> methods.
+        /// </summary>
+        /// <param name="result">Result status to return for this proposed presentation context.</param>
+        /// <param name="acceptedTransferSyntax">Accepted transfer syntax for this proposed presentation context.</param>
+        public void SetResult(DicomPresentationContextResult result, DicomTransferSyntax acceptedTransferSyntax)
+        {
+            _transferSyntaxes.Clear();
+            _transferSyntaxes.Add(acceptedTransferSyntax);
+            _result = result;
+        }
+
+        /// <summary>
+        /// Compares a list of transfer syntaxes accepted by the SCP against the list of transfer syntaxes proposed by the SCU. Sets the presentation 
+        /// context <c>Result</c> to <c>DicomPresentationContextResult.Accept</c> if an accepted transfer syntax is found. If no accepted transfer
+        /// syntax is found, the presentation context <c>Result</c> is set to <c>DicomPresentationContextResult.RejectTransferSyntaxesNotSupported</c>.
+        /// </summary>
+        /// <param name="acceptedTransferSyntaxes">Transfer syntaxes that the SCP accepts for the proposed abstract syntax.</param>
+        /// <returns>Returns <c>true</c> if an accepted transfer syntax was found. Returns <c>false</c> if no accepted transfer syntax was found.</returns>
+        public bool AcceptTransferSyntaxes(params DicomTransferSyntax[] acceptedTransferSyntaxes)
+        {
+            return AcceptTransferSyntaxes(acceptedTransferSyntaxes, false);
+        }
+
+        /// <summary>
+        /// Compares a list of transfer syntaxes accepted by the SCP against the list of transfer syntaxes proposed by the SCU. Sets the presentation 
+        /// context <c>Result</c> to <c>DicomPresentationContextResult.Accept</c> if an accepted transfer syntax is found. If no accepted transfer
+        /// syntax is found, the presentation context <c>Result</c> is set to <c>DicomPresentationContextResult.RejectTransferSyntaxesNotSupported</c>.
+        /// </summary>
+        /// <param name="acceptedTransferSyntaxes">Transfer syntaxes that the SCP accepts for the proposed abstract syntax.</param>
+        /// <param name="scpPriority">If set to <c>true</c>, transfer syntaxes will be accepted in the order specified by <paramref name="acceptedTransferSyntaxes"/>. If set to <c>false</c>, transfer syntaxes will be accepted in the order proposed by the SCU.</param>
+        /// <returns>Returns <c>true</c> if an accepted transfer syntax was found. Returns <c>false</c> if no accepted transfer syntax was found.</returns>
+        public bool AcceptTransferSyntaxes(DicomTransferSyntax[] acceptedTransferSyntaxes, bool scpPriority = false)
+        {
+            if (Result == DicomPresentationContextResult.Accept) return true;
+
+            if (scpPriority)
+            {
+                // let the SCP decide which syntax that it would prefer
+                foreach (DicomTransferSyntax ts in acceptedTransferSyntaxes)
+                {
+                    if (ts != null && HasTransferSyntax(ts))
+                    {
+                        SetResult(DicomPresentationContextResult.Accept, ts);
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                // accept syntaxes in the order that the SCU proposed them
+                foreach (DicomTransferSyntax ts in _transferSyntaxes)
+                {
+                    if (acceptedTransferSyntaxes.Contains(ts))
+                    {
+                        SetResult(DicomPresentationContextResult.Accept, ts);
+                        return true;
+                    }
+                }
+            }
+
+            SetResult(DicomPresentationContextResult.RejectTransferSyntaxesNotSupported);
+
+            return false;
+        }
+
+        public void AddTransferSyntax(DicomTransferSyntax ts)
+        {
+            if (ts != null && !_transferSyntaxes.Contains(ts)) _transferSyntaxes.Add(ts);
+        }
+
+        public void RemoveTransferSyntax(DicomTransferSyntax ts)
+        {
+            if (ts != null && _transferSyntaxes.Contains(ts)) _transferSyntaxes.Remove(ts);
+        }
+
+        public void ClearTransferSyntaxes()
+        {
+            _transferSyntaxes.Clear();
+        }
+
+        public IList<DicomTransferSyntax> GetTransferSyntaxes()
+        {
+            return _transferSyntaxes.AsReadOnly();
+        }
+
+        public bool HasTransferSyntax(DicomTransferSyntax ts)
+        {
+            return _transferSyntaxes.Contains(ts);
+        }
+
+        public string GetResultDescription()
+        {
+            switch (_result)
+            {
+                case DicomPresentationContextResult.Accept:
+                    return "Accept";
+                case DicomPresentationContextResult.Proposed:
+                    return "Proposed";
+                case DicomPresentationContextResult.RejectAbstractSyntaxNotSupported:
+                    return "Reject - Abstract Syntax Not Supported";
+                case DicomPresentationContextResult.RejectNoReason:
+                    return "Reject - No Reason";
+                case DicomPresentationContextResult.RejectTransferSyntaxesNotSupported:
+                    return "Reject - Transfer Syntaxes Not Supported";
+                case DicomPresentationContextResult.RejectUser:
+                    return "Reject - User";
+                default:
+                    return "Unknown";
+            }
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Network/DicomPresentationContextCollection.cs
+++ b/DICOM/Network/DicomPresentationContextCollection.cs
@@ -1,104 +1,131 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Dicom.Network {
-	public class DicomPresentationContextCollection : ICollection<DicomPresentationContext> {
-		private SortedList<byte, DicomPresentationContext> _pc;
+namespace Dicom.Network
+{
+    public class DicomPresentationContextCollection : ICollection<DicomPresentationContext>
+    {
+        private SortedList<byte, DicomPresentationContext> _pc;
 
-		public DicomPresentationContextCollection() {
-			_pc = new SortedList<byte, DicomPresentationContext>();
-		}
+        public DicomPresentationContextCollection()
+        {
+            _pc = new SortedList<byte, DicomPresentationContext>();
+        }
 
-		public DicomPresentationContext this[byte id] {
-			get { return _pc[id]; }
-		}
+        public DicomPresentationContext this[byte id]
+        {
+            get
+            {
+                return _pc[id];
+            }
+        }
 
-		private byte GetNextPresentationContextID() {
-			if (_pc.Count == 0)
-				return 1;
+        private byte GetNextPresentationContextID()
+        {
+            if (_pc.Count == 0) return 1;
 
-			var id = _pc.Max(x => x.Key) + 2;
+            var id = _pc.Max(x => x.Key) + 2;
 
-			if (id >= 256)
-				throw new DicomNetworkException("Too many presentation contexts configured for this association!");
+            if (id >= 256) throw new DicomNetworkException("Too many presentation contexts configured for this association!");
 
-			return (byte)id;
-		}
+            return (byte)id;
+        }
 
-		public void Add(DicomUID abstractSyntax, params DicomTransferSyntax[] transferSyntaxes) {
-			var pc = new DicomPresentationContext(GetNextPresentationContextID(), abstractSyntax);
+        public void Add(DicomUID abstractSyntax, params DicomTransferSyntax[] transferSyntaxes)
+        {
+            var pc = new DicomPresentationContext(GetNextPresentationContextID(), abstractSyntax);
 
-			foreach (var tx in transferSyntaxes)
-				pc.AddTransferSyntax(tx);
+            foreach (var tx in transferSyntaxes) pc.AddTransferSyntax(tx);
 
-			Add(pc);
-		}
+            Add(pc);
+        }
 
-		public void Add(DicomPresentationContext item) {
-			_pc.Add(item.ID, item);
-		}
+        public void Add(DicomPresentationContext item)
+        {
+            _pc.Add(item.ID, item);
+        }
 
-		public void AddFromRequest(DicomRequest request) {
-			if (request is DicomCStoreRequest) {
-				var cstore = request as DicomCStoreRequest;
+        public void AddFromRequest(DicomRequest request)
+        {
+            if (request is DicomCStoreRequest)
+            {
+                var cstore = request as DicomCStoreRequest;
 
-				var pcs = _pc.Values.Where(x => x.AbstractSyntax == request.SOPClassUID);
-				if (cstore.TransferSyntax == DicomTransferSyntax.ImplicitVRLittleEndian)
-					pcs = pcs.Where(x => x.GetTransferSyntaxes().Contains(DicomTransferSyntax.ImplicitVRLittleEndian));
-				else
-					pcs = pcs.Where(x => x.AcceptedTransferSyntax == cstore.TransferSyntax);
+                var pcs = _pc.Values.Where(x => x.AbstractSyntax == request.SOPClassUID);
+                if (cstore.TransferSyntax == DicomTransferSyntax.ImplicitVRLittleEndian) pcs = pcs.Where(x => x.GetTransferSyntaxes().Contains(DicomTransferSyntax.ImplicitVRLittleEndian));
+                else pcs = pcs.Where(x => x.AcceptedTransferSyntax == cstore.TransferSyntax);
 
-				var pc = pcs.FirstOrDefault();
-				if (pc == null) {
-					var tx = new List<DicomTransferSyntax>();
-					if (cstore.TransferSyntax != DicomTransferSyntax.ImplicitVRLittleEndian)
-						tx.Add(cstore.TransferSyntax);
-					if (cstore.AdditionalTransferSyntaxes != null)
-						tx.AddRange(cstore.AdditionalTransferSyntaxes);
-					tx.Add(DicomTransferSyntax.ExplicitVRLittleEndian);
-					tx.Add(DicomTransferSyntax.ImplicitVRLittleEndian);
-					
-					Add(cstore.SOPClassUID, tx.ToArray());
-				}
-			} else {
-				var pc = _pc.Values.FirstOrDefault(x => x.AbstractSyntax == request.SOPClassUID);
-				if (pc == null)
-					Add(request.SOPClassUID, DicomTransferSyntax.ExplicitVRLittleEndian, DicomTransferSyntax.ImplicitVRLittleEndian);
-			}
-		}
+                var pc = pcs.FirstOrDefault();
+                if (pc == null)
+                {
+                    var tx = new List<DicomTransferSyntax>();
+                    if (cstore.TransferSyntax != DicomTransferSyntax.ImplicitVRLittleEndian) tx.Add(cstore.TransferSyntax);
+                    if (cstore.AdditionalTransferSyntaxes != null) tx.AddRange(cstore.AdditionalTransferSyntaxes);
+                    tx.Add(DicomTransferSyntax.ExplicitVRLittleEndian);
+                    tx.Add(DicomTransferSyntax.ImplicitVRLittleEndian);
 
-		public void Clear() {
-			_pc.Clear();
-		}
+                    Add(cstore.SOPClassUID, tx.ToArray());
+                }
+            }
+            else
+            {
+                var pc = _pc.Values.FirstOrDefault(x => x.AbstractSyntax == request.SOPClassUID);
+                if (pc == null)
+                    Add(
+                        request.SOPClassUID,
+                        DicomTransferSyntax.ExplicitVRLittleEndian,
+                        DicomTransferSyntax.ImplicitVRLittleEndian);
+            }
+        }
 
-		public bool Contains(DicomPresentationContext item) {
-			return _pc.ContainsKey(item.ID) && _pc[item.ID].AbstractSyntax == item.AbstractSyntax;
-		}
+        public void Clear()
+        {
+            _pc.Clear();
+        }
 
-		public void CopyTo(DicomPresentationContext[] array, int arrayIndex) {
-			throw new NotImplementedException();
-		}
+        public bool Contains(DicomPresentationContext item)
+        {
+            return _pc.ContainsKey(item.ID) && _pc[item.ID].AbstractSyntax == item.AbstractSyntax;
+        }
 
-		public int Count {
-			get { return _pc.Count; }
-		}
+        public void CopyTo(DicomPresentationContext[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
 
-		public bool IsReadOnly {
-			get { return false; }
-		}
+        public int Count
+        {
+            get
+            {
+                return _pc.Count;
+            }
+        }
 
-		public bool Remove(DicomPresentationContext item) {
-			return _pc.Remove(item.ID);
-		}
+        public bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-		public IEnumerator<DicomPresentationContext> GetEnumerator() {
-			return _pc.Values.GetEnumerator();
-		}
+        public bool Remove(DicomPresentationContext item)
+        {
+            return _pc.Remove(item.ID);
+        }
 
-		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-			return GetEnumerator();
-		}
-	}
+        public IEnumerator<DicomPresentationContext> GetEnumerator()
+        {
+            return _pc.Values.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
 }

--- a/DICOM/Network/DicomPriority.cs
+++ b/DICOM/Network/DicomPriority.cs
@@ -1,12 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public enum DicomPriority : ushort {
-		Low = 0x0002,
-		Medium = 0x0000,
-		High = 0x0001
-	}
+namespace Dicom.Network
+{
+    public enum DicomPriority : ushort
+    {
+        Low = 0x0002,
+
+        Medium = 0x0000,
+
+        High = 0x0001
+    }
 }

--- a/DICOM/Network/DicomQueryRetrieveLevel.cs
+++ b/DICOM/Network/DicomQueryRetrieveLevel.cs
@@ -1,14 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public enum DicomQueryRetrieveLevel {
-		Patient,
-		Study,
-		Series,
-		Image,
-		Worklist
-	}
+namespace Dicom.Network
+{
+    public enum DicomQueryRetrieveLevel
+    {
+        Patient,
+
+        Study,
+
+        Series,
+
+        Image,
+
+        Worklist
+    }
 }

--- a/DICOM/Network/DicomRequest.cs
+++ b/DICOM/Network/DicomRequest.cs
@@ -1,36 +1,52 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public abstract class DicomRequest : DicomMessage {
-		protected DicomRequest(DicomDataset command) : base(command) {
-		}
+using System;
 
-		protected DicomRequest(DicomCommandField type, DicomUID affectedClassUid, DicomPriority priority) : base() {
-			Type = type;
-			SOPClassUID = affectedClassUid;
-			MessageID = GetNextMessageID();
-			Priority = priority;
-			Dataset = null;
-		}
+namespace Dicom.Network
+{
+    public abstract class DicomRequest : DicomMessage
+    {
+        protected DicomRequest(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomPriority Priority {
-			get { return Command.Get<DicomPriority>(DicomTag.Priority); }
-			set { Command.Add(DicomTag.Priority, (ushort)value); }
-		}
+        protected DicomRequest(DicomCommandField type, DicomUID affectedClassUid, DicomPriority priority)
+            : base()
+        {
+            Type = type;
+            SOPClassUID = affectedClassUid;
+            MessageID = GetNextMessageID();
+            Priority = priority;
+            Dataset = null;
+        }
 
-		internal abstract void PostResponse(DicomService service, DicomResponse response);
+        public DicomPriority Priority
+        {
+            get
+            {
+                return Command.Get<DicomPriority>(DicomTag.Priority);
+            }
+            set
+            {
+                Command.Add(DicomTag.Priority, (ushort)value);
+            }
+        }
 
-		private volatile static ushort _messageId = 1;
-		private static object _lock = new object();
-		internal ushort GetNextMessageID() {
-			lock (_lock) {
-				if (_messageId == UInt16.MaxValue)
-					_messageId = 1;
-				return _messageId++;
-			}
-		}
-	}
+        internal abstract void PostResponse(DicomService service, DicomResponse response);
+
+        private static volatile ushort _messageId = 1;
+
+        private static object _lock = new object();
+
+        internal ushort GetNextMessageID()
+        {
+            lock (_lock)
+            {
+                if (_messageId == UInt16.MaxValue) _messageId = 1;
+                return _messageId++;
+            }
+        }
+    }
 }

--- a/DICOM/Network/DicomResponse.cs
+++ b/DICOM/Network/DicomResponse.cs
@@ -1,58 +1,76 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 
-namespace Dicom.Network {
-	public class DicomResponse : DicomMessage {
-		public DicomResponse(DicomDataset command) : base(command) {
-		}
+namespace Dicom.Network
+{
+    public class DicomResponse : DicomMessage
+    {
+        public DicomResponse(DicomDataset command)
+            : base(command)
+        {
+        }
 
-		public DicomResponse(DicomMessage request, DicomStatus status) : base() {
+        public DicomResponse(DicomMessage request, DicomStatus status)
+            : base()
+        {
 
             PresentationContext = request.PresentationContext;
 
-			Type = (DicomCommandField)(0x8000 | (int)request.Type);
-			SOPClassUID = request.SOPClassUID;
-			RequestMessageID = request.MessageID;
-			Status = status;
-		}
+            Type = (DicomCommandField)(0x8000 | (int)request.Type);
+            SOPClassUID = request.SOPClassUID;
+            RequestMessageID = request.MessageID;
+            Status = status;
+        }
 
-		public ushort RequestMessageID {
-			get { return Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo); }
-			set { Command.Add(DicomTag.MessageIDBeingRespondedTo, value); }
-		}
+        public ushort RequestMessageID
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo);
+            }
+            set
+            {
+                Command.Add(DicomTag.MessageIDBeingRespondedTo, value);
+            }
+        }
 
-		public DicomStatus Status {
-			get {
-				var status = DicomStatus.Lookup(Command.Get<ushort>(DicomTag.Status));
-				var comment = Command.Get<string>(DicomTag.ErrorComment, null);
-				if (comment != null)
-					return new DicomStatus(status, comment);
-				return status;
-			}
-			set {
-				Command.Add(DicomTag.Status, value.Code);
-				Command.Add(DicomTag.ErrorComment, value.ErrorComment);
-			}
-		}
+        public DicomStatus Status
+        {
+            get
+            {
+                var status = DicomStatus.Lookup(Command.Get<ushort>(DicomTag.Status));
+                var comment = Command.Get<string>(DicomTag.ErrorComment, null);
+                if (comment != null) return new DicomStatus(status, comment);
+                return status;
+            }
+            set
+            {
+                Command.Add(DicomTag.Status, value.Code);
+                Command.Add(DicomTag.ErrorComment, value.ErrorComment);
+            }
+        }
 
-		public override string ToString() {
-			StringBuilder sb = new StringBuilder();
-			sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-			if (Status.State != DicomState.Pending && Status.State != DicomState.Success) {
-				if (!String.IsNullOrEmpty(Status.ErrorComment))
-					sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
-				if (Command.Contains(DicomTag.OffendingElement)) {
-					string[] tags = Command.Get<string[]>(DicomTag.OffendingElement);
-					if (tags.Length > 0) {
-						sb.Append("\n\t\tTags:		");
-						foreach (var tag in tags)
-							sb.AppendFormat(" {0}", tag);
-					}
-				}
-			}
-			return sb.ToString();
-		}
-	}
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            {
+                if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+                if (Command.Contains(DicomTag.OffendingElement))
+                {
+                    string[] tags = Command.Get<string[]>(DicomTag.OffendingElement);
+                    if (tags.Length > 0)
+                    {
+                        sb.Append("\n\t\tTags:		");
+                        foreach (var tag in tags) sb.AppendFormat(" {0}", tag);
+                    }
+                }
+            }
+            return sb.ToString();
+        }
+    }
 }

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -1,12 +1,13 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
-using System.ServiceModel.Channels;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 using Dicom.Imaging.Codec;
 using Dicom.IO;
@@ -15,320 +16,403 @@ using Dicom.IO.Writer;
 using Dicom.Log;
 using Dicom.Threading;
 
-namespace Dicom.Network {
-	public abstract class DicomService {
-		private Stream _network;
-		private object _lock;
-		private volatile bool _writing;
-		private volatile bool _sending;
-		private Queue<PDU> _pduQueue;
-		private Queue<DicomMessage> _msgQueue;
-		private List<DicomRequest> _pending;
-		private DicomMessage _dimse;
-		private Stream _dimseStream;
-	    private bool _isTempFile;
-		private int _readLength;
-		private bool _isConnected;
-		private ThreadPoolQueue<int> _processQueue;
-		private DicomServiceOptions _options;
+namespace Dicom.Network
+{
+    public abstract class DicomService
+    {
+        private Stream _network;
+
+        private object _lock;
+
+        private volatile bool _writing;
+
+        private volatile bool _sending;
+
+        private Queue<PDU> _pduQueue;
+
+        private Queue<DicomMessage> _msgQueue;
+
+        private List<DicomRequest> _pending;
+
+        private DicomMessage _dimse;
+
+        private Stream _dimseStream;
+
+        private bool _isTempFile;
+
+        private int _readLength;
+
+        private bool _isConnected;
+
+        private ThreadPoolQueue<int> _processQueue;
+
+        private DicomServiceOptions _options;
+
         private readonly Encoding _fallbackEncoding;
 
-	    protected DicomService(Stream stream, Logger log) : this(stream, DicomEncoding.Default, log) {
-	    }
+        protected DicomService(Stream stream, Logger log)
+            : this(stream, DicomEncoding.Default, log)
+        {
+        }
 
-	    protected DicomService(Stream stream, Encoding fallbackEncoding, Logger log) {
-	        if (fallbackEncoding == null)
-	        {
-	            throw new ArgumentNullException("fallbackEncoding");
-	        }
-	        _network = stream;
-			_lock = new object();
-			_pduQueue = new Queue<PDU>();
-			MaximumPDUsInQueue = 16;
-			_msgQueue = new Queue<DicomMessage>();
-			_pending = new List<DicomRequest>();
-			_processQueue = new ThreadPoolQueue<int>();
-			_processQueue.DefaultGroup = Int32.MinValue;
-			_isConnected = true;
-	        _fallbackEncoding = fallbackEncoding;
-			Logger = log ?? LogManager.Default.GetLogger("Dicom.Network");
-			BeginReadPDUHeader();
-			Options = DicomServiceOptions.Default;
-		}
+        protected DicomService(Stream stream, Encoding fallbackEncoding, Logger log)
+        {
+            if (fallbackEncoding == null)
+            {
+                throw new ArgumentNullException("fallbackEncoding");
+            }
+            _network = stream;
+            _lock = new object();
+            _pduQueue = new Queue<PDU>();
+            MaximumPDUsInQueue = 16;
+            _msgQueue = new Queue<DicomMessage>();
+            _pending = new List<DicomRequest>();
+            _processQueue = new ThreadPoolQueue<int>();
+            _processQueue.DefaultGroup = Int32.MinValue;
+            _isConnected = true;
+            _fallbackEncoding = fallbackEncoding;
+            Logger = log ?? LogManager.Default.GetLogger("Dicom.Network");
+            BeginReadPDUHeader();
+            Options = DicomServiceOptions.Default;
+        }
 
-		public Logger Logger {
-			get;
-			set;
-		}
+        public Logger Logger { get; set; }
 
-		public DicomServiceOptions Options {
-			get { return _options; }
-			set {
-				_options = value;
-				_processQueue.Linger = _options.ThreadPoolLinger;
-			}
-		}
+        public DicomServiceOptions Options
+        {
+            get
+            {
+                return _options;
+            }
+            set
+            {
+                _options = value;
+                _processQueue.Linger = _options.ThreadPoolLinger;
+            }
+        }
 
-		private string LogID {
-			get;
-			set;
-		}
+        private string LogID { get; set; }
 
-		public object UserState {
-			get;
-			set;
-		}
+        public object UserState { get; set; }
 
-		public DicomAssociation Association {
-			get;
-			internal set;
-		}
+        public DicomAssociation Association { get; internal set; }
 
-		public bool IsConnected {
-			get {
-				return _isConnected;
-			}
-		}
+        public bool IsConnected
+        {
+            get
+            {
+                return _isConnected;
+            }
+        }
 
-		public bool IsSendQueueEmpty {
-			get {
-				lock (_lock)
-					return _pending.Count == 0;
-			}
-		}
+        public bool IsSendQueueEmpty
+        {
+            get
+            {
+                lock (_lock) return _pending.Count == 0;
+            }
+        }
 
-		public int MaximumPDUsInQueue {
-			get;
-			set;
-		}
+        public int MaximumPDUsInQueue { get; set; }
 
-		private void CloseConnection(Exception exception) {
-			if (!_isConnected)
-				return;
+        private void CloseConnection(Exception exception)
+        {
+            if (!_isConnected) return;
 
-			_isConnected = false;
-			try { _network.Close(); } catch { }
+            _isConnected = false;
+            try
+            {
+                _network.Close();
+            }
+            catch
+            {
+            }
 
-			if (exception != null)
-				Logger.Error("Connection closed with error: {@error}", exception);
-			else
-				Logger.Info("Connection closed");
+            if (exception != null) Logger.Error("Connection closed with error: {@error}", exception);
+            else Logger.Info("Connection closed");
 
-			if (this is IDicomServiceProvider)
-				(this as IDicomServiceProvider).OnConnectionClosed(exception);
-			else if (this is IDicomServiceUser)
-				(this as IDicomServiceUser).OnConnectionClosed(exception);
-		}
+            if (this is IDicomServiceProvider) (this as IDicomServiceProvider).OnConnectionClosed(exception);
+            else if (this is IDicomServiceUser) (this as IDicomServiceUser).OnConnectionClosed(exception);
+        }
 
-		private void BeginReadPDUHeader() {
-			try {
-				_readLength = 6;
+        private void BeginReadPDUHeader()
+        {
+            try
+            {
+                _readLength = 6;
 
-				byte[] buffer = new byte[6];
-				_network.BeginRead(buffer, 0, 6, EndReadPDUHeader, buffer);
-			} catch (ObjectDisposedException) {
-				// silently ignore
-				CloseConnection(null);
-			} catch (NullReferenceException) {
-				// connection already closed; silently ignore
-				CloseConnection(null);
-			} catch (IOException e) {
-				if (e.InnerException is SocketException) {
-					Logger.Error("Socket error while reading PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
-				} else if (!(e.InnerException is ObjectDisposedException))
-					Logger.Error("IO exception while reading PDU: {@error}", e);
+                byte[] buffer = new byte[6];
+                _network.BeginRead(buffer, 0, 6, EndReadPDUHeader, buffer);
+            }
+            catch (ObjectDisposedException)
+            {
+                // silently ignore
+                CloseConnection(null);
+            }
+            catch (NullReferenceException)
+            {
+                // connection already closed; silently ignore
+                CloseConnection(null);
+            }
+            catch (IOException e)
+            {
+                if (e.InnerException is SocketException)
+                {
+                    Logger.Error(
+                        "Socket error while reading PDU: {socketErrorCode} [{errorCode}]",
+                        (e.InnerException as SocketException).SocketErrorCode,
+                        (e.InnerException as SocketException).ErrorCode);
+                }
+                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while reading PDU: {@error}", e);
 
-				CloseConnection(e);
-			}
-		}
+                CloseConnection(e);
+            }
+        }
 
-		private void EndReadPDUHeader(IAsyncResult result) {
-			try {
-				byte[] buffer = (byte[])result.AsyncState;
+        private void EndReadPDUHeader(IAsyncResult result)
+        {
+            try
+            {
+                byte[] buffer = (byte[])result.AsyncState;
 
-				int count = _network.EndRead(result);
-				if (count == 0) {
-					// disconnected
-					CloseConnection(null);
-					return;
-				}
+                int count = _network.EndRead(result);
+                if (count == 0)
+                {
+                    // disconnected
+                    CloseConnection(null);
+                    return;
+                }
 
-				_readLength -= count;
+                _readLength -= count;
 
-				if (_readLength > 0) {
-					_network.BeginRead(buffer, 6 - _readLength, _readLength, EndReadPDUHeader, buffer);
-					return;
-				}
+                if (_readLength > 0)
+                {
+                    _network.BeginRead(buffer, 6 - _readLength, _readLength, EndReadPDUHeader, buffer);
+                    return;
+                }
 
-				int length = BitConverter.ToInt32(buffer, 2);
-				length = Endian.Swap(length);
+                int length = BitConverter.ToInt32(buffer, 2);
+                length = Endian.Swap(length);
 
-				_readLength = length;
+                _readLength = length;
 
-				Array.Resize(ref buffer, length + 6);
+                Array.Resize(ref buffer, length + 6);
 
-				_network.BeginRead(buffer, 6, length, EndReadPDU, buffer);
-			} catch (ObjectDisposedException) {
-				// silently ignore
-				CloseConnection(null);
-			} catch (NullReferenceException) {
-				// connection already closed; silently ignore
-				CloseConnection(null);
-			} catch (IOException e) {
-				if (e.InnerException is SocketException) {
-					Logger.Error("Socket error while reading PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
-				} else if (!(e.InnerException is ObjectDisposedException))
-					Logger.Error("IO exception while reading PDU: {@error}", e);
+                _network.BeginRead(buffer, 6, length, EndReadPDU, buffer);
+            }
+            catch (ObjectDisposedException)
+            {
+                // silently ignore
+                CloseConnection(null);
+            }
+            catch (NullReferenceException)
+            {
+                // connection already closed; silently ignore
+                CloseConnection(null);
+            }
+            catch (IOException e)
+            {
+                if (e.InnerException is SocketException)
+                {
+                    Logger.Error(
+                        "Socket error while reading PDU: {socketErrorCode} [{errorCode}]",
+                        (e.InnerException as SocketException).SocketErrorCode,
+                        (e.InnerException as SocketException).ErrorCode);
+                }
+                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while reading PDU: {@error}", e);
 
-				CloseConnection(e);
-			} catch (Exception e) {
-				Logger.Error("Exception processing PDU header: {@error}", e);
-			}
-		}
+                CloseConnection(e);
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Exception processing PDU header: {@error}", e);
+            }
+        }
 
-		private void EndReadPDU(IAsyncResult result) {
-			try {
-				byte[] buffer = (byte[])result.AsyncState;
+        private void EndReadPDU(IAsyncResult result)
+        {
+            try
+            {
+                byte[] buffer = (byte[])result.AsyncState;
 
-				int count = _network.EndRead(result);
-				if (count == 0) {
-					// disconnected
-					CloseConnection(null);
-					return;
-				}
+                int count = _network.EndRead(result);
+                if (count == 0)
+                {
+                    // disconnected
+                    CloseConnection(null);
+                    return;
+                }
 
-				_readLength -= count;
+                _readLength -= count;
 
-				if (_readLength > 0) {
-					_network.BeginRead(buffer, buffer.Length - _readLength, _readLength, EndReadPDU, buffer);
-					return;
-				}
+                if (_readLength > 0)
+                {
+                    _network.BeginRead(buffer, buffer.Length - _readLength, _readLength, EndReadPDU, buffer);
+                    return;
+                }
 
-				var raw = new RawPDU(buffer);
+                var raw = new RawPDU(buffer);
 
-				switch (raw.Type) {
-				case 0x01: {
-						Association = new DicomAssociation();
-						var pdu = new AAssociateRQ(Association);
-						pdu.Read(raw);
-						LogID = Association.CallingAE;
-						if (Options.UseRemoteAEForLogName)
-							Logger = LogManager.Default.GetLogger(LogID);
-						Logger.Info("{callingAE} <- Association request:\n{association}", LogID, Association.ToString());
-						if (this is IDicomServiceProvider)
-							(this as IDicomServiceProvider).OnReceiveAssociationRequest(Association);
-						break;
-					}
-				case 0x02: {
-						var pdu = new AAssociateAC(Association);
-						pdu.Read(raw);
-						LogID = Association.CalledAE;
-						Logger.Info("{calledAE} <- Association accept:\n{assocation}", LogID, Association.ToString());
-						if (this is IDicomServiceUser)
-							(this as IDicomServiceUser).OnReceiveAssociationAccept(Association);
-						break;
-					}
-				case 0x03: {
-						var pdu = new AAssociateRJ();
-						pdu.Read(raw);
-						Logger.Info("{logId} <- Association reject [result: {pduResult}; source: {pduSource}; reason: {pduReason}]", LogID, pdu.Result, pdu.Source, pdu.Reason);
-						if (this is IDicomServiceUser)
-							(this as IDicomServiceUser).OnReceiveAssociationReject(pdu.Result, pdu.Source, pdu.Reason);
-						break;
-					}
-				case 0x04: {
-						var pdu = new PDataTF();
-						pdu.Read(raw);
-						if (Options.LogDataPDUs)
-							Logger.Info("{logId} <- {@pdu}", LogID, pdu);
-						_processQueue.Queue(ProcessPDataTF, pdu);
-						break;
-					}
-				case 0x05: {
-						var pdu = new AReleaseRQ();
-						pdu.Read(raw);
-						Logger.Info("{logId} <- Association release request", LogID);
-						if (this is IDicomServiceProvider)
-							(this as IDicomServiceProvider).OnReceiveAssociationReleaseRequest();
-						break;
-					}
-				case 0x06: {
-						var pdu = new AReleaseRP();
-						pdu.Read(raw);
-						Logger.Info("{logId} <- Association release response", LogID);
-						if (this is IDicomServiceUser)
-							(this as IDicomServiceUser).OnReceiveAssociationReleaseResponse();
-						CloseConnection(null);
-						break;
-					}
-				case 0x07: {
-						var pdu = new AAbort();
-						pdu.Read(raw);
-						Logger.Info("{logId} <- Abort: {pduSource} - {pduReason}", LogID, pdu.Source, pdu.Reason);
-						if (this is IDicomServiceProvider)
-							(this as IDicomServiceProvider).OnReceiveAbort(pdu.Source, pdu.Reason);
-						else if (this is IDicomServiceUser)
-							(this as IDicomServiceUser).OnReceiveAbort(pdu.Source, pdu.Reason);
-						CloseConnection(null);
-						break;
-					}
-				case 0xFF: {
-						break;
-					}
-				default:
-					throw new DicomNetworkException("Unknown PDU type");
-				}
+                switch (raw.Type)
+                {
+                    case 0x01:
+                        {
+                            Association = new DicomAssociation();
+                            var pdu = new AAssociateRQ(Association);
+                            pdu.Read(raw);
+                            LogID = Association.CallingAE;
+                            if (Options.UseRemoteAEForLogName) Logger = LogManager.Default.GetLogger(LogID);
+                            Logger.Info(
+                                "{callingAE} <- Association request:\n{association}",
+                                LogID,
+                                Association.ToString());
+                            if (this is IDicomServiceProvider) (this as IDicomServiceProvider).OnReceiveAssociationRequest(Association);
+                            break;
+                        }
+                    case 0x02:
+                        {
+                            var pdu = new AAssociateAC(Association);
+                            pdu.Read(raw);
+                            LogID = Association.CalledAE;
+                            Logger.Info(
+                                "{calledAE} <- Association accept:\n{assocation}",
+                                LogID,
+                                Association.ToString());
+                            if (this is IDicomServiceUser) (this as IDicomServiceUser).OnReceiveAssociationAccept(Association);
+                            break;
+                        }
+                    case 0x03:
+                        {
+                            var pdu = new AAssociateRJ();
+                            pdu.Read(raw);
+                            Logger.Info(
+                                "{logId} <- Association reject [result: {pduResult}; source: {pduSource}; reason: {pduReason}]",
+                                LogID,
+                                pdu.Result,
+                                pdu.Source,
+                                pdu.Reason);
+                            if (this is IDicomServiceUser)
+                                (this as IDicomServiceUser).OnReceiveAssociationReject(
+                                    pdu.Result,
+                                    pdu.Source,
+                                    pdu.Reason);
+                            break;
+                        }
+                    case 0x04:
+                        {
+                            var pdu = new PDataTF();
+                            pdu.Read(raw);
+                            if (Options.LogDataPDUs) Logger.Info("{logId} <- {@pdu}", LogID, pdu);
+                            _processQueue.Queue(ProcessPDataTF, pdu);
+                            break;
+                        }
+                    case 0x05:
+                        {
+                            var pdu = new AReleaseRQ();
+                            pdu.Read(raw);
+                            Logger.Info("{logId} <- Association release request", LogID);
+                            if (this is IDicomServiceProvider) (this as IDicomServiceProvider).OnReceiveAssociationReleaseRequest();
+                            break;
+                        }
+                    case 0x06:
+                        {
+                            var pdu = new AReleaseRP();
+                            pdu.Read(raw);
+                            Logger.Info("{logId} <- Association release response", LogID);
+                            if (this is IDicomServiceUser) (this as IDicomServiceUser).OnReceiveAssociationReleaseResponse();
+                            CloseConnection(null);
+                            break;
+                        }
+                    case 0x07:
+                        {
+                            var pdu = new AAbort();
+                            pdu.Read(raw);
+                            Logger.Info("{logId} <- Abort: {pduSource} - {pduReason}", LogID, pdu.Source, pdu.Reason);
+                            if (this is IDicomServiceProvider) (this as IDicomServiceProvider).OnReceiveAbort(pdu.Source, pdu.Reason);
+                            else if (this is IDicomServiceUser) (this as IDicomServiceUser).OnReceiveAbort(pdu.Source, pdu.Reason);
+                            CloseConnection(null);
+                            break;
+                        }
+                    case 0xFF:
+                        {
+                            break;
+                        }
+                    default:
+                        throw new DicomNetworkException("Unknown PDU type");
+                }
 
-				BeginReadPDUHeader();
-			} catch (IOException e) {
-				if (e.InnerException is SocketException) {
-					Logger.Error("Socket error while reading PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
-				} else if (!(e.InnerException is ObjectDisposedException))
-					Logger.Error("IO exception while reading PDU: {@error}", e);
+                BeginReadPDUHeader();
+            }
+            catch (IOException e)
+            {
+                if (e.InnerException is SocketException)
+                {
+                    Logger.Error(
+                        "Socket error while reading PDU: {socketErrorCode} [{errorCode}]",
+                        (e.InnerException as SocketException).SocketErrorCode,
+                        (e.InnerException as SocketException).ErrorCode);
+                }
+                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while reading PDU: {@error}", e);
 
-				CloseConnection(e);
-			} catch (NullReferenceException) {
-				// connection already closed; silently ignore
-				CloseConnection(null);
-			} catch (Exception e) {
-				Logger.Error("Exception processing PDU: {@error}", e);
-				CloseConnection(e);
-			}
-		}
+                CloseConnection(e);
+            }
+            catch (NullReferenceException)
+            {
+                // connection already closed; silently ignore
+                CloseConnection(null);
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Exception processing PDU: {@error}", e);
+                CloseConnection(e);
+            }
+        }
 
-		private void ProcessPDataTF(object state) {
-			var pdu = (PDataTF)state;
-			try {
-				foreach (var pdv in pdu.PDVs) {
-					if (_dimse == null) {
-						// create stream for receiving command
-						if (_dimseStream == null)
-							_dimseStream = new MemoryStream();
-					} else {
-						// create stream for receiving dataset
-						if (_dimseStream == null) {
-						    if (_dimse.Type == DicomCommandField.CStoreRequest) {
+        private void ProcessPDataTF(object state)
+        {
+            var pdu = (PDataTF)state;
+            try
+            {
+                foreach (var pdv in pdu.PDVs)
+                {
+                    if (_dimse == null)
+                    {
+                        // create stream for receiving command
+                        if (_dimseStream == null) _dimseStream = new MemoryStream();
+                    }
+                    else
+                    {
+                        // create stream for receiving dataset
+                        if (_dimseStream == null)
+                        {
+                            if (_dimse.Type == DicomCommandField.CStoreRequest)
+                            {
                                 var pc = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
 
                                 var file = new DicomFile();
                                 file.FileMetaInfo.MediaStorageSOPClassUID = pc.AbstractSyntax;
-                                file.FileMetaInfo.MediaStorageSOPInstanceUID = _dimse.Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                                file.FileMetaInfo.MediaStorageSOPInstanceUID =
+                                    _dimse.Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
                                 file.FileMetaInfo.TransferSyntax = pc.AcceptedTransferSyntax;
                                 file.FileMetaInfo.ImplementationClassUID = Association.RemoteImplemetationClassUID;
                                 file.FileMetaInfo.ImplementationVersionName = Association.RemoteImplementationVersion;
                                 file.FileMetaInfo.SourceApplicationEntityTitle = Association.CallingAE;
 
                                 _dimseStream = CreateCStoreReceiveStream(file);
-                            } else {
+                            }
+                            else
+                            {
                                 _dimseStream = new MemoryStream();
-						    }
-						}
-					}
+                            }
+                        }
+                    }
 
-					_dimseStream.Write(pdv.Value, 0, pdv.Value.Length);
+                    _dimseStream.Write(pdv.Value, 0, pdv.Value.Length);
 
-					if (pdv.IsLastFragment) {
-						if (pdv.IsCommand) {
+                    if (pdv.IsLastFragment)
+                    {
+                        if (pdv.IsCommand)
+                        {
                             _dimseStream.Seek(0, SeekOrigin.Begin);
 
                             var command = new DicomDataset();
@@ -336,86 +420,94 @@ namespace Dicom.Network {
                             var reader = new DicomReader();
                             reader.IsExplicitVR = false;
                             reader.Read(new StreamByteSource(_dimseStream), new DicomDatasetReaderObserver(command));
-                            
+
                             _dimseStream = null;
 
-						    var type = command.Get<DicomCommandField>(DicomTag.CommandField);
-							switch (type) {
-							case DicomCommandField.CStoreRequest:
-								_dimse = new DicomCStoreRequest(command);
-								break;
-							case DicomCommandField.CStoreResponse:
-								_dimse = new DicomCStoreResponse(command);
-								break;
-							case DicomCommandField.CFindRequest:
-								_dimse = new DicomCFindRequest(command);
-								break;
-							case DicomCommandField.CFindResponse:
-								_dimse = new DicomCFindResponse(command);
-								break;
-							case DicomCommandField.CMoveRequest:
-								_dimse = new DicomCMoveRequest(command);
-								break;
-							case DicomCommandField.CMoveResponse:
-								_dimse = new DicomCMoveResponse(command);
-								break;
-							case DicomCommandField.CEchoRequest:
-								_dimse = new DicomCEchoRequest(command);
-								break;
-							case DicomCommandField.CEchoResponse:
-								_dimse = new DicomCEchoResponse(command);
-								break;
-							case DicomCommandField.NActionRequest:
-								_dimse = new DicomNActionRequest(command);
-								break;
-							case DicomCommandField.NActionResponse:
-								_dimse = new DicomNActionResponse(command);
-								break;
-							case DicomCommandField.NCreateRequest:
-								_dimse = new DicomNCreateRequest(command);
-								break;
-							case DicomCommandField.NCreateResponse:
-								_dimse = new DicomNCreateResponse(command);
-								break;
-							case DicomCommandField.NDeleteRequest:
-								_dimse = new DicomNDeleteRequest(command);
-								break;
-							case DicomCommandField.NDeleteResponse:
-								_dimse = new DicomNDeleteResponse(command);
-								break;
-							case DicomCommandField.NEventReportRequest:
-								_dimse = new DicomNEventReportRequest(command);
-								break;
-							case DicomCommandField.NEventReportResponse:
-								_dimse = new DicomNEventReportResponse(command);
-								break;
-							case DicomCommandField.NGetRequest:
-								_dimse = new DicomNGetRequest(command);
-								break;
-							case DicomCommandField.NGetResponse:
-								_dimse = new DicomNGetResponse(command);
-								break;
-							case DicomCommandField.NSetRequest:
-								_dimse = new DicomNSetRequest(command);
-								break;
-							case DicomCommandField.NSetResponse:
-								_dimse = new DicomNSetResponse(command);
-								break;
-							default:
-								_dimse = new DicomMessage(command);
-								break;
-							}
-                            _dimse.PresentationContext = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
-							if (!_dimse.HasDataset) {
-								if (DicomMessage.IsRequest(_dimse.Type))
-									ThreadPool.QueueUserWorkItem(PerformDimseCallback, _dimse);
-								else
-									_processQueue.Queue((_dimse as DicomResponse).RequestMessageID, PerformDimseCallback, _dimse);
-								_dimse = null;
-								return;
-							}
-						} else {
-                            if (_dimse.Type != DicomCommandField.CStoreRequest) {
+                            var type = command.Get<DicomCommandField>(DicomTag.CommandField);
+                            switch (type)
+                            {
+                                case DicomCommandField.CStoreRequest:
+                                    _dimse = new DicomCStoreRequest(command);
+                                    break;
+                                case DicomCommandField.CStoreResponse:
+                                    _dimse = new DicomCStoreResponse(command);
+                                    break;
+                                case DicomCommandField.CFindRequest:
+                                    _dimse = new DicomCFindRequest(command);
+                                    break;
+                                case DicomCommandField.CFindResponse:
+                                    _dimse = new DicomCFindResponse(command);
+                                    break;
+                                case DicomCommandField.CMoveRequest:
+                                    _dimse = new DicomCMoveRequest(command);
+                                    break;
+                                case DicomCommandField.CMoveResponse:
+                                    _dimse = new DicomCMoveResponse(command);
+                                    break;
+                                case DicomCommandField.CEchoRequest:
+                                    _dimse = new DicomCEchoRequest(command);
+                                    break;
+                                case DicomCommandField.CEchoResponse:
+                                    _dimse = new DicomCEchoResponse(command);
+                                    break;
+                                case DicomCommandField.NActionRequest:
+                                    _dimse = new DicomNActionRequest(command);
+                                    break;
+                                case DicomCommandField.NActionResponse:
+                                    _dimse = new DicomNActionResponse(command);
+                                    break;
+                                case DicomCommandField.NCreateRequest:
+                                    _dimse = new DicomNCreateRequest(command);
+                                    break;
+                                case DicomCommandField.NCreateResponse:
+                                    _dimse = new DicomNCreateResponse(command);
+                                    break;
+                                case DicomCommandField.NDeleteRequest:
+                                    _dimse = new DicomNDeleteRequest(command);
+                                    break;
+                                case DicomCommandField.NDeleteResponse:
+                                    _dimse = new DicomNDeleteResponse(command);
+                                    break;
+                                case DicomCommandField.NEventReportRequest:
+                                    _dimse = new DicomNEventReportRequest(command);
+                                    break;
+                                case DicomCommandField.NEventReportResponse:
+                                    _dimse = new DicomNEventReportResponse(command);
+                                    break;
+                                case DicomCommandField.NGetRequest:
+                                    _dimse = new DicomNGetRequest(command);
+                                    break;
+                                case DicomCommandField.NGetResponse:
+                                    _dimse = new DicomNGetResponse(command);
+                                    break;
+                                case DicomCommandField.NSetRequest:
+                                    _dimse = new DicomNSetRequest(command);
+                                    break;
+                                case DicomCommandField.NSetResponse:
+                                    _dimse = new DicomNSetResponse(command);
+                                    break;
+                                default:
+                                    _dimse = new DicomMessage(command);
+                                    break;
+                            }
+                            _dimse.PresentationContext =
+                                Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
+                            if (!_dimse.HasDataset)
+                            {
+                                if (DicomMessage.IsRequest(_dimse.Type)) ThreadPool.QueueUserWorkItem(PerformDimseCallback, _dimse);
+                                else
+                                    _processQueue.Queue(
+                                        (_dimse as DicomResponse).RequestMessageID,
+                                        PerformDimseCallback,
+                                        _dimse);
+                                _dimse = null;
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            if (_dimse.Type != DicomCommandField.CStoreRequest)
+                            {
                                 _dimseStream.Seek(0, SeekOrigin.Begin);
 
                                 var pc = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
@@ -431,7 +523,9 @@ namespace Dicom.Network {
                                 reader.Read(source, new DicomDatasetReaderObserver(_dimse.Dataset));
 
                                 _dimseStream = null;
-                            } else {
+                            }
+                            else
+                            {
                                 var request = _dimse as DicomCStoreRequest;
 
                                 try
@@ -458,28 +552,37 @@ namespace Dicom.Network {
                                         fileName = (_dimseStream as FileStream).Name;
                                     }
                                     // failed to parse received DICOM file; send error response instead of aborting connection
-                                    SendResponse(new DicomCStoreResponse(request, new DicomStatus(DicomStatus.ProcessingFailure, e.Message)));
+                                    SendResponse(
+                                        new DicomCStoreResponse(
+                                            request,
+                                            new DicomStatus(DicomStatus.ProcessingFailure, e.Message)));
                                     Logger.Error("Error parsing C-Store dataset: {@error}", e);
                                     (this as IDicomCStoreProvider).OnCStoreRequestException(fileName, e);
                                     return;
                                 }
                             }
 
-							if (DicomMessage.IsRequest(_dimse.Type))
-								ThreadPool.QueueUserWorkItem(PerformDimseCallback, _dimse);
-							else
-								_processQueue.Queue((_dimse as DicomResponse).RequestMessageID, PerformDimseCallback, _dimse);
-							_dimse = null;
-						}
-					}
-				}
-			} catch (Exception e) {
-				SendAbort(DicomAbortSource.ServiceUser, DicomAbortReason.NotSpecified);
-				Logger.Error("Exception processing P-Data-TF PDU: {@error}", e);
-			} finally {
-				SendNextMessage();
-			}
-		}
+                            if (DicomMessage.IsRequest(_dimse.Type)) ThreadPool.QueueUserWorkItem(PerformDimseCallback, _dimse);
+                            else
+                                _processQueue.Queue(
+                                    (_dimse as DicomResponse).RequestMessageID,
+                                    PerformDimseCallback,
+                                    _dimse);
+                            _dimse = null;
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                SendAbort(DicomAbortSource.ServiceUser, DicomAbortReason.NotSpecified);
+                Logger.Error("Exception processing P-Data-TF PDU: {@error}", e);
+            }
+            finally
+            {
+                SendNextMessage();
+            }
+        }
 
         /// <summary>
         /// The purpose of this method is to return the Stream that a SopInstance received
@@ -502,7 +605,7 @@ namespace Dicom.Network {
             dimseStream.Seek(0, SeekOrigin.End);
             return dimseStream;
         }
-        
+
         /// <summary>
         /// The purpose of this method is to create a DicomFile for the SopInstance received via
         /// CStoreSCP to pass to the IDicomCStoreProvider.OnCStoreRequest method for processing.
@@ -514,15 +617,18 @@ namespace Dicom.Network {
         /// <returns>The DicomFile or null if the stream is not seekable</returns>
         protected virtual DicomFile GetCStoreDicomFile()
         {
-			if (_dimseStream is FileStream) {
-				var name = (_dimseStream as FileStream).Name;
-				_dimseStream.Close();
-				_dimseStream = null;
+            if (_dimseStream is FileStream)
+            {
+                var name = (_dimseStream as FileStream).Name;
+                _dimseStream.Close();
+                _dimseStream = null;
 
-				var file = DicomFile.Open(name, _fallbackEncoding);
-				file.File.IsTempFile = _isTempFile;
-				return file;
-			} else if (_dimseStream.CanSeek) {
+                var file = DicomFile.Open(name, _fallbackEncoding);
+                file.File.IsTempFile = _isTempFile;
+                return file;
+            }
+            else if (_dimseStream.CanSeek)
+            {
                 _dimseStream.Seek(0, SeekOrigin.Begin);
                 var file = DicomFile.Open(_dimseStream, _fallbackEncoding);
                 return file;
@@ -533,546 +639,713 @@ namespace Dicom.Network {
             }
         }
 
-	    private void PerformDimseCallback(object state) {
-			var dimse = state as DicomMessage;
+        private void PerformDimseCallback(object state)
+        {
+            var dimse = state as DicomMessage;
 
-			try {
-				Logger.Info("{logId} <- {dicomMessage}", LogID, dimse.ToString(Options.LogDimseDatasets));
+            try
+            {
+                Logger.Info("{logId} <- {dicomMessage}", LogID, dimse.ToString(Options.LogDimseDatasets));
 
-				if (!DicomMessage.IsRequest(dimse.Type)) {
-					var rsp = dimse as DicomResponse;
-					lock (_lock) {
-						var req = _pending.FirstOrDefault(x => x.MessageID == rsp.RequestMessageID);
-						if (req != null) {
-							rsp.UserState = req.UserState;
-							(req as DicomRequest).PostResponse(this, rsp);
-							if (rsp.Status.State != DicomState.Pending)
-								_pending.Remove(req);
-						}
-					}
-					return;
-				}
+                if (!DicomMessage.IsRequest(dimse.Type))
+                {
+                    var rsp = dimse as DicomResponse;
+                    lock (_lock)
+                    {
+                        var req = _pending.FirstOrDefault(x => x.MessageID == rsp.RequestMessageID);
+                        if (req != null)
+                        {
+                            rsp.UserState = req.UserState;
+                            (req as DicomRequest).PostResponse(this, rsp);
+                            if (rsp.Status.State != DicomState.Pending) _pending.Remove(req);
+                        }
+                    }
+                    return;
+                }
 
-				if (dimse.Type == DicomCommandField.CStoreRequest) {
-					if (this is IDicomCStoreProvider) {
-						var response = (this as IDicomCStoreProvider).OnCStoreRequest(dimse as DicomCStoreRequest);
-						SendResponse(response);
-						return;
-					} else
-						throw new DicomNetworkException("C-Store SCP not implemented");
-				}
+                if (dimse.Type == DicomCommandField.CStoreRequest)
+                {
+                    if (this is IDicomCStoreProvider)
+                    {
+                        var response = (this as IDicomCStoreProvider).OnCStoreRequest(dimse as DicomCStoreRequest);
+                        SendResponse(response);
+                        return;
+                    }
+                    else throw new DicomNetworkException("C-Store SCP not implemented");
+                }
 
-				if (dimse.Type == DicomCommandField.CFindRequest) {
-					if (this is IDicomCFindProvider) {
-						var responses = (this as IDicomCFindProvider).OnCFindRequest(dimse as DicomCFindRequest);
-						foreach (var response in responses)
-							SendResponse(response);
-						return;
-					} else
-						throw new DicomNetworkException("C-Find SCP not implemented");
-				}
+                if (dimse.Type == DicomCommandField.CFindRequest)
+                {
+                    if (this is IDicomCFindProvider)
+                    {
+                        var responses = (this as IDicomCFindProvider).OnCFindRequest(dimse as DicomCFindRequest);
+                        foreach (var response in responses) SendResponse(response);
+                        return;
+                    }
+                    else throw new DicomNetworkException("C-Find SCP not implemented");
+                }
 
-				if (dimse.Type == DicomCommandField.CMoveRequest) {
-					if (this is IDicomCMoveProvider) {
-						var responses = (this as IDicomCMoveProvider).OnCMoveRequest(dimse as DicomCMoveRequest);
-						foreach (var response in responses)
-							SendResponse(response);
-						return;
-					} else
-						throw new DicomNetworkException("C-Move SCP not implemented");
-				}
+                if (dimse.Type == DicomCommandField.CMoveRequest)
+                {
+                    if (this is IDicomCMoveProvider)
+                    {
+                        var responses = (this as IDicomCMoveProvider).OnCMoveRequest(dimse as DicomCMoveRequest);
+                        foreach (var response in responses) SendResponse(response);
+                        return;
+                    }
+                    else throw new DicomNetworkException("C-Move SCP not implemented");
+                }
 
-				if (dimse.Type == DicomCommandField.CEchoRequest) {
-					if (this is IDicomCEchoProvider) {
-						var response = (this as IDicomCEchoProvider).OnCEchoRequest(dimse as DicomCEchoRequest);
-						SendResponse(response);
-						return;
-					} else
-						throw new DicomNetworkException("C-Echo SCP not implemented");
-				}
+                if (dimse.Type == DicomCommandField.CEchoRequest)
+                {
+                    if (this is IDicomCEchoProvider)
+                    {
+                        var response = (this as IDicomCEchoProvider).OnCEchoRequest(dimse as DicomCEchoRequest);
+                        SendResponse(response);
+                        return;
+                    }
+                    else throw new DicomNetworkException("C-Echo SCP not implemented");
+                }
 
-				if (dimse.Type == DicomCommandField.NActionRequest || dimse.Type == DicomCommandField.NCreateRequest ||
-					dimse.Type == DicomCommandField.NDeleteRequest || dimse.Type == DicomCommandField.NEventReportRequest ||
-					dimse.Type == DicomCommandField.NGetRequest || dimse.Type == DicomCommandField.NSetRequest) {
-					if (!(this is IDicomNServiceProvider))
-						throw new DicomNetworkException("N-Service SCP not implemented");
+                if (dimse.Type == DicomCommandField.NActionRequest || dimse.Type == DicomCommandField.NCreateRequest
+                    || dimse.Type == DicomCommandField.NDeleteRequest
+                    || dimse.Type == DicomCommandField.NEventReportRequest
+                    || dimse.Type == DicomCommandField.NGetRequest || dimse.Type == DicomCommandField.NSetRequest)
+                {
+                    if (!(this is IDicomNServiceProvider)) throw new DicomNetworkException("N-Service SCP not implemented");
 
-					DicomResponse response = null;
-					if (dimse.Type == DicomCommandField.NActionRequest)
-						response = (this as IDicomNServiceProvider).OnNActionRequest(dimse as DicomNActionRequest);
-					else if (dimse.Type == DicomCommandField.NCreateRequest)
-						response = (this as IDicomNServiceProvider).OnNCreateRequest(dimse as DicomNCreateRequest);
-					else if (dimse.Type == DicomCommandField.NDeleteRequest)
-						response = (this as IDicomNServiceProvider).OnNDeleteRequest(dimse as DicomNDeleteRequest);
-					else if (dimse.Type == DicomCommandField.NEventReportRequest)
-						response = (this as IDicomNServiceProvider).OnNEventReportRequest(dimse as DicomNEventReportRequest);
-					else if (dimse.Type == DicomCommandField.NGetRequest)
-						response = (this as IDicomNServiceProvider).OnNGetRequest(dimse as DicomNGetRequest);
-					else if (dimse.Type == DicomCommandField.NSetRequest)
-						response = (this as IDicomNServiceProvider).OnNSetRequest(dimse as DicomNSetRequest);
+                    DicomResponse response = null;
+                    if (dimse.Type == DicomCommandField.NActionRequest) response = (this as IDicomNServiceProvider).OnNActionRequest(dimse as DicomNActionRequest);
+                    else if (dimse.Type == DicomCommandField.NCreateRequest) response = (this as IDicomNServiceProvider).OnNCreateRequest(dimse as DicomNCreateRequest);
+                    else if (dimse.Type == DicomCommandField.NDeleteRequest)
+                        response =
+                            (this as IDicomNServiceProvider).OnNDeleteRequest(dimse as DicomNDeleteRequest);
+                    else if (dimse.Type == DicomCommandField.NEventReportRequest)
+                        response =
+                            (this as IDicomNServiceProvider).OnNEventReportRequest(
+                                dimse as DicomNEventReportRequest);
+                    else if (dimse.Type == DicomCommandField.NGetRequest)
+                        response =
+                            (this as IDicomNServiceProvider).OnNGetRequest(dimse as DicomNGetRequest);
+                    else if (dimse.Type == DicomCommandField.NSetRequest)
+                        response =
+                            (this as IDicomNServiceProvider).OnNSetRequest(
+                                dimse as DicomNSetRequest);
 
-					SendResponse(response);
-					return;
-				}
+                    SendResponse(response);
+                    return;
+                }
 
-				throw new DicomNetworkException("Operation not implemented");
-			} finally {
-				SendNextMessage();
-			}
-		}
+                throw new DicomNetworkException("Operation not implemented");
+            }
+            finally
+            {
+                SendNextMessage();
+            }
+        }
 
-		protected void SendPDU(PDU pdu) {
-			// throttle queueing of PDUs to prevent out of memory errors for very large datasets
-			do {
-				if (_pduQueue.Count >= MaximumPDUsInQueue) {
-					Thread.Sleep(10);
-					continue;
-				}
+        protected void SendPDU(PDU pdu)
+        {
+            // throttle queueing of PDUs to prevent out of memory errors for very large datasets
+            do
+            {
+                if (_pduQueue.Count >= MaximumPDUsInQueue)
+                {
+                    Thread.Sleep(10);
+                    continue;
+                }
 
-				lock (_lock)
-					_pduQueue.Enqueue(pdu);
+                lock (_lock) _pduQueue.Enqueue(pdu);
 
-				break;
-			} while (true);
+                break;
+            }
+            while (true);
 
-			SendNextPDU();
-		}
+            SendNextPDU();
+        }
 
-		private void SendNextPDU() {
-			if (!_isConnected)
-				return;
+        private void SendNextPDU()
+        {
+            if (!_isConnected) return;
 
-			PDU pdu;
+            PDU pdu;
 
-			lock (_lock) {
-				if (_writing)
-					return;
+            lock (_lock)
+            {
+                if (_writing) return;
 
-				if (_pduQueue.Count == 0)
-					return;
-				
-				_writing = true;
+                if (_pduQueue.Count == 0) return;
 
-				pdu = _pduQueue.Dequeue();
-			}
+                _writing = true;
 
-			if (Options.LogDataPDUs && pdu is PDataTF)
-				Logger.Info("{logId} -> {pdu}", LogID, pdu);
+                pdu = _pduQueue.Dequeue();
+            }
 
-			MemoryStream ms = new MemoryStream();
-			pdu.Write().WritePDU(ms);
+            if (Options.LogDataPDUs && pdu is PDataTF) Logger.Info("{logId} -> {pdu}", LogID, pdu);
 
-			byte[] buffer = ms.ToArray();
+            MemoryStream ms = new MemoryStream();
+            pdu.Write().WritePDU(ms);
 
-			try {
-				_network.BeginWrite(buffer, 0, (int)ms.Length, OnEndSendPDU, buffer);
-			} catch (IOException e) {
-				if (e.InnerException is SocketException) {
-					Logger.Error("Socket error while writing PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
-				} else if (!(e.InnerException is ObjectDisposedException))
-					Logger.Error("IO exception while writing PDU: {@error}", e);
+            byte[] buffer = ms.ToArray();
 
-				CloseConnection(e);
-			}
-		}
+            try
+            {
+                _network.BeginWrite(buffer, 0, (int)ms.Length, OnEndSendPDU, buffer);
+            }
+            catch (IOException e)
+            {
+                if (e.InnerException is SocketException)
+                {
+                    Logger.Error(
+                        "Socket error while writing PDU: {socketErrorCode} [{errorCode}]",
+                        (e.InnerException as SocketException).SocketErrorCode,
+                        (e.InnerException as SocketException).ErrorCode);
+                }
+                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while writing PDU: {@error}", e);
 
-		private void OnEndSendPDU(IAsyncResult ar) {
-			byte[] buffer = (byte[])ar.AsyncState;
+                CloseConnection(e);
+            }
+        }
 
-			try {
-				_network.EndWrite(ar);
-			} catch (IOException e) {
-				if (e.InnerException is SocketException) {
-					Logger.Error("Socket error while writing PDU: {socketErrorCode} [{errorCode}]", (e.InnerException as SocketException).SocketErrorCode, (e.InnerException as SocketException).ErrorCode);
-				} else if (!(e.InnerException is ObjectDisposedException))
-					Logger.Error("IO exception while writing PDU: {@error}", e);
+        private void OnEndSendPDU(IAsyncResult ar)
+        {
+            byte[] buffer = (byte[])ar.AsyncState;
 
-				CloseConnection(e);
-			} catch {
-			} finally {
-				lock (_lock)
-					_writing = false;
-				SendNextPDU();
-			}
-		}
+            try
+            {
+                _network.EndWrite(ar);
+            }
+            catch (IOException e)
+            {
+                if (e.InnerException is SocketException)
+                {
+                    Logger.Error(
+                        "Socket error while writing PDU: {socketErrorCode} [{errorCode}]",
+                        (e.InnerException as SocketException).SocketErrorCode,
+                        (e.InnerException as SocketException).ErrorCode);
+                }
+                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while writing PDU: {@error}", e);
 
-		private void SendMessage(DicomMessage message) {
-			lock (_lock)
-				_msgQueue.Enqueue(message);
-			SendNextMessage();
-		}
+                CloseConnection(e);
+            }
+            catch
+            {
+            }
+            finally
+            {
+                lock (_lock) _writing = false;
+                SendNextPDU();
+            }
+        }
 
-		private class Dimse {
-			public DicomMessage Message;
-			public PDataTFStream Stream;
-			public DicomDatasetWalker Walker;
-			public DicomPresentationContext PresentationContext;
-		}
+        private void SendMessage(DicomMessage message)
+        {
+            lock (_lock) _msgQueue.Enqueue(message);
+            SendNextMessage();
+        }
 
-		private void SendNextMessage() {
-			DicomMessage msg;
+        private class Dimse
+        {
+            public DicomMessage Message;
 
-			lock (_lock) {
-				if (_msgQueue.Count == 0) {
-					if (_pending.Count == 0)
-						OnSendQueueEmpty();
-					return;
-				}
+            public PDataTFStream Stream;
 
-				if (_sending)
-					return;
+            public DicomDatasetWalker Walker;
 
-				if (Association.MaxAsyncOpsInvoked > 0 && _pending.Count >= Association.MaxAsyncOpsInvoked)
-					return;
+            public DicomPresentationContext PresentationContext;
+        }
 
-				_sending = true;
+        private void SendNextMessage()
+        {
+            DicomMessage msg;
 
-				msg = _msgQueue.Dequeue();
-			}
+            lock (_lock)
+            {
+                if (_msgQueue.Count == 0)
+                {
+                    if (_pending.Count == 0) OnSendQueueEmpty();
+                    return;
+                }
 
-			if (msg is DicomRequest)
-				_pending.Add(msg as DicomRequest);
+                if (_sending) return;
 
-			DicomPresentationContext pc = null;
-			if (msg is DicomCStoreRequest) {
-				pc = Association.PresentationContexts.FirstOrDefault(x => x.Result == DicomPresentationContextResult.Accept && x.AbstractSyntax == msg.SOPClassUID && x.AcceptedTransferSyntax == (msg as DicomCStoreRequest).TransferSyntax);
-				if (pc == null)
-					pc = Association.PresentationContexts.FirstOrDefault(x => x.Result == DicomPresentationContextResult.Accept && x.AbstractSyntax == msg.SOPClassUID);
-			} else {
-				pc = Association.PresentationContexts.FirstOrDefault(x => x.Result == DicomPresentationContextResult.Accept && x.AbstractSyntax == msg.SOPClassUID);
-			}
+                if (Association.MaxAsyncOpsInvoked > 0 && _pending.Count >= Association.MaxAsyncOpsInvoked) return;
 
-            if( pc == null){
+                _sending = true;
+
+                msg = _msgQueue.Dequeue();
+            }
+
+            if (msg is DicomRequest) _pending.Add(msg as DicomRequest);
+
+            DicomPresentationContext pc = null;
+            if (msg is DicomCStoreRequest)
+            {
+                pc =
+                    Association.PresentationContexts.FirstOrDefault(
+                        x =>
+                        x.Result == DicomPresentationContextResult.Accept && x.AbstractSyntax == msg.SOPClassUID
+                        && x.AcceptedTransferSyntax == (msg as DicomCStoreRequest).TransferSyntax);
+                if (pc == null)
+                    pc =
+                        Association.PresentationContexts.FirstOrDefault(
+                            x =>
+                            x.Result == DicomPresentationContextResult.Accept && x.AbstractSyntax == msg.SOPClassUID);
+            }
+            else
+            {
+                pc =
+                    Association.PresentationContexts.FirstOrDefault(
+                        x => x.Result == DicomPresentationContextResult.Accept && x.AbstractSyntax == msg.SOPClassUID);
+            }
+
+            if (pc == null)
+            {
                 pc = msg.PresentationContext;
             }
-            
-			if (pc == null) {
-				_pending.Remove(msg as DicomRequest);
 
-				try {
-					if (msg is DicomCStoreRequest)
-						(msg as DicomCStoreRequest).PostResponse(this, new DicomCStoreResponse(msg as DicomCStoreRequest, DicomStatus.SOPClassNotSupported));
-					else if (msg is DicomCEchoRequest)
-						(msg as DicomCEchoRequest).PostResponse(this, new DicomCEchoResponse(msg as DicomCEchoRequest, DicomStatus.SOPClassNotSupported));
-					else if (msg is DicomCFindRequest)
-						(msg as DicomCFindRequest).PostResponse(this, new DicomCFindResponse(msg as DicomCFindRequest, DicomStatus.SOPClassNotSupported));
-					else if (msg is DicomCMoveRequest)
-						(msg as DicomCMoveRequest).PostResponse(this, new DicomCMoveResponse(msg as DicomCMoveRequest, DicomStatus.SOPClassNotSupported));
+            if (pc == null)
+            {
+                _pending.Remove(msg as DicomRequest);
 
-					//TODO: add N services
-				} catch {
-				}
+                try
+                {
+                    if (msg is DicomCStoreRequest)
+                        (msg as DicomCStoreRequest).PostResponse(
+                            this,
+                            new DicomCStoreResponse(msg as DicomCStoreRequest, DicomStatus.SOPClassNotSupported));
+                    else if (msg is DicomCEchoRequest)
+                        (msg as DicomCEchoRequest).PostResponse(
+                            this,
+                            new DicomCEchoResponse(msg as DicomCEchoRequest, DicomStatus.SOPClassNotSupported));
+                    else if (msg is DicomCFindRequest)
+                        (msg as DicomCFindRequest).PostResponse(
+                            this,
+                            new DicomCFindResponse(msg as DicomCFindRequest, DicomStatus.SOPClassNotSupported));
+                    else if (msg is DicomCMoveRequest)
+                        (msg as DicomCMoveRequest).PostResponse(
+                            this,
+                            new DicomCMoveResponse(
+                                msg as DicomCMoveRequest,
+                                DicomStatus.SOPClassNotSupported));
 
-				Logger.Error("No accepted presentation context found for abstract syntax: {sopClassUid}", msg.SOPClassUID);
-				lock (_lock)
-					_sending = false;
-				SendNextMessage();
-				return;
-			}
+                    //TODO: add N services
+                }
+                catch
+                {
+                }
 
-			var dimse = new Dimse();
-			dimse.Message = msg;
-			dimse.PresentationContext = pc;
+                Logger.Error(
+                    "No accepted presentation context found for abstract syntax: {sopClassUid}",
+                    msg.SOPClassUID);
+                lock (_lock) _sending = false;
+                SendNextMessage();
+                return;
+            }
 
-			// force calculation of command group length as required by standard
-			msg.Command.RecalculateGroupLengths();
+            var dimse = new Dimse();
+            dimse.Message = msg;
+            dimse.PresentationContext = pc;
 
-			if (msg.HasDataset) {
-				// remove group lengths as recommended in PS 3.5 7.2
-				//
-				//	2. It is recommended that Group Length elements be removed during storage or transfer 
-				//	   in order to avoid the risk of inconsistencies arising during coercion of data 
-				//	   element values and changes in transfer syntax.
-				msg.Dataset.RemoveGroupLengths();
+            // force calculation of command group length as required by standard
+            msg.Command.RecalculateGroupLengths();
 
-				if (msg.Dataset.InternalTransferSyntax != dimse.PresentationContext.AcceptedTransferSyntax)
-					msg.Dataset = msg.Dataset.ChangeTransferSyntax(dimse.PresentationContext.AcceptedTransferSyntax);
-			}
+            if (msg.HasDataset)
+            {
+                // remove group lengths as recommended in PS 3.5 7.2
+                //
+                //	2. It is recommended that Group Length elements be removed during storage or transfer 
+                //	   in order to avoid the risk of inconsistencies arising during coercion of data 
+                //	   element values and changes in transfer syntax.
+                msg.Dataset.RemoveGroupLengths();
 
-			Logger.Info("{logId} -> {dicomMessage}", LogID, msg.ToString(Options.LogDimseDatasets));
+                if (msg.Dataset.InternalTransferSyntax != dimse.PresentationContext.AcceptedTransferSyntax) msg.Dataset = msg.Dataset.ChangeTransferSyntax(dimse.PresentationContext.AcceptedTransferSyntax);
+            }
 
-			dimse.Stream = new PDataTFStream(this, pc.ID, Association.MaximumPDULength);
+            Logger.Info("{logId} -> {dicomMessage}", LogID, msg.ToString(Options.LogDimseDatasets));
 
-			var writer = new DicomWriter(DicomTransferSyntax.ImplicitVRLittleEndian, DicomWriteOptions.Default, new StreamByteTarget(dimse.Stream));
+            dimse.Stream = new PDataTFStream(this, pc.ID, Association.MaximumPDULength);
 
-			dimse.Walker = new DicomDatasetWalker(msg.Command);
+            var writer = new DicomWriter(
+                DicomTransferSyntax.ImplicitVRLittleEndian,
+                DicomWriteOptions.Default,
+                new StreamByteTarget(dimse.Stream));
 
-			if (dimse.Message.HasDataset)
-				dimse.Walker.BeginWalk(writer, OnEndSendCommand, dimse);
-			else
-				dimse.Walker.BeginWalk(writer, OnEndSendMessage, dimse);
-		}
+            dimse.Walker = new DicomDatasetWalker(msg.Command);
 
-		private void OnEndSendCommand(IAsyncResult result) {
-			var dimse = result.AsyncState as Dimse;
-			try {
-				dimse.Walker.EndWalk(result);
+            if (dimse.Message.HasDataset) dimse.Walker.BeginWalk(writer, OnEndSendCommand, dimse);
+            else dimse.Walker.BeginWalk(writer, OnEndSendMessage, dimse);
+        }
 
-				dimse.Stream.IsCommand = false;
+        private void OnEndSendCommand(IAsyncResult result)
+        {
+            var dimse = result.AsyncState as Dimse;
+            try
+            {
+                dimse.Walker.EndWalk(result);
 
-				var writer = new DicomWriter(dimse.PresentationContext.AcceptedTransferSyntax, DicomWriteOptions.Default, new StreamByteTarget(dimse.Stream));
+                dimse.Stream.IsCommand = false;
 
-				dimse.Walker = new DicomDatasetWalker(dimse.Message.Dataset);
-				dimse.Walker.BeginWalk(writer, OnEndSendMessage, dimse);
-			} catch (Exception e) {
-				Logger.Error("Exception sending DIMSE: {@error}", e);
-			} finally {
-				if (!dimse.Message.HasDataset) {
-					lock (_lock)
-						_sending = false;
-					SendNextMessage();
-				}
-			}
-		}
+                var writer = new DicomWriter(
+                    dimse.PresentationContext.AcceptedTransferSyntax,
+                    DicomWriteOptions.Default,
+                    new StreamByteTarget(dimse.Stream));
 
-		private void OnEndSendMessage(IAsyncResult result) {
-			var dimse = result.AsyncState as Dimse;
-			try {
-				dimse.Walker.EndWalk(result);
-			} catch (Exception e) {
-				Logger.Error("Exception sending DIMSE: {@error}", e);
-			} finally {
-				dimse.Stream.Flush(true);
-				dimse.Stream.Close();
+                dimse.Walker = new DicomDatasetWalker(dimse.Message.Dataset);
+                dimse.Walker.BeginWalk(writer, OnEndSendMessage, dimse);
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Exception sending DIMSE: {@error}", e);
+            }
+            finally
+            {
+                if (!dimse.Message.HasDataset)
+                {
+                    lock (_lock) _sending = false;
+                    SendNextMessage();
+                }
+            }
+        }
 
-				lock (_lock)
-					_sending = false;
-				SendNextMessage();
-			}
-		}
+        private void OnEndSendMessage(IAsyncResult result)
+        {
+            var dimse = result.AsyncState as Dimse;
+            try
+            {
+                dimse.Walker.EndWalk(result);
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Exception sending DIMSE: {@error}", e);
+            }
+            finally
+            {
+                dimse.Stream.Flush(true);
+                dimse.Stream.Close();
 
-		public void SendRequest(DicomRequest request) {
-			SendMessage(request);
-		}
+                lock (_lock) _sending = false;
+                SendNextMessage();
+            }
+        }
 
-		protected void SendResponse(DicomResponse response) {
-			SendMessage(response);
-		}
+        public void SendRequest(DicomRequest request)
+        {
+            SendMessage(request);
+        }
 
-		private class PDataTFStream : Stream {
-			#region Private Members
-			private DicomService _service;
-			private bool _command;
-			private uint _pduMax;
-			private uint _max;
-			private byte _pcid;
-			private PDataTF _pdu;
-			private byte[] _bytes;
-			private int _length;
-			#endregion
+        protected void SendResponse(DicomResponse response)
+        {
+            SendMessage(response);
+        }
 
-			#region Public Constructors
-			public PDataTFStream(DicomService service, byte pcid, uint max) {
-				_service = service;
-				_command = true;
-				_pcid = pcid;
-				_pduMax = Math.Min(max, Int32.MaxValue);
-				_max = (_pduMax == 0) ? _service.Options.MaxCommandBuffer : Math.Min(_pduMax, _service.Options.MaxCommandBuffer);
+        private class PDataTFStream : Stream
+        {
+            #region Private Members
 
-				_pdu = new PDataTF();
+            private DicomService _service;
 
-				// Max PDU Size - Current Size - Size of PDV header
-				_bytes = new byte[_max - CurrentPduSize() - 6];
-			}
-			#endregion
+            private bool _command;
 
-			#region Public Properties
-			public bool IsCommand {
-				get { return _command; }
-				set {
-					// recalculate maximum PDU buffer size
-					if (_command != value) {
-						if (value)
-							_max = (_pduMax == 0) ? _service.Options.MaxCommandBuffer : Math.Min(_pduMax, _service.Options.MaxCommandBuffer);
-						else
-							_max = (_pduMax == 0) ? _service.Options.MaxDataBuffer : Math.Min(_pduMax, _service.Options.MaxDataBuffer);
+            private uint _pduMax;
 
-						CreatePDV(true);
-						_command = value;
-					}
-				}
-			}
-			#endregion
+            private uint _max;
 
-			#region Public Members
-			public void Flush(bool last) {
-				CreatePDV(last);
-				WritePDU(last);
-			}
-			#endregion
+            private byte _pcid;
 
-			#region Private Members
-			private uint CurrentPduSize() {
-				// PDU header + PDV header + PDV data
-				return 6 + _pdu.GetLengthOfPDVs();
-			}
+            private PDataTF _pdu;
 
-			private void CreatePDV(bool last) {
-				try {
-					if (_bytes == null)
-						_bytes = new byte[0];
+            private byte[] _bytes;
 
-					if (_length < _bytes.Length)
-						Array.Resize(ref _bytes, _length);
+            private int _length;
 
-					PDV pdv = new PDV(_pcid, _bytes, _command, last);
-					_pdu.PDVs.Add(pdv);
+            #endregion
 
-					//_service.Logger.Info(pdv);
+            #region Public Constructors
 
-					// reset length in case we recurse into WritePDU()
-					_length = 0;
-					// is the current PDU at its maximum size or do we have room for another PDV?
-					if ((CurrentPduSize() + 6) >= _max || (!_command && last))
-						WritePDU(last);
+            public PDataTFStream(DicomService service, byte pcid, uint max)
+            {
+                _service = service;
+                _command = true;
+                _pcid = pcid;
+                _pduMax = Math.Min(max, Int32.MaxValue);
+                _max = (_pduMax == 0)
+                           ? _service.Options.MaxCommandBuffer
+                           : Math.Min(_pduMax, _service.Options.MaxCommandBuffer);
 
-					// Max PDU Size - Current Size - Size of PDV header
-					uint max = _max - CurrentPduSize() - 6;
-				  _bytes = last ? null : new byte[max];
-				} catch (Exception e) {
-					_service.Logger.Error("Exception creating PDV: {@error}", e);
-					throw;
-				}
-			}
+                _pdu = new PDataTF();
 
-			private void WritePDU(bool last) {
-				if (_length > 0)
-					CreatePDV(last);
-				
-				if (_pdu.PDVs.Count > 0) {
-					if (last)
-						_pdu.PDVs[_pdu.PDVs.Count - 1].IsLastFragment = true;
+                // Max PDU Size - Current Size - Size of PDV header
+                _bytes = new byte[_max - CurrentPduSize() - 6];
+            }
 
-					_service.SendPDU(_pdu);
+            #endregion
 
-					_pdu = new PDataTF();
-				}
-			}
-			#endregion
+            #region Public Properties
 
-			#region Stream Members
-			public override bool CanRead {
-				get { return false; }
-			}
+            public bool IsCommand
+            {
+                get
+                {
+                    return _command;
+                }
+                set
+                {
+                    // recalculate maximum PDU buffer size
+                    if (_command != value)
+                    {
+                        if (value)
+                            _max = (_pduMax == 0)
+                                       ? _service.Options.MaxCommandBuffer
+                                       : Math.Min(_pduMax, _service.Options.MaxCommandBuffer);
+                        else
+                            _max = (_pduMax == 0)
+                                       ? _service.Options.MaxDataBuffer
+                                       : Math.Min(_pduMax, _service.Options.MaxDataBuffer);
 
-			public override bool CanSeek {
-				get { return false; }
-			}
+                        CreatePDV(true);
+                        _command = value;
+                    }
+                }
+            }
 
-			public override bool CanWrite {
-				get { return true; }
-			}
+            #endregion
 
-			public override void Flush() {
-			}
+            #region Public Members
 
-			public override long Length {
-				get { throw new NotImplementedException(); }
-			}
+            public void Flush(bool last)
+            {
+                CreatePDV(last);
+                WritePDU(last);
+            }
 
-			public override long Position {
-				get {
-					throw new NotImplementedException();
-				}
-				set {
-					throw new NotImplementedException();
-				}
-			}
+            #endregion
 
-			public override int Read(byte[] buffer, int offset, int count) {
-				throw new NotImplementedException();
-			}
+            #region Private Members
 
-			public override long Seek(long offset, SeekOrigin origin) {
-				throw new NotImplementedException();
-			}
+            private uint CurrentPduSize()
+            {
+                // PDU header + PDV header + PDV data
+                return 6 + _pdu.GetLengthOfPDVs();
+            }
 
-			public override void SetLength(long value) {
-				throw new NotImplementedException();
-			}
+            private void CreatePDV(bool last)
+            {
+                try
+                {
+                    if (_bytes == null) _bytes = new byte[0];
 
-			public override void Write(byte[] buffer, int offset, int count) {
-				try {
-					if (_bytes == null || _bytes.Length == 0) {
-						// Max PDU Size - Current Size - Size of PDV header
-						uint max = _max - CurrentPduSize() - 6;
-						_bytes = new byte[max];
-					}
+                    if (_length < _bytes.Length) Array.Resize(ref _bytes, _length);
 
-					while (count >= (_bytes.Length - _length)) {
-						int c = Math.Min(count, _bytes.Length - _length);
+                    PDV pdv = new PDV(_pcid, _bytes, _command, last);
+                    _pdu.PDVs.Add(pdv);
 
-						Array.Copy(buffer, offset, _bytes, _length, c);
+                    //_service.Logger.Info(pdv);
 
-						_length += c;
-						offset += c;
-						count -= c;
+                    // reset length in case we recurse into WritePDU()
+                    _length = 0;
+                    // is the current PDU at its maximum size or do we have room for another PDV?
+                    if ((CurrentPduSize() + 6) >= _max || (!_command && last)) WritePDU(last);
 
-						CreatePDV(false);
-					}
+                    // Max PDU Size - Current Size - Size of PDV header
+                    uint max = _max - CurrentPduSize() - 6;
+                    _bytes = last ? null : new byte[max];
+                }
+                catch (Exception e)
+                {
+                    _service.Logger.Error("Exception creating PDV: {@error}", e);
+                    throw;
+                }
+            }
 
-					if (count > 0) {
-						Array.Copy(buffer, offset, _bytes, _length, count);
-						_length += count;
+            private void WritePDU(bool last)
+            {
+                if (_length > 0) CreatePDV(last);
 
-						if (_bytes.Length == _length)
-							CreatePDV(false);
-					}
-				} catch (Exception e) {
-					_service.Logger.Error("Exception writing data to PDV: {@error}", e);
-					throw;
-				}
-			}
-			#endregion
-		}
+                if (_pdu.PDVs.Count > 0)
+                {
+                    if (last) _pdu.PDVs[_pdu.PDVs.Count - 1].IsLastFragment = true;
 
-		#region Send Methods
-		protected void SendAssociationRequest(DicomAssociation association) {
-			LogID = association.CalledAE;
-			if (Options.UseRemoteAEForLogName)
-				Logger = LogManager.Default.GetLogger(LogID);
-			Logger.Info("{calledAE} -> Association request:\n{association}", LogID, association.ToString());
-			Association = association;
-			SendPDU(new AAssociateRQ(Association));
-		}
+                    _service.SendPDU(_pdu);
 
-		protected void SendAssociationAccept(DicomAssociation association) {
-			Association = association;
+                    _pdu = new PDataTF();
+                }
+            }
 
-			// reject all presentation contexts that have not already been accepted or rejected
-			foreach (var pc in Association.PresentationContexts) {
-				if (pc.Result == DicomPresentationContextResult.Proposed)
-					pc.SetResult(DicomPresentationContextResult.RejectNoReason);
-			}
+            #endregion
 
-			Logger.Info("{logId} -> Association accept:\n{association}", LogID, association.ToString());
-			SendPDU(new AAssociateAC(Association));
-		}
+            #region Stream Members
 
-		protected void SendAssociationReject(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason) {
-			Logger.Info("{logId} -> Association reject [result: {result}; source: {source}; reason: {reason}]", LogID, result, source, reason);
-			SendPDU(new AAssociateRJ(result, source, reason));
-		}
+            public override bool CanRead
+            {
+                get
+                {
+                    return false;
+                }
+            }
 
-		protected void SendAssociationReleaseRequest() {
-			Logger.Info("{logId} -> Association release request", LogID);
-			SendPDU(new AReleaseRQ());
-		}
+            public override bool CanSeek
+            {
+                get
+                {
+                    return false;
+                }
+            }
 
-		protected void SendAssociationReleaseResponse() {
-			Logger.Info("{logId} -> Association release response", LogID);
-			SendPDU(new AReleaseRP());
-		}
+            public override bool CanWrite
+            {
+                get
+                {
+                    return true;
+                }
+            }
 
-		protected void SendAbort(DicomAbortSource source, DicomAbortReason reason) {
-			Logger.Info("{logId} -> Abort [source: {source}; reason: {reason}]", LogID, source, reason);
-			SendPDU(new AAbort(source, reason));
-		}
-		#endregion
+            public override void Flush()
+            {
+            }
 
-		#region Override Methods
-		protected virtual void OnSendQueueEmpty() {
-		}
-		#endregion
-	}
+            public override long Length
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override long Position
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+                set
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                try
+                {
+                    if (_bytes == null || _bytes.Length == 0)
+                    {
+                        // Max PDU Size - Current Size - Size of PDV header
+                        uint max = _max - CurrentPduSize() - 6;
+                        _bytes = new byte[max];
+                    }
+
+                    while (count >= (_bytes.Length - _length))
+                    {
+                        int c = Math.Min(count, _bytes.Length - _length);
+
+                        Array.Copy(buffer, offset, _bytes, _length, c);
+
+                        _length += c;
+                        offset += c;
+                        count -= c;
+
+                        CreatePDV(false);
+                    }
+
+                    if (count > 0)
+                    {
+                        Array.Copy(buffer, offset, _bytes, _length, count);
+                        _length += count;
+
+                        if (_bytes.Length == _length) CreatePDV(false);
+                    }
+                }
+                catch (Exception e)
+                {
+                    _service.Logger.Error("Exception writing data to PDV: {@error}", e);
+                    throw;
+                }
+            }
+
+            #endregion
+        }
+
+        #region Send Methods
+
+        protected void SendAssociationRequest(DicomAssociation association)
+        {
+            LogID = association.CalledAE;
+            if (Options.UseRemoteAEForLogName) Logger = LogManager.Default.GetLogger(LogID);
+            Logger.Info("{calledAE} -> Association request:\n{association}", LogID, association.ToString());
+            Association = association;
+            SendPDU(new AAssociateRQ(Association));
+        }
+
+        protected void SendAssociationAccept(DicomAssociation association)
+        {
+            Association = association;
+
+            // reject all presentation contexts that have not already been accepted or rejected
+            foreach (var pc in Association.PresentationContexts)
+            {
+                if (pc.Result == DicomPresentationContextResult.Proposed) pc.SetResult(DicomPresentationContextResult.RejectNoReason);
+            }
+
+            Logger.Info("{logId} -> Association accept:\n{association}", LogID, association.ToString());
+            SendPDU(new AAssociateAC(Association));
+        }
+
+        protected void SendAssociationReject(
+            DicomRejectResult result,
+            DicomRejectSource source,
+            DicomRejectReason reason)
+        {
+            Logger.Info(
+                "{logId} -> Association reject [result: {result}; source: {source}; reason: {reason}]",
+                LogID,
+                result,
+                source,
+                reason);
+            SendPDU(new AAssociateRJ(result, source, reason));
+        }
+
+        protected void SendAssociationReleaseRequest()
+        {
+            Logger.Info("{logId} -> Association release request", LogID);
+            SendPDU(new AReleaseRQ());
+        }
+
+        protected void SendAssociationReleaseResponse()
+        {
+            Logger.Info("{logId} -> Association release response", LogID);
+            SendPDU(new AReleaseRP());
+        }
+
+        protected void SendAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+            Logger.Info("{logId} -> Abort [source: {source}; reason: {reason}]", LogID, source, reason);
+            SendPDU(new AAbort(source, reason));
+        }
+
+        #endregion
+
+        #region Override Methods
+
+        protected virtual void OnSendQueueEmpty()
+        {
+        }
+
+        #endregion
+    }
 }

--- a/DICOM/Network/DicomServiceOptions.cs
+++ b/DICOM/Network/DicomServiceOptions.cs
@@ -1,74 +1,51 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	/// <summary>
-	/// Options to control the behavior of the <see cref="DicomService"/> base class.
-	/// </summary>
-	public class DicomServiceOptions {
-		/// <summary>Default options for use with the <see cref="DicomService"/> base class.</summary>
-		public readonly static DicomServiceOptions Default = new DicomServiceOptions();
-		
-		/// <summary>Constructor</summary>
-		public DicomServiceOptions() {
-			LogDataPDUs = false;
-			LogDimseDatasets = false;
-			UseRemoteAEForLogName = false;
-			MaxCommandBuffer = 1 * 1024;		//1KB
-			MaxDataBuffer = 1 * 1024 * 1024;	//1MB
-			ThreadPoolLinger = 200;
-			IgnoreSslPolicyErrors = false;
-			TcpNoDelay = true;
-		}
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Options to control the behavior of the <see cref="DicomService"/> base class.
+    /// </summary>
+    public class DicomServiceOptions
+    {
+        /// <summary>Default options for use with the <see cref="DicomService"/> base class.</summary>
+        public static readonly DicomServiceOptions Default = new DicomServiceOptions();
 
-		/// <summary>Write message to log for each P-Data-TF PDU sent or received.</summary>
-		public bool LogDataPDUs {
-			get;
-			set;
-		}
+        /// <summary>Constructor</summary>
+        public DicomServiceOptions()
+        {
+            LogDataPDUs = false;
+            LogDimseDatasets = false;
+            UseRemoteAEForLogName = false;
+            MaxCommandBuffer = 1 * 1024; //1KB
+            MaxDataBuffer = 1 * 1024 * 1024; //1MB
+            ThreadPoolLinger = 200;
+            IgnoreSslPolicyErrors = false;
+            TcpNoDelay = true;
+        }
 
-		/// <summary>Write command and data datasets to log.</summary>
-		public bool LogDimseDatasets {
-			get;
-			set;
-		}
+        /// <summary>Write message to log for each P-Data-TF PDU sent or received.</summary>
+        public bool LogDataPDUs { get; set; }
 
-		/// <summary>Use the AE Title of the remote host as the log name.</summary>
-		public bool UseRemoteAEForLogName {
-			get;
-			set;
-		}
+        /// <summary>Write command and data datasets to log.</summary>
+        public bool LogDimseDatasets { get; set; }
 
-		/// <summary>Maximum buffer length for command PDVs when generating P-Data-TF PDUs.</summary>
-		public uint MaxCommandBuffer {
-			get;
-			set;
-		}
+        /// <summary>Use the AE Title of the remote host as the log name.</summary>
+        public bool UseRemoteAEForLogName { get; set; }
 
-		/// <summary>Maximum buffer length for data PDVs when generating P-Data-TF PDUs.</summary>
-		public uint MaxDataBuffer {
-			get;
-			set;
-		}
+        /// <summary>Maximum buffer length for command PDVs when generating P-Data-TF PDUs.</summary>
+        public uint MaxCommandBuffer { get; set; }
 
-		/// <summary>Amount of time in milliseconds to retain Thread Pool thread to process additional requests.</summary>
-		public int ThreadPoolLinger {
-			get;
-			set;
-		}
+        /// <summary>Maximum buffer length for data PDVs when generating P-Data-TF PDUs.</summary>
+        public uint MaxDataBuffer { get; set; }
 
-		/// <summary>DICOM client should ignore SSL certificate errors.</summary>
-		public bool IgnoreSslPolicyErrors {
-			get;
-			set;
-		}
+        /// <summary>Amount of time in milliseconds to retain Thread Pool thread to process additional requests.</summary>
+        public int ThreadPoolLinger { get; set; }
 
-		/// <summary>Enable or disable TCP Nagle algorithm.</summary>
-		public bool TcpNoDelay {
-			get;
-			set;
-		}
-	}
+        /// <summary>DICOM client should ignore SSL certificate errors.</summary>
+        public bool IgnoreSslPolicyErrors { get; set; }
+
+        /// <summary>Enable or disable TCP Nagle algorithm.</summary>
+        public bool TcpNoDelay { get; set; }
+    }
 }

--- a/DICOM/Network/DicomStatus.cs
+++ b/DICOM/Network/DicomStatus.cs
@@ -1,391 +1,562 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
-namespace Dicom.Network {
-	/// <summary>State of a DICOM status code</summary>
-	public enum DicomState {
-		/// <summary>Success.</summary>
-		Success,
-
-		/// <summary>Cancel.</summary>
-		Cancel,
-
-		/// <summary>Pending.</summary>
-		Pending,
-
-		/// <summary>Warning.</summary>
-		Warning,
-
-		/// <summary>Failure.</summary>
-		Failure
-	}
-
-	/// <summary>DICOM Status</summary>
-	public class DicomStatus {
-		/// <summary>DICOM status code.</summary>
-		public readonly ushort Code;
-
-		/// <summary>State of this DICOM status code.</summary>
-		public readonly DicomState State;
-
-		/// <summary>Description.</summary>
-		public readonly string Description;
-
-		public readonly string ErrorComment = null;
-
-		private readonly ushort Mask;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DicomStatus"/> class.
-		/// </summary>
-		/// <param name="code">The code.</param>
-		/// <param name="status">The status.</param>
-		/// <param name="desc">The desc.</param>
-		public DicomStatus(string code, DicomState status, string desc) {
-			Code = ushort.Parse(code.Replace('x', '0'), System.Globalization.NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-			StringBuilder msb = new StringBuilder();
-			msb.Append(code.ToLower());
-			msb.Replace('0', 'F').Replace('1', 'F').Replace('2', 'F')
-				.Replace('3', 'F').Replace('4', 'F').Replace('5', 'F')
-				.Replace('6', 'F').Replace('7', 'F').Replace('8', 'F')
-				.Replace('9', 'F').Replace('a', 'F').Replace('b', 'F')
-				.Replace('c', 'F').Replace('d', 'F').Replace('e', 'F')
-				.Replace('x', '0');
-			Mask = ushort.Parse(msb.ToString(), System.Globalization.NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-			State = status;
-			Description = desc;
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DicomStatus"/> class.
-		/// </summary>
-		/// <param name="code">The code.</param>
-		/// <param name="status">The status.</param>
-		/// <param name="desc">The desc.</param>
-		/// <param name="comment">The comment.</param>
-		public DicomStatus(string code, DicomState status, string desc, string comment)
-			: this(code, status, desc) {
-			ErrorComment = comment;
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DicomStatus"/> class.
-		/// </summary>
-		/// <param name="status">The status.</param>
-		/// <param name="comment">The comment.</param>
-		public DicomStatus(DicomStatus status, string comment)
-			: this(String.Format("{0:x4}", status.Code), status.State, status.Description, comment) {
-		}
-
-		/// <summary>
-		/// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.
-		/// </summary>
-		/// <returns>
-		/// A <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.
-		/// </returns>
-		public override string ToString() {
-			if (State == DicomState.Warning || State == DicomState.Failure) {
-				if (!String.IsNullOrEmpty(ErrorComment))
-					return String.Format("{0} [{1:x4}: {2}] -> {3}", State, Code, Description, ErrorComment);
-				return String.Format("{0} [{1:x4}: {2}]", State, Code, Description);
-			}
-			return Description;
-		}
-
-		/// <summary>
-		/// Implements the operator ==.
-		/// </summary>
-		/// <param name="s1">DICOM Status</param>
-		/// <param name="s2">DICOM Status</param>
-		/// <returns>The result of the operator.</returns>
-		public static bool operator ==(DicomStatus s1, DicomStatus s2) {
-			if ((object)s1 == null || (object)s2 == null)
-				return false;
-			return (s1.Code & s2.Mask) == (s2.Code & s1.Mask);
-		}
-
-		/// <summary>
-		/// Implements the operator !=.
-		/// </summary>
-		/// <param name="s1">DICOM Status</param>
-		/// <param name="s2">DICOM Status</param>
-		/// <returns>The result of the operator.</returns>
-		public static bool operator !=(DicomStatus s1, DicomStatus s2) {
-			if ((object)s1 == null || (object)s2 == null)
-				return false;
-			return !(s1 == s2);
-		}
-
-
-		/// <summary>
-		/// Determines whether the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>.
-		/// </summary>
-		/// <param name="obj">The <see cref="T:System.Object"/> to compare with the current <see cref="T:System.Object"/>.</param>
-		/// <returns>
-		/// true if the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>; otherwise, false.
-		/// </returns>
-		/// <exception cref="T:System.NullReferenceException">The <paramref name="obj"/> parameter is null.</exception>
-		public override bool Equals(object obj) {
-			return (DicomStatus)obj == this;
-		}
-
-
-		/// <summary>
-		/// Serves as a hash function for a particular type.
-		/// </summary>
-		/// <returns>
-		/// A hash code for the current <see cref="T:System.Object"/>.
-		/// </returns>
-		public override int GetHashCode() {
-			return base.GetHashCode();
-		}
-
-		#region Static
-		private static List<DicomStatus> Entries = new List<DicomStatus>();
-
-		static DicomStatus() {
-			#region Load Dicom Status List
-			Entries.Add(Success);
-			Entries.Add(Cancel);
-			Entries.Add(Pending);
-			Entries.Add(AttributeListError);
-			Entries.Add(AttributeValueOutOfRange);
-			Entries.Add(SOPClassNotSupported);
-			Entries.Add(ClassInstanceConflict);
-			Entries.Add(DuplicateSOPInstance);
-			Entries.Add(DuplicateInvocation);
-			Entries.Add(InvalidArgumentValue);
-			Entries.Add(InvalidAttributeValue);
-			Entries.Add(InvalidObjectInstance);
-			Entries.Add(MissingAttribute);
-			Entries.Add(MissingAttributeValue);
-			Entries.Add(MistypedArgument);
-			Entries.Add(NoSuchArgument);
-			Entries.Add(NoSuchEventType);
-			Entries.Add(NoSuchObjectInstance);
-			Entries.Add(NoSuchSOPClass);
-			Entries.Add(ProcessingFailure);
-			Entries.Add(ResourceLimitation);
-			Entries.Add(UnrecognizedOperation);
-			Entries.Add(NoSuchActionType);
-			Entries.Add(StorageStorageOutOfResources);
-			Entries.Add(StorageDataSetDoesNotMatchSOPClassError);
-			Entries.Add(StorageCannotUnderstand);
-			Entries.Add(StorageCoercionOfDataElements);
-			Entries.Add(StorageDataSetDoesNotMatchSOPClassWarning);
-			Entries.Add(StorageElementsDiscarded);
-			Entries.Add(QueryRetrieveOutOfResources);
-			Entries.Add(QueryRetrieveUnableToCalculateNumberOfMatches);
-			Entries.Add(QueryRetrieveUnableToPerformSuboperations);
-			Entries.Add(QueryRetrieveMoveDestinationUnknown);
-			Entries.Add(QueryRetrieveIdentifierDoesNotMatchSOPClass);
-			Entries.Add(QueryRetrieveUnableToProcess);
-			Entries.Add(QueryRetrieveOptionalKeysNotSupported);
-			Entries.Add(QueryRetrieveSubOpsOneOrMoreFailures);
-			Entries.Add(PrintManagementMemoryAllocationNotSupported);
-			Entries.Add(PrintManagementFilmSessionPrintingNotSupported);
-			Entries.Add(PrintManagementFilmSessionEmptyPage);
-			Entries.Add(PrintManagementFilmBoxEmptyPage);
-			Entries.Add(PrintManagementImageDemagnified);
-			Entries.Add(PrintManagementMinMaxDensityOutOfRange);
-			Entries.Add(PrintManagementImageCropped);
-			Entries.Add(PrintManagementImageDecimated);
-			Entries.Add(PrintManagementFilmSessionEmpty);
-			Entries.Add(PrintManagementPrintQueueFull);
-			Entries.Add(PrintManagementImageLargerThanImageBox);
-			Entries.Add(PrintManagementInsufficientMemoryInPrinter);
-			Entries.Add(PrintManagementCombinedImageLargerThanImageBox);
-			Entries.Add(PrintManagementExistingFilmBoxNotPrinted);
-			Entries.Add(MediaCreationManagementDuplicateInitiateMediaCreation);
-			Entries.Add(MediaCreationManagementMediaCreationRequestAlreadyCompleted);
-			Entries.Add(MediaCreationManagementMediaCreationRequestAlreadyInProgress);
-			Entries.Add(MediaCreationManagementCancellationDeniedForUnspecifiedReason);
-			#endregion
-		}
-
-		/// <summary>
-		/// Looks up the specified code.
-		/// </summary>
-		/// <param name="code">The code.</param>
-		/// <returns></returns>
-		public static DicomStatus Lookup(ushort code) {
-			foreach (DicomStatus status in Entries) {
-				if (status.Code == (code & status.Mask))
-					return status;
-			}
-			return ProcessingFailure;
-		}
-
-		#region Dicom Statuses
-		/// <summary>Success: Success</summary>
-		public static DicomStatus Success = new DicomStatus("0000", DicomState.Success, "Success");
-
-		/// <summary>Cancel: Cancel</summary>
-		public static DicomStatus Cancel = new DicomStatus("FE00", DicomState.Cancel, "Cancel");
-
-		/// <summary>Pending: Pending</summary>
-		public static DicomStatus Pending = new DicomStatus("FF00", DicomState.Pending, "Pending");
-
-		/// <summary>Warning: Attribute list error</summary>
-		public static DicomStatus AttributeListError = new DicomStatus("0107", DicomState.Warning, "Attribute list error");
-
-		/// <summary>Warning: Attribute Value Out of Range</summary>
-		public static DicomStatus AttributeValueOutOfRange = new DicomStatus("0116", DicomState.Warning, "Attribute Value Out of Range");
-
-		/// <summary>Failure: Refused: SOP class not supported</summary>
-		public static DicomStatus SOPClassNotSupported = new DicomStatus("0122", DicomState.Failure, "Refused: SOP class not supported");
-
-		/// <summary>Failure: Class-instance conflict</summary>
-		public static DicomStatus ClassInstanceConflict = new DicomStatus("0119", DicomState.Failure, "Class-instance conflict");
-
-		/// <summary>Failure: Duplicate SOP instance</summary>
-		public static DicomStatus DuplicateSOPInstance = new DicomStatus("0111", DicomState.Failure, "Duplicate SOP instance");
-
-		/// <summary>Failure: Duplicate invocation</summary>
-		public static DicomStatus DuplicateInvocation = new DicomStatus("0210", DicomState.Failure, "Duplicate invocation");
-
-		/// <summary>Failure: Invalid argument value</summary>
-		public static DicomStatus InvalidArgumentValue = new DicomStatus("0115", DicomState.Failure, "Invalid argument value");
-
-		/// <summary>Failure: Invalid attribute value</summary>
-		public static DicomStatus InvalidAttributeValue = new DicomStatus("0106", DicomState.Failure, "Invalid attribute value");
-
-		/// <summary>Failure: Invalid object instance</summary>
-		public static DicomStatus InvalidObjectInstance = new DicomStatus("0117", DicomState.Failure, "Invalid object instance");
-
-		/// <summary>Failure: Missing attribute</summary>
-		public static DicomStatus MissingAttribute = new DicomStatus("0120", DicomState.Failure, "Missing attribute");
-
-		/// <summary>Failure: Missing attribute value</summary>
-		public static DicomStatus MissingAttributeValue = new DicomStatus("0121", DicomState.Failure, "Missing attribute value");
-
-		/// <summary>Failure: Mistyped argument</summary>
-		public static DicomStatus MistypedArgument = new DicomStatus("0212", DicomState.Failure, "Mistyped argument");
-
-		/// <summary>Failure: No such argument</summary>
-		public static DicomStatus NoSuchArgument = new DicomStatus("0114", DicomState.Failure, "No such argument");
-
-		/// <summary>Failure: No such event type</summary>
-		public static DicomStatus NoSuchEventType = new DicomStatus("0113", DicomState.Failure, "No such event type");
-
-		/// <summary>Failure: No Such object instance</summary>
-		public static DicomStatus NoSuchObjectInstance = new DicomStatus("0112", DicomState.Failure, "No Such object instance");
-
-		/// <summary>Failure: No Such SOP class</summary>
-		public static DicomStatus NoSuchSOPClass = new DicomStatus("0118", DicomState.Failure, "No Such SOP class");
-
-		/// <summary>Failure: Processing failure</summary>
-		public static DicomStatus ProcessingFailure = new DicomStatus("0110", DicomState.Failure, "Processing failure");
-
-		/// <summary>Failure: Resource limitation</summary>
-		public static DicomStatus ResourceLimitation = new DicomStatus("0213", DicomState.Failure, "Resource limitation");
-
-		/// <summary>Failure: Unrecognized operation</summary>
-		public static DicomStatus UnrecognizedOperation = new DicomStatus("0211", DicomState.Failure, "Unrecognized operation");
-
-		/// <summary>Failure: No such action type</summary>
-		public static DicomStatus NoSuchActionType = new DicomStatus("0123", DicomState.Failure, "No such action type");
-
-		/// <summary>Storage Failure: Out of Resources</summary>
-		public static DicomStatus StorageStorageOutOfResources = new DicomStatus("A7xx", DicomState.Failure, "Out of Resources");
-
-		/// <summary>Storage Failure: Data Set does not match SOP Class (Error)</summary>
-		public static DicomStatus StorageDataSetDoesNotMatchSOPClassError = new DicomStatus("A9xx", DicomState.Failure, "Data Set does not match SOP Class (Error)");
-
-		/// <summary>Storage Failure: Cannot understand</summary>
-		public static DicomStatus StorageCannotUnderstand = new DicomStatus("Cxxx", DicomState.Failure, "Cannot understand");
-
-		/// <summary>Storage Warning: Coercion of Data Elements</summary>
-		public static DicomStatus StorageCoercionOfDataElements = new DicomStatus("B000", DicomState.Warning, "Coercion of Data Elements");
-
-		/// <summary>Storage Warning: Data Set does not match SOP Class (Warning)</summary>
-		public static DicomStatus StorageDataSetDoesNotMatchSOPClassWarning = new DicomStatus("B007", DicomState.Warning, "Data Set does not match SOP Class (Warning)");
-
-		/// <summary>Storage Warning: Elements Discarded</summary>
-		public static DicomStatus StorageElementsDiscarded = new DicomStatus("B006", DicomState.Warning, "Elements Discarded");
-
-		/// <summary>QueryRetrieve Failure: Out of Resources</summary>
-		public static DicomStatus QueryRetrieveOutOfResources = new DicomStatus("A700", DicomState.Failure, "Out of Resources");
-
-		/// <summary>QueryRetrieve Failure: Unable to calculate number of matches</summary>
-		public static DicomStatus QueryRetrieveUnableToCalculateNumberOfMatches = new DicomStatus("A701", DicomState.Failure, "Unable to calculate number of matches");
-
-		/// <summary>QueryRetrieve Failure: Unable to perform suboperations</summary>
-		public static DicomStatus QueryRetrieveUnableToPerformSuboperations = new DicomStatus("A702", DicomState.Failure, "Unable to perform suboperations");
-
-		/// <summary>QueryRetrieve Failure: Move Destination unknown</summary>
-		public static DicomStatus QueryRetrieveMoveDestinationUnknown = new DicomStatus("A801", DicomState.Failure, "Move Destination unknown");
-
-		/// <summary>QueryRetrieve Failure: Identifier does not match SOP Class</summary>
-		public static DicomStatus QueryRetrieveIdentifierDoesNotMatchSOPClass = new DicomStatus("A900", DicomState.Failure, "Identifier does not match SOP Class");
-
-		/// <summary>QueryRetrieve Failure: Unable to process</summary>
-		public static DicomStatus QueryRetrieveUnableToProcess = new DicomStatus("Cxxx", DicomState.Failure, "Unable to process");
-
-		/// <summary>QueryRetrieve Pending: Optional Keys Not Supported</summary>
-		public static DicomStatus QueryRetrieveOptionalKeysNotSupported = new DicomStatus("FF01", DicomState.Pending, "Optional Keys Not Supported");
-
-		/// <summary>QueryRetrieve Warning: Sub-operations Complete - One or more Failures</summary>
-		public static DicomStatus QueryRetrieveSubOpsOneOrMoreFailures = new DicomStatus("B000", DicomState.Warning, "Sub-operations Complete - One or more Failures");
-
-		/// <summary>PrintManagement Warning: Memory allocation not supported</summary>
-		public static DicomStatus PrintManagementMemoryAllocationNotSupported = new DicomStatus("B000", DicomState.Warning, "Memory allocation not supported");
-
-		/// <summary>PrintManagement Warning: Film session printing (collation) is not supported</summary>
-		public static DicomStatus PrintManagementFilmSessionPrintingNotSupported = new DicomStatus("B601", DicomState.Warning, "Film session printing (collation) is not supported");
-
-		/// <summary>PrintManagement Warning: Film session SOP instance hierarchy does not contain image box SOP instances (empty page)</summary>
-		public static DicomStatus PrintManagementFilmSessionEmptyPage = new DicomStatus("B602", DicomState.Warning, "Film session SOP instance hierarchy does not contain image box SOP instances (empty page)");
-
-		/// <summary>PrintManagement Warning: Film box SOP instance hierarchy does not contain image box SOP instances (empty page)</summary>
-		public static DicomStatus PrintManagementFilmBoxEmptyPage = new DicomStatus("B603", DicomState.Warning, "Film box SOP instance hierarchy does not contain image box SOP instances (empty page)");
-
-		/// <summary>PrintManagement Warning: Image size is larger than image box size, the image has been demagnified</summary>
-		public static DicomStatus PrintManagementImageDemagnified = new DicomStatus("B604", DicomState.Warning, "Image size is larger than image box size, the image has been demagnified");
-
-		/// <summary>PrintManagement Warning: Requested min density or max density outside of printer's operating range</summary>
-		public static DicomStatus PrintManagementMinMaxDensityOutOfRange = new DicomStatus("B605", DicomState.Warning, "Requested min density or max density outside of printer's operating range");
-
-		/// <summary>PrintManagement Warning: Image size is larger than the image box size, the Image has been cropped to fit</summary>
-		public static DicomStatus PrintManagementImageCropped = new DicomStatus("B609", DicomState.Warning, "Image size is larger than the image box size, the Image has been cropped to fit");
-
-		/// <summary>PrintManagement Warning: Image size or combined print image size is larger than the image box size, image or combined print image has been decimated to fit</summary>
-		public static DicomStatus PrintManagementImageDecimated = new DicomStatus("B60A", DicomState.Warning, "Image size or combined print image size is larger than the image box size, image or combined print image has been decimated to fit");
-
-		/// <summary>PrintManagement Failure: Film session SOP instance hierarchy does not contain film box SOP instances</summary>
-		public static DicomStatus PrintManagementFilmSessionEmpty = new DicomStatus("C600", DicomState.Failure, "Film session SOP instance hierarchy does not contain film box SOP instances");
-
-		/// <summary>PrintManagement Failure: Unable to create Print Job SOP Instance; print queue is full</summary>
-		public static DicomStatus PrintManagementPrintQueueFull = new DicomStatus("C601", DicomState.Failure, "Unable to create Print Job SOP Instance; print queue is full");
-
-		/// <summary>PrintManagement Failure: Image size is larger than image box size</summary>
-		public static DicomStatus PrintManagementImageLargerThanImageBox = new DicomStatus("C603", DicomState.Failure, "Image size is larger than image box size");
-
-		/// <summary>PrintManagement Failure: Insufficient memory in printer to store the image</summary>
-		public static DicomStatus PrintManagementInsufficientMemoryInPrinter = new DicomStatus("C605", DicomState.Failure, "Insufficient memory in printer to store the image");
-
-		/// <summary>PrintManagement Failure: Combined Print Image size is larger than the Image Box size</summary>
-		public static DicomStatus PrintManagementCombinedImageLargerThanImageBox = new DicomStatus("C613", DicomState.Failure, "Combined Print Image size is larger than the Image Box size");
-
-		/// <summary>PrintManagement Failure: There is an existing film box that has not been printed and N-ACTION at the Film Session level is not supported.</summary>
-		public static DicomStatus PrintManagementExistingFilmBoxNotPrinted = new DicomStatus("C616", DicomState.Failure, "There is an existing film box that has not been printed and N-ACTION at the Film Session level is not supported.");
-
-		/// <summary>MediaCreationManagement Failure: Refused because an Initiate Media Creation action has already been received for this SOP Instance</summary>
-		public static DicomStatus MediaCreationManagementDuplicateInitiateMediaCreation = new DicomStatus("A510", DicomState.Failure, "Refused because an Initiate Media Creation action has already been received for this SOP Instance");
-
-		/// <summary>MediaCreationManagement Failure: Media creation request already completed</summary>
-		public static DicomStatus MediaCreationManagementMediaCreationRequestAlreadyCompleted = new DicomStatus("C201", DicomState.Failure, "Media creation request already completed");
-
-		/// <summary>MediaCreationManagement Failure: Media creation request already in progress and cannot be interrupted</summary>
-		public static DicomStatus MediaCreationManagementMediaCreationRequestAlreadyInProgress = new DicomStatus("C202", DicomState.Failure, "Media creation request already in progress and cannot be interrupted");
-
-		/// <summary>MediaCreationManagement Failure: Cancellation denied for unspecified reason</summary>
-		public static DicomStatus MediaCreationManagementCancellationDeniedForUnspecifiedReason = new DicomStatus("C203", DicomState.Failure, "Cancellation denied for unspecified reason");
-		#endregion
-		#endregion
-	}
+namespace Dicom.Network
+{
+    /// <summary>State of a DICOM status code</summary>
+    public enum DicomState
+    {
+        /// <summary>Success.</summary>
+        Success,
+
+        /// <summary>Cancel.</summary>
+        Cancel,
+
+        /// <summary>Pending.</summary>
+        Pending,
+
+        /// <summary>Warning.</summary>
+        Warning,
+
+        /// <summary>Failure.</summary>
+        Failure
+    }
+
+    /// <summary>DICOM Status</summary>
+    public class DicomStatus
+    {
+        /// <summary>DICOM status code.</summary>
+        public readonly ushort Code;
+
+        /// <summary>State of this DICOM status code.</summary>
+        public readonly DicomState State;
+
+        /// <summary>Description.</summary>
+        public readonly string Description;
+
+        public readonly string ErrorComment = null;
+
+        private readonly ushort Mask;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomStatus"/> class.
+        /// </summary>
+        /// <param name="code">The code.</param>
+        /// <param name="status">The status.</param>
+        /// <param name="desc">The desc.</param>
+        public DicomStatus(string code, DicomState status, string desc)
+        {
+            Code = ushort.Parse(
+                code.Replace('x', '0'),
+                System.Globalization.NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture);
+
+            StringBuilder msb = new StringBuilder();
+            msb.Append(code.ToLower());
+            msb.Replace('0', 'F')
+                .Replace('1', 'F')
+                .Replace('2', 'F')
+                .Replace('3', 'F')
+                .Replace('4', 'F')
+                .Replace('5', 'F')
+                .Replace('6', 'F')
+                .Replace('7', 'F')
+                .Replace('8', 'F')
+                .Replace('9', 'F')
+                .Replace('a', 'F')
+                .Replace('b', 'F')
+                .Replace('c', 'F')
+                .Replace('d', 'F')
+                .Replace('e', 'F')
+                .Replace('x', '0');
+            Mask = ushort.Parse(
+                msb.ToString(),
+                System.Globalization.NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture);
+
+            State = status;
+            Description = desc;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomStatus"/> class.
+        /// </summary>
+        /// <param name="code">The code.</param>
+        /// <param name="status">The status.</param>
+        /// <param name="desc">The desc.</param>
+        /// <param name="comment">The comment.</param>
+        public DicomStatus(string code, DicomState status, string desc, string comment)
+            : this(code, status, desc)
+        {
+            ErrorComment = comment;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomStatus"/> class.
+        /// </summary>
+        /// <param name="status">The status.</param>
+        /// <param name="comment">The comment.</param>
+        public DicomStatus(DicomStatus status, string comment)
+            : this(String.Format("{0:x4}", status.Code), status.State, status.Description, comment)
+        {
+        }
+
+        /// <summary>
+        /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.
+        /// </returns>
+        public override string ToString()
+        {
+            if (State == DicomState.Warning || State == DicomState.Failure)
+            {
+                if (!String.IsNullOrEmpty(ErrorComment)) return String.Format("{0} [{1:x4}: {2}] -> {3}", State, Code, Description, ErrorComment);
+                return String.Format("{0} [{1:x4}: {2}]", State, Code, Description);
+            }
+            return Description;
+        }
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="s1">DICOM Status</param>
+        /// <param name="s2">DICOM Status</param>
+        /// <returns>The result of the operator.</returns>
+        public static bool operator ==(DicomStatus s1, DicomStatus s2)
+        {
+            if ((object)s1 == null || (object)s2 == null) return false;
+            return (s1.Code & s2.Mask) == (s2.Code & s1.Mask);
+        }
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="s1">DICOM Status</param>
+        /// <param name="s2">DICOM Status</param>
+        /// <returns>The result of the operator.</returns>
+        public static bool operator !=(DicomStatus s1, DicomStatus s2)
+        {
+            if ((object)s1 == null || (object)s2 == null) return false;
+            return !(s1 == s2);
+        }
+
+
+        /// <summary>
+        /// Determines whether the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="T:System.Object"/> to compare with the current <see cref="T:System.Object"/>.</param>
+        /// <returns>
+        /// true if the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>; otherwise, false.
+        /// </returns>
+        /// <exception cref="T:System.NullReferenceException">The <paramref name="obj"/> parameter is null.</exception>
+        public override bool Equals(object obj)
+        {
+            return (DicomStatus)obj == this;
+        }
+
+
+        /// <summary>
+        /// Serves as a hash function for a particular type.
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        #region Static
+
+        private static List<DicomStatus> Entries = new List<DicomStatus>();
+
+        static DicomStatus()
+        {
+            #region Load Dicom Status List
+
+            Entries.Add(Success);
+            Entries.Add(Cancel);
+            Entries.Add(Pending);
+            Entries.Add(AttributeListError);
+            Entries.Add(AttributeValueOutOfRange);
+            Entries.Add(SOPClassNotSupported);
+            Entries.Add(ClassInstanceConflict);
+            Entries.Add(DuplicateSOPInstance);
+            Entries.Add(DuplicateInvocation);
+            Entries.Add(InvalidArgumentValue);
+            Entries.Add(InvalidAttributeValue);
+            Entries.Add(InvalidObjectInstance);
+            Entries.Add(MissingAttribute);
+            Entries.Add(MissingAttributeValue);
+            Entries.Add(MistypedArgument);
+            Entries.Add(NoSuchArgument);
+            Entries.Add(NoSuchEventType);
+            Entries.Add(NoSuchObjectInstance);
+            Entries.Add(NoSuchSOPClass);
+            Entries.Add(ProcessingFailure);
+            Entries.Add(ResourceLimitation);
+            Entries.Add(UnrecognizedOperation);
+            Entries.Add(NoSuchActionType);
+            Entries.Add(StorageStorageOutOfResources);
+            Entries.Add(StorageDataSetDoesNotMatchSOPClassError);
+            Entries.Add(StorageCannotUnderstand);
+            Entries.Add(StorageCoercionOfDataElements);
+            Entries.Add(StorageDataSetDoesNotMatchSOPClassWarning);
+            Entries.Add(StorageElementsDiscarded);
+            Entries.Add(QueryRetrieveOutOfResources);
+            Entries.Add(QueryRetrieveUnableToCalculateNumberOfMatches);
+            Entries.Add(QueryRetrieveUnableToPerformSuboperations);
+            Entries.Add(QueryRetrieveMoveDestinationUnknown);
+            Entries.Add(QueryRetrieveIdentifierDoesNotMatchSOPClass);
+            Entries.Add(QueryRetrieveUnableToProcess);
+            Entries.Add(QueryRetrieveOptionalKeysNotSupported);
+            Entries.Add(QueryRetrieveSubOpsOneOrMoreFailures);
+            Entries.Add(PrintManagementMemoryAllocationNotSupported);
+            Entries.Add(PrintManagementFilmSessionPrintingNotSupported);
+            Entries.Add(PrintManagementFilmSessionEmptyPage);
+            Entries.Add(PrintManagementFilmBoxEmptyPage);
+            Entries.Add(PrintManagementImageDemagnified);
+            Entries.Add(PrintManagementMinMaxDensityOutOfRange);
+            Entries.Add(PrintManagementImageCropped);
+            Entries.Add(PrintManagementImageDecimated);
+            Entries.Add(PrintManagementFilmSessionEmpty);
+            Entries.Add(PrintManagementPrintQueueFull);
+            Entries.Add(PrintManagementImageLargerThanImageBox);
+            Entries.Add(PrintManagementInsufficientMemoryInPrinter);
+            Entries.Add(PrintManagementCombinedImageLargerThanImageBox);
+            Entries.Add(PrintManagementExistingFilmBoxNotPrinted);
+            Entries.Add(MediaCreationManagementDuplicateInitiateMediaCreation);
+            Entries.Add(MediaCreationManagementMediaCreationRequestAlreadyCompleted);
+            Entries.Add(MediaCreationManagementMediaCreationRequestAlreadyInProgress);
+            Entries.Add(MediaCreationManagementCancellationDeniedForUnspecifiedReason);
+
+            #endregion
+        }
+
+        /// <summary>
+        /// Looks up the specified code.
+        /// </summary>
+        /// <param name="code">The code.</param>
+        /// <returns></returns>
+        public static DicomStatus Lookup(ushort code)
+        {
+            foreach (DicomStatus status in Entries)
+            {
+                if (status.Code == (code & status.Mask)) return status;
+            }
+            return ProcessingFailure;
+        }
+
+        #region Dicom Statuses
+
+        /// <summary>Success: Success</summary>
+        public static DicomStatus Success = new DicomStatus("0000", DicomState.Success, "Success");
+
+        /// <summary>Cancel: Cancel</summary>
+        public static DicomStatus Cancel = new DicomStatus("FE00", DicomState.Cancel, "Cancel");
+
+        /// <summary>Pending: Pending</summary>
+        public static DicomStatus Pending = new DicomStatus("FF00", DicomState.Pending, "Pending");
+
+        /// <summary>Warning: Attribute list error</summary>
+        public static DicomStatus AttributeListError = new DicomStatus(
+            "0107",
+            DicomState.Warning,
+            "Attribute list error");
+
+        /// <summary>Warning: Attribute Value Out of Range</summary>
+        public static DicomStatus AttributeValueOutOfRange = new DicomStatus(
+            "0116",
+            DicomState.Warning,
+            "Attribute Value Out of Range");
+
+        /// <summary>Failure: Refused: SOP class not supported</summary>
+        public static DicomStatus SOPClassNotSupported = new DicomStatus(
+            "0122",
+            DicomState.Failure,
+            "Refused: SOP class not supported");
+
+        /// <summary>Failure: Class-instance conflict</summary>
+        public static DicomStatus ClassInstanceConflict = new DicomStatus(
+            "0119",
+            DicomState.Failure,
+            "Class-instance conflict");
+
+        /// <summary>Failure: Duplicate SOP instance</summary>
+        public static DicomStatus DuplicateSOPInstance = new DicomStatus(
+            "0111",
+            DicomState.Failure,
+            "Duplicate SOP instance");
+
+        /// <summary>Failure: Duplicate invocation</summary>
+        public static DicomStatus DuplicateInvocation = new DicomStatus(
+            "0210",
+            DicomState.Failure,
+            "Duplicate invocation");
+
+        /// <summary>Failure: Invalid argument value</summary>
+        public static DicomStatus InvalidArgumentValue = new DicomStatus(
+            "0115",
+            DicomState.Failure,
+            "Invalid argument value");
+
+        /// <summary>Failure: Invalid attribute value</summary>
+        public static DicomStatus InvalidAttributeValue = new DicomStatus(
+            "0106",
+            DicomState.Failure,
+            "Invalid attribute value");
+
+        /// <summary>Failure: Invalid object instance</summary>
+        public static DicomStatus InvalidObjectInstance = new DicomStatus(
+            "0117",
+            DicomState.Failure,
+            "Invalid object instance");
+
+        /// <summary>Failure: Missing attribute</summary>
+        public static DicomStatus MissingAttribute = new DicomStatus("0120", DicomState.Failure, "Missing attribute");
+
+        /// <summary>Failure: Missing attribute value</summary>
+        public static DicomStatus MissingAttributeValue = new DicomStatus(
+            "0121",
+            DicomState.Failure,
+            "Missing attribute value");
+
+        /// <summary>Failure: Mistyped argument</summary>
+        public static DicomStatus MistypedArgument = new DicomStatus("0212", DicomState.Failure, "Mistyped argument");
+
+        /// <summary>Failure: No such argument</summary>
+        public static DicomStatus NoSuchArgument = new DicomStatus("0114", DicomState.Failure, "No such argument");
+
+        /// <summary>Failure: No such event type</summary>
+        public static DicomStatus NoSuchEventType = new DicomStatus("0113", DicomState.Failure, "No such event type");
+
+        /// <summary>Failure: No Such object instance</summary>
+        public static DicomStatus NoSuchObjectInstance = new DicomStatus(
+            "0112",
+            DicomState.Failure,
+            "No Such object instance");
+
+        /// <summary>Failure: No Such SOP class</summary>
+        public static DicomStatus NoSuchSOPClass = new DicomStatus("0118", DicomState.Failure, "No Such SOP class");
+
+        /// <summary>Failure: Processing failure</summary>
+        public static DicomStatus ProcessingFailure = new DicomStatus("0110", DicomState.Failure, "Processing failure");
+
+        /// <summary>Failure: Resource limitation</summary>
+        public static DicomStatus ResourceLimitation = new DicomStatus(
+            "0213",
+            DicomState.Failure,
+            "Resource limitation");
+
+        /// <summary>Failure: Unrecognized operation</summary>
+        public static DicomStatus UnrecognizedOperation = new DicomStatus(
+            "0211",
+            DicomState.Failure,
+            "Unrecognized operation");
+
+        /// <summary>Failure: No such action type</summary>
+        public static DicomStatus NoSuchActionType = new DicomStatus("0123", DicomState.Failure, "No such action type");
+
+        /// <summary>Storage Failure: Out of Resources</summary>
+        public static DicomStatus StorageStorageOutOfResources = new DicomStatus(
+            "A7xx",
+            DicomState.Failure,
+            "Out of Resources");
+
+        /// <summary>Storage Failure: Data Set does not match SOP Class (Error)</summary>
+        public static DicomStatus StorageDataSetDoesNotMatchSOPClassError = new DicomStatus(
+            "A9xx",
+            DicomState.Failure,
+            "Data Set does not match SOP Class (Error)");
+
+        /// <summary>Storage Failure: Cannot understand</summary>
+        public static DicomStatus StorageCannotUnderstand = new DicomStatus(
+            "Cxxx",
+            DicomState.Failure,
+            "Cannot understand");
+
+        /// <summary>Storage Warning: Coercion of Data Elements</summary>
+        public static DicomStatus StorageCoercionOfDataElements = new DicomStatus(
+            "B000",
+            DicomState.Warning,
+            "Coercion of Data Elements");
+
+        /// <summary>Storage Warning: Data Set does not match SOP Class (Warning)</summary>
+        public static DicomStatus StorageDataSetDoesNotMatchSOPClassWarning = new DicomStatus(
+            "B007",
+            DicomState.Warning,
+            "Data Set does not match SOP Class (Warning)");
+
+        /// <summary>Storage Warning: Elements Discarded</summary>
+        public static DicomStatus StorageElementsDiscarded = new DicomStatus(
+            "B006",
+            DicomState.Warning,
+            "Elements Discarded");
+
+        /// <summary>QueryRetrieve Failure: Out of Resources</summary>
+        public static DicomStatus QueryRetrieveOutOfResources = new DicomStatus(
+            "A700",
+            DicomState.Failure,
+            "Out of Resources");
+
+        /// <summary>QueryRetrieve Failure: Unable to calculate number of matches</summary>
+        public static DicomStatus QueryRetrieveUnableToCalculateNumberOfMatches = new DicomStatus(
+            "A701",
+            DicomState.Failure,
+            "Unable to calculate number of matches");
+
+        /// <summary>QueryRetrieve Failure: Unable to perform suboperations</summary>
+        public static DicomStatus QueryRetrieveUnableToPerformSuboperations = new DicomStatus(
+            "A702",
+            DicomState.Failure,
+            "Unable to perform suboperations");
+
+        /// <summary>QueryRetrieve Failure: Move Destination unknown</summary>
+        public static DicomStatus QueryRetrieveMoveDestinationUnknown = new DicomStatus(
+            "A801",
+            DicomState.Failure,
+            "Move Destination unknown");
+
+        /// <summary>QueryRetrieve Failure: Identifier does not match SOP Class</summary>
+        public static DicomStatus QueryRetrieveIdentifierDoesNotMatchSOPClass = new DicomStatus(
+            "A900",
+            DicomState.Failure,
+            "Identifier does not match SOP Class");
+
+        /// <summary>QueryRetrieve Failure: Unable to process</summary>
+        public static DicomStatus QueryRetrieveUnableToProcess = new DicomStatus(
+            "Cxxx",
+            DicomState.Failure,
+            "Unable to process");
+
+        /// <summary>QueryRetrieve Pending: Optional Keys Not Supported</summary>
+        public static DicomStatus QueryRetrieveOptionalKeysNotSupported = new DicomStatus(
+            "FF01",
+            DicomState.Pending,
+            "Optional Keys Not Supported");
+
+        /// <summary>QueryRetrieve Warning: Sub-operations Complete - One or more Failures</summary>
+        public static DicomStatus QueryRetrieveSubOpsOneOrMoreFailures = new DicomStatus(
+            "B000",
+            DicomState.Warning,
+            "Sub-operations Complete - One or more Failures");
+
+        /// <summary>PrintManagement Warning: Memory allocation not supported</summary>
+        public static DicomStatus PrintManagementMemoryAllocationNotSupported = new DicomStatus(
+            "B000",
+            DicomState.Warning,
+            "Memory allocation not supported");
+
+        /// <summary>PrintManagement Warning: Film session printing (collation) is not supported</summary>
+        public static DicomStatus PrintManagementFilmSessionPrintingNotSupported = new DicomStatus(
+            "B601",
+            DicomState.Warning,
+            "Film session printing (collation) is not supported");
+
+        /// <summary>PrintManagement Warning: Film session SOP instance hierarchy does not contain image box SOP instances (empty page)</summary>
+        public static DicomStatus PrintManagementFilmSessionEmptyPage = new DicomStatus(
+            "B602",
+            DicomState.Warning,
+            "Film session SOP instance hierarchy does not contain image box SOP instances (empty page)");
+
+        /// <summary>PrintManagement Warning: Film box SOP instance hierarchy does not contain image box SOP instances (empty page)</summary>
+        public static DicomStatus PrintManagementFilmBoxEmptyPage = new DicomStatus(
+            "B603",
+            DicomState.Warning,
+            "Film box SOP instance hierarchy does not contain image box SOP instances (empty page)");
+
+        /// <summary>PrintManagement Warning: Image size is larger than image box size, the image has been demagnified</summary>
+        public static DicomStatus PrintManagementImageDemagnified = new DicomStatus(
+            "B604",
+            DicomState.Warning,
+            "Image size is larger than image box size, the image has been demagnified");
+
+        /// <summary>PrintManagement Warning: Requested min density or max density outside of printer's operating range</summary>
+        public static DicomStatus PrintManagementMinMaxDensityOutOfRange = new DicomStatus(
+            "B605",
+            DicomState.Warning,
+            "Requested min density or max density outside of printer's operating range");
+
+        /// <summary>PrintManagement Warning: Image size is larger than the image box size, the Image has been cropped to fit</summary>
+        public static DicomStatus PrintManagementImageCropped = new DicomStatus(
+            "B609",
+            DicomState.Warning,
+            "Image size is larger than the image box size, the Image has been cropped to fit");
+
+        /// <summary>PrintManagement Warning: Image size or combined print image size is larger than the image box size, image or combined print image has been decimated to fit</summary>
+        public static DicomStatus PrintManagementImageDecimated = new DicomStatus(
+            "B60A",
+            DicomState.Warning,
+            "Image size or combined print image size is larger than the image box size, image or combined print image has been decimated to fit");
+
+        /// <summary>PrintManagement Failure: Film session SOP instance hierarchy does not contain film box SOP instances</summary>
+        public static DicomStatus PrintManagementFilmSessionEmpty = new DicomStatus(
+            "C600",
+            DicomState.Failure,
+            "Film session SOP instance hierarchy does not contain film box SOP instances");
+
+        /// <summary>PrintManagement Failure: Unable to create Print Job SOP Instance; print queue is full</summary>
+        public static DicomStatus PrintManagementPrintQueueFull = new DicomStatus(
+            "C601",
+            DicomState.Failure,
+            "Unable to create Print Job SOP Instance; print queue is full");
+
+        /// <summary>PrintManagement Failure: Image size is larger than image box size</summary>
+        public static DicomStatus PrintManagementImageLargerThanImageBox = new DicomStatus(
+            "C603",
+            DicomState.Failure,
+            "Image size is larger than image box size");
+
+        /// <summary>PrintManagement Failure: Insufficient memory in printer to store the image</summary>
+        public static DicomStatus PrintManagementInsufficientMemoryInPrinter = new DicomStatus(
+            "C605",
+            DicomState.Failure,
+            "Insufficient memory in printer to store the image");
+
+        /// <summary>PrintManagement Failure: Combined Print Image size is larger than the Image Box size</summary>
+        public static DicomStatus PrintManagementCombinedImageLargerThanImageBox = new DicomStatus(
+            "C613",
+            DicomState.Failure,
+            "Combined Print Image size is larger than the Image Box size");
+
+        /// <summary>PrintManagement Failure: There is an existing film box that has not been printed and N-ACTION at the Film Session level is not supported.</summary>
+        public static DicomStatus PrintManagementExistingFilmBoxNotPrinted = new DicomStatus(
+            "C616",
+            DicomState.Failure,
+            "There is an existing film box that has not been printed and N-ACTION at the Film Session level is not supported.");
+
+        /// <summary>MediaCreationManagement Failure: Refused because an Initiate Media Creation action has already been received for this SOP Instance</summary>
+        public static DicomStatus MediaCreationManagementDuplicateInitiateMediaCreation = new DicomStatus(
+            "A510",
+            DicomState.Failure,
+            "Refused because an Initiate Media Creation action has already been received for this SOP Instance");
+
+        /// <summary>MediaCreationManagement Failure: Media creation request already completed</summary>
+        public static DicomStatus MediaCreationManagementMediaCreationRequestAlreadyCompleted = new DicomStatus(
+            "C201",
+            DicomState.Failure,
+            "Media creation request already completed");
+
+        /// <summary>MediaCreationManagement Failure: Media creation request already in progress and cannot be interrupted</summary>
+        public static DicomStatus MediaCreationManagementMediaCreationRequestAlreadyInProgress = new DicomStatus(
+            "C202",
+            DicomState.Failure,
+            "Media creation request already in progress and cannot be interrupted");
+
+        /// <summary>MediaCreationManagement Failure: Cancellation denied for unspecified reason</summary>
+        public static DicomStatus MediaCreationManagementCancellationDeniedForUnspecifiedReason = new DicomStatus(
+            "C203",
+            DicomState.Failure,
+            "Cancellation denied for unspecified reason");
+
+        #endregion
+
+        #endregion
+    }
 }

--- a/DICOM/Network/DicomTimeout.cs
+++ b/DICOM/Network/DicomTimeout.cs
@@ -1,12 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public enum DicomTimeout {
-		ACSE,
-		DIMSE,
-		Socket
-	}
+namespace Dicom.Network
+{
+    public enum DicomTimeout
+    {
+        ACSE,
+
+        DIMSE,
+
+        Socket
+    }
 }

--- a/DICOM/Network/IDicomCEchoProvider.cs
+++ b/DICOM/Network/IDicomCEchoProvider.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public interface IDicomCEchoProvider {
-		DicomCEchoResponse OnCEchoRequest(DicomCEchoRequest request);
-	}
+namespace Dicom.Network
+{
+    public interface IDicomCEchoProvider
+    {
+        DicomCEchoResponse OnCEchoRequest(DicomCEchoRequest request);
+    }
 }

--- a/DICOM/Network/IDicomCFindProvider.cs
+++ b/DICOM/Network/IDicomCFindProvider.cs
@@ -1,8 +1,12 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 
-namespace Dicom.Network {
-	public interface IDicomCFindProvider {
-		IEnumerable<DicomCFindResponse> OnCFindRequest(DicomCFindRequest request);
-	}
+namespace Dicom.Network
+{
+    public interface IDicomCFindProvider
+    {
+        IEnumerable<DicomCFindResponse> OnCFindRequest(DicomCFindRequest request);
+    }
 }

--- a/DICOM/Network/IDicomCMoveProvider.cs
+++ b/DICOM/Network/IDicomCMoveProvider.cs
@@ -1,8 +1,12 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Collections.Generic;
 
-namespace Dicom.Network {
-	public interface IDicomCMoveProvider {
-		IEnumerable<DicomCMoveResponse> OnCMoveRequest(DicomCMoveRequest request);
-	}
+namespace Dicom.Network
+{
+    public interface IDicomCMoveProvider
+    {
+        IEnumerable<DicomCMoveResponse> OnCMoveRequest(DicomCMoveRequest request);
+    }
 }

--- a/DICOM/Network/IDicomCStoreProvider.cs
+++ b/DICOM/Network/IDicomCStoreProvider.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public interface IDicomCStoreProvider {
+using System;
+
+namespace Dicom.Network
+{
+    public interface IDicomCStoreProvider
+    {
         /// <summary>
         /// Callback for each Sop Instance received.  The default implementation of
         /// DicomService is to write a temporary file that is automatically deleted
@@ -12,15 +14,15 @@ namespace Dicom.Network {
         /// and DicomService.GetCStoreDicomFile() for information about changing this 
         /// behavior (e.g. writing to your own custom stream and avoiding the temporary file)
         /// <returns></returns>
-		DicomCStoreResponse OnCStoreRequest(DicomCStoreRequest request);
-		
+        DicomCStoreResponse OnCStoreRequest(DicomCStoreRequest request);
+
         /// <summary>
-		/// Callback for exceptions raised during the parsing of the received SopInstance.  Note that
+        /// Callback for exceptions raised during the parsing of the received SopInstance.  Note that
         /// it is possible to avoid parsing the file by overriding DicomService.GetCStoreDicomFile() if
         /// desired.
-		/// </summary>
-		/// <param name="tempFileName"></param>
-		/// <param name="e"></param>
+        /// </summary>
+        /// <param name="tempFileName"></param>
+        /// <param name="e"></param>
         void OnCStoreRequestException(string tempFileName, Exception e);
-	}
+    }
 }

--- a/DICOM/Network/IDicomNServiceProvider.cs
+++ b/DICOM/Network/IDicomNServiceProvider.cs
@@ -1,15 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public interface IDicomNServiceProvider {
-		DicomNActionResponse OnNActionRequest(DicomNActionRequest request);
-		DicomNCreateResponse OnNCreateRequest(DicomNCreateRequest request);
-		DicomNDeleteResponse OnNDeleteRequest(DicomNDeleteRequest request);
-		DicomNEventReportResponse OnNEventReportRequest(DicomNEventReportRequest request);
-		DicomNGetResponse OnNGetRequest(DicomNGetRequest request);
-		DicomNSetResponse OnNSetRequest(DicomNSetRequest request);
-	}
+namespace Dicom.Network
+{
+    public interface IDicomNServiceProvider
+    {
+        DicomNActionResponse OnNActionRequest(DicomNActionRequest request);
+
+        DicomNCreateResponse OnNCreateRequest(DicomNCreateRequest request);
+
+        DicomNDeleteResponse OnNDeleteRequest(DicomNDeleteRequest request);
+
+        DicomNEventReportResponse OnNEventReportRequest(DicomNEventReportRequest request);
+
+        DicomNGetResponse OnNGetRequest(DicomNGetRequest request);
+
+        DicomNSetResponse OnNSetRequest(DicomNSetRequest request);
+    }
 }

--- a/DICOM/Network/IDicomServiceProvider.cs
+++ b/DICOM/Network/IDicomServiceProvider.cs
@@ -1,13 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public interface IDicomServiceProvider {
-		void OnReceiveAssociationRequest(DicomAssociation association);
-		void OnReceiveAssociationReleaseRequest();
-		void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
-		void OnConnectionClosed(Exception exception);
-	}
+using System;
+
+namespace Dicom.Network
+{
+    public interface IDicomServiceProvider
+    {
+        void OnReceiveAssociationRequest(DicomAssociation association);
+
+        void OnReceiveAssociationReleaseRequest();
+
+        void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
+
+        void OnConnectionClosed(Exception exception);
+    }
 }

--- a/DICOM/Network/IDicomServiceUser.cs
+++ b/DICOM/Network/IDicomServiceUser.cs
@@ -1,14 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Network {
-	public interface IDicomServiceUser {
-		void OnReceiveAssociationAccept(DicomAssociation association);
-		void OnReceiveAssociationReject(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason);
-		void OnReceiveAssociationReleaseResponse();
-		void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
-		void OnConnectionClosed(Exception exception);
-	}
+using System;
+
+namespace Dicom.Network
+{
+    public interface IDicomServiceUser
+    {
+        void OnReceiveAssociationAccept(DicomAssociation association);
+
+        void OnReceiveAssociationReject(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason);
+
+        void OnReceiveAssociationReleaseResponse();
+
+        void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
+
+        void OnConnectionClosed(Exception exception);
+    }
 }

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -1,1139 +1,1406 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
 using Dicom.IO;
 
-namespace Dicom.Network {
-	#region Raw PDU
-	/// <summary>Encapsulates PDU data for reading or writing</summary>
-	public class RawPDU : IDisposable {
-		#region Private members
-		private byte _type;
-		private MemoryStream _ms;
-		private BinaryReader _br;
-		private BinaryWriter _bw;
-		private Stack<long> _m16;
-		private Stack<long> _m32;
-		#endregion
-
-		#region Public Constructors
-		/// <summary>
-		/// Initializes new PDU for writing
-		/// </summary>
-		/// <param name="type">Type of PDU</param>
-		public RawPDU(byte type) {
-			_type = type;
-			_ms = new MemoryStream();
-			_ms.Seek(0, SeekOrigin.Begin);
-			_bw = EndianBinaryWriter.Create(_ms, Encoding.ASCII, Endian.Big);
-			_m16 = new Stack<long>();
-			_m32 = new Stack<long>();
-		}
-
-		/// <summary>
-		/// Initializes new PDU reader from buffer
-		/// </summary>
-		/// <param name="buffer">Buffer</param>
-		public RawPDU(byte[] buffer) {
-			_ms = new MemoryStream(buffer);
-			_br = EndianBinaryReader.Create(_ms, Endian.Big);
-			_type = _br.ReadByte();
-			_ms.Seek(6, SeekOrigin.Begin);
-		}
-		#endregion
-
-		#region Public Properties
-		/// <summary>PDU type</summary>
-		public byte Type {
-			get { return _type; }
-		}
-
-		/// <summary>PDU length</summary>
-		public uint Length {
-			get { return (uint)_ms.Length; }
-		}
-		#endregion
-
-		#region Public Methods
-		/// <summary>
-		/// Writes PDU to stream
-		/// </summary>
-		/// <param name="s">Output stream</param>
-		public void WritePDU(Stream s) {
-			byte[] buffer = new byte[6];
-
-			unchecked {
-				buffer[0] = _type;
-
-				uint length = (uint)_ms.Length;
-				buffer[2] = (byte)((length & 0xff000000U) >> 24);
-				buffer[3] = (byte)((length & 0x00ff0000U) >> 16);
-				buffer[4] = (byte)((length & 0x0000ff00U) >> 8);
-				buffer[5] = (byte)((length & 0x000000ffU));
-			}
-
-			s.Write(buffer, 0, 6);
-			_ms.WriteTo(s);
-			s.Flush();
-		}
-
-		/// <summary>
-		/// Saves PDU to file
-		/// </summary>
-		/// <param name="file">Filename</param>
-		public void Save(String file) {
-			FileInfo f = new FileInfo(file);
-			DirectoryInfo d = f.Directory;
-
-			if (!d.Exists) {
-				d.Create();
-			}
-			using (FileStream fs = f.OpenWrite()) {
-				WritePDU(fs);
-			}
-		}
-
-		/// <summary>
-		/// Gets string describing this PDU
-		/// </summary>
-		/// <returns>PDU description</returns>
-		public override String ToString() {
-			return String.Format("Pdu[type={0:X2}, length={1}]", Type, Length);
-		}
-
-		/// <summary>
-		/// Reset PDU read stream
-		/// </summary>
-		public void Reset() {
-			_ms.Seek(0, SeekOrigin.Begin);
-		}
-
-		#region Read Methods
-		private void CheckOffset(int bytes, String name) {
-			if ((_ms.Position + bytes) > _ms.Length) {
-				String msg = String.Format("{0} (offset={1}, bytes={2}, field=\"{3}\") Requested offset out of range!", ToString(),
-					_ms.Position, bytes, name);
-				throw new DicomNetworkException(msg);
-			}
-		}
-
-		/// <summary>
-		/// Read byte from PDU
-		/// </summary>
-		/// <param name="name">Name of field</param>
-		/// <returns>Field value</returns>
-		public byte ReadByte(String name) {
-			CheckOffset(1, name);
-			return _br.ReadByte();
-		}
-
-		/// <summary>
-		/// Read bytes from PDU
-		/// </summary>
-		/// <param name="name">Name of field</param>
-		/// <param name="count">Number of bytes to read</param>
-		/// <returns>Field value</returns>
-		public byte[] ReadBytes(String name, int count) {
-			CheckOffset(count, name);
-			return _br.ReadBytes(count);
-		}
-
-		/// <summary>
-		/// Read ushort from PDU
-		/// </summary>
-		/// <param name="name">Name of field</param>
-		/// <returns>Field value</returns>
-		public ushort ReadUInt16(String name) {
-			CheckOffset(2, name);
-			return _br.ReadUInt16();
-		}
-
-		/// <summary>
-		/// Reads uint from PDU
-		/// </summary>
-		/// <param name="name">Name of field</param>
-		/// <returns>Field value</returns>
-		public uint ReadUInt32(String name) {
-			CheckOffset(4, name);
-			return _br.ReadUInt32();
-		}
-
-		private char[] trimChars = { ' ', '\0' };
-
-		/// <summary>
-		/// Reads string from PDU
-		/// </summary>
-		/// <param name="name">Name of field</param>
-		/// <param name="count">Length of string</param>
-		/// <returns>Field value</returns>
-		public String ReadString(String name, int count) {
-			CheckOffset(count, name);
-			char[] c = _br.ReadChars(count);
-			return new String(c).Trim(trimChars);
-		}
-
-		/// <summary>
-		/// Skips ahead in PDU
-		/// </summary>
-		/// <param name="name">Name of field</param>
-		/// <param name="count">Number of bytes to skip</param>
-		public void SkipBytes(String name, int count) {
-			CheckOffset(count, name);
-			_ms.Seek(count, SeekOrigin.Current);
-		}
-		#endregion
-
-		#region Write Methods
-		/// <summary>
-		/// Writes byte to PDU
-		/// </summary>
-		/// <param name="name">Field name</param>
-		/// <param name="value">Field value</param>
-		public void Write(String name, byte value) {
-			_bw.Write(value);
-		}
-
-		/// <summary>
-		/// Writes byte to PDU multiple times
-		/// </summary>
-		/// <param name="name">Field name</param>
-		/// <param name="value">Field value</param>
-		/// <param name="count">Number of times to write PDU value</param>
-		public void Write(String name, byte value, int count) {
-			for (int i = 0; i < count; i++)
-				_bw.Write(value);
-		}
-
-		/// <summary>
-		/// Writes byte[] to PDU
-		/// </summary>
-		/// <param name="name">Field name</param>
-		/// <param name="value">Field value</param>
-		public void Write(String name, byte[] value) {
-			_bw.Write(value);
-		}
-
-		/// <summary>
-		/// Writes ushort to PDU
-		/// </summary>
-		/// <param name="name">Field name</param>
-		/// <param name="value">Field value</param>
-		public void Write(String name, ushort value) {
-			_bw.Write(value);
-		}
-
-		/// <summary>
-		/// Writes uint to PDU
-		/// </summary>
-		/// <param name="name">Field name</param>
-		/// <param name="value">Field value</param>
-		public void Write(String name, uint value) {
-			_bw.Write(value);
-		}
-
-		/// <summary>
-		/// Writes string to PDU
-		/// </summary>
-		/// <param name="name">Field name</param>
-		/// <param name="value">Field value</param>
-		public void Write(String name, String value) {
-			_bw.Write(value.ToCharArray());
-		}
-
-		/// <summary>
-		/// Writes string to PDU
-		/// </summary>
-		/// <param name="name">Field name</param>
-		/// <param name="value">Field value</param>
-		/// <param name="count">Number of characters to write</param>
-		/// <param name="pad">Padding character</param>
-		public void Write(String name, String value, int count, char pad) {
-			_bw.Write(ToCharArray(value, count, pad));
-		}
-
-		/// <summary>
-		/// Marks position to write 16-bit length value
-		/// </summary>
-		/// <param name="name">Field name</param>
-		public void MarkLength16(String name) {
-			_m16.Push(_ms.Position);
-			_bw.Write((ushort)0);
-		}
-
-		/// <summary>
-		/// Writes 16-bit length to top length marker
-		/// </summary>
-		public void WriteLength16() {
-			long p1 = _m16.Pop();
-			long p2 = _ms.Position;
-			_ms.Position = p1;
-			_bw.Write((ushort)(p2 - p1 - 2));
-			_ms.Position = p2;
-		}
-
-		/// <summary>
-		/// Marks position to write 32-bit length value
-		/// </summary>
-		/// <param name="name">Field name</param>
-		public void MarkLength32(String name) {
-			_m32.Push(_ms.Position);
-			_bw.Write((uint)0);
-		}
-
-		/// <summary>
-		/// Writes 32-bit length to top length marker
-		/// </summary>
-		public void WriteLength32() {
-			long p1 = _m32.Pop();
-			long p2 = _ms.Position;
-			_ms.Position = p1;
-			_bw.Write((uint)(p2 - p1 - 4));
-			_ms.Position = p2;
-		}
-
-		private static char[] ToCharArray(String s, int l, char p) {
-			char[] c = new char[l];
-			for (int i = 0; i < l; i++) {
-				if (i < s.Length)
-					c[i] = s[i];
-				else
-					c[i] = p;
-			}
-			return c;
-		}
-		#endregion
-		#endregion
-
-		public void Dispose() {
-			_ms = null;
-			_br = null;
-		}
-	}
-	#endregion
-
-	#region PDU Interface
-	/// <summary>
-	/// Interface for PDU
-	/// </summary>
-	public interface PDU {
-		/// <summary>
-		/// Writes PDU to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		RawPDU Write();
-
-		/// <summary>
-		/// Reads PDU from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		void Read(RawPDU raw);
-	}
-	#endregion
-
-	#region A-Associate-RQ
-	/// <summary>A-ASSOCIATE-RQ</summary>
-	public class AAssociateRQ : PDU {
-		private DicomAssociation _assoc;
-
-		/// <summary>
-		/// Initializes new A-ASSOCIATE-RQ
-		/// </summary>
-		/// <param name="assoc">Association parameters</param>
-		public AAssociateRQ(DicomAssociation assoc) {
-			_assoc = assoc;
-		}
-
-		public override string ToString() {
-			return "A-ASSOCIATE-RQ";
-		}
-
-		#region Write
-		/// <summary>
-		/// Writes A-ASSOCIATE-RQ to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		public RawPDU Write() {
-			RawPDU pdu = new RawPDU((byte)0x01);
-
-			pdu.Write("Version", (ushort)0x0001);
-			pdu.Write("Reserved", 0x00, 2);
-			pdu.Write("Called AE", _assoc.CalledAE, 16, ' ');
-			pdu.Write("Calling AE", _assoc.CallingAE, 16, ' ');
-			pdu.Write("Reserved", 0x00, 32);
-
-			// Application Context
-			pdu.Write("Item-Type", (byte)0x10);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-			pdu.Write("Application Context Name", DicomUID.DICOMApplicationContextName.UID);
-			pdu.WriteLength16();
-
-			foreach (var pc in _assoc.PresentationContexts) {
-				// Presentation Context
-				pdu.Write("Item-Type", (byte)0x20);
-				pdu.Write("Reserved", (byte)0x00);
-				pdu.MarkLength16("Item-Length");
-				pdu.Write("Presentation Context ID", (byte)pc.ID);
-				pdu.Write("Reserved", (byte)0x00, 3);
-
-				// Abstract Syntax
-				pdu.Write("Item-Type", (byte)0x30);
-				pdu.Write("Reserved", (byte)0x00);
-				pdu.MarkLength16("Item-Length");
-				pdu.Write("Abstract Syntax UID", pc.AbstractSyntax.UID);
-				pdu.WriteLength16();
-
-				// Transfer Syntax
-				foreach (DicomTransferSyntax ts in pc.GetTransferSyntaxes()) {
-					pdu.Write("Item-Type", (byte)0x40);
-					pdu.Write("Reserved", (byte)0x00);
-					pdu.MarkLength16("Item-Length");
-					pdu.Write("Transfer Syntax UID", ts.UID.UID);
-					pdu.WriteLength16();
-				}
-
-				pdu.WriteLength16();
-			}
-
-			// User Data Fields
-			pdu.Write("Item-Type", (byte)0x50);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-
-			// Maximum PDU
-			pdu.Write("Item-Type", (byte)0x51);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.Write("Item-Length", (ushort)0x0004);
-			pdu.Write("Max PDU Length", (uint)_assoc.MaximumPDULength);
-
-			// Implementation Class UID
-			pdu.Write("Item-Type", (byte)0x52);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-			pdu.Write("Implementation Class UID", DicomImplementation.ClassUID.UID);
-			pdu.WriteLength16();
-
-			// Asynchronous Operations Negotiation
-			if (_assoc.MaxAsyncOpsInvoked != 1 || _assoc.MaxAsyncOpsPerformed != 1) {
-			    pdu.Write("Item-Type", (byte)0x53);
-			    pdu.Write("Reserved", (byte)0x00);
-			    pdu.Write("Item-Length", (ushort)0x0004);
-			    pdu.Write("Asynchronous Operations Invoked", (ushort)_assoc.MaxAsyncOpsInvoked);
-			    pdu.Write("Asynchronous Operations Performed", (ushort)_assoc.MaxAsyncOpsPerformed);
-			}
-
-			// Implementation Version
-			pdu.Write("Item-Type", (byte)0x55);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-			pdu.Write("Implementation Version", DicomImplementation.Version);
-			pdu.WriteLength16();
-
-			pdu.WriteLength16();
-
-			return pdu;
-		}
-		#endregion
-
-		#region Read
-		/// <summary>
-		/// Reads A-ASSOCIATE-RQ from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public void Read(RawPDU raw) {
-			uint l = raw.Length - 6;
-
-			raw.ReadUInt16("Version");
-			raw.SkipBytes("Reserved", 2);
-			_assoc.CalledAE = raw.ReadString("Called AE", 16);
-			_assoc.CallingAE = raw.ReadString("Calling AE", 16);
-			raw.SkipBytes("Reserved", 32);
-			l -= 2 + 2 + 16 + 16 + 32;
-
-			while (l > 0) {
-				byte type = raw.ReadByte("Item-Type");
-				raw.SkipBytes("Reserved", 1);
-				ushort il = raw.ReadUInt16("Item-Length");
-
-				l -= 4 + (uint)il;
-
-				if (type == 0x10) {
-					// Application Context
-					raw.SkipBytes("Application Context", il);
-				} else
-
-					if (type == 0x20) {
-						// Presentation Context
-						byte id = raw.ReadByte("Presentation Context ID");
-						raw.SkipBytes("Reserved", 3);
-						il -= 4;
-
-						while (il > 0) {
-							byte pt = raw.ReadByte("Presentation Context Item-Type");
-							raw.SkipBytes("Reserved", 1);
-							ushort pl = raw.ReadUInt16("Presentation Context Item-Length");
-							string sx = raw.ReadString("Presentation Context Syntax UID", pl);
-							if (pt == 0x30) {
-								var pc = new DicomPresentationContext(id, DicomUID.Parse(sx));
-								_assoc.PresentationContexts.Add(pc);
-							} else if (pt == 0x40) {
-								var pc = _assoc.PresentationContexts[id];
-								pc.AddTransferSyntax(DicomTransferSyntax.Parse(sx));
-							}
-							il -= (ushort)(4 + pl);
-						}
-					} else
-
-						if (type == 0x50) {
-							// User Information
-							while (il > 0) {
-								byte ut = raw.ReadByte("User Information Item-Type");
-								raw.SkipBytes("Reserved", 1);
-								ushort ul = raw.ReadUInt16("User Information Item-Length");
-								il -= (ushort)(4 + ul);
-								if (ut == 0x51) {
-									_assoc.MaximumPDULength = raw.ReadUInt32("Max PDU Length");
-								} else if (ut == 0x52) {
-									_assoc.RemoteImplemetationClassUID = new DicomUID(raw.ReadString("Implementation Class UID", ul), "Implementation Class UID", DicomUidType.Unknown);
-								} else if (ut == 0x55) {
-									_assoc.RemoteImplementationVersion = raw.ReadString("Implementation Version", ul);
-								} else if (ut == 0x53) {
-									_assoc.MaxAsyncOpsInvoked = raw.ReadUInt16("Asynchronous Operations Invoked");
-									_assoc.MaxAsyncOpsPerformed = raw.ReadUInt16("Asynchronous Operations Performed");
-								} else if (ut == 0x54) {
-									raw.SkipBytes("SCU/SCP Role Selection", ul);
-									/*
-									ushort rsul = raw.ReadUInt16();
-									if ((rsul + 4) != ul) {
-										throw new DicomNetworkException("SCU/SCP role selection length (" + ul + " bytes) does not match uid length (" + rsul + " + 4 bytes)");
-									}
-									raw.ReadChars(rsul);	// Abstract Syntax
-									raw.ReadByte();		// SCU role
-									raw.ReadByte();		// SCP role
-									*/
-								} else {
-									//Debug.Log.Error("Unhandled user item: 0x{0:x2} ({1} + 4 bytes)", ut, ul);
-									raw.SkipBytes("Unhandled User Item", ul);
-								}
-							}
-						}
-			}
-		}
-		#endregion
-	}
-	#endregion
-
-	#region A-Associate-AC
-	/// <summary>A-ASSOCIATE-AC</summary>
-	public class AAssociateAC : PDU {
-		private DicomAssociation _assoc;
-
-		/// <summary>
-		/// Initializes new A-ASSOCIATE-AC
-		/// </summary>
-		/// <param name="assoc">Association parameters</param>
-		public AAssociateAC(DicomAssociation assoc) {
-			_assoc = assoc;
-		}
-
-		public override string ToString() {
-			return "A-ASSOCIATE-AC";
-		}
-
-		#region Write
-		/// <summary>
-		/// Writes A-ASSOCIATE-AC to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		public RawPDU Write() {
-			RawPDU pdu = new RawPDU((byte)0x02);
-
-			pdu.Write("Version", (ushort)0x0001);
-			pdu.Write("Reserved", 0x00, 2);
-			pdu.Write("Called AE", _assoc.CalledAE, 16, ' ');
-			pdu.Write("Calling AE", _assoc.CallingAE, 16, ' ');
-			pdu.Write("Reserved", 0x00, 32);
-
-			// Application Context
-			pdu.Write("Item-Type", (byte)0x10);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-			pdu.Write("Application Context Name", DicomUID.DICOMApplicationContextName.UID);
-			pdu.WriteLength16();
-
-			foreach (var pc in _assoc.PresentationContexts) {
-				// Presentation Context
-				pdu.Write("Item-Type", (byte)0x21);
-				pdu.Write("Reserved", (byte)0x00);
-				pdu.MarkLength16("Item-Length");
-				pdu.Write("Presentation Context ID", (byte)pc.ID);
-				pdu.Write("Reserved", (byte)0x00);
-				pdu.Write("Result", (byte)pc.Result);
-				pdu.Write("Reserved", (byte)0x00);
-
-				// Transfer Syntax
-				pdu.Write("Item-Type", (byte)0x40);
-				pdu.Write("Reserved", (byte)0x00);
-				pdu.MarkLength16("Item-Length");
-				pdu.Write("Transfer Syntax UID", pc.AcceptedTransferSyntax.UID.UID);
-				pdu.WriteLength16();
-
-				pdu.WriteLength16();
-			}
-
-			// User Data Fields
-			pdu.Write("Item-Type", (byte)0x50);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-
-			// Maximum PDU
-			pdu.Write("Item-Type", (byte)0x51);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.Write("Item-Length", (ushort)0x0004);
-			pdu.Write("Max PDU Length", (uint)_assoc.MaximumPDULength);
-
-			// Implementation Class UID
-			pdu.Write("Item-Type", (byte)0x52);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-			pdu.Write("Implementation Class UID", DicomImplementation.ClassUID.UID);
-			pdu.WriteLength16();
-
-			// Asynchronous Operations Negotiation
-			if (_assoc.MaxAsyncOpsInvoked != 1 || _assoc.MaxAsyncOpsPerformed != 1) {
-				pdu.Write("Item-Type", (byte)0x53);
-				pdu.Write("Reserved", (byte)0x00);
-				pdu.Write("Item-Length", (ushort)0x0004);
-				pdu.Write("Asynchronous Operations Invoked", (ushort)_assoc.MaxAsyncOpsInvoked);
-				pdu.Write("Asynchronous Operations Performed", (ushort)_assoc.MaxAsyncOpsPerformed);
-			}
-
-			// Implementation Version
-			pdu.Write("Item-Type", (byte)0x55);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.MarkLength16("Item-Length");
-			pdu.Write("Implementation Version", DicomImplementation.Version);
-			pdu.WriteLength16();
-
-			pdu.WriteLength16();
-
-			return pdu;
-		}
-		#endregion
-
-		#region Read
-		/// <summary>
-		/// Reads A-ASSOCIATE-AC from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public void Read(RawPDU raw) {
-			// reset async ops in case remote end does not negotiate
-			_assoc.MaxAsyncOpsInvoked = 1;
-			_assoc.MaxAsyncOpsPerformed = 1;
-
-			uint l = raw.Length - 6;
-			ushort c = 0;
-
-			raw.ReadUInt16("Version");
-			raw.SkipBytes("Reserved", 2);
-			raw.SkipBytes("Reserved", 16);
-			raw.SkipBytes("Reserved", 16);
-			raw.SkipBytes("Reserved", 32);
-			l -= 68;
-
-			while (l > 0) {
-				byte type = raw.ReadByte("Item-Type");
-				l -= 1;
-
-				if (type == 0x10) {
-					// Application Context
-					raw.SkipBytes("Reserved", 1);
-					c = raw.ReadUInt16("Item-Length");
-					raw.SkipBytes("Value", (int)c);
-					l -= 3 + (uint)c;
-				} else
-
-					if (type == 0x21) {
-						// Presentation Context
-						raw.ReadByte("Reserved");
-						ushort pl = raw.ReadUInt16("Presentation Context Item-Length");
-						byte id = raw.ReadByte("Presentation Context ID");
-						raw.ReadByte("Reserved");
-						byte res = raw.ReadByte("Presentation Context Result/Reason");
-						raw.ReadByte("Reserved");
-						l -= (uint)pl + 3;
-						pl -= 4;
-
-						// Presentation Context Transfer Syntax
-						raw.ReadByte("Presentation Context Item-Type (0x40)");
-						raw.ReadByte("Reserved");
-						ushort tl = raw.ReadUInt16("Presentation Context Item-Length");
-						string tx = raw.ReadString("Presentation Context Syntax UID", tl);
-						pl -= (ushort)(tl + 4);
-
-						_assoc.PresentationContexts[id].SetResult((DicomPresentationContextResult)res, DicomTransferSyntax.Parse(tx));
-					} else if (type == 0x50) {
-						// User Information
-						raw.ReadByte("Reserved");
-						ushort il = raw.ReadUInt16("User Information Item-Length");
-						l -= (uint)(il + 3);
-						while (il > 0) {
-							byte ut = raw.ReadByte("User Item-Type");
-							raw.ReadByte("Reserved");
-							ushort ul = raw.ReadUInt16("User Item-Length");
-							il -= (ushort)(ul + 4);
-							if (ut == 0x51) {
-								_assoc.MaximumPDULength = raw.ReadUInt32("Max PDU Length");
-							} else if (ut == 0x52) {
-								_assoc.RemoteImplemetationClassUID = DicomUID.Parse(raw.ReadString("Implementation Class UID", ul));
-							} else if (ut == 0x53) {
-								_assoc.MaxAsyncOpsInvoked = raw.ReadUInt16("Asynchronous Operations Invoked");
-								_assoc.MaxAsyncOpsPerformed = raw.ReadUInt16("Asynchronous Operations Performed");
-							} else if (ut == 0x55) {
-								_assoc.RemoteImplementationVersion = raw.ReadString("Implementation Version", ul);
-							} else {
-								raw.SkipBytes("User Item Value", (int)ul);
-							}
-						}
-					} else {
-						raw.SkipBytes("Reserved", 1);
-						ushort il = raw.ReadUInt16("User Item-Length");
-						raw.SkipBytes("Unknown User Item", il);
-						l -= (uint)(il + 3);
-					}
-			}
-		}
-		#endregion
-	}
-	#endregion
-
-	#region A-Associate-RJ
-	/// <summary>Rejection result</summary>
-	public enum DicomRejectResult {
-		/// <summary>Permanent rejection</summary>
-		Permanent = 1,
-
-		/// <summary>Transient rejection</summary>
-		Transient = 2
-	}
-
-	/// <summary>Rejection source</summary>
-	public enum DicomRejectSource {
-		/// <summary>Service user</summary>
-		ServiceUser = 1,
-
-		/// <summary>Service provider - ACSE</summary>
-		ServiceProviderACSE = 2,
-
-		/// <summary>Service provider - Presentation</summary>
-		ServiceProviderPresentation = 3
-	}
-
-	/// <summary>Rejection reason</summary>
-	public enum DicomRejectReason {
-		/// <summary>No reason given (Service user)</summary>
-		NoReasonGiven = 1,
-
-		/// <summary>Application context not supported (Service user)</summary>
-		ApplicationContextNotSupported = 2,
-
-		/// <summary>Calling AE not recognized (Service user)</summary>
-		CallingAENotRecognized = 3,
-
-		/// <summary>Called AE not recognized (Service user)</summary>
-		CalledAENotRecognized = 7,
-
-		/// <summary>Protocol version not supported (Service provider - ACSE)</summary>
-		ProtocolVersionNotSupported = 1,
-
-		/// <summary>Temporary congestion (Service provider - Presentation)</summary>
-		TemporaryCongestion = 1,
-
-		/// <summary>Local limit exceeded (Service provider - Presentation)</summary>
-		LocalLimitExceeded = 2
-	}
-
-	/// <summary>A-ASSOCIATE-RJ</summary>
-	public class AAssociateRJ : PDU {
-		private DicomRejectResult _rt = DicomRejectResult.Permanent;
-		private DicomRejectSource _so = DicomRejectSource.ServiceUser;
-		private DicomRejectReason _rn = DicomRejectReason.NoReasonGiven;
-
-		/// <summary>
-		/// Initializes new A-ASSOCIATE-RJ
-		/// </summary>
-		public AAssociateRJ() {
-		}
-
-		/// <summary>
-		/// Initializes new A-ASSOCIATE-RJ
-		/// </summary>
-		/// <param name="rt">Rejection result</param>
-		/// <param name="so">Rejection source</param>
-		/// <param name="rn">Rejection reason</param>
-		public AAssociateRJ(DicomRejectResult rt, DicomRejectSource so, DicomRejectReason rn) {
-			_rt = rt;
-			_so = so;
-			_rn = rn;
-		}
-
-		/// <summary>Rejection result</summary>
-		public DicomRejectResult Result {
-			get { return _rt; }
-		}
-
-		/// <summary>Rejection source</summary>
-		public DicomRejectSource Source {
-			get { return _so; }
-		}
-
-		/// <summary>Rejection reason</summary>
-		public DicomRejectReason Reason {
-			get { return _rn; }
-		}
-
-		public override string ToString() {
-			return "A-ASSOCIATE-RJ";
-		}
-
-		/// <summary>
-		/// Writes A-ASSOCIATE-RJ to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		public RawPDU Write() {
-			RawPDU pdu = new RawPDU((byte)0x03);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.Write("Result", (byte)_rt);
-			pdu.Write("Source", (byte)_so);
-			pdu.Write("Reason", (byte)_rn);
-			return pdu;
-		}
-
-		/// <summary>
-		/// Reads A-ASSOCIATE-RJ from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public void Read(RawPDU raw) {
-			raw.ReadByte("Reserved");
-			_rt = (DicomRejectResult)raw.ReadByte("Result");
-			_so = (DicomRejectSource)raw.ReadByte("Source");
-			_rn = (DicomRejectReason)raw.ReadByte("Reason");
-		}
-	}
-	#endregion
-
-	#region A-Release-RQ
-	/// <summary>A-RELEASE-RQ</summary>
-	public class AReleaseRQ : PDU {
-		public override string ToString() {
-			return "A-RELEASE-RQ";
-		}
-
-		/// <summary>
-		/// Writes A-RELEASE-RQ to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		public RawPDU Write() {
-			RawPDU pdu = new RawPDU((byte)0x05);
-			pdu.Write("Reserved", (uint)0x00000000);
-			return pdu;
-		}
-
-		/// <summary>
-		/// Reads A-RELEASE-RQ from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public void Read(RawPDU raw) {
-			raw.ReadUInt32("Reserved");
-		}
-	}
-	#endregion
-
-	#region A-Release-RP
-	/// <summary>A-RELEASE-RP</summary>
-	public class AReleaseRP : PDU {
-		public override string ToString() {
-			return "A-RELEASE-RP";
-		}
-
-		/// <summary>
-		/// Writes A-RELEASE-RP to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		public RawPDU Write() {
-			RawPDU pdu = new RawPDU((byte)0x06);
-			pdu.Write("Reserved", (uint)0x00000000);
-			return pdu;
-		}
-
-		/// <summary>
-		/// Reads A-RELEASE-RP from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public void Read(RawPDU raw) {
-			raw.ReadUInt32("Reserved");
-		}
-	}
-	#endregion
-
-	#region A-Abort
-	/// <summary>Abort source</summary>
-	public enum DicomAbortSource {
-		/// <summary>Unknown</summary>
-		Unknown = 0,
-
-		/// <summary>Service user</summary>
-		ServiceUser = 1,
-
-		/// <summary>Service provider</summary>
-		ServiceProvider = 2
-	}
-
-	/// <summary>Abort reason</summary>
-	public enum DicomAbortReason {
-		/// <summary>Not specified</summary>
-		NotSpecified = 0,
-
-		/// <summary>Unrecognized PDU type</summary>
-		UnrecognizedPDU = 1,
-
-		/// <summary>Unexpected PDU</summary>
-		UnexpectedPDU = 2,
-
-		/// <summary>Unrecognized PDU parameter</summary>
-		UnrecognizedPDUParameter = 4,
-
-		/// <summary>Unexpected PDU parameter</summary>
-		UnexpectedPDUParameter = 5,
-
-		/// <summary>Invalid PDU parameter</summary>
-		InvalidPDUParameter = 6
-	}
-
-	/// <summary>A-ABORT</summary>
-	public class AAbort : PDU {
-		private DicomAbortSource _s;
-		private DicomAbortReason _r;
-
-		/// <summary>Abort source</summary>
-		public DicomAbortSource Source {
-			get { return _s; }
-		}
-
-		/// <summary>Abort reason</summary>
-		public DicomAbortReason Reason {
-			get { return _r; }
-		}
-
-		/// <summary>
-		/// Initializes new A-ABORT
-		/// </summary>
-		public AAbort() {
-			_s = DicomAbortSource.ServiceUser;
-			_r = DicomAbortReason.NotSpecified;
-		}
-
-		/// <summary>
-		/// Initializes new A-ABORT
-		/// </summary>
-		/// <param name="source">Abort source</param>
-		/// <param name="reason">Abort reason</param>
-		public AAbort(DicomAbortSource source, DicomAbortReason reason) {
-			_s = source; _r = reason;
-		}
-
-		public override string ToString() {
-			return "A-ABORT";
-		}
-
-		#region Write
-		/// <summary>
-		/// Writes A-ABORT to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		public RawPDU Write() {
-			RawPDU pdu = new RawPDU((byte)0x07);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.Write("Reserved", (byte)0x00);
-			pdu.Write("Source", (byte)_s);
-			pdu.Write("Reason", (byte)_r);
-			return pdu;
-		}
-		#endregion
-
-		#region Read
-		/// <summary>
-		/// Reads A-ABORT from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public void Read(RawPDU raw) {
-			raw.ReadByte("Reserved");
-			raw.ReadByte("Reserved");
-			_s = (DicomAbortSource)raw.ReadByte("Source");
-			_r = (DicomAbortReason)raw.ReadByte("Reason");
-		}
-		#endregion
-	}
-	#endregion
-
-	#region P-Data-TF
-	/// <summary>P-DATA-TF</summary>
-	public class PDataTF : PDU {
-		private List<PDV> _pdvs = new List<PDV>();
-
-		/// <summary>
-		/// Initializes new P-DATA-TF
-		/// </summary>
-		public PDataTF() {
-		}
-
-		/// <summary>PDVs in this P-DATA-TF</summary>
-		public List<PDV> PDVs {
-			get { return _pdvs; }
-		}
-
-		/// <summary>Calculates the total length of the PDVs in this P-DATA-TF</summary>
-		/// <returns>Length of PDVs</returns>
-		public uint GetLengthOfPDVs() {
-			uint len = 0;
-			foreach (PDV pdv in _pdvs) {
-				len += pdv.PDVLength;
-			}
-			return len;
-		}
-
-		public override string ToString() {
-			var value = String.Format("P-DATA-TF [Length: {0}]", 6 + GetLengthOfPDVs());
-			foreach (var pdv in PDVs)
-				value += "\n\t" + pdv.ToString();
-			return value;
-		}
-
-		#region Write
-		/// <summary>
-		/// Writes P-DATA-TF to PDU buffer
-		/// </summary>
-		/// <returns>PDU buffer</returns>
-		public RawPDU Write() {
-			RawPDU pdu = new RawPDU((byte)0x04);
-			foreach (PDV pdv in _pdvs) {
-				pdv.Write(pdu);
-			}
-			return pdu;
-		}
-		#endregion
-
-		#region Read
-		/// <summary>
-		/// Reads P-DATA-TF from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public void Read(RawPDU raw) {
-			uint len = raw.Length - 6;
-			uint read = 0;
-			while (read < len) {
-				PDV pdv = new PDV();
-				read += pdv.Read(raw);
-				_pdvs.Add(pdv);
-			}
-		}
-		#endregion
-	}
-	#endregion
-
-	#region PDV
-	/// <summary>PDV</summary>
-	public class PDV {
-		private byte _pcid;
-		private byte[] _value = new byte[0];
-		private bool _command = false;
-		private bool _last = false;
-
-		/// <summary>
-		/// Initializes new PDV
-		/// </summary>
-		/// <param name="pcid">Presentation context ID</param>
-		/// <param name="value">PDV data</param>
-		/// <param name="command">Is command</param>
-		/// <param name="last">Is last fragment of command or data</param>
-		public PDV(byte pcid, byte[] value, bool command, bool last) {
-			_pcid = pcid;
-			_value = value;
-			_command = command;
-			_last = last;
-		}
-
-		/// <summary>
-		/// Initializes new PDV
-		/// </summary>
-		public PDV() {
-		}
-
-		/// <summary>Presentation context ID</summary>
-		public byte PCID {
-			get { return _pcid; }
-			set { _pcid = value; }
-		}
-
-		/// <summary>PDV data</summary>
-		public byte[] Value {
-			get { return _value; }
-			set { _value = value; }
-		}
-
-		/// <summary>PDV is command</summary>
-		public bool IsCommand {
-			get { return _command; }
-			set { _command = value; }
-		}
-
-		/// <summary>PDV is last fragment of command or data</summary>
-		public bool IsLastFragment {
-			get { return _last; }
-			set { _last = value; }
-		}
-
-		/// <summary>Length of this PDV</summary>
-		public uint PDVLength {
-			get { return (uint)_value.Length + 6; }
-		}
-
-		public override string ToString() {
-			return String.Format("PDV [PCID: {0}; Length: {1}; Command: {2}; Last: {3}]", PCID, Value.Length, IsCommand, IsLastFragment);
-		}
-
-		#region Write
-		/// <summary>
-		/// Writes PDV to PDU buffer
-		/// </summary>
-		/// <param name="pdu">PDU buffer</param>
-		public void Write(RawPDU pdu) {
-			byte mch = (byte)((_last ? 2 : 0) + (_command ? 1 : 0));
-			pdu.MarkLength32("PDV-Length");
-			pdu.Write("Presentation Context ID", (byte)_pcid);
-			pdu.Write("Message Control Header", (byte)mch);
-			pdu.Write("PDV Value", _value);
-			pdu.WriteLength32();
-		}
-		#endregion
-
-		#region Read
-		/// <summary>
-		/// Reads PDV from PDU buffer
-		/// </summary>
-		/// <param name="raw">PDU buffer</param>
-		public uint Read(RawPDU raw) {
-			uint len = raw.ReadUInt32("PDV-Length");
-			_pcid = raw.ReadByte("Presentation Context ID");
-			byte mch = raw.ReadByte("Message Control Header");
-			_value = raw.ReadBytes("PDV Value", (int)len - 2);
-			_command = (mch & 0x01) != 0;
-			_last = (mch & 0x02) != 0;
-			return len + 4;
-		}
-		#endregion
-	}
-	#endregion
+namespace Dicom.Network
+{
+
+    #region Raw PDU
+
+    /// <summary>Encapsulates PDU data for reading or writing</summary>
+    public class RawPDU : IDisposable
+    {
+        #region Private members
+
+        private byte _type;
+
+        private MemoryStream _ms;
+
+        private BinaryReader _br;
+
+        private BinaryWriter _bw;
+
+        private Stack<long> _m16;
+
+        private Stack<long> _m32;
+
+        #endregion
+
+        #region Public Constructors
+
+        /// <summary>
+        /// Initializes new PDU for writing
+        /// </summary>
+        /// <param name="type">Type of PDU</param>
+        public RawPDU(byte type)
+        {
+            _type = type;
+            _ms = new MemoryStream();
+            _ms.Seek(0, SeekOrigin.Begin);
+            _bw = EndianBinaryWriter.Create(_ms, Encoding.ASCII, Endian.Big);
+            _m16 = new Stack<long>();
+            _m32 = new Stack<long>();
+        }
+
+        /// <summary>
+        /// Initializes new PDU reader from buffer
+        /// </summary>
+        /// <param name="buffer">Buffer</param>
+        public RawPDU(byte[] buffer)
+        {
+            _ms = new MemoryStream(buffer);
+            _br = EndianBinaryReader.Create(_ms, Endian.Big);
+            _type = _br.ReadByte();
+            _ms.Seek(6, SeekOrigin.Begin);
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>PDU type</summary>
+        public byte Type
+        {
+            get
+            {
+                return _type;
+            }
+        }
+
+        /// <summary>PDU length</summary>
+        public uint Length
+        {
+            get
+            {
+                return (uint)_ms.Length;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Writes PDU to stream
+        /// </summary>
+        /// <param name="s">Output stream</param>
+        public void WritePDU(Stream s)
+        {
+            byte[] buffer = new byte[6];
+
+            unchecked
+            {
+                buffer[0] = _type;
+
+                uint length = (uint)_ms.Length;
+                buffer[2] = (byte)((length & 0xff000000U) >> 24);
+                buffer[3] = (byte)((length & 0x00ff0000U) >> 16);
+                buffer[4] = (byte)((length & 0x0000ff00U) >> 8);
+                buffer[5] = (byte)((length & 0x000000ffU));
+            }
+
+            s.Write(buffer, 0, 6);
+            _ms.WriteTo(s);
+            s.Flush();
+        }
+
+        /// <summary>
+        /// Saves PDU to file
+        /// </summary>
+        /// <param name="file">Filename</param>
+        public void Save(String file)
+        {
+            FileInfo f = new FileInfo(file);
+            DirectoryInfo d = f.Directory;
+
+            if (!d.Exists)
+            {
+                d.Create();
+            }
+            using (FileStream fs = f.OpenWrite())
+            {
+                WritePDU(fs);
+            }
+        }
+
+        /// <summary>
+        /// Gets string describing this PDU
+        /// </summary>
+        /// <returns>PDU description</returns>
+        public override String ToString()
+        {
+            return String.Format("Pdu[type={0:X2}, length={1}]", Type, Length);
+        }
+
+        /// <summary>
+        /// Reset PDU read stream
+        /// </summary>
+        public void Reset()
+        {
+            _ms.Seek(0, SeekOrigin.Begin);
+        }
+
+        #region Read Methods
+
+        private void CheckOffset(int bytes, String name)
+        {
+            if ((_ms.Position + bytes) > _ms.Length)
+            {
+                String msg = String.Format(
+                    "{0} (offset={1}, bytes={2}, field=\"{3}\") Requested offset out of range!",
+                    ToString(),
+                    _ms.Position,
+                    bytes,
+                    name);
+                throw new DicomNetworkException(msg);
+            }
+        }
+
+        /// <summary>
+        /// Read byte from PDU
+        /// </summary>
+        /// <param name="name">Name of field</param>
+        /// <returns>Field value</returns>
+        public byte ReadByte(String name)
+        {
+            CheckOffset(1, name);
+            return _br.ReadByte();
+        }
+
+        /// <summary>
+        /// Read bytes from PDU
+        /// </summary>
+        /// <param name="name">Name of field</param>
+        /// <param name="count">Number of bytes to read</param>
+        /// <returns>Field value</returns>
+        public byte[] ReadBytes(String name, int count)
+        {
+            CheckOffset(count, name);
+            return _br.ReadBytes(count);
+        }
+
+        /// <summary>
+        /// Read ushort from PDU
+        /// </summary>
+        /// <param name="name">Name of field</param>
+        /// <returns>Field value</returns>
+        public ushort ReadUInt16(String name)
+        {
+            CheckOffset(2, name);
+            return _br.ReadUInt16();
+        }
+
+        /// <summary>
+        /// Reads uint from PDU
+        /// </summary>
+        /// <param name="name">Name of field</param>
+        /// <returns>Field value</returns>
+        public uint ReadUInt32(String name)
+        {
+            CheckOffset(4, name);
+            return _br.ReadUInt32();
+        }
+
+        private char[] trimChars = { ' ', '\0' };
+
+        /// <summary>
+        /// Reads string from PDU
+        /// </summary>
+        /// <param name="name">Name of field</param>
+        /// <param name="count">Length of string</param>
+        /// <returns>Field value</returns>
+        public String ReadString(String name, int count)
+        {
+            CheckOffset(count, name);
+            char[] c = _br.ReadChars(count);
+            return new String(c).Trim(trimChars);
+        }
+
+        /// <summary>
+        /// Skips ahead in PDU
+        /// </summary>
+        /// <param name="name">Name of field</param>
+        /// <param name="count">Number of bytes to skip</param>
+        public void SkipBytes(String name, int count)
+        {
+            CheckOffset(count, name);
+            _ms.Seek(count, SeekOrigin.Current);
+        }
+
+        #endregion
+
+        #region Write Methods
+
+        /// <summary>
+        /// Writes byte to PDU
+        /// </summary>
+        /// <param name="name">Field name</param>
+        /// <param name="value">Field value</param>
+        public void Write(String name, byte value)
+        {
+            _bw.Write(value);
+        }
+
+        /// <summary>
+        /// Writes byte to PDU multiple times
+        /// </summary>
+        /// <param name="name">Field name</param>
+        /// <param name="value">Field value</param>
+        /// <param name="count">Number of times to write PDU value</param>
+        public void Write(String name, byte value, int count)
+        {
+            for (int i = 0; i < count; i++) _bw.Write(value);
+        }
+
+        /// <summary>
+        /// Writes byte[] to PDU
+        /// </summary>
+        /// <param name="name">Field name</param>
+        /// <param name="value">Field value</param>
+        public void Write(String name, byte[] value)
+        {
+            _bw.Write(value);
+        }
+
+        /// <summary>
+        /// Writes ushort to PDU
+        /// </summary>
+        /// <param name="name">Field name</param>
+        /// <param name="value">Field value</param>
+        public void Write(String name, ushort value)
+        {
+            _bw.Write(value);
+        }
+
+        /// <summary>
+        /// Writes uint to PDU
+        /// </summary>
+        /// <param name="name">Field name</param>
+        /// <param name="value">Field value</param>
+        public void Write(String name, uint value)
+        {
+            _bw.Write(value);
+        }
+
+        /// <summary>
+        /// Writes string to PDU
+        /// </summary>
+        /// <param name="name">Field name</param>
+        /// <param name="value">Field value</param>
+        public void Write(String name, String value)
+        {
+            _bw.Write(value.ToCharArray());
+        }
+
+        /// <summary>
+        /// Writes string to PDU
+        /// </summary>
+        /// <param name="name">Field name</param>
+        /// <param name="value">Field value</param>
+        /// <param name="count">Number of characters to write</param>
+        /// <param name="pad">Padding character</param>
+        public void Write(String name, String value, int count, char pad)
+        {
+            _bw.Write(ToCharArray(value, count, pad));
+        }
+
+        /// <summary>
+        /// Marks position to write 16-bit length value
+        /// </summary>
+        /// <param name="name">Field name</param>
+        public void MarkLength16(String name)
+        {
+            _m16.Push(_ms.Position);
+            _bw.Write((ushort)0);
+        }
+
+        /// <summary>
+        /// Writes 16-bit length to top length marker
+        /// </summary>
+        public void WriteLength16()
+        {
+            long p1 = _m16.Pop();
+            long p2 = _ms.Position;
+            _ms.Position = p1;
+            _bw.Write((ushort)(p2 - p1 - 2));
+            _ms.Position = p2;
+        }
+
+        /// <summary>
+        /// Marks position to write 32-bit length value
+        /// </summary>
+        /// <param name="name">Field name</param>
+        public void MarkLength32(String name)
+        {
+            _m32.Push(_ms.Position);
+            _bw.Write((uint)0);
+        }
+
+        /// <summary>
+        /// Writes 32-bit length to top length marker
+        /// </summary>
+        public void WriteLength32()
+        {
+            long p1 = _m32.Pop();
+            long p2 = _ms.Position;
+            _ms.Position = p1;
+            _bw.Write((uint)(p2 - p1 - 4));
+            _ms.Position = p2;
+        }
+
+        private static char[] ToCharArray(String s, int l, char p)
+        {
+            char[] c = new char[l];
+            for (int i = 0; i < l; i++)
+            {
+                if (i < s.Length) c[i] = s[i];
+                else c[i] = p;
+            }
+            return c;
+        }
+
+        #endregion
+
+        #endregion
+
+        public void Dispose()
+        {
+            _ms = null;
+            _br = null;
+        }
+    }
+
+    #endregion
+
+    #region PDU Interface
+
+    /// <summary>
+    /// Interface for PDU
+    /// </summary>
+    public interface PDU
+    {
+        /// <summary>
+        /// Writes PDU to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        RawPDU Write();
+
+        /// <summary>
+        /// Reads PDU from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        void Read(RawPDU raw);
+    }
+
+    #endregion
+
+    #region A-Associate-RQ
+
+    /// <summary>A-ASSOCIATE-RQ</summary>
+    public class AAssociateRQ : PDU
+    {
+        private DicomAssociation _assoc;
+
+        /// <summary>
+        /// Initializes new A-ASSOCIATE-RQ
+        /// </summary>
+        /// <param name="assoc">Association parameters</param>
+        public AAssociateRQ(DicomAssociation assoc)
+        {
+            _assoc = assoc;
+        }
+
+        public override string ToString()
+        {
+            return "A-ASSOCIATE-RQ";
+        }
+
+        #region Write
+
+        /// <summary>
+        /// Writes A-ASSOCIATE-RQ to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        public RawPDU Write()
+        {
+            RawPDU pdu = new RawPDU((byte)0x01);
+
+            pdu.Write("Version", (ushort)0x0001);
+            pdu.Write("Reserved", 0x00, 2);
+            pdu.Write("Called AE", _assoc.CalledAE, 16, ' ');
+            pdu.Write("Calling AE", _assoc.CallingAE, 16, ' ');
+            pdu.Write("Reserved", 0x00, 32);
+
+            // Application Context
+            pdu.Write("Item-Type", (byte)0x10);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+            pdu.Write("Application Context Name", DicomUID.DICOMApplicationContextName.UID);
+            pdu.WriteLength16();
+
+            foreach (var pc in _assoc.PresentationContexts)
+            {
+                // Presentation Context
+                pdu.Write("Item-Type", (byte)0x20);
+                pdu.Write("Reserved", (byte)0x00);
+                pdu.MarkLength16("Item-Length");
+                pdu.Write("Presentation Context ID", (byte)pc.ID);
+                pdu.Write("Reserved", (byte)0x00, 3);
+
+                // Abstract Syntax
+                pdu.Write("Item-Type", (byte)0x30);
+                pdu.Write("Reserved", (byte)0x00);
+                pdu.MarkLength16("Item-Length");
+                pdu.Write("Abstract Syntax UID", pc.AbstractSyntax.UID);
+                pdu.WriteLength16();
+
+                // Transfer Syntax
+                foreach (DicomTransferSyntax ts in pc.GetTransferSyntaxes())
+                {
+                    pdu.Write("Item-Type", (byte)0x40);
+                    pdu.Write("Reserved", (byte)0x00);
+                    pdu.MarkLength16("Item-Length");
+                    pdu.Write("Transfer Syntax UID", ts.UID.UID);
+                    pdu.WriteLength16();
+                }
+
+                pdu.WriteLength16();
+            }
+
+            // User Data Fields
+            pdu.Write("Item-Type", (byte)0x50);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+
+            // Maximum PDU
+            pdu.Write("Item-Type", (byte)0x51);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.Write("Item-Length", (ushort)0x0004);
+            pdu.Write("Max PDU Length", (uint)_assoc.MaximumPDULength);
+
+            // Implementation Class UID
+            pdu.Write("Item-Type", (byte)0x52);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+            pdu.Write("Implementation Class UID", DicomImplementation.ClassUID.UID);
+            pdu.WriteLength16();
+
+            // Asynchronous Operations Negotiation
+            if (_assoc.MaxAsyncOpsInvoked != 1 || _assoc.MaxAsyncOpsPerformed != 1)
+            {
+                pdu.Write("Item-Type", (byte)0x53);
+                pdu.Write("Reserved", (byte)0x00);
+                pdu.Write("Item-Length", (ushort)0x0004);
+                pdu.Write("Asynchronous Operations Invoked", (ushort)_assoc.MaxAsyncOpsInvoked);
+                pdu.Write("Asynchronous Operations Performed", (ushort)_assoc.MaxAsyncOpsPerformed);
+            }
+
+            // Implementation Version
+            pdu.Write("Item-Type", (byte)0x55);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+            pdu.Write("Implementation Version", DicomImplementation.Version);
+            pdu.WriteLength16();
+
+            pdu.WriteLength16();
+
+            return pdu;
+        }
+
+        #endregion
+
+        #region Read
+
+        /// <summary>
+        /// Reads A-ASSOCIATE-RQ from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public void Read(RawPDU raw)
+        {
+            uint l = raw.Length - 6;
+
+            raw.ReadUInt16("Version");
+            raw.SkipBytes("Reserved", 2);
+            _assoc.CalledAE = raw.ReadString("Called AE", 16);
+            _assoc.CallingAE = raw.ReadString("Calling AE", 16);
+            raw.SkipBytes("Reserved", 32);
+            l -= 2 + 2 + 16 + 16 + 32;
+
+            while (l > 0)
+            {
+                byte type = raw.ReadByte("Item-Type");
+                raw.SkipBytes("Reserved", 1);
+                ushort il = raw.ReadUInt16("Item-Length");
+
+                l -= 4 + (uint)il;
+
+                if (type == 0x10)
+                {
+                    // Application Context
+                    raw.SkipBytes("Application Context", il);
+                }
+                else if (type == 0x20)
+                {
+                    // Presentation Context
+                    byte id = raw.ReadByte("Presentation Context ID");
+                    raw.SkipBytes("Reserved", 3);
+                    il -= 4;
+
+                    while (il > 0)
+                    {
+                        byte pt = raw.ReadByte("Presentation Context Item-Type");
+                        raw.SkipBytes("Reserved", 1);
+                        ushort pl = raw.ReadUInt16("Presentation Context Item-Length");
+                        string sx = raw.ReadString("Presentation Context Syntax UID", pl);
+                        if (pt == 0x30)
+                        {
+                            var pc = new DicomPresentationContext(id, DicomUID.Parse(sx));
+                            _assoc.PresentationContexts.Add(pc);
+                        }
+                        else if (pt == 0x40)
+                        {
+                            var pc = _assoc.PresentationContexts[id];
+                            pc.AddTransferSyntax(DicomTransferSyntax.Parse(sx));
+                        }
+                        il -= (ushort)(4 + pl);
+                    }
+                }
+                else if (type == 0x50)
+                {
+                    // User Information
+                    while (il > 0)
+                    {
+                        byte ut = raw.ReadByte("User Information Item-Type");
+                        raw.SkipBytes("Reserved", 1);
+                        ushort ul = raw.ReadUInt16("User Information Item-Length");
+                        il -= (ushort)(4 + ul);
+                        if (ut == 0x51)
+                        {
+                            _assoc.MaximumPDULength = raw.ReadUInt32("Max PDU Length");
+                        }
+                        else if (ut == 0x52)
+                        {
+                            _assoc.RemoteImplemetationClassUID =
+                                new DicomUID(
+                                    raw.ReadString("Implementation Class UID", ul),
+                                    "Implementation Class UID",
+                                    DicomUidType.Unknown);
+                        }
+                        else if (ut == 0x55)
+                        {
+                            _assoc.RemoteImplementationVersion = raw.ReadString("Implementation Version", ul);
+                        }
+                        else if (ut == 0x53)
+                        {
+                            _assoc.MaxAsyncOpsInvoked = raw.ReadUInt16("Asynchronous Operations Invoked");
+                            _assoc.MaxAsyncOpsPerformed = raw.ReadUInt16("Asynchronous Operations Performed");
+                        }
+                        else if (ut == 0x54)
+                        {
+                            raw.SkipBytes("SCU/SCP Role Selection", ul);
+                            /*
+                                    ushort rsul = raw.ReadUInt16();
+                                    if ((rsul + 4) != ul) {
+                                        throw new DicomNetworkException("SCU/SCP role selection length (" + ul + " bytes) does not match uid length (" + rsul + " + 4 bytes)");
+                                    }
+                                    raw.ReadChars(rsul);	// Abstract Syntax
+                                    raw.ReadByte();		// SCU role
+                                    raw.ReadByte();		// SCP role
+                                    */
+                        }
+                        else
+                        {
+                            //Debug.Log.Error("Unhandled user item: 0x{0:x2} ({1} + 4 bytes)", ut, ul);
+                            raw.SkipBytes("Unhandled User Item", ul);
+                        }
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region A-Associate-AC
+
+    /// <summary>A-ASSOCIATE-AC</summary>
+    public class AAssociateAC : PDU
+    {
+        private DicomAssociation _assoc;
+
+        /// <summary>
+        /// Initializes new A-ASSOCIATE-AC
+        /// </summary>
+        /// <param name="assoc">Association parameters</param>
+        public AAssociateAC(DicomAssociation assoc)
+        {
+            _assoc = assoc;
+        }
+
+        public override string ToString()
+        {
+            return "A-ASSOCIATE-AC";
+        }
+
+        #region Write
+
+        /// <summary>
+        /// Writes A-ASSOCIATE-AC to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        public RawPDU Write()
+        {
+            RawPDU pdu = new RawPDU((byte)0x02);
+
+            pdu.Write("Version", (ushort)0x0001);
+            pdu.Write("Reserved", 0x00, 2);
+            pdu.Write("Called AE", _assoc.CalledAE, 16, ' ');
+            pdu.Write("Calling AE", _assoc.CallingAE, 16, ' ');
+            pdu.Write("Reserved", 0x00, 32);
+
+            // Application Context
+            pdu.Write("Item-Type", (byte)0x10);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+            pdu.Write("Application Context Name", DicomUID.DICOMApplicationContextName.UID);
+            pdu.WriteLength16();
+
+            foreach (var pc in _assoc.PresentationContexts)
+            {
+                // Presentation Context
+                pdu.Write("Item-Type", (byte)0x21);
+                pdu.Write("Reserved", (byte)0x00);
+                pdu.MarkLength16("Item-Length");
+                pdu.Write("Presentation Context ID", (byte)pc.ID);
+                pdu.Write("Reserved", (byte)0x00);
+                pdu.Write("Result", (byte)pc.Result);
+                pdu.Write("Reserved", (byte)0x00);
+
+                // Transfer Syntax
+                pdu.Write("Item-Type", (byte)0x40);
+                pdu.Write("Reserved", (byte)0x00);
+                pdu.MarkLength16("Item-Length");
+                pdu.Write("Transfer Syntax UID", pc.AcceptedTransferSyntax.UID.UID);
+                pdu.WriteLength16();
+
+                pdu.WriteLength16();
+            }
+
+            // User Data Fields
+            pdu.Write("Item-Type", (byte)0x50);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+
+            // Maximum PDU
+            pdu.Write("Item-Type", (byte)0x51);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.Write("Item-Length", (ushort)0x0004);
+            pdu.Write("Max PDU Length", (uint)_assoc.MaximumPDULength);
+
+            // Implementation Class UID
+            pdu.Write("Item-Type", (byte)0x52);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+            pdu.Write("Implementation Class UID", DicomImplementation.ClassUID.UID);
+            pdu.WriteLength16();
+
+            // Asynchronous Operations Negotiation
+            if (_assoc.MaxAsyncOpsInvoked != 1 || _assoc.MaxAsyncOpsPerformed != 1)
+            {
+                pdu.Write("Item-Type", (byte)0x53);
+                pdu.Write("Reserved", (byte)0x00);
+                pdu.Write("Item-Length", (ushort)0x0004);
+                pdu.Write("Asynchronous Operations Invoked", (ushort)_assoc.MaxAsyncOpsInvoked);
+                pdu.Write("Asynchronous Operations Performed", (ushort)_assoc.MaxAsyncOpsPerformed);
+            }
+
+            // Implementation Version
+            pdu.Write("Item-Type", (byte)0x55);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.MarkLength16("Item-Length");
+            pdu.Write("Implementation Version", DicomImplementation.Version);
+            pdu.WriteLength16();
+
+            pdu.WriteLength16();
+
+            return pdu;
+        }
+
+        #endregion
+
+        #region Read
+
+        /// <summary>
+        /// Reads A-ASSOCIATE-AC from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public void Read(RawPDU raw)
+        {
+            // reset async ops in case remote end does not negotiate
+            _assoc.MaxAsyncOpsInvoked = 1;
+            _assoc.MaxAsyncOpsPerformed = 1;
+
+            uint l = raw.Length - 6;
+            ushort c = 0;
+
+            raw.ReadUInt16("Version");
+            raw.SkipBytes("Reserved", 2);
+            raw.SkipBytes("Reserved", 16);
+            raw.SkipBytes("Reserved", 16);
+            raw.SkipBytes("Reserved", 32);
+            l -= 68;
+
+            while (l > 0)
+            {
+                byte type = raw.ReadByte("Item-Type");
+                l -= 1;
+
+                if (type == 0x10)
+                {
+                    // Application Context
+                    raw.SkipBytes("Reserved", 1);
+                    c = raw.ReadUInt16("Item-Length");
+                    raw.SkipBytes("Value", (int)c);
+                    l -= 3 + (uint)c;
+                }
+                else if (type == 0x21)
+                {
+                    // Presentation Context
+                    raw.ReadByte("Reserved");
+                    ushort pl = raw.ReadUInt16("Presentation Context Item-Length");
+                    byte id = raw.ReadByte("Presentation Context ID");
+                    raw.ReadByte("Reserved");
+                    byte res = raw.ReadByte("Presentation Context Result/Reason");
+                    raw.ReadByte("Reserved");
+                    l -= (uint)pl + 3;
+                    pl -= 4;
+
+                    // Presentation Context Transfer Syntax
+                    raw.ReadByte("Presentation Context Item-Type (0x40)");
+                    raw.ReadByte("Reserved");
+                    ushort tl = raw.ReadUInt16("Presentation Context Item-Length");
+                    string tx = raw.ReadString("Presentation Context Syntax UID", tl);
+                    pl -= (ushort)(tl + 4);
+
+                    _assoc.PresentationContexts[id].SetResult(
+                        (DicomPresentationContextResult)res,
+                        DicomTransferSyntax.Parse(tx));
+                }
+                else if (type == 0x50)
+                {
+                    // User Information
+                    raw.ReadByte("Reserved");
+                    ushort il = raw.ReadUInt16("User Information Item-Length");
+                    l -= (uint)(il + 3);
+                    while (il > 0)
+                    {
+                        byte ut = raw.ReadByte("User Item-Type");
+                        raw.ReadByte("Reserved");
+                        ushort ul = raw.ReadUInt16("User Item-Length");
+                        il -= (ushort)(ul + 4);
+                        if (ut == 0x51)
+                        {
+                            _assoc.MaximumPDULength = raw.ReadUInt32("Max PDU Length");
+                        }
+                        else if (ut == 0x52)
+                        {
+                            _assoc.RemoteImplemetationClassUID =
+                                DicomUID.Parse(raw.ReadString("Implementation Class UID", ul));
+                        }
+                        else if (ut == 0x53)
+                        {
+                            _assoc.MaxAsyncOpsInvoked = raw.ReadUInt16("Asynchronous Operations Invoked");
+                            _assoc.MaxAsyncOpsPerformed = raw.ReadUInt16("Asynchronous Operations Performed");
+                        }
+                        else if (ut == 0x55)
+                        {
+                            _assoc.RemoteImplementationVersion = raw.ReadString("Implementation Version", ul);
+                        }
+                        else
+                        {
+                            raw.SkipBytes("User Item Value", (int)ul);
+                        }
+                    }
+                }
+                else
+                {
+                    raw.SkipBytes("Reserved", 1);
+                    ushort il = raw.ReadUInt16("User Item-Length");
+                    raw.SkipBytes("Unknown User Item", il);
+                    l -= (uint)(il + 3);
+                }
+            }
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region A-Associate-RJ
+
+    /// <summary>Rejection result</summary>
+    public enum DicomRejectResult
+    {
+        /// <summary>Permanent rejection</summary>
+        Permanent = 1,
+
+        /// <summary>Transient rejection</summary>
+        Transient = 2
+    }
+
+    /// <summary>Rejection source</summary>
+    public enum DicomRejectSource
+    {
+        /// <summary>Service user</summary>
+        ServiceUser = 1,
+
+        /// <summary>Service provider - ACSE</summary>
+        ServiceProviderACSE = 2,
+
+        /// <summary>Service provider - Presentation</summary>
+        ServiceProviderPresentation = 3
+    }
+
+    /// <summary>Rejection reason</summary>
+    public enum DicomRejectReason
+    {
+        /// <summary>No reason given (Service user)</summary>
+        NoReasonGiven = 1,
+
+        /// <summary>Application context not supported (Service user)</summary>
+        ApplicationContextNotSupported = 2,
+
+        /// <summary>Calling AE not recognized (Service user)</summary>
+        CallingAENotRecognized = 3,
+
+        /// <summary>Called AE not recognized (Service user)</summary>
+        CalledAENotRecognized = 7,
+
+        /// <summary>Protocol version not supported (Service provider - ACSE)</summary>
+        ProtocolVersionNotSupported = 1,
+
+        /// <summary>Temporary congestion (Service provider - Presentation)</summary>
+        TemporaryCongestion = 1,
+
+        /// <summary>Local limit exceeded (Service provider - Presentation)</summary>
+        LocalLimitExceeded = 2
+    }
+
+    /// <summary>A-ASSOCIATE-RJ</summary>
+    public class AAssociateRJ : PDU
+    {
+        private DicomRejectResult _rt = DicomRejectResult.Permanent;
+
+        private DicomRejectSource _so = DicomRejectSource.ServiceUser;
+
+        private DicomRejectReason _rn = DicomRejectReason.NoReasonGiven;
+
+        /// <summary>
+        /// Initializes new A-ASSOCIATE-RJ
+        /// </summary>
+        public AAssociateRJ()
+        {
+        }
+
+        /// <summary>
+        /// Initializes new A-ASSOCIATE-RJ
+        /// </summary>
+        /// <param name="rt">Rejection result</param>
+        /// <param name="so">Rejection source</param>
+        /// <param name="rn">Rejection reason</param>
+        public AAssociateRJ(DicomRejectResult rt, DicomRejectSource so, DicomRejectReason rn)
+        {
+            _rt = rt;
+            _so = so;
+            _rn = rn;
+        }
+
+        /// <summary>Rejection result</summary>
+        public DicomRejectResult Result
+        {
+            get
+            {
+                return _rt;
+            }
+        }
+
+        /// <summary>Rejection source</summary>
+        public DicomRejectSource Source
+        {
+            get
+            {
+                return _so;
+            }
+        }
+
+        /// <summary>Rejection reason</summary>
+        public DicomRejectReason Reason
+        {
+            get
+            {
+                return _rn;
+            }
+        }
+
+        public override string ToString()
+        {
+            return "A-ASSOCIATE-RJ";
+        }
+
+        /// <summary>
+        /// Writes A-ASSOCIATE-RJ to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        public RawPDU Write()
+        {
+            RawPDU pdu = new RawPDU((byte)0x03);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.Write("Result", (byte)_rt);
+            pdu.Write("Source", (byte)_so);
+            pdu.Write("Reason", (byte)_rn);
+            return pdu;
+        }
+
+        /// <summary>
+        /// Reads A-ASSOCIATE-RJ from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public void Read(RawPDU raw)
+        {
+            raw.ReadByte("Reserved");
+            _rt = (DicomRejectResult)raw.ReadByte("Result");
+            _so = (DicomRejectSource)raw.ReadByte("Source");
+            _rn = (DicomRejectReason)raw.ReadByte("Reason");
+        }
+    }
+
+    #endregion
+
+    #region A-Release-RQ
+
+    /// <summary>A-RELEASE-RQ</summary>
+    public class AReleaseRQ : PDU
+    {
+        public override string ToString()
+        {
+            return "A-RELEASE-RQ";
+        }
+
+        /// <summary>
+        /// Writes A-RELEASE-RQ to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        public RawPDU Write()
+        {
+            RawPDU pdu = new RawPDU((byte)0x05);
+            pdu.Write("Reserved", (uint)0x00000000);
+            return pdu;
+        }
+
+        /// <summary>
+        /// Reads A-RELEASE-RQ from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public void Read(RawPDU raw)
+        {
+            raw.ReadUInt32("Reserved");
+        }
+    }
+
+    #endregion
+
+    #region A-Release-RP
+
+    /// <summary>A-RELEASE-RP</summary>
+    public class AReleaseRP : PDU
+    {
+        public override string ToString()
+        {
+            return "A-RELEASE-RP";
+        }
+
+        /// <summary>
+        /// Writes A-RELEASE-RP to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        public RawPDU Write()
+        {
+            RawPDU pdu = new RawPDU((byte)0x06);
+            pdu.Write("Reserved", (uint)0x00000000);
+            return pdu;
+        }
+
+        /// <summary>
+        /// Reads A-RELEASE-RP from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public void Read(RawPDU raw)
+        {
+            raw.ReadUInt32("Reserved");
+        }
+    }
+
+    #endregion
+
+    #region A-Abort
+
+    /// <summary>Abort source</summary>
+    public enum DicomAbortSource
+    {
+        /// <summary>Unknown</summary>
+        Unknown = 0,
+
+        /// <summary>Service user</summary>
+        ServiceUser = 1,
+
+        /// <summary>Service provider</summary>
+        ServiceProvider = 2
+    }
+
+    /// <summary>Abort reason</summary>
+    public enum DicomAbortReason
+    {
+        /// <summary>Not specified</summary>
+        NotSpecified = 0,
+
+        /// <summary>Unrecognized PDU type</summary>
+        UnrecognizedPDU = 1,
+
+        /// <summary>Unexpected PDU</summary>
+        UnexpectedPDU = 2,
+
+        /// <summary>Unrecognized PDU parameter</summary>
+        UnrecognizedPDUParameter = 4,
+
+        /// <summary>Unexpected PDU parameter</summary>
+        UnexpectedPDUParameter = 5,
+
+        /// <summary>Invalid PDU parameter</summary>
+        InvalidPDUParameter = 6
+    }
+
+    /// <summary>A-ABORT</summary>
+    public class AAbort : PDU
+    {
+        private DicomAbortSource _s;
+
+        private DicomAbortReason _r;
+
+        /// <summary>Abort source</summary>
+        public DicomAbortSource Source
+        {
+            get
+            {
+                return _s;
+            }
+        }
+
+        /// <summary>Abort reason</summary>
+        public DicomAbortReason Reason
+        {
+            get
+            {
+                return _r;
+            }
+        }
+
+        /// <summary>
+        /// Initializes new A-ABORT
+        /// </summary>
+        public AAbort()
+        {
+            _s = DicomAbortSource.ServiceUser;
+            _r = DicomAbortReason.NotSpecified;
+        }
+
+        /// <summary>
+        /// Initializes new A-ABORT
+        /// </summary>
+        /// <param name="source">Abort source</param>
+        /// <param name="reason">Abort reason</param>
+        public AAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+            _s = source;
+            _r = reason;
+        }
+
+        public override string ToString()
+        {
+            return "A-ABORT";
+        }
+
+        #region Write
+
+        /// <summary>
+        /// Writes A-ABORT to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        public RawPDU Write()
+        {
+            RawPDU pdu = new RawPDU((byte)0x07);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.Write("Reserved", (byte)0x00);
+            pdu.Write("Source", (byte)_s);
+            pdu.Write("Reason", (byte)_r);
+            return pdu;
+        }
+
+        #endregion
+
+        #region Read
+
+        /// <summary>
+        /// Reads A-ABORT from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public void Read(RawPDU raw)
+        {
+            raw.ReadByte("Reserved");
+            raw.ReadByte("Reserved");
+            _s = (DicomAbortSource)raw.ReadByte("Source");
+            _r = (DicomAbortReason)raw.ReadByte("Reason");
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region P-Data-TF
+
+    /// <summary>P-DATA-TF</summary>
+    public class PDataTF : PDU
+    {
+        private List<PDV> _pdvs = new List<PDV>();
+
+        /// <summary>
+        /// Initializes new P-DATA-TF
+        /// </summary>
+        public PDataTF()
+        {
+        }
+
+        /// <summary>PDVs in this P-DATA-TF</summary>
+        public List<PDV> PDVs
+        {
+            get
+            {
+                return _pdvs;
+            }
+        }
+
+        /// <summary>Calculates the total length of the PDVs in this P-DATA-TF</summary>
+        /// <returns>Length of PDVs</returns>
+        public uint GetLengthOfPDVs()
+        {
+            uint len = 0;
+            foreach (PDV pdv in _pdvs)
+            {
+                len += pdv.PDVLength;
+            }
+            return len;
+        }
+
+        public override string ToString()
+        {
+            var value = String.Format("P-DATA-TF [Length: {0}]", 6 + GetLengthOfPDVs());
+            foreach (var pdv in PDVs) value += "\n\t" + pdv.ToString();
+            return value;
+        }
+
+        #region Write
+
+        /// <summary>
+        /// Writes P-DATA-TF to PDU buffer
+        /// </summary>
+        /// <returns>PDU buffer</returns>
+        public RawPDU Write()
+        {
+            RawPDU pdu = new RawPDU((byte)0x04);
+            foreach (PDV pdv in _pdvs)
+            {
+                pdv.Write(pdu);
+            }
+            return pdu;
+        }
+
+        #endregion
+
+        #region Read
+
+        /// <summary>
+        /// Reads P-DATA-TF from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public void Read(RawPDU raw)
+        {
+            uint len = raw.Length - 6;
+            uint read = 0;
+            while (read < len)
+            {
+                PDV pdv = new PDV();
+                read += pdv.Read(raw);
+                _pdvs.Add(pdv);
+            }
+        }
+
+        #endregion
+    }
+
+    #endregion
+
+    #region PDV
+
+    /// <summary>PDV</summary>
+    public class PDV
+    {
+        private byte _pcid;
+
+        private byte[] _value = new byte[0];
+
+        private bool _command = false;
+
+        private bool _last = false;
+
+        /// <summary>
+        /// Initializes new PDV
+        /// </summary>
+        /// <param name="pcid">Presentation context ID</param>
+        /// <param name="value">PDV data</param>
+        /// <param name="command">Is command</param>
+        /// <param name="last">Is last fragment of command or data</param>
+        public PDV(byte pcid, byte[] value, bool command, bool last)
+        {
+            _pcid = pcid;
+            _value = value;
+            _command = command;
+            _last = last;
+        }
+
+        /// <summary>
+        /// Initializes new PDV
+        /// </summary>
+        public PDV()
+        {
+        }
+
+        /// <summary>Presentation context ID</summary>
+        public byte PCID
+        {
+            get
+            {
+                return _pcid;
+            }
+            set
+            {
+                _pcid = value;
+            }
+        }
+
+        /// <summary>PDV data</summary>
+        public byte[] Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value;
+            }
+        }
+
+        /// <summary>PDV is command</summary>
+        public bool IsCommand
+        {
+            get
+            {
+                return _command;
+            }
+            set
+            {
+                _command = value;
+            }
+        }
+
+        /// <summary>PDV is last fragment of command or data</summary>
+        public bool IsLastFragment
+        {
+            get
+            {
+                return _last;
+            }
+            set
+            {
+                _last = value;
+            }
+        }
+
+        /// <summary>Length of this PDV</summary>
+        public uint PDVLength
+        {
+            get
+            {
+                return (uint)_value.Length + 6;
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format(
+                "PDV [PCID: {0}; Length: {1}; Command: {2}; Last: {3}]",
+                PCID,
+                Value.Length,
+                IsCommand,
+                IsLastFragment);
+        }
+
+        #region Write
+
+        /// <summary>
+        /// Writes PDV to PDU buffer
+        /// </summary>
+        /// <param name="pdu">PDU buffer</param>
+        public void Write(RawPDU pdu)
+        {
+            byte mch = (byte)((_last ? 2 : 0) + (_command ? 1 : 0));
+            pdu.MarkLength32("PDV-Length");
+            pdu.Write("Presentation Context ID", (byte)_pcid);
+            pdu.Write("Message Control Header", (byte)mch);
+            pdu.Write("PDV Value", _value);
+            pdu.WriteLength32();
+        }
+
+        #endregion
+
+        #region Read
+
+        /// <summary>
+        /// Reads PDV from PDU buffer
+        /// </summary>
+        /// <param name="raw">PDU buffer</param>
+        public uint Read(RawPDU raw)
+        {
+            uint len = raw.ReadUInt32("PDV-Length");
+            _pcid = raw.ReadByte("Presentation Context ID");
+            byte mch = raw.ReadByte("Message Control Header");
+            _value = raw.ReadBytes("PDV Value", (int)len - 2);
+            _command = (mch & 0x01) != 0;
+            _last = (mch & 0x02) != 0;
+            return len + 4;
+        }
+
+        #endregion
+    }
+
+    #endregion
 }

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Drawing;
 using Dicom.Log;
 
@@ -16,10 +18,15 @@ namespace Dicom.Printing
         #region Properites and Attributes
 
         private readonly FilmSession _filmSession = null;
+
         public FilmSession FilmSession
         {
-            get { return _filmSession; }
+            get
+            {
+                return _filmSession;
+            }
         }
+
         /// <summary>
         /// Basic film box SOP class UID
         /// </summary>
@@ -90,8 +97,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string ImageDisplayFormat
         {
-            get { return this.Get<string>(DicomTag.ImageDisplayFormat); }
-            set { this.Add(DicomTag.ImageDisplayFormat, value); }
+            get
+            {
+                return this.Get<string>(DicomTag.ImageDisplayFormat);
+            }
+            set
+            {
+                this.Add(DicomTag.ImageDisplayFormat, value);
+            }
         }
 
         /// <summary>
@@ -112,8 +125,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string FilmOrienation
         {
-            get { return this.Get<string>(DicomTag.FilmOrientation, "PORTRAIT"); }
-            set { this.Add(DicomTag.FilmOrientation, value); }
+            get
+            {
+                return this.Get<string>(DicomTag.FilmOrientation, "PORTRAIT");
+            }
+            set
+            {
+                this.Add(DicomTag.FilmOrientation, value);
+            }
         }
 
         /// <summary>
@@ -143,8 +162,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string FilmSizeID
         {
-            get { return this.Get<string>(DicomTag.FilmSizeID, "A4"); }
-            set { this.Add(DicomTag.FilmSizeID, value); }
+            get
+            {
+                return this.Get<string>(DicomTag.FilmSizeID, "A4");
+            }
+            set
+            {
+                this.Add(DicomTag.FilmSizeID, value);
+            }
         }
 
         /// <summary>
@@ -162,8 +187,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string MagnificationType
         {
-            get { return this.Get<string>(DicomTag.MagnificationType, "BILINEAR"); }
-            set { this.Add(DicomTag.MagnificationType, value); }
+            get
+            {
+                return this.Get<string>(DicomTag.MagnificationType, "BILINEAR");
+            }
+            set
+            {
+                this.Add(DicomTag.MagnificationType, value);
+            }
         }
 
         /// <summary>
@@ -172,8 +203,14 @@ namespace Dicom.Printing
         /// </summary>
         public ushort MaxDensity
         {
-            get { return this.Get<ushort>(DicomTag.MaxDensity, 0); }
-            set { this.Add(DicomTag.MaxDensity, value); }
+            get
+            {
+                return this.Get<ushort>(DicomTag.MaxDensity, 0);
+            }
+            set
+            {
+                this.Add(DicomTag.MaxDensity, value);
+            }
         }
 
 
@@ -183,8 +220,14 @@ namespace Dicom.Printing
         /// </summary>
         public ushort MinDensity
         {
-            get { return this.Get<ushort>(DicomTag.MinDensity, 0); }
-            set { this.Add(DicomTag.MinDensity, value); }
+            get
+            {
+                return this.Get<ushort>(DicomTag.MinDensity, 0);
+            }
+            set
+            {
+                this.Add(DicomTag.MinDensity, value);
+            }
         }
 
         /// <summary>
@@ -208,8 +251,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string ConfigurationInformation
         {
-            get { return this.Get(DicomTag.ConfigurationInformation, string.Empty); }
-            set { this.Add(DicomTag.ConfigurationInformation, value); }
+            get
+            {
+                return this.Get(DicomTag.ConfigurationInformation, string.Empty);
+            }
+            set
+            {
+                this.Add(DicomTag.ConfigurationInformation, value);
+            }
         }
 
         /// <summary>
@@ -219,8 +268,14 @@ namespace Dicom.Printing
         /// </summary>
         public string AnnotationDisplayFormatID
         {
-            get { return this.Get(DicomTag.AnnotationDisplayFormatID, string.Empty); }
-            set { this.Add(DicomTag.AnnotationDisplayFormatID, value); }
+            get
+            {
+                return this.Get(DicomTag.AnnotationDisplayFormatID, string.Empty);
+            }
+            set
+            {
+                this.Add(DicomTag.AnnotationDisplayFormatID, value);
+            }
         }
 
         /// <summary>
@@ -229,8 +284,14 @@ namespace Dicom.Printing
         /// </summary>
         public string SmoothingType
         {
-            get { return this.Get(DicomTag.SmoothingType, string.Empty); }
-            set { this.Add(DicomTag.SmoothingType, value); }
+            get
+            {
+                return this.Get(DicomTag.SmoothingType, string.Empty);
+            }
+            set
+            {
+                this.Add(DicomTag.SmoothingType, value);
+            }
         }
 
         /// <summary>
@@ -250,8 +311,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string BorderDensity
         {
-            get { return this.Get(DicomTag.BorderDensity, "BLACK"); }
-            set { this.Add(DicomTag.BorderDensity, value); }
+            get
+            {
+                return this.Get(DicomTag.BorderDensity, "BLACK");
+            }
+            set
+            {
+                this.Add(DicomTag.BorderDensity, value);
+            }
         }
 
 
@@ -271,8 +338,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string EmptyImageDensity
         {
-            get { return this.Get(DicomTag.EmptyImageDensity, "BLACK"); }
-            set { this.Add(DicomTag.EmptyImageDensity, value); }
+            get
+            {
+                return this.Get(DicomTag.EmptyImageDensity, "BLACK");
+            }
+            set
+            {
+                this.Add(DicomTag.EmptyImageDensity, value);
+            }
         }
 
         /// <summary>
@@ -287,8 +360,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string Trim
         {
-            get { return this.Get(DicomTag.Trim, "NO"); }
-            set { this.Add(DicomTag.Trim, value); }
+            get
+            {
+                return this.Get(DicomTag.Trim, "NO");
+            }
+            set
+            {
+                this.Add(DicomTag.Trim, value);
+            }
         }
 
         /// <summary>
@@ -298,8 +377,14 @@ namespace Dicom.Printing
         /// </summary>
         public ushort Illumination
         {
-            get { return this.Get<ushort>(DicomTag.Illumination, 0); }
-            set { this.Add(DicomTag.Illumination, value); }
+            get
+            {
+                return this.Get<ushort>(DicomTag.Illumination, 0);
+            }
+            set
+            {
+                this.Add(DicomTag.Illumination, value);
+            }
         }
 
         /// <summary>
@@ -308,8 +393,14 @@ namespace Dicom.Printing
         /// </summary>
         public ushort ReflectedAmbientLight
         {
-            get { return this.Get<ushort>(DicomTag.ReflectedAmbientLight, 0); }
-            set { this.Add(DicomTag.ReflectedAmbientLight, value); }
+            get
+            {
+                return this.Get<ushort>(DicomTag.ReflectedAmbientLight, 0);
+            }
+            set
+            {
+                this.Add(DicomTag.ReflectedAmbientLight, value);
+            }
         }
 
         /// <summary>
@@ -330,8 +421,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string RequestedResolutionID
         {
-            get { return this.Get(DicomTag.RequestedResolutionID, "STANDARD"); }
-            set { this.Add(DicomTag.RequestedResolutionID, value); }
+            get
+            {
+                return this.Get(DicomTag.RequestedResolutionID, "STANDARD");
+            }
+            set
+            {
+                this.Add(DicomTag.RequestedResolutionID, value);
+            }
         }
 
         public DicomSequence ReferencedPresentationLutSequence
@@ -352,7 +449,8 @@ namespace Dicom.Printing
             {
                 if (ReferencedPresentationLutSequence != null && ReferencedPresentationLutSequence.Items.Count > 0)
                 {
-                    var sopInstanceUid = ReferencedPresentationLutSequence.Items[0].Get<DicomUID>(DicomTag.ReferencedSOPInstanceUID);
+                    var sopInstanceUid =
+                        ReferencedPresentationLutSequence.Items[0].Get<DicomUID>(DicomTag.ReferencedSOPInstanceUID);
                     return _filmSession.FindPresentationLut(sopInstanceUid);
                 }
                 else
@@ -361,9 +459,11 @@ namespace Dicom.Printing
                 }
             }
         }
+
         #endregion
 
         #region Constructors and Initialization
+
         /// <summary>
         /// Create baisc film box for specified film session
         /// </summary>
@@ -542,7 +642,10 @@ namespace Dicom.Printing
                 classUid = DicomUID.BasicColorImageBoxSOPClass;
             }
 
-            DicomUID sopInstance = new DicomUID(string.Format("{0}.{1}", SOPInstanceUID.UID, BasicImageBoxes.Count + 1), SOPInstanceUID.Name, SOPInstanceUID.Type);
+            DicomUID sopInstance = new DicomUID(
+                string.Format("{0}.{1}", SOPInstanceUID.UID, BasicImageBoxes.Count + 1),
+                SOPInstanceUID.Name,
+                SOPInstanceUID.Type);
 
             var imageBox = new ImageBox(this, classUid, sopInstance);
             imageBox.ImageBoxPosition = (ushort)(BasicImageBoxes.Count + 1);
@@ -550,8 +653,8 @@ namespace Dicom.Printing
             BasicImageBoxes.Add(imageBox);
 
             var item = new DicomDataset();
-            item.Add(DicomTag.ReferencedSOPClassUID,classUid);
-            item.Add(DicomTag.ReferencedSOPInstanceUID,sopInstance);
+            item.Add(DicomTag.ReferencedSOPClassUID, classUid);
+            item.Add(DicomTag.ReferencedSOPInstanceUID, sopInstance);
 
             var seq = Get<DicomSequence>(DicomTag.ReferencedImageBoxSequence);
             seq.Items.Add(item);
@@ -561,6 +664,7 @@ namespace Dicom.Printing
         {
             return BasicImageBoxes.FirstOrDefault(i => i.SOPClassUID == ImageBox.ColorSOPClassUID) != null;
         }
+
         #endregion
 
         #region Printing Methods
@@ -620,7 +724,8 @@ namespace Dicom.Printing
                 }
                 else
                 {
-                    throw new ArgumentException(string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
+                    throw new ArgumentException(
+                        string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
                         "ImageDisplayFormat");
                 }
 
@@ -649,20 +754,22 @@ namespace Dicom.Printing
 
                     for (int r = 0; r < rowsCount; r++)
                     {
-                        boxes.Add(new RectangleF
-                        {
-                            X = marginBounds.X + c * boxSize.Width,
-                            Y = marginBounds.Y + r * boxSize.Height,
-                            Width = boxSize.Width,
-                            Height = boxSize.Height
-                        });
+                        boxes.Add(
+                            new RectangleF
+                                {
+                                    X = marginBounds.X + c * boxSize.Width,
+                                    Y = marginBounds.Y + r * boxSize.Height,
+                                    Width = boxSize.Width,
+                                    Height = boxSize.Height
+                                });
                     }
                 }
                 return boxes.ToArray();
             }
             else
             {
-                throw new ArgumentException(string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
+                throw new ArgumentException(
+                    string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
                     "ImageDisplayFormat");
             }
         }
@@ -685,20 +792,22 @@ namespace Dicom.Printing
 
                     for (int c = 0; c < colsCount; c++)
                     {
-                        boxes.Add(new RectangleF
-                        {
-                            X = marginBounds.X + c * boxSize.Width,
-                            Y = marginBounds.Y + r * boxSize.Height,
-                            Width = boxSize.Width,
-                            Height = boxSize.Height
-                        });
+                        boxes.Add(
+                            new RectangleF
+                                {
+                                    X = marginBounds.X + c * boxSize.Width,
+                                    Y = marginBounds.Y + r * boxSize.Height,
+                                    Width = boxSize.Width,
+                                    Height = boxSize.Height
+                                });
                     }
                 }
                 return boxes.ToArray();
             }
             else
             {
-                throw new ArgumentException(string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
+                throw new ArgumentException(
+                    string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
                     "ImageDisplayFormat");
             }
         }
@@ -719,13 +828,14 @@ namespace Dicom.Printing
                     for (int c = 0; c < columns; c++)
                     {
 
-                        boxes.Add(new RectangleF
-                        {
-                            X = marginBounds.X + c * boxSize.Width,
-                            Y = marginBounds.Y + r * boxSize.Height,
-                            Width = boxSize.Width,
-                            Height = boxSize.Height
-                        });
+                        boxes.Add(
+                            new RectangleF
+                                {
+                                    X = marginBounds.X + c * boxSize.Width,
+                                    Y = marginBounds.Y + r * boxSize.Height,
+                                    Width = boxSize.Width,
+                                    Height = boxSize.Height
+                                });
                     }
                 }
 
@@ -733,7 +843,8 @@ namespace Dicom.Printing
             }
             else
             {
-                throw new ArgumentException(string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
+                throw new ArgumentException(
+                    string.Format("ImageDisplayFormat {0} invalid", this.ImageDisplayFormat),
                     "ImageDisplayFormat");
             }
         }
@@ -761,12 +872,13 @@ namespace Dicom.Printing
                 imageBox.Save(string.Format(@"{0}\I{1:000000}", imageBoxFolderInfo.FullName, i + 1));
             }
         }
+
         public static FilmBox Load(FilmSession filmSession, string filmBoxFolder)
         {
             var filmBoxFile = string.Format(@"{0}\FilmBox.dcm", filmBoxFolder);
 
             var file = DicomFile.Open(filmBoxFile);
-            
+
 
             var filmBox = new FilmBox(filmSession, file.FileMetaInfo.MediaStorageSOPInstanceUID, file.Dataset);
 

--- a/DICOM/Printing/FilmSession.cs
+++ b/DICOM/Printing/FilmSession.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Dicom.Log;
 
 namespace Dicom.Printing
 {
@@ -48,14 +50,26 @@ namespace Dicom.Printing
         /// </remarks>
         public string FilmDestination
         {
-            get { return this.Get(DicomTag.FilmDestination, string.Empty); }
-            set { this.Add(DicomTag.FilmDestination, value); }
+            get
+            {
+                return this.Get(DicomTag.FilmDestination, string.Empty);
+            }
+            set
+            {
+                this.Add(DicomTag.FilmDestination, value);
+            }
         }
 
         public string FilmSessionLabel
         {
-            get { return this.Get(DicomTag.FilmSessionLabel, string.Empty); }
-            set { this.Add(DicomTag.FilmSessionLabel, value); }
+            get
+            {
+                return this.Get(DicomTag.FilmSessionLabel, string.Empty);
+            }
+            set
+            {
+                this.Add(DicomTag.FilmSessionLabel, value);
+            }
         }
 
         /// <summary>
@@ -63,8 +77,14 @@ namespace Dicom.Printing
         /// </summary>
         public int MemoryAllocation
         {
-            get { return this.Get(DicomTag.MemoryAllocation, 0); }
-            set { this.Add(DicomTag.MemoryAllocation, value); }
+            get
+            {
+                return this.Get(DicomTag.MemoryAllocation, 0);
+            }
+            set
+            {
+                this.Add(DicomTag.MemoryAllocation, value);
+            }
         }
 
         /// <summary>
@@ -82,8 +102,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string MediumType
         {
-            get { return this.Get(DicomTag.MediumType, string.Empty); }
-            set { this.Add(DicomTag.MediumType, value); }
+            get
+            {
+                return this.Get(DicomTag.MediumType, string.Empty);
+            }
+            set
+            {
+                this.Add(DicomTag.MediumType, value);
+            }
         }
 
         /// <summary>
@@ -99,8 +125,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string PrintPriority
         {
-            get { return this.Get(DicomTag.PrintPriority, string.Empty); }
-            set { this.Add(DicomTag.PrintPriority, value); }
+            get
+            {
+                return this.Get(DicomTag.PrintPriority, string.Empty);
+            }
+            set
+            {
+                this.Add(DicomTag.PrintPriority, value);
+            }
         }
 
         /// <summary>
@@ -108,8 +140,14 @@ namespace Dicom.Printing
         /// </summary>
         public int NumberOfCopies
         {
-            get { return this.Get(DicomTag.NumberOfCopies, 1); }
-            set { this.Add(DicomTag.NumberOfCopies, value); }
+            get
+            {
+                return this.Get(DicomTag.NumberOfCopies, 1);
+            }
+            set
+            {
+                this.Add(DicomTag.NumberOfCopies, value);
+            }
         }
 
         /// <summary>
@@ -121,9 +159,11 @@ namespace Dicom.Printing
         public IList<PresentationLut> PresentationLuts { get; private set; }
 
         public bool IsColor { get; set; }
+
         #endregion
 
         #region Constructors
+
         /// <summary>
         /// Construct new film session from scratch
         /// </summary>
@@ -254,7 +294,10 @@ namespace Dicom.Printing
             DicomUID uid = sopInstance;
             if (uid == null || uid.UID == string.Empty)
             {
-                uid = new DicomUID(string.Format("{0}.{1}", SOPInstanceUID.UID, BasicFilmBoxes.Count + 1), SOPInstanceUID.Name, SOPInstanceUID.Type);
+                uid = new DicomUID(
+                    string.Format("{0}.{1}", SOPInstanceUID.UID, BasicFilmBoxes.Count + 1),
+                    SOPInstanceUID.Name,
+                    SOPInstanceUID.Type);
             }
 
             var presentationLut = new PresentationLut(uid, dataset);
@@ -296,7 +339,10 @@ namespace Dicom.Printing
         {
             var file = DicomFile.Open(filmSessionFile);
 
-            var filmSession = new FilmSession(file.FileMetaInfo.MediaStorageSOPClassUID, file.FileMetaInfo.MediaStorageSOPInstanceUID, file.Dataset);
+            var filmSession = new FilmSession(
+                file.FileMetaInfo.MediaStorageSOPClassUID,
+                file.FileMetaInfo.MediaStorageSOPInstanceUID,
+                file.Dataset);
             return filmSession;
         }
 

--- a/DICOM/Printing/ImageBox.cs
+++ b/DICOM/Printing/ImageBox.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Drawing;
-using System.Drawing.Imaging;
-using System.Linq;
-using System.Text;
+
 using Dicom.Log;
 
 namespace Dicom.Printing
@@ -14,6 +14,7 @@ namespace Dicom.Printing
     public class ImageBox : DicomDataset
     {
         #region Properties and Attributes
+
         //border in 100th of inches
         protected const float BORDER = (float)(100 * 2 / 25.4);
 
@@ -69,7 +70,7 @@ namespace Dicom.Printing
                 {
                     this.Add(DicomTag.BasicColorImageSequence, value);
                 }
-                else 
+                else
                 {
                     this.Add(DicomTag.BasicGrayscaleImageSequence, value);
 
@@ -82,8 +83,14 @@ namespace Dicom.Printing
         /// </summary>
         public ushort ImageBoxPosition
         {
-            get { return this.Get<ushort>(DicomTag.ImageBoxPosition, 1); }
-            set { this.Add(DicomTag.ImageBoxPosition, value); }
+            get
+            {
+                return this.Get<ushort>(DicomTag.ImageBoxPosition, 1);
+            }
+            set
+            {
+                this.Add(DicomTag.ImageBoxPosition, value);
+            }
         }
 
         /// <summary>
@@ -106,8 +113,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string Polarity
         {
-            get { return this.Get(DicomTag.Polarity, "NORMAL"); }
-            set { this.Add(DicomTag.Polarity, value); }
+            get
+            {
+                return this.Get(DicomTag.Polarity, "NORMAL");
+            }
+            set
+            {
+                this.Add(DicomTag.Polarity, value);
+            }
         }
 
         /// <summary>
@@ -125,8 +138,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string MagnificationType
         {
-            get { return this.Get(DicomTag.MagnificationType, FilmBox.MagnificationType); }
-            set { this.Add(DicomTag.MagnificationType, value); }
+            get
+            {
+                return this.Get(DicomTag.MagnificationType, FilmBox.MagnificationType);
+            }
+            set
+            {
+                this.Add(DicomTag.MagnificationType, value);
+            }
         }
 
         /// <summary>
@@ -135,8 +154,14 @@ namespace Dicom.Printing
         /// </summary>
         public string SmoothingType
         {
-            get { return this.Get(DicomTag.SmoothingType, FilmBox.SmoothingType); }
-            set { this.Add(DicomTag.SmoothingType, value); }
+            get
+            {
+                return this.Get(DicomTag.SmoothingType, FilmBox.SmoothingType);
+            }
+            set
+            {
+                this.Add(DicomTag.SmoothingType, value);
+            }
         }
 
         /// <summary>
@@ -145,8 +170,14 @@ namespace Dicom.Printing
         /// </summary>
         public ushort MaxDensity
         {
-            get { return this.Get<ushort>(DicomTag.MaxDensity, FilmBox.MaxDensity); }
-            set { this.Add(DicomTag.MaxDensity, value); }
+            get
+            {
+                return this.Get<ushort>(DicomTag.MaxDensity, FilmBox.MaxDensity);
+            }
+            set
+            {
+                this.Add(DicomTag.MaxDensity, value);
+            }
         }
 
         /// <summary>
@@ -155,8 +186,14 @@ namespace Dicom.Printing
         /// </summary>
         public ushort MinDensity
         {
-            get { return this.Get<ushort>(DicomTag.MinDensity, FilmBox.MinDensity); }
-            set { this.Add(DicomTag.MinDensity, value); }
+            get
+            {
+                return this.Get<ushort>(DicomTag.MinDensity, FilmBox.MinDensity);
+            }
+            set
+            {
+                this.Add(DicomTag.MinDensity, value);
+            }
         }
 
         /// <summary>
@@ -178,8 +215,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string ConfigurationInformation
         {
-            get { return this.Get(DicomTag.ConfigurationInformation, FilmBox.ConfigurationInformation); }
-            set { this.Add(DicomTag.ConfigurationInformation, value); }
+            get
+            {
+                return this.Get(DicomTag.ConfigurationInformation, FilmBox.ConfigurationInformation);
+            }
+            set
+            {
+                this.Add(DicomTag.ConfigurationInformation, value);
+            }
         }
 
         /// <summary>
@@ -188,8 +231,14 @@ namespace Dicom.Printing
         /// </summary>
         public double RequestedImageSize
         {
-            get { return this.Get<double>(DicomTag.RequestedImageSize, 0.0); }
-            set { this.Add(DicomTag.RequestedImageSize, value); }
+            get
+            {
+                return this.Get<double>(DicomTag.RequestedImageSize, 0.0);
+            }
+            set
+            {
+                this.Add(DicomTag.RequestedImageSize, value);
+            }
         }
 
         /// <summary>
@@ -222,13 +271,20 @@ namespace Dicom.Printing
         /// </remarks>
         public string RequestedDecimateCropBehavior
         {
-            get { return this.Get(DicomTag.RequestedDecimateCropBehavior, "DECIMATE"); }
-            set { this.Add(DicomTag.RequestedDecimateCropBehavior, value); }
+            get
+            {
+                return this.Get(DicomTag.RequestedDecimateCropBehavior, "DECIMATE");
+            }
+            set
+            {
+                this.Add(DicomTag.RequestedDecimateCropBehavior, value);
+            }
         }
 
         #endregion
 
         #region Constructors and Initialization
+
         /// <summary>
         /// Construct new ImageBox for specified filmBox using specified SOP class UID and SOP instance UID
         /// </summary>
@@ -296,10 +352,10 @@ namespace Dicom.Printing
                 Image bitmap = null;
                 try
                 {
-                var image = new Dicom.Imaging.DicomImage(ImageSequence);
+                    var image = new Dicom.Imaging.DicomImage(ImageSequence);
                     var frame = image.RenderImage(0);
 
-                    bitmap = frame;// new Bitmap(frame);
+                    bitmap = frame; // new Bitmap(frame);
                     //frame.Dispose();
 
                     DrawBitmap(graphics, box, bitmap, imageResolution);
@@ -308,8 +364,8 @@ namespace Dicom.Printing
                 {
                     if (bitmap != null)
                     {
-                bitmap.Dispose();
-            }
+                        bitmap.Dispose();
+                    }
                 }
             }
 
@@ -340,10 +396,10 @@ namespace Dicom.Printing
             if (factor > 1)
             {
                 var targetSize = new Size
-            {
-                    Width = (int)(imageResolution * box.Width / 100),
-                    Height = (int)(imageResolution * box.Height / 100)
-            };
+                                     {
+                                         Width = (int)(imageResolution * box.Width / 100),
+                                         Height = (int)(imageResolution * box.Height / 100)
+                                     };
 
 
                 using (var membmp = new Bitmap(targetSize.Width, targetSize.Height))
@@ -364,17 +420,22 @@ namespace Dicom.Printing
                             }
                         }
 
-                        factor = Math.Min(targetSize.Height / (double)bitmap.Height,
+                        factor = Math.Min(
+                            targetSize.Height / (double)bitmap.Height,
                             targetSize.Width / (double)bitmap.Width);
 
-            RectangleF srcRect = new RectangleF(0, 0, bitmap.Width, bitmap.Height);
-            RectangleF dstRect = new RectangleF
-            {
-                X = (float)((targetSize.Width - bitmap.Width * factor) / 2.0f),
-                Y = (float)((targetSize.Height - bitmap.Height * factor) / 2.0f),
-                Width = (float)(bitmap.Width * factor),
-                Height = (float)(bitmap.Height * factor),
-            };
+                        RectangleF srcRect = new RectangleF(0, 0, bitmap.Width, bitmap.Height);
+                        RectangleF dstRect = new RectangleF
+                                                 {
+                                                     X =
+                                                         (float)
+                                                         ((targetSize.Width - bitmap.Width * factor) / 2.0f),
+                                                     Y =
+                                                         (float)
+                                                         ((targetSize.Height - bitmap.Height * factor) / 2.0f),
+                                                     Width = (float)(bitmap.Width * factor),
+                                                     Height = (float)(bitmap.Height * factor),
+                                                 };
                         memg.DrawImage(bitmap, dstRect, srcRect, GraphicsUnit.Pixel);
                     }
                     graphics.DrawImage(membmp, box.X, box.Y, box.Width, box.Height);
@@ -385,18 +446,24 @@ namespace Dicom.Printing
                 //var bmp = new Bitmap(bitmap);
                 //bmp.SetResolution(imageResolution, imageResolution);
                 RectangleF dstRect = new RectangleF
-                {
-                    X = box.X + (float)(box.Width - imageSizeInInch.Width * factor) / 2.0f,
-                    Y = box.Y + (float)(box.Height - imageSizeInInch.Height * factor) / 2.0f,
-                    Width = (float)(imageSizeInInch.Width * factor),
-                    Height = (float)(imageSizeInInch.Height * factor),
-                };
+                                         {
+                                             X =
+                                                 box.X
+                                                 + (float)(box.Width - imageSizeInInch.Width * factor) / 2.0f,
+                                             Y =
+                                                 box.Y
+                                                 + (float)(box.Height - imageSizeInInch.Height * factor)
+                                                 / 2.0f,
+                                             Width = (float)(imageSizeInInch.Width * factor),
+                                             Height = (float)(imageSizeInInch.Height * factor),
+                                         };
 
                 graphics.DrawImage(bitmap, dstRect);
                 //bmp.Dispose();
             }
 
         }
+
         #endregion
 
         #region Load and Save
@@ -405,7 +472,10 @@ namespace Dicom.Printing
         {
             var file = DicomFile.Open(imageBoxFile);
 
-            var imageBox = new ImageBox(filmBox, file.FileMetaInfo.MediaStorageSOPClassUID, file.FileMetaInfo.MediaStorageSOPInstanceUID);
+            var imageBox = new ImageBox(
+                filmBox,
+                file.FileMetaInfo.MediaStorageSOPClassUID,
+                file.FileMetaInfo.MediaStorageSOPInstanceUID);
 
             file.Dataset.CopyTo(imageBox);
             return imageBox;

--- a/DICOM/Printing/PresentationLut.cs
+++ b/DICOM/Printing/PresentationLut.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 
 namespace Dicom.Printing
 {
@@ -142,7 +142,7 @@ namespace Dicom.Printing
                 throw new ArgumentNullException("dataset");
             }
             dataset.CopyTo(this);
-         
+
         }
 
         public void CreateLutSequence()

--- a/DICOM/Properties/AssemblyInfo.cs
+++ b/DICOM/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/DICOM/StringExtensions.cs
+++ b/DICOM/StringExtensions.cs
@@ -1,103 +1,115 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom {
-	internal static class StringExtensions {
-		public static bool IsDigits(this string s) {
-			foreach (char c in s)
-				if (!Char.IsDigit(c))
-					return false;
-			return true;
-		}
+using System;
 
-		public static bool ListContains(this string s, char separator, string value) {
-			var parts = s.Split(separator);
-			foreach (string part in parts) {
-				if (part.Trim() == value)
-					return true;
-			}
-			return false;
-		}
+namespace Dicom
+{
+    internal static class StringExtensions
+    {
+        public static bool IsDigits(this string s)
+        {
+            foreach (char c in s) if (!Char.IsDigit(c)) return false;
+            return true;
+        }
 
-		/// <summary>
-		/// Array of valid wildcards
-		/// </summary>
-		private static char[] Wildcards = new char[] { '*', '?' };
+        public static bool ListContains(this string s, char separator, string value)
+        {
+            var parts = s.Split(separator);
+            foreach (string part in parts)
+            {
+                if (part.Trim() == value) return true;
+            }
+            return false;
+        }
 
-		/// <summary>
-		/// Returns true if the string matches the pattern which may contain * and ? wildcards.
-		/// Matching is done without regard to case.
-		/// </summary>
-		/// <param name="pattern"></param>
-		/// <param name="s"></param>
-		/// <returns></returns>
-		public static bool Wildcard(this string s, string pattern) {
-			return Wildcard(s, pattern, false);
-		}
+        /// <summary>
+        /// Array of valid wildcards
+        /// </summary>
+        private static char[] Wildcards = new char[] { '*', '?' };
 
-		/// <summary>
-		/// Returns true if the string matches the pattern which may contain * and ? wildcards.
-		/// </summary>
-		/// <param name="pattern"></param>
-		/// <param name="s"></param>
-		/// <param name="caseSensitive"></param>
-		/// <returns></returns>
-		public static bool Wildcard(this string s, string pattern, bool caseSensitive) {
-			if (pattern == "*")
-				return true;
+        /// <summary>
+        /// Returns true if the string matches the pattern which may contain * and ? wildcards.
+        /// Matching is done without regard to case.
+        /// </summary>
+        /// <param name="pattern"></param>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        public static bool Wildcard(this string s, string pattern)
+        {
+            return Wildcard(s, pattern, false);
+        }
 
-			// if not concerned about case, convert both string and pattern
-			// to lower case for comparison
-			if (!caseSensitive) {
-				pattern = pattern.ToLower();
-				s = s.ToLower();
-			}
+        /// <summary>
+        /// Returns true if the string matches the pattern which may contain * and ? wildcards.
+        /// </summary>
+        /// <param name="pattern"></param>
+        /// <param name="s"></param>
+        /// <param name="caseSensitive"></param>
+        /// <returns></returns>
+        public static bool Wildcard(this string s, string pattern, bool caseSensitive)
+        {
+            if (pattern == "*") return true;
 
-			// if pattern doesn't actually contain any wildcards, use simple equality
-			if (pattern.IndexOfAny(Wildcards) == -1)
-				return (s == pattern);
+            // if not concerned about case, convert both string and pattern
+            // to lower case for comparison
+            if (!caseSensitive)
+            {
+                pattern = pattern.ToLower();
+                s = s.ToLower();
+            }
 
-			// otherwise do pattern matching
-			int i = 0;
-			int j = 0;
-			while (i < s.Length && j < pattern.Length && pattern[j] != '*') {
-				if ((pattern[j] != s[i]) && (pattern[j] != '?')) {
-					return false;
-				}
-				i++;
-				j++;
-			}
+            // if pattern doesn't actually contain any wildcards, use simple equality
+            if (pattern.IndexOfAny(Wildcards) == -1) return (s == pattern);
 
-			// if we have reached the end of the pattern without finding a * wildcard,
-			// the match must fail if the string is longer or shorter than the pattern
-			if (j == pattern.Length)
-				return s.Length == pattern.Length;
+            // otherwise do pattern matching
+            int i = 0;
+            int j = 0;
+            while (i < s.Length && j < pattern.Length && pattern[j] != '*')
+            {
+                if ((pattern[j] != s[i]) && (pattern[j] != '?'))
+                {
+                    return false;
+                }
+                i++;
+                j++;
+            }
 
-			int cp = 0;
-			int mp = 0;
-			while (i < s.Length) {
-				if (j < pattern.Length && pattern[j] == '*') {
-					if ((j++) >= pattern.Length) {
-						return true;
-					}
-					mp = j;
-					cp = i + 1;
-				} else if (j < pattern.Length && (pattern[j] == s[i] || pattern[j] == '?')) {
-					j++;
-					i++;
-				} else {
-					j = mp;
-					i = cp++;
-				}
-			}
+            // if we have reached the end of the pattern without finding a * wildcard,
+            // the match must fail if the string is longer or shorter than the pattern
+            if (j == pattern.Length) return s.Length == pattern.Length;
 
-			while (j < pattern.Length && pattern[j] == '*') {
-				j++;
-			}
+            int cp = 0;
+            int mp = 0;
+            while (i < s.Length)
+            {
+                if (j < pattern.Length && pattern[j] == '*')
+                {
+                    if ((j++) >= pattern.Length)
+                    {
+                        return true;
+                    }
+                    mp = j;
+                    cp = i + 1;
+                }
+                else if (j < pattern.Length && (pattern[j] == s[i] || pattern[j] == '?'))
+                {
+                    j++;
+                    i++;
+                }
+                else
+                {
+                    j = mp;
+                    i = cp++;
+                }
+            }
 
-			return j >= pattern.Length;
-		}
-	}
+            while (j < pattern.Length && pattern[j] == '*')
+            {
+                j++;
+            }
+
+            return j >= pattern.Length;
+        }
+    }
 }

--- a/DICOM/StructuredReport/DicomCodeItem.cs
+++ b/DICOM/StructuredReport/DicomCodeItem.cs
@@ -1,74 +1,95 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.StructuredReport {
-	public class DicomCodeItem : DicomDataset {
-		public DicomCodeItem(DicomDataset dataset) : base(dataset) {
-		}
+using System;
 
-		public DicomCodeItem(DicomSequence sequence) {
-			if (sequence.Items.Count == 0)
-				throw new DicomDataException("No code item found in sequence.");
-			Add(sequence.Items[0]);
-		}
+namespace Dicom.StructuredReport
+{
+    public class DicomCodeItem : DicomDataset
+    {
+        public DicomCodeItem(DicomDataset dataset)
+            : base(dataset)
+        {
+        }
 
-		public DicomCodeItem(string value, string scheme, string meaning, string version=null) {
-			Add(DicomTag.CodeValue, value);
-			Add(DicomTag.CodingSchemeDesignator, scheme);
-			Add(DicomTag.CodeMeaning, meaning);
-			if (version != null)
-				Add(DicomTag.CodingSchemeVersion, version);
-		}
+        public DicomCodeItem(DicomSequence sequence)
+        {
+            if (sequence.Items.Count == 0) throw new DicomDataException("No code item found in sequence.");
+            Add(sequence.Items[0]);
+        }
 
-		public string Value {
-			get { return Get<string>(DicomTag.CodeValue, 0, String.Empty); }
-		}
+        public DicomCodeItem(string value, string scheme, string meaning, string version = null)
+        {
+            Add(DicomTag.CodeValue, value);
+            Add(DicomTag.CodingSchemeDesignator, scheme);
+            Add(DicomTag.CodeMeaning, meaning);
+            if (version != null) Add(DicomTag.CodingSchemeVersion, version);
+        }
 
-		public string Scheme {
-			get { return Get<string>(DicomTag.CodingSchemeDesignator, 0, String.Empty); }
-		}
+        public string Value
+        {
+            get
+            {
+                return Get<string>(DicomTag.CodeValue, 0, String.Empty);
+            }
+        }
 
-		public string Meaning {
-			get { return Get<string>(DicomTag.CodeMeaning, 0, String.Empty); }
-		}
+        public string Scheme
+        {
+            get
+            {
+                return Get<string>(DicomTag.CodingSchemeDesignator, 0, String.Empty);
+            }
+        }
 
-		public string Version {
-			get { return Get<string>(DicomTag.CodingSchemeVersion, 0, String.Empty); }
-		}
+        public string Meaning
+        {
+            get
+            {
+                return Get<string>(DicomTag.CodeMeaning, 0, String.Empty);
+            }
+        }
 
-		public override bool Equals(object obj) {
-			if (Object.ReferenceEquals(this, obj))
-				return true;
-			if (obj.GetType() != typeof(DicomCodeItem))
-				return false;
-			return Value == ((DicomCodeItem)obj).Value && Scheme == ((DicomCodeItem)obj).Scheme && Version == ((DicomCodeItem)obj).Version;
-		}
+        public string Version
+        {
+            get
+            {
+                return Get<string>(DicomTag.CodingSchemeVersion, 0, String.Empty);
+            }
+        }
 
-		public static bool operator ==(DicomCodeItem a, DicomCodeItem b) {
-			if (((object)a == null) && ((object)b == null))
-				return true;
-			if (((object)a == null) || ((object)b == null))
-				return false;
-			return a.Equals(b);
-		}
+        public override bool Equals(object obj)
+        {
+            if (Object.ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(DicomCodeItem)) return false;
+            return Value == ((DicomCodeItem)obj).Value && Scheme == ((DicomCodeItem)obj).Scheme
+                   && Version == ((DicomCodeItem)obj).Version;
+        }
 
-		public static bool operator !=(DicomCodeItem a, DicomCodeItem b) {
-			return !(a == b);
-		}
+        public static bool operator ==(DicomCodeItem a, DicomCodeItem b)
+        {
+            if (((object)a == null) && ((object)b == null)) return true;
+            if (((object)a == null) || ((object)b == null)) return false;
+            return a.Equals(b);
+        }
 
-		private int _hash = 0;
-		public override int GetHashCode() {
-			if (_hash == 0)
-				_hash = ToString().GetHashCode();
-			return _hash;
-		}
+        public static bool operator !=(DicomCodeItem a, DicomCodeItem b)
+        {
+            return !(a == b);
+        }
 
-		public override string ToString() {
-			if (!String.IsNullOrEmpty(Version))
-				return String.Format("({0},{1}:{2},\"{3}\")", Value, Scheme, Version, Meaning);
-			return String.Format("({0},{1},\"{2}\")", Value, Scheme, Meaning);
-		}
-	}
+        private int _hash = 0;
+
+        public override int GetHashCode()
+        {
+            if (_hash == 0) _hash = ToString().GetHashCode();
+            return _hash;
+        }
+
+        public override string ToString()
+        {
+            if (!String.IsNullOrEmpty(Version)) return String.Format("({0},{1}:{2},\"{3}\")", Value, Scheme, Version, Meaning);
+            return String.Format("({0},{1},\"{2}\")", Value, Scheme, Meaning);
+        }
+    }
 }

--- a/DICOM/StructuredReport/DicomContentItem.cs
+++ b/DICOM/StructuredReport/DicomContentItem.cs
@@ -1,392 +1,547 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace Dicom.StructuredReport {
-	public enum DicomValueType {
-		Container,
-		Text,
-		Code,
-		Numeric,
-		PersonName,
-		Date,
-		Time,
-		DateTime,
-		UIDReference,
-		Composite,
-		Image,
-		Waveform,
-		SpatialCoordinate,
-		TemporalCoordinate
-	}
+namespace Dicom.StructuredReport
+{
+    public enum DicomValueType
+    {
+        Container,
 
-	public enum DicomContinuity {
-		None,
-		Separate,
-		Continuous
-	}
+        Text,
 
-	public enum DicomRelationship {
-		Contains,
-		HasProperties,
-		InferredFrom,
-		SelectedFrom,
-		HasObservationContext,
-		HasAcquisitionContext,
-		HasConceptModifier
-	}
+        Code,
 
-	public class DicomContentItem {
-		private DicomDataset _dataset;
+        Numeric,
 
-		public DicomContentItem(DicomDataset dataset) {
-			Dataset = dataset;
-		}
+        PersonName,
 
-		public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, string value) {
-			Dataset = new DicomDataset();
-			Code = code;
-			Relationship = relationship;
-			Type = type;
+        Date,
 
-			if (type == DicomValueType.Text)
-				Dataset.Add(DicomTag.TextValue, value);
-			else if (type == DicomValueType.PersonName)
-				Dataset.Add(DicomTag.PersonName, value);
-			else
-				throw new DicomStructuredReportException("Type of string is not the correct value type for {0} content item.", type);
-		}
+        Time,
 
-		public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, DateTime value) {
-			Dataset = new DicomDataset();
-			Code = code;
-			Relationship = relationship;
-			Type = type;
+        DateTime,
 
-			if (type == DicomValueType.Date)
-				Dataset.Add(DicomTag.Date, value);
-			else if (type == DicomValueType.Time)
-				Dataset.Add(DicomTag.Time, value);
-			else if (type == DicomValueType.DateTime)
-				Dataset.Add(DicomTag.DateTime, value);
-			else
-				throw new DicomStructuredReportException("Type of DateTime is not the correct value type for {0} content item.", type);
-		}
+        UIDReference,
 
-		public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomUID value) {
-			Dataset = new DicomDataset();
-			Code = code;
-			Relationship = relationship;
-			Type = DicomValueType.UIDReference;
+        Composite,
 
-			Dataset.Add(DicomTag.UID, value);
-		}
+        Image,
 
-		public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomCodeItem value) {
-			Dataset = new DicomDataset();
-			Code = code;
-			Relationship = relationship;
-			Type = DicomValueType.Code;
+        Waveform,
 
-			Dataset.Add(DicomTag.ConceptCodeSequence, value);
-		}
+        SpatialCoordinate,
 
-		public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomMeasuredValue value) {
-			Dataset = new DicomDataset();
-			Code = code;
-			Relationship = relationship;
-			Type = DicomValueType.Numeric;
+        TemporalCoordinate
+    }
 
-			Dataset.Add(DicomTag.MeasuredValueSequence, value);
-		}
+    public enum DicomContinuity
+    {
+        None,
 
-		public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, DicomReferencedSOP value) {
-			Dataset = new DicomDataset();
-			Code = code;
-			Relationship = relationship;
-			Type = type;
+        Separate,
 
-			if (type == DicomValueType.Composite || type == DicomValueType.Image || type == DicomValueType.Waveform)
-				Dataset.Add(DicomTag.ReferencedSOPSequence, value);
-			else
-				throw new DicomStructuredReportException("Type of DicomReferencedSOP is not the correct value type for {0} content item.", type);
-		}
+        Continuous
+    }
 
-		public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomContinuity continuity, params DicomContentItem[] items) {
-			Dataset = new DicomDataset();
-			Code = code;
-			Relationship = relationship;
-			Type = DicomValueType.Container;
-			Continuity = continuity;
+    public enum DicomRelationship
+    {
+        Contains,
 
-			Dataset.Add(DicomTag.ContentSequence, items);
-		}
+        HasProperties,
 
-		public DicomDataset Dataset {
-			get {
-				return _dataset;
-			}
-			private set {
-				_dataset = value;
-			}
-		}
+        InferredFrom,
 
-		public DicomCodeItem Code {
-			get {
-				return Dataset.Get<DicomCodeItem>(DicomTag.ConceptNameCodeSequence);
-			}
-			private set {
-				Dataset.Add(DicomTag.ConceptNameCodeSequence, value);
-			}
-		}
+        SelectedFrom,
 
-		public DicomValueType Type {
-			get {
-				var type = Dataset.Get<string>(DicomTag.ValueType, 0, "UNKNOWN");
-				switch (type) {
-				case "CONTAINER": return DicomValueType.Container;
-				case "TEXT": return DicomValueType.Text;
-				case "CODE": return DicomValueType.Code;
-				case "NUM": return DicomValueType.Numeric;
-				case "PNAME": return DicomValueType.PersonName;
-				case "DATE": return DicomValueType.Date;
-				case "TIME": return DicomValueType.Time;
-				case "DATETIME": return DicomValueType.DateTime;
-				case "UIDREF": return DicomValueType.UIDReference;
-				case "COMPOSITE": return DicomValueType.Composite;
-				case "IMAGE": return DicomValueType.Image;
-				case "WAVEFORM": return DicomValueType.Waveform;
-				case "SCOORD": return DicomValueType.SpatialCoordinate;
-				case "TCOORD": return DicomValueType.TemporalCoordinate;
-				default:
-					throw new DicomStructuredReportException("Unknown value type: {0}", type);
-				}
-			}
-			private set {
-				switch (value) {
-				case DicomValueType.Container: Dataset.Add(DicomTag.ValueType, "CONTAINER"); return;
-				case DicomValueType.Text: Dataset.Add(DicomTag.ValueType, "TEXT"); return;
-				case DicomValueType.Code: Dataset.Add(DicomTag.ValueType, "CODE"); return;
-				case DicomValueType.Numeric: Dataset.Add(DicomTag.ValueType, "NUM"); return;
-				case DicomValueType.PersonName: Dataset.Add(DicomTag.ValueType, "PNAME"); return;
-				case DicomValueType.Date: Dataset.Add(DicomTag.ValueType, "DATE"); return;
-				case DicomValueType.Time: Dataset.Add(DicomTag.ValueType, "TIME"); return;
-				case DicomValueType.DateTime: Dataset.Add(DicomTag.ValueType, "DATETIME"); return;
-				case DicomValueType.UIDReference: Dataset.Add(DicomTag.ValueType, "UIDREF"); return;
-				case DicomValueType.Composite: Dataset.Add(DicomTag.ValueType, "COMPOSITE"); return;
-				case DicomValueType.Image: Dataset.Add(DicomTag.ValueType, "IMAGE"); return;
-				case DicomValueType.Waveform: Dataset.Add(DicomTag.ValueType, "WAVEFORM"); return;
-				case DicomValueType.SpatialCoordinate: Dataset.Add(DicomTag.ValueType, "SCOORD"); return;
-				case DicomValueType.TemporalCoordinate: Dataset.Add(DicomTag.ValueType, "TCOORD"); return;
-				default: break;
-				}
-			}
-		}
+        HasObservationContext,
 
-		public DicomRelationship Relationship {
-			get {
-				var type = Dataset.Get<string>(DicomTag.RelationshipType, 0, "UNKNOWN");
-				switch (type) {
-				case "CONTAINS": return DicomRelationship.Contains;
-				case "HAS PROPERTIES": return DicomRelationship.HasProperties;
-				case "INFERRED FROM": return DicomRelationship.InferredFrom;
-				case "SELECTED FROM": return DicomRelationship.SelectedFrom;
-				case "HAS OBS CONTEXT": return DicomRelationship.HasObservationContext;
-				case "HAS ACQ CONTEXT": return DicomRelationship.HasAcquisitionContext;
-				case "HAS CONCEPT MOD": return DicomRelationship.HasConceptModifier;
-				default:
-					throw new DicomStructuredReportException("Unknown relationship type: {0}", type);
-				}
-			}
-			private set {
-				switch (value) {
-				case DicomRelationship.Contains: Dataset.Add(DicomTag.RelationshipType, "CONTAINS"); return;
-				case DicomRelationship.HasProperties: Dataset.Add(DicomTag.RelationshipType, "HAS PROPERTIES"); return;
-				case DicomRelationship.InferredFrom: Dataset.Add(DicomTag.RelationshipType, "INFERRED FROM"); return;
-				case DicomRelationship.SelectedFrom: Dataset.Add(DicomTag.RelationshipType, "SELECTED FROM"); return;
-				case DicomRelationship.HasObservationContext: Dataset.Add(DicomTag.RelationshipType, "HAS OBS CONTEXT"); return;
-				case DicomRelationship.HasAcquisitionContext: Dataset.Add(DicomTag.RelationshipType, "HAS ACQ CONTEXT"); return;
-				case DicomRelationship.HasConceptModifier: Dataset.Add(DicomTag.RelationshipType, "HAS CONCEPT MOD"); return;
-				default: break;
-				}
-			}
-		}
+        HasAcquisitionContext,
 
-		public DicomContinuity Continuity {
-			get {
-				return Dataset.Get<DicomContinuity>(DicomTag.ContinuityOfContent, 0, DicomContinuity.None);
-			}
-			private set {
-				Dataset.Add(DicomTag.ContinuityOfContent, value.ToString().ToUpper());
-			}
-		}
+        HasConceptModifier
+    }
 
-		public IEnumerable<DicomContentItem> Children() {
-			var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence);
+    public class DicomContentItem
+    {
+        private DicomDataset _dataset;
 
-			// silence exceptions for items without a content sequence
-			if (sequence == null)
-				sequence = new DicomSequence(DicomTag.ContentSequence);
+        public DicomContentItem(DicomDataset dataset)
+        {
+            Dataset = dataset;
+        }
 
-			foreach (var item in sequence)
-				yield return new DicomContentItem(item);
-		}
+        public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, string value)
+        {
+            Dataset = new DicomDataset();
+            Code = code;
+            Relationship = relationship;
+            Type = type;
 
-		public DicomContentItem Add(DicomContentItem item) {
-			var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence);
+            if (type == DicomValueType.Text) Dataset.Add(DicomTag.TextValue, value);
+            else if (type == DicomValueType.PersonName) Dataset.Add(DicomTag.PersonName, value);
+            else
+                throw new DicomStructuredReportException(
+                    "Type of string is not the correct value type for {0} content item.",
+                    type);
+        }
 
-			if (sequence == null) {
-				sequence = new DicomSequence(DicomTag.ContentSequence);
-				Dataset.Add(sequence);
-			}
+        public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, DateTime value)
+        {
+            Dataset = new DicomDataset();
+            Code = code;
+            Relationship = relationship;
+            Type = type;
 
-			sequence.Items.Add(item.Dataset);
+            if (type == DicomValueType.Date) Dataset.Add(DicomTag.Date, value);
+            else if (type == DicomValueType.Time) Dataset.Add(DicomTag.Time, value);
+            else if (type == DicomValueType.DateTime) Dataset.Add(DicomTag.DateTime, value);
+            else
+                throw new DicomStructuredReportException(
+                    "Type of DateTime is not the correct value type for {0} content item.",
+                    type);
+        }
 
-			return item;
-		}
+        public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomUID value)
+        {
+            Dataset = new DicomDataset();
+            Code = code;
+            Relationship = relationship;
+            Type = DicomValueType.UIDReference;
 
-		public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, string value) {
-			return Add(new DicomContentItem(code, relationship, type, value));
-		}
+            Dataset.Add(DicomTag.UID, value);
+        }
 
-		public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, DateTime value) {
-			return Add(new DicomContentItem(code, relationship, type, value));
-		}
+        public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomCodeItem value)
+        {
+            Dataset = new DicomDataset();
+            Code = code;
+            Relationship = relationship;
+            Type = DicomValueType.Code;
 
-		public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomUID value) {
-			return Add(new DicomContentItem(code, relationship, value));
-		}
+            Dataset.Add(DicomTag.ConceptCodeSequence, value);
+        }
 
-		public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomCodeItem value) {
-			return Add(new DicomContentItem(code, relationship, value));
-		}
+        public DicomContentItem(DicomCodeItem code, DicomRelationship relationship, DicomMeasuredValue value)
+        {
+            Dataset = new DicomDataset();
+            Code = code;
+            Relationship = relationship;
+            Type = DicomValueType.Numeric;
 
-		public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomMeasuredValue value) {
-			return Add(new DicomContentItem(code, relationship, value));
-		}
+            Dataset.Add(DicomTag.MeasuredValueSequence, value);
+        }
 
-		public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomValueType type, DicomReferencedSOP value) {
-			return Add(new DicomContentItem(code, relationship, type, value));
-		}
+        public DicomContentItem(
+            DicomCodeItem code,
+            DicomRelationship relationship,
+            DicomValueType type,
+            DicomReferencedSOP value)
+        {
+            Dataset = new DicomDataset();
+            Code = code;
+            Relationship = relationship;
+            Type = type;
 
-		public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomContinuity continuity, params DicomContentItem[] items) {
-			return Add(new DicomContentItem(code, relationship, continuity, items));
-		}
+            if (type == DicomValueType.Composite || type == DicomValueType.Image || type == DicomValueType.Waveform) Dataset.Add(DicomTag.ReferencedSOPSequence, value);
+            else
+                throw new DicomStructuredReportException(
+                    "Type of DicomReferencedSOP is not the correct value type for {0} content item.",
+                    type);
+        }
 
-		public T Get<T>() {
-			if (typeof(T) == typeof(string)) {
-				if (Type == DicomValueType.Text)
-					return (T)(object)Dataset.Get<string>(DicomTag.TextValue, 0, String.Empty);
-				if (Type == DicomValueType.PersonName)
-					return (T)(object)Dataset.Get<string>(DicomTag.PersonName, 0, String.Empty);
-				if (Type == DicomValueType.Numeric) {
-					var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
-					if (mv == null)
-						return default(T);
-					return (T)(object)mv.ToString();
-				}
-				if (Type == DicomValueType.Date)
-					return (T)(object)Dataset.Get<string>(DicomTag.Date, 0, String.Empty);
-				if (Type == DicomValueType.Time)
-					return (T)(object)Dataset.Get<string>(DicomTag.Time, 0, String.Empty);
-				if (Type == DicomValueType.DateTime)
-					return (T)(object)Dataset.Get<string>(DicomTag.DateTime, 0, String.Empty);
-				if (Type == DicomValueType.UIDReference)
-					return (T)(object)Dataset.Get<string>(DicomTag.UID);
-				if (Type == DicomValueType.Code) {
-					var c = Dataset.Get<DicomCodeItem>(DicomTag.ConceptCodeSequence);
-					if (c == null)
-						return default(T);
-					return (T)(object)c.ToString();
-				}
-			}
+        public DicomContentItem(
+            DicomCodeItem code,
+            DicomRelationship relationship,
+            DicomContinuity continuity,
+            params DicomContentItem[] items)
+        {
+            Dataset = new DicomDataset();
+            Code = code;
+            Relationship = relationship;
+            Type = DicomValueType.Container;
+            Continuity = continuity;
 
-			if (typeof(T) == typeof(DateTime)) {
-				if (Type == DicomValueType.Date)
-					return (T)(object)Dataset.Get<DateTime>(DicomTag.Date, 0, DateTime.Today);
-				if (Type == DicomValueType.Time)
-					return (T)(object)Dataset.Get<DateTime>(DicomTag.Time, 0, DateTime.Today);
-				if (Type == DicomValueType.DateTime)
-					return (T)(object)Dataset.Get<DateTime>(DicomTag.DateTime, 0, DateTime.Today);
-			}
+            Dataset.Add(DicomTag.ContentSequence, items);
+        }
 
-			if (typeof(T) == typeof(decimal)) {
-				if (Type == DicomValueType.Numeric) {
-					var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
-					if (mv == null)
-						return default(T);
-					return (T)(object)mv.Value;
-				}
-			}
+        public DicomDataset Dataset
+        {
+            get
+            {
+                return _dataset;
+            }
+            private set
+            {
+                _dataset = value;
+            }
+        }
 
-			if (typeof(T) == typeof(double)) {
-				if (Type == DicomValueType.Numeric) {
-					var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
-					if (mv == null)
-						return default(T);
-					return (T)(object)(double)mv.Value;
-				}
-			}
+        public DicomCodeItem Code
+        {
+            get
+            {
+                return Dataset.Get<DicomCodeItem>(DicomTag.ConceptNameCodeSequence);
+            }
+            private set
+            {
+                Dataset.Add(DicomTag.ConceptNameCodeSequence, value);
+            }
+        }
 
-			if (typeof(T) == typeof(int)) {
-				if (Type == DicomValueType.Numeric) {
-					var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
-					if (mv == null)
-						return default(T);
-					return (T)(object)(int)mv.Value;
-				}
-			}
+        public DicomValueType Type
+        {
+            get
+            {
+                var type = Dataset.Get<string>(DicomTag.ValueType, 0, "UNKNOWN");
+                switch (type)
+                {
+                    case "CONTAINER":
+                        return DicomValueType.Container;
+                    case "TEXT":
+                        return DicomValueType.Text;
+                    case "CODE":
+                        return DicomValueType.Code;
+                    case "NUM":
+                        return DicomValueType.Numeric;
+                    case "PNAME":
+                        return DicomValueType.PersonName;
+                    case "DATE":
+                        return DicomValueType.Date;
+                    case "TIME":
+                        return DicomValueType.Time;
+                    case "DATETIME":
+                        return DicomValueType.DateTime;
+                    case "UIDREF":
+                        return DicomValueType.UIDReference;
+                    case "COMPOSITE":
+                        return DicomValueType.Composite;
+                    case "IMAGE":
+                        return DicomValueType.Image;
+                    case "WAVEFORM":
+                        return DicomValueType.Waveform;
+                    case "SCOORD":
+                        return DicomValueType.SpatialCoordinate;
+                    case "TCOORD":
+                        return DicomValueType.TemporalCoordinate;
+                    default:
+                        throw new DicomStructuredReportException("Unknown value type: {0}", type);
+                }
+            }
+            private set
+            {
+                switch (value)
+                {
+                    case DicomValueType.Container:
+                        Dataset.Add(DicomTag.ValueType, "CONTAINER");
+                        return;
+                    case DicomValueType.Text:
+                        Dataset.Add(DicomTag.ValueType, "TEXT");
+                        return;
+                    case DicomValueType.Code:
+                        Dataset.Add(DicomTag.ValueType, "CODE");
+                        return;
+                    case DicomValueType.Numeric:
+                        Dataset.Add(DicomTag.ValueType, "NUM");
+                        return;
+                    case DicomValueType.PersonName:
+                        Dataset.Add(DicomTag.ValueType, "PNAME");
+                        return;
+                    case DicomValueType.Date:
+                        Dataset.Add(DicomTag.ValueType, "DATE");
+                        return;
+                    case DicomValueType.Time:
+                        Dataset.Add(DicomTag.ValueType, "TIME");
+                        return;
+                    case DicomValueType.DateTime:
+                        Dataset.Add(DicomTag.ValueType, "DATETIME");
+                        return;
+                    case DicomValueType.UIDReference:
+                        Dataset.Add(DicomTag.ValueType, "UIDREF");
+                        return;
+                    case DicomValueType.Composite:
+                        Dataset.Add(DicomTag.ValueType, "COMPOSITE");
+                        return;
+                    case DicomValueType.Image:
+                        Dataset.Add(DicomTag.ValueType, "IMAGE");
+                        return;
+                    case DicomValueType.Waveform:
+                        Dataset.Add(DicomTag.ValueType, "WAVEFORM");
+                        return;
+                    case DicomValueType.SpatialCoordinate:
+                        Dataset.Add(DicomTag.ValueType, "SCOORD");
+                        return;
+                    case DicomValueType.TemporalCoordinate:
+                        Dataset.Add(DicomTag.ValueType, "TCOORD");
+                        return;
+                    default:
+                        break;
+                }
+            }
+        }
 
-			if (typeof(T) == typeof(DicomUID)) {
-				if (Type == DicomValueType.UIDReference)
-					return (T)(object)Dataset.Get<DicomUID>(DicomTag.UID);
-			}
+        public DicomRelationship Relationship
+        {
+            get
+            {
+                var type = Dataset.Get<string>(DicomTag.RelationshipType, 0, "UNKNOWN");
+                switch (type)
+                {
+                    case "CONTAINS":
+                        return DicomRelationship.Contains;
+                    case "HAS PROPERTIES":
+                        return DicomRelationship.HasProperties;
+                    case "INFERRED FROM":
+                        return DicomRelationship.InferredFrom;
+                    case "SELECTED FROM":
+                        return DicomRelationship.SelectedFrom;
+                    case "HAS OBS CONTEXT":
+                        return DicomRelationship.HasObservationContext;
+                    case "HAS ACQ CONTEXT":
+                        return DicomRelationship.HasAcquisitionContext;
+                    case "HAS CONCEPT MOD":
+                        return DicomRelationship.HasConceptModifier;
+                    default:
+                        throw new DicomStructuredReportException("Unknown relationship type: {0}", type);
+                }
+            }
+            private set
+            {
+                switch (value)
+                {
+                    case DicomRelationship.Contains:
+                        Dataset.Add(DicomTag.RelationshipType, "CONTAINS");
+                        return;
+                    case DicomRelationship.HasProperties:
+                        Dataset.Add(DicomTag.RelationshipType, "HAS PROPERTIES");
+                        return;
+                    case DicomRelationship.InferredFrom:
+                        Dataset.Add(DicomTag.RelationshipType, "INFERRED FROM");
+                        return;
+                    case DicomRelationship.SelectedFrom:
+                        Dataset.Add(DicomTag.RelationshipType, "SELECTED FROM");
+                        return;
+                    case DicomRelationship.HasObservationContext:
+                        Dataset.Add(DicomTag.RelationshipType, "HAS OBS CONTEXT");
+                        return;
+                    case DicomRelationship.HasAcquisitionContext:
+                        Dataset.Add(DicomTag.RelationshipType, "HAS ACQ CONTEXT");
+                        return;
+                    case DicomRelationship.HasConceptModifier:
+                        Dataset.Add(DicomTag.RelationshipType, "HAS CONCEPT MOD");
+                        return;
+                    default:
+                        break;
+                }
+            }
+        }
 
-			if (typeof(T) == typeof(DicomCodeItem)) {
-				if (Type == DicomValueType.Code)
-					return (T)(object)Dataset.Get<DicomCodeItem>(DicomTag.ConceptCodeSequence);
-			}
+        public DicomContinuity Continuity
+        {
+            get
+            {
+                return Dataset.Get<DicomContinuity>(DicomTag.ContinuityOfContent, 0, DicomContinuity.None);
+            }
+            private set
+            {
+                Dataset.Add(DicomTag.ContinuityOfContent, value.ToString().ToUpper());
+            }
+        }
 
-			if (typeof(T) == typeof(DicomMeasuredValue)) {
-				if (Type == DicomValueType.Numeric)
-					return (T)(object)Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
-			}
+        public IEnumerable<DicomContentItem> Children()
+        {
+            var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence);
 
-			if (typeof(T) == typeof(DicomReferencedSOP)) {
-				if (Type == DicomValueType.Composite || Type == DicomValueType.Image || Type == DicomValueType.Waveform)
-					return (T)(object)Dataset.Get<DicomReferencedSOP>(DicomTag.ReferencedSOPSequence);
-			}
+            // silence exceptions for items without a content sequence
+            if (sequence == null) sequence = new DicomSequence(DicomTag.ContentSequence);
 
-			throw new DicomStructuredReportException("Unable to get type of {0} from {1} content item.", typeof(T), Type);
-		}
+            foreach (var item in sequence) yield return new DicomContentItem(item);
+        }
 
-		public T Get<T>(DicomCodeItem code, T defaultValue) {
-			var item = Children().FirstOrDefault(x => x.Code == code);
-			if (item == null)
-				return default(T);
+        public DicomContentItem Add(DicomContentItem item)
+        {
+            var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence);
 
-			if (typeof(T) == typeof(DicomContentItem))
-				return (T)(object)item;
+            if (sequence == null)
+            {
+                sequence = new DicomSequence(DicomTag.ContentSequence);
+                Dataset.Add(sequence);
+            }
 
-			return item.Get<T>();
-		}
+            sequence.Items.Add(item.Dataset);
 
-		public override string ToString() {
-			var s = Dataset.Get<string>(DicomTag.RelationshipType, 0, String.Empty);
-			if (!String.IsNullOrEmpty(s))
-				s += " ";
-			else
-				s = String.Empty;
-			if (Code != null)
-				s += String.Format("{0} {1}", Code.ToString(), Dataset.Get<string>(DicomTag.ValueType, 0, "UNKNOWN"));
-			else
-				s += String.Format("{0} {1}", "(no code provided)", Dataset.Get<string>(DicomTag.ValueType, 0, "UNKNOWN"));
-			try {
-				s += String.Format(" [{0}]", Get<string>());
-			} catch {
-			}
-			return s;
-		}
-	}
+            return item;
+        }
+
+        public DicomContentItem Add(
+            DicomCodeItem code,
+            DicomRelationship relationship,
+            DicomValueType type,
+            string value)
+        {
+            return Add(new DicomContentItem(code, relationship, type, value));
+        }
+
+        public DicomContentItem Add(
+            DicomCodeItem code,
+            DicomRelationship relationship,
+            DicomValueType type,
+            DateTime value)
+        {
+            return Add(new DicomContentItem(code, relationship, type, value));
+        }
+
+        public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomUID value)
+        {
+            return Add(new DicomContentItem(code, relationship, value));
+        }
+
+        public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomCodeItem value)
+        {
+            return Add(new DicomContentItem(code, relationship, value));
+        }
+
+        public DicomContentItem Add(DicomCodeItem code, DicomRelationship relationship, DicomMeasuredValue value)
+        {
+            return Add(new DicomContentItem(code, relationship, value));
+        }
+
+        public DicomContentItem Add(
+            DicomCodeItem code,
+            DicomRelationship relationship,
+            DicomValueType type,
+            DicomReferencedSOP value)
+        {
+            return Add(new DicomContentItem(code, relationship, type, value));
+        }
+
+        public DicomContentItem Add(
+            DicomCodeItem code,
+            DicomRelationship relationship,
+            DicomContinuity continuity,
+            params DicomContentItem[] items)
+        {
+            return Add(new DicomContentItem(code, relationship, continuity, items));
+        }
+
+        public T Get<T>()
+        {
+            if (typeof(T) == typeof(string))
+            {
+                if (Type == DicomValueType.Text) return (T)(object)Dataset.Get<string>(DicomTag.TextValue, 0, String.Empty);
+                if (Type == DicomValueType.PersonName) return (T)(object)Dataset.Get<string>(DicomTag.PersonName, 0, String.Empty);
+                if (Type == DicomValueType.Numeric)
+                {
+                    var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
+                    if (mv == null) return default(T);
+                    return (T)(object)mv.ToString();
+                }
+                if (Type == DicomValueType.Date) return (T)(object)Dataset.Get<string>(DicomTag.Date, 0, String.Empty);
+                if (Type == DicomValueType.Time) return (T)(object)Dataset.Get<string>(DicomTag.Time, 0, String.Empty);
+                if (Type == DicomValueType.DateTime) return (T)(object)Dataset.Get<string>(DicomTag.DateTime, 0, String.Empty);
+                if (Type == DicomValueType.UIDReference) return (T)(object)Dataset.Get<string>(DicomTag.UID);
+                if (Type == DicomValueType.Code)
+                {
+                    var c = Dataset.Get<DicomCodeItem>(DicomTag.ConceptCodeSequence);
+                    if (c == null) return default(T);
+                    return (T)(object)c.ToString();
+                }
+            }
+
+            if (typeof(T) == typeof(DateTime))
+            {
+                if (Type == DicomValueType.Date) return (T)(object)Dataset.Get<DateTime>(DicomTag.Date, 0, DateTime.Today);
+                if (Type == DicomValueType.Time) return (T)(object)Dataset.Get<DateTime>(DicomTag.Time, 0, DateTime.Today);
+                if (Type == DicomValueType.DateTime) return (T)(object)Dataset.Get<DateTime>(DicomTag.DateTime, 0, DateTime.Today);
+            }
+
+            if (typeof(T) == typeof(decimal))
+            {
+                if (Type == DicomValueType.Numeric)
+                {
+                    var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
+                    if (mv == null) return default(T);
+                    return (T)(object)mv.Value;
+                }
+            }
+
+            if (typeof(T) == typeof(double))
+            {
+                if (Type == DicomValueType.Numeric)
+                {
+                    var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
+                    if (mv == null) return default(T);
+                    return (T)(object)(double)mv.Value;
+                }
+            }
+
+            if (typeof(T) == typeof(int))
+            {
+                if (Type == DicomValueType.Numeric)
+                {
+                    var mv = Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
+                    if (mv == null) return default(T);
+                    return (T)(object)(int)mv.Value;
+                }
+            }
+
+            if (typeof(T) == typeof(DicomUID))
+            {
+                if (Type == DicomValueType.UIDReference) return (T)(object)Dataset.Get<DicomUID>(DicomTag.UID);
+            }
+
+            if (typeof(T) == typeof(DicomCodeItem))
+            {
+                if (Type == DicomValueType.Code) return (T)(object)Dataset.Get<DicomCodeItem>(DicomTag.ConceptCodeSequence);
+            }
+
+            if (typeof(T) == typeof(DicomMeasuredValue))
+            {
+                if (Type == DicomValueType.Numeric) return (T)(object)Dataset.Get<DicomMeasuredValue>(DicomTag.MeasuredValueSequence);
+            }
+
+            if (typeof(T) == typeof(DicomReferencedSOP))
+            {
+                if (Type == DicomValueType.Composite || Type == DicomValueType.Image || Type == DicomValueType.Waveform) return (T)(object)Dataset.Get<DicomReferencedSOP>(DicomTag.ReferencedSOPSequence);
+            }
+
+            throw new DicomStructuredReportException(
+                "Unable to get type of {0} from {1} content item.",
+                typeof(T),
+                Type);
+        }
+
+        public T Get<T>(DicomCodeItem code, T defaultValue)
+        {
+            var item = Children().FirstOrDefault(x => x.Code == code);
+            if (item == null) return default(T);
+
+            if (typeof(T) == typeof(DicomContentItem)) return (T)(object)item;
+
+            return item.Get<T>();
+        }
+
+        public override string ToString()
+        {
+            var s = Dataset.Get<string>(DicomTag.RelationshipType, 0, String.Empty);
+            if (!String.IsNullOrEmpty(s)) s += " ";
+            else s = String.Empty;
+            if (Code != null) s += String.Format("{0} {1}", Code.ToString(), Dataset.Get<string>(DicomTag.ValueType, 0, "UNKNOWN"));
+            else
+                s += String.Format(
+                    "{0} {1}",
+                    "(no code provided)",
+                    Dataset.Get<string>(DicomTag.ValueType, 0, "UNKNOWN"));
+            try
+            {
+                s += String.Format(" [{0}]", Get<string>());
+            }
+            catch
+            {
+            }
+            return s;
+        }
+    }
 }

--- a/DICOM/StructuredReport/DicomMeasuredValue.cs
+++ b/DICOM/StructuredReport/DicomMeasuredValue.cs
@@ -1,34 +1,48 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.StructuredReport {
-	public class DicomMeasuredValue : DicomDataset {
-		public DicomMeasuredValue(DicomDataset dataset) : base(dataset) {
-		}
+using System;
 
-		public DicomMeasuredValue(DicomSequence sequence) {
-			if (sequence.Items.Count == 0)
-				throw new DicomDataException("No measurement item found in sequence.");
-			Add(sequence.Items[0]);
-		}
+namespace Dicom.StructuredReport
+{
+    public class DicomMeasuredValue : DicomDataset
+    {
+        public DicomMeasuredValue(DicomDataset dataset)
+            : base(dataset)
+        {
+        }
 
-		public DicomMeasuredValue(decimal value, DicomCodeItem units) {
-			Add(DicomTag.NumericValue, value);
-			Add(new DicomSequence(DicomTag.MeasurementUnitsCodeSequence, units));
-		}
+        public DicomMeasuredValue(DicomSequence sequence)
+        {
+            if (sequence.Items.Count == 0) throw new DicomDataException("No measurement item found in sequence.");
+            Add(sequence.Items[0]);
+        }
 
-		public DicomCodeItem Code {
-			get { return Get<DicomCodeItem>(DicomTag.MeasurementUnitsCodeSequence); }
-		}
+        public DicomMeasuredValue(decimal value, DicomCodeItem units)
+        {
+            Add(DicomTag.NumericValue, value);
+            Add(new DicomSequence(DicomTag.MeasurementUnitsCodeSequence, units));
+        }
 
-		public decimal Value {
-			get { return Get<decimal>(DicomTag.NumericValue); }
-		}
+        public DicomCodeItem Code
+        {
+            get
+            {
+                return Get<DicomCodeItem>(DicomTag.MeasurementUnitsCodeSequence);
+            }
+        }
 
-		public override string ToString() {
-			return String.Format("{0} {1}", Value, Code.Value);
-		}
-	}
+        public decimal Value
+        {
+            get
+            {
+                return Get<decimal>(DicomTag.NumericValue);
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0} {1}", Value, Code.Value);
+        }
+    }
 }

--- a/DICOM/StructuredReport/DicomReferencedSOP.cs
+++ b/DICOM/StructuredReport/DicomReferencedSOP.cs
@@ -1,30 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.StructuredReport {
-	public class DicomReferencedSOP : DicomDataset {
-		public DicomReferencedSOP(DicomDataset dataset) : base(dataset) {
-		}
+namespace Dicom.StructuredReport
+{
+    public class DicomReferencedSOP : DicomDataset
+    {
+        public DicomReferencedSOP(DicomDataset dataset)
+            : base(dataset)
+        {
+        }
 
-		public DicomReferencedSOP(DicomSequence sequence) {
-			if (sequence.Items.Count == 0)
-				throw new DicomDataException("No referenced SOP pair item found in sequence.");
-			Add(sequence.Items[0]);
-		}
+        public DicomReferencedSOP(DicomSequence sequence)
+        {
+            if (sequence.Items.Count == 0) throw new DicomDataException("No referenced SOP pair item found in sequence.");
+            Add(sequence.Items[0]);
+        }
 
-		public DicomReferencedSOP(DicomUID inst, DicomUID clazz) {
-			Add(DicomTag.ReferencedSOPInstanceUID, inst);
-			Add(DicomTag.ReferencedSOPClassUID, clazz);
-		}
+        public DicomReferencedSOP(DicomUID inst, DicomUID clazz)
+        {
+            Add(DicomTag.ReferencedSOPInstanceUID, inst);
+            Add(DicomTag.ReferencedSOPClassUID, clazz);
+        }
 
-		public DicomUID Instance {
-			get { return Get<DicomUID>(DicomTag.ReferencedSOPInstanceUID); }
-		}
+        public DicomUID Instance
+        {
+            get
+            {
+                return Get<DicomUID>(DicomTag.ReferencedSOPInstanceUID);
+            }
+        }
 
-		public DicomUID Class {
-			get { return Get<DicomUID>(DicomTag.ReferencedSOPClassUID); }
-		}
-	}
+        public DicomUID Class
+        {
+            get
+            {
+                return Get<DicomUID>(DicomTag.ReferencedSOPClassUID);
+            }
+        }
+    }
 }

--- a/DICOM/StructuredReport/DicomStructuredReport.cs
+++ b/DICOM/StructuredReport/DicomStructuredReport.cs
@@ -1,16 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.StructuredReport {
-	public class DicomStructuredReport : DicomContentItem {
-		public DicomStructuredReport(DicomDataset dataset) : base(dataset) {
-		}
+namespace Dicom.StructuredReport
+{
+    public class DicomStructuredReport : DicomContentItem
+    {
+        public DicomStructuredReport(DicomDataset dataset)
+            : base(dataset)
+        {
+        }
 
-		public DicomStructuredReport(DicomCodeItem code, params DicomContentItem[] items) : base(code, DicomRelationship.Contains, DicomContinuity.Separate, items) {
-			// relationship type is not needed for root element
-			Dataset.Remove(DicomTag.RelationshipType);
-		}
-	}
+        public DicomStructuredReport(DicomCodeItem code, params DicomContentItem[] items)
+            : base(code, DicomRelationship.Contains, DicomContinuity.Separate, items)
+        {
+            // relationship type is not needed for root element
+            Dataset.Remove(DicomTag.RelationshipType);
+        }
+    }
 }

--- a/DICOM/StructuredReport/DicomStructuredReportException.cs
+++ b/DICOM/StructuredReport/DicomStructuredReportException.cs
@@ -1,17 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.StructuredReport {
-	public class DicomStructuredReportException : DicomException {
-		public DicomStructuredReportException(string message) : base(message) {
-		}
+using System;
 
-		public DicomStructuredReportException(string format, params object[] args) : base(format, args) {
-		}
+namespace Dicom.StructuredReport
+{
+    public class DicomStructuredReportException : DicomException
+    {
+        public DicomStructuredReportException(string message)
+            : base(message)
+        {
+        }
 
-		public DicomStructuredReportException(string message, Exception innerException) : base(message, innerException) {
-		}
-	}
+        public DicomStructuredReportException(string format, params object[] args)
+            : base(format, args)
+        {
+        }
+
+        public DicomStructuredReportException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
 }

--- a/DICOM/Threading/ActionCallback.cs
+++ b/DICOM/Threading/ActionCallback.cs
@@ -1,65 +1,94 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Threading {
-	public static class ActionExtensions {
-		public static void InvokeAsync(this Action action) {
-			action.BeginInvoke(OnEndInvoke, action);
-		}
-		private static void OnEndInvoke(IAsyncResult result) {
-			try {
-				Action action = result.AsyncState as Action;
-				action.EndInvoke(result);
-			} catch {
-			}
-		}
-	}
+using System;
 
-	public class ActionCallback {
-		private Action _action;
+namespace Dicom.Threading
+{
+    public static class ActionExtensions
+    {
+        public static void InvokeAsync(this Action action)
+        {
+            action.BeginInvoke(OnEndInvoke, action);
+        }
 
-		public ActionCallback(Action action) {
-			_action = action;
-		}
+        private static void OnEndInvoke(IAsyncResult result)
+        {
+            try
+            {
+                Action action = result.AsyncState as Action;
+                action.EndInvoke(result);
+            }
+            catch
+            {
+            }
+        }
+    }
 
-		public void Invoke() {
-			_action.Invoke();
-		}
+    public class ActionCallback
+    {
+        private Action _action;
 
-		public IAsyncResult BeginInvoke(AsyncCallback callback, object @object) {
-			return _action.BeginInvoke(callback, @object);
-		}
+        public ActionCallback(Action action)
+        {
+            _action = action;
+        }
 
-		public void EndInvoke(IAsyncResult result) {
-			_action.EndInvoke(result);
-		}
+        public void Invoke()
+        {
+            _action.Invoke();
+        }
 
-		public static implicit operator Action(ActionCallback callback) {
-			return callback._action;
-		}
+        public IAsyncResult BeginInvoke(AsyncCallback callback, object @object)
+        {
+            return _action.BeginInvoke(callback, @object);
+        }
 
-		public static implicit operator Delegate(ActionCallback callback) {
-			return callback._action;
-		}
-	}
+        public void EndInvoke(IAsyncResult result)
+        {
+            _action.EndInvoke(result);
+        }
 
-	public class ActionCallback<T1> : ActionCallback {
-		public ActionCallback(Action<T1> action, T1 arg0) : base(() => { action(arg0); }) {
-		}
-	}
+        public static implicit operator Action(ActionCallback callback)
+        {
+            return callback._action;
+        }
 
-	public class ActionCallback<T1, T2> : ActionCallback {
-		public ActionCallback(Action<T1, T2> action, T1 arg0, T2 arg1) : base(() => { action(arg0, arg1); }) {
-		}
-	}
+        public static implicit operator Delegate(ActionCallback callback)
+        {
+            return callback._action;
+        }
+    }
 
-	public class ActionCallback<T1, T2, T3> : ActionCallback {
-		public ActionCallback(Action<T1, T2, T3> action, T1 arg0, T2 arg1, T3 arg2) : base(() => { action(arg0, arg1, arg2); }) {
-		}
-	}
+    public class ActionCallback<T1> : ActionCallback
+    {
+        public ActionCallback(Action<T1> action, T1 arg0)
+            : base(() => { action(arg0); })
+        {
+        }
+    }
 
-	public class ActionCallback<T1, T2, T3, T4> : ActionCallback {
-		public ActionCallback(Action<T1, T2, T3, T4> action, T1 arg0, T2 arg1, T3 arg2, T4 arg3) : base(() => { action(arg0, arg1, arg2, arg3); }) {
-		}
-	}
+    public class ActionCallback<T1, T2> : ActionCallback
+    {
+        public ActionCallback(Action<T1, T2> action, T1 arg0, T2 arg1)
+            : base(() => { action(arg0, arg1); })
+        {
+        }
+    }
+
+    public class ActionCallback<T1, T2, T3> : ActionCallback
+    {
+        public ActionCallback(Action<T1, T2, T3> action, T1 arg0, T2 arg1, T3 arg2)
+            : base(() => { action(arg0, arg1, arg2); })
+        {
+        }
+    }
+
+    public class ActionCallback<T1, T2, T3, T4> : ActionCallback
+    {
+        public ActionCallback(Action<T1, T2, T3, T4> action, T1 arg0, T2 arg1, T3 arg2, T4 arg3)
+            : base(() => { action(arg0, arg1, arg2, arg3); })
+        {
+        }
+    }
 }

--- a/DICOM/Threading/ActionQueue.cs
+++ b/DICOM/Threading/ActionQueue.cs
@@ -1,119 +1,144 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 
-namespace Dicom.Threading {
-	/// <summary>
-	/// Executes a queue of actions on a single thread.
-	/// </summary>
-	public class ActionQueue : IDisposable {
-		private Thread _thread;
-		private ManualResetEventSlim _event;
-		private volatile bool _stop;
-		private object _lock;
-		private Queue<Action> _actions;
+namespace Dicom.Threading
+{
+    /// <summary>
+    /// Executes a queue of actions on a single thread.
+    /// </summary>
+    public class ActionQueue : IDisposable
+    {
+        private Thread _thread;
 
-		public ActionQueue() {
-		}
+        private ManualResetEventSlim _event;
 
-		~ActionQueue() {
-			Stop();
-		}
+        private volatile bool _stop;
 
-		public int Count {
-			get {
-				if (_actions == null)
-					return 0;
+        private object _lock;
 
-				lock (_lock)
-					return _actions.Count;
-			}
-		}
+        private Queue<Action> _actions;
 
-		public void Enqueue(Action action) {
-			if (_thread == null)
-				Start();
+        public ActionQueue()
+        {
+        }
 
-			lock (_lock) {
-				_actions.Enqueue(action);
-				_event.Set();
-			}
-		}
+        ~ActionQueue()
+        {
+            Stop();
+        }
 
-		public void Enqueue<T1>(Action<T1> action, T1 arg0) {
-			Enqueue(new ActionCallback<T1>(action, arg0));
-		}
+        public int Count
+        {
+            get
+            {
+                if (_actions == null) return 0;
 
-		public void Enqueue<T1, T2>(Action<T1, T2> action, T1 arg0, T2 arg1) {
-			Enqueue(new ActionCallback<T1, T2>(action, arg0, arg1));
-		}
+                lock (_lock) return _actions.Count;
+            }
+        }
 
-		public void Enqueue<T1, T2, T3, T4>(Action<T1, T2, T3> action, T1 arg0, T2 arg1, T3 arg2) {
-			Enqueue(new ActionCallback<T1, T2, T3>(action, arg0, arg1, arg2));
-		}
+        public void Enqueue(Action action)
+        {
+            if (_thread == null) Start();
 
-		public void Enqueue<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg0, T2 arg1, T3 arg2, T4 arg3) {
-			Enqueue(new ActionCallback<T1, T2, T3, T4>(action, arg0, arg1, arg2, arg3));
-		}
+            lock (_lock)
+            {
+                _actions.Enqueue(action);
+                _event.Set();
+            }
+        }
 
-		private void Start() {
-			if (_thread != null)
-				return;
+        public void Enqueue<T1>(Action<T1> action, T1 arg0)
+        {
+            Enqueue(new ActionCallback<T1>(action, arg0));
+        }
 
-			_event = new ManualResetEventSlim(false);
-			_stop = false;
-			_lock = new object();
-			_actions = new Queue<Action>();
-			_thread = new Thread(Proc);
-			_thread.IsBackground = true;
-			_thread.Start();
-		}
+        public void Enqueue<T1, T2>(Action<T1, T2> action, T1 arg0, T2 arg1)
+        {
+            Enqueue(new ActionCallback<T1, T2>(action, arg0, arg1));
+        }
 
-		private void Stop() {
-			if (_thread != null) {
-				_stop = true;
-				_event.Set();
-				_thread = null;
-			}
-		}
+        public void Enqueue<T1, T2, T3, T4>(Action<T1, T2, T3> action, T1 arg0, T2 arg1, T3 arg2)
+        {
+            Enqueue(new ActionCallback<T1, T2, T3>(action, arg0, arg1, arg2));
+        }
 
-		private void Proc() {
-			while (true) {
-				_event.Wait(1000);
+        public void Enqueue<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action, T1 arg0, T2 arg1, T3 arg2, T4 arg3)
+        {
+            Enqueue(new ActionCallback<T1, T2, T3, T4>(action, arg0, arg1, arg2, arg3));
+        }
 
-				while (!_stop) {
-					Action action;
+        private void Start()
+        {
+            if (_thread != null) return;
 
-					lock (_lock) {
-						if (_actions.Count == 0) {
-							_event.Reset();
-							break;
-						}
+            _event = new ManualResetEventSlim(false);
+            _stop = false;
+            _lock = new object();
+            _actions = new Queue<Action>();
+            _thread = new Thread(Proc);
+            _thread.IsBackground = true;
+            _thread.Start();
+        }
 
-						action = _actions.Dequeue();
+        private void Stop()
+        {
+            if (_thread != null)
+            {
+                _stop = true;
+                _event.Set();
+                _thread = null;
+            }
+        }
 
-						if (_actions.Count == 0)
-							_event.Reset();
-					}
+        private void Proc()
+        {
+            while (true)
+            {
+                _event.Wait(1000);
 
-					try {
-						action.Invoke();
-					} catch {
-						// log this somewhere?
-					}
+                while (!_stop)
+                {
+                    Action action;
 
-					// force dereference
-					action = null;
-				}
+                    lock (_lock)
+                    {
+                        if (_actions.Count == 0)
+                        {
+                            _event.Reset();
+                            break;
+                        }
 
-				if (_stop)
-					return;
-			}
-		}
+                        action = _actions.Dequeue();
 
-		public void Dispose() {
-			GC.SuppressFinalize(this);
-			Stop();
-		}
-	}
+                        if (_actions.Count == 0) _event.Reset();
+                    }
+
+                    try
+                    {
+                        action.Invoke();
+                    }
+                    catch
+                    {
+                        // log this somewhere?
+                    }
+
+                    // force dereference
+                    action = null;
+                }
+
+                if (_stop) return;
+            }
+        }
+
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+            Stop();
+        }
+    }
 }

--- a/DICOM/Threading/CompoundAction.cs
+++ b/DICOM/Threading/CompoundAction.cs
@@ -1,41 +1,52 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 
-namespace Dicom.Threading {
-	public class CompoundAction {
-		private Action _action;
-		private List<Action> _actions;
+namespace Dicom.Threading
+{
+    public class CompoundAction
+    {
+        private Action _action;
 
-		public CompoundAction() {
-			_actions = new List<Action>();
-			_action = () => {
-				foreach (Action action in _actions)
-					if (action != null) action();
-			};
-		}
+        private List<Action> _actions;
 
-		public CompoundAction(params Action[] actions) : this() {
-			_actions.AddRange(actions);
-		}
+        public CompoundAction()
+        {
+            _actions = new List<Action>();
+            _action = () => { foreach (Action action in _actions) if (action != null) action(); };
+        }
 
-		public void Add(Action action) {
-			_actions.Add(action);
-		}
+        public CompoundAction(params Action[] actions)
+            : this()
+        {
+            _actions.AddRange(actions);
+        }
 
-		public void Invoke() {
-			_action.Invoke();
-		}
+        public void Add(Action action)
+        {
+            _actions.Add(action);
+        }
 
-		public IAsyncResult BeginInvoke(AsyncCallback callback, object @object) {
-			return _action.BeginInvoke(callback, @object);
-		}
+        public void Invoke()
+        {
+            _action.Invoke();
+        }
 
-		public void EndInvoke(IAsyncResult result) {
-			_action.EndInvoke(result);
-		}
+        public IAsyncResult BeginInvoke(AsyncCallback callback, object @object)
+        {
+            return _action.BeginInvoke(callback, @object);
+        }
 
-		public static implicit operator Action(CompoundAction compound) {
-			return compound._action;
-		}
-	}
+        public void EndInvoke(IAsyncResult result)
+        {
+            _action.EndInvoke(result);
+        }
+
+        public static implicit operator Action(CompoundAction compound)
+        {
+            return compound._action;
+        }
+    }
 }

--- a/Examples/C-Store SCP/Program.cs
+++ b/Examples/C-Store SCP/Program.cs
@@ -1,111 +1,142 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-using Dicom;
+using System;
+using System.IO;
+
 using Dicom.Log;
 using Dicom.Network;
 
-namespace Dicom.CStoreSCP {
-	class Program {
-		static string StoragePath = @".\DICOM";
+namespace Dicom.CStoreSCP
+{
+    internal class Program
+    {
+        private static string StoragePath = @".\DICOM";
 
-		static void Main(string[] args) {
-			// preload dictionary to prevent timeouts
-			var dict = DicomDictionary.Default;
+        private static void Main(string[] args)
+        {
+            // preload dictionary to prevent timeouts
+            var dict = DicomDictionary.Default;
 
 
-			// start DICOM server on port 104
-			var server = new DicomServer<CStoreSCP>(104);
+            // start DICOM server on port 104
+            var server = new DicomServer<CStoreSCP>(104);
 
 
-			// end process
-			Console.WriteLine("Press <return> to end...");
-			Console.ReadLine();
-		}
+            // end process
+            Console.WriteLine("Press <return> to end...");
+            Console.ReadLine();
+        }
 
-		class CStoreSCP : DicomService, IDicomServiceProvider, IDicomCStoreProvider, IDicomCEchoProvider {
-			private static DicomTransferSyntax[] AcceptedTransferSyntaxes = new DicomTransferSyntax[] {
-				DicomTransferSyntax.ExplicitVRLittleEndian,
-				DicomTransferSyntax.ExplicitVRBigEndian,
-				DicomTransferSyntax.ImplicitVRLittleEndian
-			};
+        private class CStoreSCP : DicomService, IDicomServiceProvider, IDicomCStoreProvider, IDicomCEchoProvider
+        {
+            private static DicomTransferSyntax[] AcceptedTransferSyntaxes = new DicomTransferSyntax[]
+                                                                                {
+                                                                                    DicomTransferSyntax
+                                                                                        .ExplicitVRLittleEndian,
+                                                                                    DicomTransferSyntax
+                                                                                        .ExplicitVRBigEndian,
+                                                                                    DicomTransferSyntax
+                                                                                        .ImplicitVRLittleEndian
+                                                                                };
 
-			private static DicomTransferSyntax[] AcceptedImageTransferSyntaxes = new DicomTransferSyntax[] {
-				// Lossless
-				DicomTransferSyntax.JPEGLSLossless,
-				DicomTransferSyntax.JPEG2000Lossless,
-				DicomTransferSyntax.JPEGProcess14SV1,
-				DicomTransferSyntax.JPEGProcess14,
-				DicomTransferSyntax.RLELossless,
-			
-				// Lossy
-				DicomTransferSyntax.JPEGLSNearLossless,
-				DicomTransferSyntax.JPEG2000Lossy,
-				DicomTransferSyntax.JPEGProcess1,
-				DicomTransferSyntax.JPEGProcess2_4,
+            private static DicomTransferSyntax[] AcceptedImageTransferSyntaxes = new DicomTransferSyntax[]
+                                                                                     {
+                                                                                         // Lossless
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEGLSLossless,
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEG2000Lossless,
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEGProcess14SV1,
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEGProcess14,
+                                                                                         DicomTransferSyntax
+                                                                                             .RLELossless,
 
-				// Uncompressed
-				DicomTransferSyntax.ExplicitVRLittleEndian,
-				DicomTransferSyntax.ExplicitVRBigEndian,
-				DicomTransferSyntax.ImplicitVRLittleEndian
-			};
+                                                                                         // Lossy
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEGLSNearLossless,
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEG2000Lossy,
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEGProcess1,
+                                                                                         DicomTransferSyntax
+                                                                                             .JPEGProcess2_4,
 
-			public CStoreSCP(Stream stream, Logger log) : base(stream, log) {
-			}
+                                                                                         // Uncompressed
+                                                                                         DicomTransferSyntax
+                                                                                             .ExplicitVRLittleEndian,
+                                                                                         DicomTransferSyntax
+                                                                                             .ExplicitVRBigEndian,
+                                                                                         DicomTransferSyntax
+                                                                                             .ImplicitVRLittleEndian
+                                                                                     };
 
-			public void OnReceiveAssociationRequest(DicomAssociation association) {
-				if (association.CalledAE != "STORESCP") {
-					SendAssociationReject(DicomRejectResult.Permanent, DicomRejectSource.ServiceUser, DicomRejectReason.CalledAENotRecognized);
-					return;
-				}
+            public CStoreSCP(Stream stream, Logger log)
+                : base(stream, log)
+            {
+            }
 
-				foreach (var pc in association.PresentationContexts) {
-					if (pc.AbstractSyntax == DicomUID.Verification)
-						pc.AcceptTransferSyntaxes(AcceptedTransferSyntaxes);
-					else if (pc.AbstractSyntax.StorageCategory != DicomStorageCategory.None)
-						pc.AcceptTransferSyntaxes(AcceptedImageTransferSyntaxes);
-				}
+            public void OnReceiveAssociationRequest(DicomAssociation association)
+            {
+                if (association.CalledAE != "STORESCP")
+                {
+                    SendAssociationReject(
+                        DicomRejectResult.Permanent,
+                        DicomRejectSource.ServiceUser,
+                        DicomRejectReason.CalledAENotRecognized);
+                    return;
+                }
 
-				SendAssociationAccept(association);
-			}
+                foreach (var pc in association.PresentationContexts)
+                {
+                    if (pc.AbstractSyntax == DicomUID.Verification) pc.AcceptTransferSyntaxes(AcceptedTransferSyntaxes);
+                    else if (pc.AbstractSyntax.StorageCategory != DicomStorageCategory.None) pc.AcceptTransferSyntaxes(AcceptedImageTransferSyntaxes);
+                }
 
-			public void OnReceiveAssociationReleaseRequest() {
-				SendAssociationReleaseResponse();
-			}
+                SendAssociationAccept(association);
+            }
 
-			public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason) {
-			}
+            public void OnReceiveAssociationReleaseRequest()
+            {
+                SendAssociationReleaseResponse();
+            }
 
-			public void OnConnectionClosed(Exception exception) {
-			}
+            public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+            {
+            }
 
-			public DicomCStoreResponse OnCStoreRequest(DicomCStoreRequest request) {
-				var studyUid = request.Dataset.Get<string>(DicomTag.StudyInstanceUID);
-				var instUid = request.SOPInstanceUID.UID;
+            public void OnConnectionClosed(Exception exception)
+            {
+            }
 
-				var path = Path.GetFullPath(Program.StoragePath);
-				path = Path.Combine(path, studyUid);
+            public DicomCStoreResponse OnCStoreRequest(DicomCStoreRequest request)
+            {
+                var studyUid = request.Dataset.Get<string>(DicomTag.StudyInstanceUID);
+                var instUid = request.SOPInstanceUID.UID;
 
-				if (!Directory.Exists(path))
-					Directory.CreateDirectory(path);
+                var path = Path.GetFullPath(Program.StoragePath);
+                path = Path.Combine(path, studyUid);
 
-				path = Path.Combine(path, instUid) + ".dcm";
+                if (!Directory.Exists(path)) Directory.CreateDirectory(path);
 
-				request.File.Save(path);
+                path = Path.Combine(path, instUid) + ".dcm";
 
-				return new DicomCStoreResponse(request, DicomStatus.Success);
-			}
+                request.File.Save(path);
 
-			public void OnCStoreRequestException(string tempFileName, Exception e) {
-				// let library handle logging and error response
-			}
+                return new DicomCStoreResponse(request, DicomStatus.Success);
+            }
 
-			public DicomCEchoResponse OnCEchoRequest(DicomCEchoRequest request) {
-				return new DicomCEchoResponse(request, DicomStatus.Success);
-			}
-		}
-	}
+            public void OnCStoreRequestException(string tempFileName, Exception e)
+            {
+                // let library handle logging and error response
+            }
+
+            public DicomCEchoResponse OnCEchoRequest(DicomCEchoRequest request)
+            {
+                return new DicomCEchoResponse(request, DicomStatus.Success);
+            }
+        }
+    }
 }

--- a/Examples/C-Store SCP/Properties/AssemblyInfo.cs
+++ b/Examples/C-Store SCP/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Examples/DICOM Media/Program.cs
+++ b/Examples/DICOM Media/Program.cs
@@ -1,78 +1,103 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.IO;
-using System.Linq;
-using System.Text;
 
-namespace Dicom.Media {
-	class Program {
-		static void Main(string[] args) {
-			try {
-				if (args.Length < 2) {
-					PrintUsage();
-					return;
-				}
+namespace Dicom.Media
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            try
+            {
+                if (args.Length < 2)
+                {
+                    PrintUsage();
+                    return;
+                }
 
-				var action = args[0];
-				var path = args[1];
+                var action = args[0];
+                var path = args[1];
 
-				if (action == "read") {
-					path = Path.Combine(path, "DICOMDIR");
+                if (action == "read")
+                {
+                    path = Path.Combine(path, "DICOMDIR");
 
-					if (!File.Exists(path)) {
-						Console.WriteLine("DICOMDIR file not found: {0}", path);
-						return;
-					}
+                    if (!File.Exists(path))
+                    {
+                        Console.WriteLine("DICOMDIR file not found: {0}", path);
+                        return;
+                    }
 
-					ReadMedia(path);
-					return;
-				}
+                    ReadMedia(path);
+                    return;
+                }
 
-				WriteMedia(path);
-			} catch (Exception ex) {
-				Console.WriteLine(ex.Message);
-			} finally {
+                WriteMedia(path);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+            finally
+            {
 
-			}
-		}
+            }
+        }
 
-		private static void WriteMedia(string path) {
-			var dicomDirPath = Path.Combine(path, "DICOMDIR");
+        private static void WriteMedia(string path)
+        {
+            var dicomDirPath = Path.Combine(path, "DICOMDIR");
 
-			var dirInfo = new DirectoryInfo(path);
+            var dirInfo = new DirectoryInfo(path);
 
-			var dicomDir = new DicomDirectory();
-			foreach (var file in dirInfo.GetFiles("*.*", SearchOption.AllDirectories)) {
-				var dicomFile = Dicom.DicomFile.Open(file.FullName);
+            var dicomDir = new DicomDirectory();
+            foreach (var file in dirInfo.GetFiles("*.*", SearchOption.AllDirectories))
+            {
+                var dicomFile = Dicom.DicomFile.Open(file.FullName);
 
-				dicomDir.AddFile(dicomFile, String.Format(@"000001\{0}", file.Name));
-			}
+                dicomDir.AddFile(dicomFile, String.Format(@"000001\{0}", file.Name));
+            }
 
-			dicomDir.Save(dicomDirPath);
-		}
+            dicomDir.Save(dicomDirPath);
+        }
 
-		private static void ReadMedia(string fileName) {
-			var dicomDirectory = DicomDirectory.Open(fileName);
+        private static void ReadMedia(string fileName)
+        {
+            var dicomDirectory = DicomDirectory.Open(fileName);
 
-			foreach (var patientRecord in dicomDirectory.RootDirectoryRecordCollection) {
-				Console.WriteLine("Patient: {0} ({1})", patientRecord.Get<string>(DicomTag.PatientName), patientRecord.Get<string>(DicomTag.PatientID));
+            foreach (var patientRecord in dicomDirectory.RootDirectoryRecordCollection)
+            {
+                Console.WriteLine(
+                    "Patient: {0} ({1})",
+                    patientRecord.Get<string>(DicomTag.PatientName),
+                    patientRecord.Get<string>(DicomTag.PatientID));
 
-				foreach (var studyRecord in patientRecord.LowerLevelDirectoryRecordCollection) {
-					Console.WriteLine("\tStudy: {0}", studyRecord.Get<string>(DicomTag.StudyInstanceUID));
+                foreach (var studyRecord in patientRecord.LowerLevelDirectoryRecordCollection)
+                {
+                    Console.WriteLine("\tStudy: {0}", studyRecord.Get<string>(DicomTag.StudyInstanceUID));
 
-					foreach (var seriesRecord in studyRecord.LowerLevelDirectoryRecordCollection) {
-						Console.WriteLine("\t\tSeries: {0}", seriesRecord.Get<string>(DicomTag.SeriesInstanceUID));
+                    foreach (var seriesRecord in studyRecord.LowerLevelDirectoryRecordCollection)
+                    {
+                        Console.WriteLine("\t\tSeries: {0}", seriesRecord.Get<string>(DicomTag.SeriesInstanceUID));
 
-						foreach (var imageRecord in seriesRecord.LowerLevelDirectoryRecordCollection) {
-							Console.WriteLine("\t\t\tImage: {0} [{1}]", imageRecord.Get<string>(DicomTag.ReferencedSOPInstanceUIDInFile), imageRecord.Get<string>(Dicom.DicomTag.ReferencedFileID));
-						}
-					}
-				}
-			}
-		}
+                        foreach (var imageRecord in seriesRecord.LowerLevelDirectoryRecordCollection)
+                        {
+                            Console.WriteLine(
+                                "\t\t\tImage: {0} [{1}]",
+                                imageRecord.Get<string>(DicomTag.ReferencedSOPInstanceUIDInFile),
+                                imageRecord.Get<string>(Dicom.DicomTag.ReferencedFileID));
+                        }
+                    }
+                }
+            }
+        }
 
-		private static void PrintUsage() {
-			Console.WriteLine("Usage: Dicom.Media.exe read|write <directory>");
-		}
-	}
+        private static void PrintUsage()
+        {
+            Console.WriteLine("Usage: Dicom.Media.exe read|write <directory>");
+        }
+    }
 }

--- a/Examples/DICOM Media/Properties/AssemblyInfo.cs
+++ b/Examples/DICOM Media/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Examples/Logging Serilog/Program.cs
+++ b/Examples/Logging Serilog/Program.cs
@@ -1,16 +1,23 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
+
 using Dicom.Log;
+
 using Serilog;
 using Serilog.Enrichers;
 
 namespace Dicom.Demo.SerilogDemo
 {
-    class Program {
-        
+    internal class Program
+    {
+
         //Set this to false if Seq (http://getseq.net) is not present
         private static bool useSeq = true;
 
-        static void Main(string[] args) {
+        private static void Main(string[] args)
+        {
 
             //SPECIFIC LOGGER VERSUS GLOBAL LOGGER
             //UseSpecificSerilogLogger();
@@ -35,20 +42,21 @@ namespace Dicom.Demo.SerilogDemo
         }
 
 
-        static void UseSpecificSerilogLogger() {
+        private static void UseSpecificSerilogLogger()
+        {
             //Get a Serilog logger instance
             var logger = ConfigureLogging();
 
             //Wrap it in some extra context as an example
-            logger = logger
-                .ForContext("Purpose", "Demonstration");
-            
+            logger = logger.ForContext("Purpose", "Demonstration");
+
             //Configure fo-dicom & Serilog
             LogManager.Default = new SerilogManager(logger);
 
         }
 
-        static void UseGlobalSerilogLogger() {
+        private static void UseGlobalSerilogLogger()
+        {
             //Configure logging
             ConfigureLogging();
 
@@ -57,13 +65,14 @@ namespace Dicom.Demo.SerilogDemo
 
         }
 
-        
+
         /// <summary>
         /// Create and return a serilog ILogger instance.  
         /// For convenience this also sets the global Serilog.Log instance
         /// </summary>
         /// <returns></returns>
-        public static ILogger ConfigureLogging() {
+        public static ILogger ConfigureLogging()
+        {
             var loggerConfig = new LoggerConfiguration()
                 //Enrich each log message with the machine name
                 .Enrich.With<MachineNameEnricher>()
@@ -72,13 +81,12 @@ namespace Dicom.Demo.SerilogDemo
                 //Write out to the console using the "Literate" console sink (colours the text based on the logged type)
                 .WriteTo.LiterateConsole()
                 //Also write out to a file based on the date and restrict these writes to warnings or worse (warning, error, fatal)
-                .WriteTo.RollingFile(@"Warnings_{Date}.txt", global::Serilog.Events.LogEventLevel.Warning)
-                ;
+                .WriteTo.RollingFile(@"Warnings_{Date}.txt", global::Serilog.Events.LogEventLevel.Warning);
 
-            if (useSeq) {
+            if (useSeq)
+            {
                 //Send events to a default installation of Seq on the local computer
-                loggerConfig = loggerConfig
-                    .WriteTo.Seq("http://localhost:5341");
+                loggerConfig = loggerConfig.WriteTo.Seq("http://localhost:5341");
             }
 
             var logger = loggerConfig

--- a/Examples/Logging Serilog/Properties/AssemblyInfo.cs
+++ b/Examples/Logging Serilog/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Examples/Print SCP/PrintJob.cs
+++ b/Examples/Print SCP/PrintJob.cs
@@ -1,14 +1,12 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
 using System.Drawing.Printing;
 //using System.Drawing.Printing;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using Dicom;
-using Dicom.Imaging;
-using Dicom.Printing;
-
 
 namespace Dicom.Printing
 {
@@ -19,7 +17,11 @@ namespace Dicom.Printing
         public string FilmSessionLabel { get; private set; }
         public string PrinterName { get; private set; }
 
-        public StatusUpdateEventArgs(ushort eventTypeId, string executionStatusInfo, string filmSessionLabel, string printerName)
+        public StatusUpdateEventArgs(
+            ushort eventTypeId,
+            string executionStatusInfo,
+            string filmSessionLabel,
+            string printerName)
         {
             EventTypeId = eventTypeId;
             ExecutionStatusInfo = executionStatusInfo;
@@ -27,11 +29,15 @@ namespace Dicom.Printing
             PrinterName = printerName;
         }
     }
+
     public enum PrintJobStatus : ushort
     {
         Pending = 1,
+
         Printing = 2,
+
         Done = 3,
+
         Failure = 4
     }
 
@@ -60,7 +66,9 @@ namespace Dicom.Printing
         public string FilmSessionLabel { get; private set; }
 
         private int _currentPage;
+
         private FilmBox _currentFilmBox;
+
         /// <summary>
         /// Print job SOP class UID
         /// </summary>
@@ -85,8 +93,14 @@ namespace Dicom.Printing
         /// </remarks> 
         public string ExecutionStatus
         {
-            get { return Get(DicomTag.ExecutionStatus, string.Empty); }
-            set { Add(DicomTag.ExecutionStatus, value); }
+            get
+            {
+                return Get(DicomTag.ExecutionStatus, string.Empty);
+            }
+            set
+            {
+                Add(DicomTag.ExecutionStatus, value);
+            }
         }
 
         /// <summary>
@@ -94,8 +108,14 @@ namespace Dicom.Printing
         /// </summary>
         public string ExecutionStatusInfo
         {
-            get { return Get(DicomTag.ExecutionStatusInfo, string.Empty); }
-            set { Add(DicomTag.ExecutionStatusInfo, value); }
+            get
+            {
+                return Get(DicomTag.ExecutionStatusInfo, string.Empty);
+            }
+            set
+            {
+                Add(DicomTag.ExecutionStatusInfo, value);
+            }
         }
 
         /// <summary>
@@ -111,8 +131,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string PrintPriority
         {
-            get { return Get(DicomTag.PrintPriority, "MED"); }
-            set { Add(DicomTag.PrintPriority, value); }
+            get
+            {
+                return Get(DicomTag.PrintPriority, "MED");
+            }
+            set
+            {
+                Add(DicomTag.PrintPriority, value);
+            }
         }
 
         /// <summary>
@@ -120,7 +146,10 @@ namespace Dicom.Printing
         /// </summary>
         public DateTime CreationDateTime
         {
-            get { return this.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime); }
+            get
+            {
+                return this.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
+            }
             set
             {
                 Add(DicomTag.CreationDate, value);
@@ -133,8 +162,14 @@ namespace Dicom.Printing
         /// </summary>
         public string PrinterName
         {
-            get { return Get(DicomTag.PrinterName, string.Empty); }
-            set { Add(DicomTag.PrinterName, value); }
+            get
+            {
+                return Get(DicomTag.PrinterName, string.Empty);
+            }
+            set
+            {
+                Add(DicomTag.PrinterName, value);
+            }
         }
 
         /// <summary>
@@ -142,14 +177,21 @@ namespace Dicom.Printing
         /// </summary>
         public string Originator
         {
-            get { return Get(DicomTag.Originator, string.Empty); }
-            set { Add(DicomTag.Originator, value); }
+            get
+            {
+                return Get(DicomTag.Originator, string.Empty);
+            }
+            set
+            {
+                Add(DicomTag.Originator, value);
+            }
         }
 
         public Dicom.Log.Logger Log { get; private set; }
 
 
         public event EventHandler<StatusUpdateEventArgs> StatusUpdate;
+
         #endregion
 
         #region Constructors
@@ -260,18 +302,22 @@ namespace Dicom.Printing
                 OnStatusUpdate("Printing Started");
 
                 var printerSettings = new PrinterSettings
-                {
-                    PrinterName = "Microsoft XPS Document Writer",
-                    PrintToFile = true,
-                    PrintFileName = string.Format("{0}\\{1}.xps", FullPrintJobFolder, SOPInstanceUID.UID)
-                };
+                                          {
+                                              PrinterName = "Microsoft XPS Document Writer",
+                                              PrintToFile = true,
+                                              PrintFileName =
+                                                  string.Format(
+                                                      "{0}\\{1}.xps",
+                                                      FullPrintJobFolder,
+                                                      SOPInstanceUID.UID)
+                                          };
 
                 printDocument = new PrintDocument
-                {
-                    PrinterSettings = printerSettings,
-                    DocumentName = Thread.CurrentThread.Name,
-                    PrintController = new StandardPrintController()
-                };
+                                    {
+                                        PrinterSettings = printerSettings,
+                                        DocumentName = Thread.CurrentThread.Name,
+                                        PrintController = new StandardPrintController()
+                                    };
 
                 printDocument.QueryPageSettings += OnQueryPageSettings;
                 printDocument.PrintPage += OnPrintPage;
@@ -299,7 +345,7 @@ namespace Dicom.Printing
             }
         }
 
-        void OnPrintPage(object sender, PrintPageEventArgs e)
+        private void OnPrintPage(object sender, PrintPageEventArgs e)
         {
             _currentFilmBox.Print(e.Graphics, e.MarginBounds, 100);
 
@@ -309,7 +355,7 @@ namespace Dicom.Printing
             e.HasMorePages = _currentPage < FilmBoxFolderList.Count;
         }
 
-        void OnQueryPageSettings(object sender, QueryPageSettingsEventArgs e)
+        private void OnQueryPageSettings(object sender, QueryPageSettingsEventArgs e)
         {
             OnStatusUpdate(string.Format("Printing film {0} of {1}", _currentPage + 1, FilmBoxFolderList.Count));
             var filmBoxFolder = string.Format("{0}\\{1}", FullPrintJobFolder, FilmBoxFolderList[_currentPage]);

--- a/Examples/Print SCP/Printer.cs
+++ b/Examples/Print SCP/Printer.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 
 //[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("PaXtreme.Dicom.Test")]
 
@@ -10,6 +10,7 @@ namespace Dicom.Printing
     public class Printer : DicomDataset
     {
         #region Properties and Attributes
+
         public string PrinterAet { get; private set; }
 
         /// <summary>
@@ -25,8 +26,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string PrinterStatus
         {
-            get { return Get<string>(DicomTag.PrinterStatus, "NORMAL"); }
-            private set { Add(DicomTag.PrinterStatus, value); }
+            get
+            {
+                return Get<string>(DicomTag.PrinterStatus, "NORMAL");
+            }
+            private set
+            {
+                Add(DicomTag.PrinterStatus, value);
+            }
         }
 
         /// <summary>
@@ -38,8 +45,14 @@ namespace Dicom.Printing
         /// </remarks>
         public string PrinterStatusInfo
         {
-            get { return Get<string>(DicomTag.PrinterStatusInfo, "NORMAL"); }
-            private set { Add(DicomTag.PrinterStatusInfo, value); }
+            get
+            {
+                return Get<string>(DicomTag.PrinterStatusInfo, "NORMAL");
+            }
+            private set
+            {
+                Add(DicomTag.PrinterStatusInfo, value);
+            }
         }
 
         /// <summary>
@@ -47,8 +60,14 @@ namespace Dicom.Printing
         /// </summary>
         public string PrinterName
         {
-            get { return Get(DicomTag.PrinterName, string.Empty); }
-            private set { Add(DicomTag.PrinterName, value); }
+            get
+            {
+                return Get(DicomTag.PrinterName, string.Empty);
+            }
+            private set
+            {
+                Add(DicomTag.PrinterName, value);
+            }
         }
 
         /// <summary>
@@ -56,8 +75,14 @@ namespace Dicom.Printing
         /// </summary>
         public string Manufacturer
         {
-            get { return Get(DicomTag.Manufacturer, "Nebras Technology"); }
-            private set { Add(DicomTag.Manufacturer, value); }
+            get
+            {
+                return Get(DicomTag.Manufacturer, "Nebras Technology");
+            }
+            private set
+            {
+                Add(DicomTag.Manufacturer, value);
+            }
         }
 
         /// <summary>
@@ -65,8 +90,14 @@ namespace Dicom.Printing
         /// </summary>
         public string ManufacturerModelName
         {
-            get { return Get(DicomTag.ManufacturerModelName, "PaXtreme Printer"); }
-            private set { Add(DicomTag.ManufacturerModelName, value); }
+            get
+            {
+                return Get(DicomTag.ManufacturerModelName, "PaXtreme Printer");
+            }
+            private set
+            {
+                Add(DicomTag.ManufacturerModelName, value);
+            }
         }
 
         /// <summary>
@@ -74,8 +105,14 @@ namespace Dicom.Printing
         /// </summary>
         public string DeviceSerialNumber
         {
-            get { return Get(DicomTag.DeviceSerialNumber, string.Empty); }
-            private set { Add(DicomTag.DeviceSerialNumber, value); }
+            get
+            {
+                return Get(DicomTag.DeviceSerialNumber, string.Empty);
+            }
+            private set
+            {
+                Add(DicomTag.DeviceSerialNumber, value);
+            }
         }
 
         /// <summary>
@@ -83,8 +120,14 @@ namespace Dicom.Printing
         /// </summary>
         public string SoftwareVersions
         {
-            get { return Get(DicomTag.SoftwareVersions, string.Empty); }
-            private set { Add(DicomTag.SoftwareVersions, value); }
+            get
+            {
+                return Get(DicomTag.SoftwareVersions, string.Empty);
+            }
+            private set
+            {
+                Add(DicomTag.SoftwareVersions, value);
+            }
         }
 
         /// <summary>
@@ -92,14 +135,18 @@ namespace Dicom.Printing
         /// </summary>
         public DateTime DateTimeOfLastCalibration
         {
-            get { return this.GetDateTime(DicomTag.DateOfLastCalibration, DicomTag.TimeOfLastCalibration); }
-            private set 
-            { 
+            get
+            {
+                return this.GetDateTime(DicomTag.DateOfLastCalibration, DicomTag.TimeOfLastCalibration);
+            }
+            private set
+            {
                 Add(DicomTag.DateOfLastCalibration, value);
                 Add(DicomTag.TimeOfLastCalibration, value);
 
             }
         }
+
         #endregion
 
         #region Constructors and Initialization
@@ -117,6 +164,7 @@ namespace Dicom.Printing
             PrinterStatusInfo = "NORMAL";
 
         }
+
         #endregion
     }
 }

--- a/Examples/Print SCP/Program.cs
+++ b/Examples/Print SCP/Program.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
+
 using Dicom.Printing;
 
 namespace Print_SCP
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             //This is a simple DICOM Print SCP implementation with Print Job and Send Event Report Support
             //This sample depends on the Microsoft XPS Document Writer Printer to be installed on the system
@@ -19,8 +19,8 @@ namespace Print_SCP
             //All print jobs willbe created to the exe folder under a folder named PrintJobs
 
             Console.WriteLine("Starting print SCP server with AET: PRINTSCP on port 8000");
-            
-            PrintService.Start(8000,"PRINTSCP");
+
+            PrintService.Start(8000, "PRINTSCP");
 
             Console.WriteLine("Press any key to stop the service");
 

--- a/Examples/Print SCP/Properties/AssemblyInfo.cs
+++ b/Examples/Print SCP/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Examples/Print SCU/PrintJob.cs
+++ b/Examples/Print SCU/PrintJob.cs
@@ -1,19 +1,20 @@
-﻿using Dicom;
-using Dicom.Imaging;
-using Dicom.IO;
-using Dicom.Network;
-using Dicom.Printing;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using Dicom;
+using Dicom.Imaging;
+using Dicom.IO;
+using Dicom.Network;
+using Dicom.Printing;
 
 namespace Print_SCU
 {
-    class PrintJob
+    internal class PrintJob
     {
         public string CallingAE { get; set; }
         public string CalledAE { get; set; }
@@ -23,27 +24,35 @@ namespace Print_SCU
         public FilmSession FilmSession { get; private set; }
 
         private FilmBox _currentFilmBox;
+
         public PrintJob(string jobLabel)
         {
             FilmSession = new FilmSession(DicomUID.BasicFilmSessionSOPClass)
-            {
-                FilmSessionLabel = jobLabel,
-                MediumType = "PAPER",
-                NumberOfCopies = 1
-            };
+                              {
+                                  FilmSessionLabel = jobLabel,
+                                  MediumType = "PAPER",
+                                  NumberOfCopies = 1
+                              };
         }
 
         public FilmBox StartFilmBox(string format, string orientation, string filmSize)
         {
             var filmBox = new FilmBox(FilmSession, null, DicomTransferSyntax.ExplicitVRLittleEndian)
-            {
-                ImageDisplayFormat = format,
-                FilmOrienation = orientation,
-                FilmSizeID = filmSize,
-                MagnificationType = "NONE",
-                BorderDensity = "BLACK",
-                EmptyImageDensity = "BLACK"
-            };
+                              {
+                                  ImageDisplayFormat
+                                      = format,
+                                  FilmOrienation
+                                      =
+                                      orientation,
+                                  FilmSizeID =
+                                      filmSize,
+                                  MagnificationType
+                                      = "NONE",
+                                  BorderDensity =
+                                      "BLACK",
+                                  EmptyImageDensity
+                                      = "BLACK"
+                              };
 
             filmBox.Initialize();
             FilmSession.BasicFilmBoxes.Add(filmBox);
@@ -54,7 +63,7 @@ namespace Print_SCU
 
         public void AddImage(Bitmap bitmap, int index)
         {
-            if(FilmSession.IsColor)
+            if (FilmSession.IsColor)
             {
                 AddColorImage(bitmap, index);
             }
@@ -63,6 +72,7 @@ namespace Print_SCU
                 AddGreyscaleImage(bitmap, index);
             }
         }
+
         private void AddGreyscaleImage(Bitmap bitmap, int index)
         {
             if (_currentFilmBox == null)
@@ -74,24 +84,22 @@ namespace Print_SCU
                 throw new ArgumentOutOfRangeException("Image box index out of range");
             }
 
-            if (bitmap.PixelFormat != PixelFormat.Format24bppRgb &&
-               bitmap.PixelFormat != PixelFormat.Format32bppArgb &&
-               bitmap.PixelFormat != PixelFormat.Format32bppRgb
-              )
+            if (bitmap.PixelFormat != PixelFormat.Format24bppRgb && bitmap.PixelFormat != PixelFormat.Format32bppArgb
+                && bitmap.PixelFormat != PixelFormat.Format32bppRgb)
             {
                 throw new ArgumentException("Not supported bitmap format");
             }
 
             var dataset = new DicomDataset();
             dataset.Add<ushort>(DicomTag.Columns, (ushort)bitmap.Width)
-                   .Add<ushort>(DicomTag.Rows, (ushort)bitmap.Height)
-                   .Add<ushort>(DicomTag.BitsAllocated, 8)
-                   .Add<ushort>(DicomTag.BitsStored, 8)
-                   .Add<ushort>(DicomTag.HighBit, 7)
-                   .Add(DicomTag.PixelRepresentation, (ushort)PixelRepresentation.Unsigned)
-                   .Add(DicomTag.PlanarConfiguration, (ushort)PlanarConfiguration.Interleaved)
-                   .Add<ushort>(DicomTag.SamplesPerPixel, 1)
-                   .Add(DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value);
+                .Add<ushort>(DicomTag.Rows, (ushort)bitmap.Height)
+                .Add<ushort>(DicomTag.BitsAllocated, 8)
+                .Add<ushort>(DicomTag.BitsStored, 8)
+                .Add<ushort>(DicomTag.HighBit, 7)
+                .Add(DicomTag.PixelRepresentation, (ushort)PixelRepresentation.Unsigned)
+                .Add(DicomTag.PlanarConfiguration, (ushort)PlanarConfiguration.Interleaved)
+                .Add<ushort>(DicomTag.SamplesPerPixel, 1)
+                .Add(DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value);
 
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -117,24 +125,22 @@ namespace Print_SCU
                 throw new ArgumentOutOfRangeException("Image box index out of range");
             }
 
-            if (bitmap.PixelFormat != PixelFormat.Format24bppRgb &&
-               bitmap.PixelFormat != PixelFormat.Format32bppArgb &&
-               bitmap.PixelFormat != PixelFormat.Format32bppRgb
-              )
+            if (bitmap.PixelFormat != PixelFormat.Format24bppRgb && bitmap.PixelFormat != PixelFormat.Format32bppArgb
+                && bitmap.PixelFormat != PixelFormat.Format32bppRgb)
             {
                 throw new ArgumentException("Not supported bitmap format");
             }
 
             var dataset = new DicomDataset();
             dataset.Add<ushort>(DicomTag.Columns, (ushort)bitmap.Width)
-                   .Add<ushort>(DicomTag.Rows, (ushort)bitmap.Height)
-                   .Add<ushort>(DicomTag.BitsAllocated, 8)
-                   .Add<ushort>(DicomTag.BitsStored, 8)
-                   .Add<ushort>(DicomTag.HighBit, 7)
-                   .Add(DicomTag.PixelRepresentation, (ushort)PixelRepresentation.Unsigned)
-                   .Add(DicomTag.PlanarConfiguration, (ushort)PlanarConfiguration.Interleaved)
-                   .Add<ushort>(DicomTag.SamplesPerPixel, 3)
-                   .Add(DicomTag.PhotometricInterpretation, PhotometricInterpretation.Rgb.Value);
+                .Add<ushort>(DicomTag.Rows, (ushort)bitmap.Height)
+                .Add<ushort>(DicomTag.BitsAllocated, 8)
+                .Add<ushort>(DicomTag.BitsStored, 8)
+                .Add<ushort>(DicomTag.HighBit, 7)
+                .Add(DicomTag.PixelRepresentation, (ushort)PixelRepresentation.Unsigned)
+                .Add(DicomTag.PlanarConfiguration, (ushort)PlanarConfiguration.Interleaved)
+                .Add<ushort>(DicomTag.SamplesPerPixel, 3)
+                .Add(DicomTag.PhotometricInterpretation, PhotometricInterpretation.Rgb.Value);
 
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -157,10 +163,11 @@ namespace Print_SCU
         public void Print()
         {
             var dicomClient = new DicomClient();
-            dicomClient.AddRequest(new DicomNCreateRequest(FilmSession.SOPClassUID, FilmSession.SOPInstanceUID, 0)
-            {
-                Dataset = FilmSession
-            });
+            dicomClient.AddRequest(
+                new DicomNCreateRequest(FilmSession.SOPClassUID, FilmSession.SOPInstanceUID, 0)
+                    {
+                        Dataset = FilmSession
+                    });
 
 
             foreach (var filmbox in FilmSession.BasicFilmBoxes)
@@ -169,34 +176,33 @@ namespace Print_SCU
                 var imageBoxRequests = new List<DicomNSetRequest>();
 
                 var filmBoxRequest = new DicomNCreateRequest(FilmBox.SOPClassUID, filmbox.SOPInstanceUID, 0)
-                {
-                    Dataset = filmbox
-                };
+                                         {
+                                             Dataset
+                                                 =
+                                                 filmbox
+                                         };
                 filmBoxRequest.OnResponseReceived = (request, response) =>
-                {
-                    if (response.HasDataset)
                     {
-                        var seq = response.Dataset.Get<DicomSequence>(DicomTag.ReferencedImageBoxSequence);
-                        for (int i = 0; i < seq.Items.Count; i++)
+                        if (response.HasDataset)
                         {
-                            var req = imageBoxRequests[i];
-                            var imageBox = req.Dataset;
-                            var sopInstanceUid = seq.Items[i].Get<string>(DicomTag.ReferencedSOPInstanceUID);
-                            imageBox.Add(DicomTag.SOPInstanceUID, sopInstanceUid);
-                            req.Command.Add(DicomTag.RequestedSOPInstanceUID, sopInstanceUid);
+                            var seq = response.Dataset.Get<DicomSequence>(DicomTag.ReferencedImageBoxSequence);
+                            for (int i = 0; i < seq.Items.Count; i++)
+                            {
+                                var req = imageBoxRequests[i];
+                                var imageBox = req.Dataset;
+                                var sopInstanceUid = seq.Items[i].Get<string>(DicomTag.ReferencedSOPInstanceUID);
+                                imageBox.Add(DicomTag.SOPInstanceUID, sopInstanceUid);
+                                req.Command.Add(DicomTag.RequestedSOPInstanceUID, sopInstanceUid);
+                            }
                         }
-                    }
-                };
+                    };
                 dicomClient.AddRequest(filmBoxRequest);
 
 
 
                 foreach (var image in filmbox.BasicImageBoxes)
                 {
-                    var req = new DicomNSetRequest(image.SOPClassUID, image.SOPInstanceUID)
-                    {
-                        Dataset = image
-                    };
+                    var req = new DicomNSetRequest(image.SOPClassUID, image.SOPInstanceUID) { Dataset = image };
 
                     imageBoxRequests.Add(req);
                     dicomClient.AddRequest(req);
@@ -213,7 +219,10 @@ namespace Print_SCU
         {
             var pixels = new PinnedByteArray(bitmap.Width * bitmap.Height);
 
-            var data = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadOnly, bitmap.PixelFormat);
+            var data = bitmap.LockBits(
+                new Rectangle(0, 0, bitmap.Width, bitmap.Height),
+                ImageLockMode.ReadOnly,
+                bitmap.PixelFormat);
 
             var srcComponents = bitmap.PixelFormat == PixelFormat.Format24bppRgb ? 3 : 4;
 
@@ -241,7 +250,10 @@ namespace Print_SCU
         {
             var pixels = new PinnedByteArray(bitmap.Width * bitmap.Height * 3);
 
-            var data = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadOnly, bitmap.PixelFormat);
+            var data = bitmap.LockBits(
+                new Rectangle(0, 0, bitmap.Width, bitmap.Height),
+                ImageLockMode.ReadOnly,
+                bitmap.PixelFormat);
 
             var srcComponents = bitmap.PixelFormat == PixelFormat.Format24bppRgb ? 3 : 4;
 

--- a/Examples/Print SCU/Program.cs
+++ b/Examples/Print SCU/Program.cs
@@ -1,47 +1,41 @@
-﻿using Dicom;
-using Dicom.Imaging;
-using Dicom.IO;
-using Dicom.Network;
-using Dicom.Printing;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Drawing.Imaging;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using Dicom.Imaging;
 
 namespace Print_SCU
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             var stopwatch = new System.Diagnostics.Stopwatch();
             stopwatch.Start();
 
             var printJob = new PrintJob("DICOM PRINT JOB")
-            {
-                RemoteAddress = "localhost",
-                RemotePort = 8000,
-                CallingAE = "PRINTSCU",
-                CalledAE = "PRINTSCP"
-            };
+                               {
+                                   RemoteAddress = "localhost",
+                                   RemotePort = 8000,
+                                   CallingAE = "PRINTSCU",
+                                   CalledAE = "PRINTSCP"
+                               };
 
             printJob.StartFilmBox("STANDARD\\1,1", "PORTRAIT", "A4");
 
             printJob.FilmSession.IsColor = false; //set to true to print in color
-            
+
             //greyscale
             var dicomImage = new DicomImage(@"Data\1.3.51.5155.1353.20020423.1100947.1.0.0.dcm");
-            
+
             //color
             //var dicomImage = new DicomImage(@"Data\US-RGB-8-epicard.dcm");
-            
+
             var bitmap = dicomImage.RenderImage() as System.Drawing.Bitmap;
-            
+
             printJob.AddImage(bitmap, 0);
-            
+
             bitmap.Dispose();
 
             printJob.EndFilmBox();
@@ -54,5 +48,4 @@ namespace Print_SCU
 
         }
     }
-
 }

--- a/Examples/Print SCU/Properties/AssemblyInfo.cs
+++ b/Examples/Print SCU/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Logging/DICOM.NLog/NLogManager.cs
+++ b/Logging/DICOM.NLog/NLogManager.cs
@@ -1,48 +1,56 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
 
-namespace Dicom.Log {
-	/// <summary>
-	/// LogManager for the NLog logging framework.
-	/// </summary>
-	/// <example>
-	/// LogManager.Default = new NLogManager();
-	/// </example>
-	public class NLogManager : LogManager {
-		public override Logger GetLogger(string name) {
-			return new NLogger(NLog.LogManager.GetLogger(name));
-		}
+namespace Dicom.Log
+{
+    /// <summary>
+    /// LogManager for the NLog logging framework.
+    /// </summary>
+    /// <example>
+    /// LogManager.Default = new NLogManager();
+    /// </example>
+    public class NLogManager : LogManager
+    {
+        public override Logger GetLogger(string name)
+        {
+            return new NLogger(NLog.LogManager.GetLogger(name));
+        }
 
-		private class NLogger : Logger {
-			private readonly NLog.Logger _logger;
+        private class NLogger : Logger
+        {
+            private readonly NLog.Logger _logger;
 
-			public NLogger(NLog.Logger logger) {
-				_logger = logger;
-			}
+            public NLogger(NLog.Logger logger)
+            {
+                _logger = logger;
+            }
 
-			public override void Log(LogLevel level, string msg, params object[] args) {
-			    var ordinalFormattedMessage = NameFormatToPositionalFormat(msg);
-                
-                switch (level) {
-				case LogLevel.Debug:
+            public override void Log(LogLevel level, string msg, params object[] args)
+            {
+                var ordinalFormattedMessage = NameFormatToPositionalFormat(msg);
+
+                switch (level)
+                {
+                    case LogLevel.Debug:
                         _logger.Debug(ordinalFormattedMessage, args);
-					break;
-				case LogLevel.Info:
-                    _logger.Info(ordinalFormattedMessage, args);
-					break;
-				case LogLevel.Warning:
-                    _logger.Warn(ordinalFormattedMessage, args);
-					break;
-				case LogLevel.Error:
-                    _logger.Error(ordinalFormattedMessage, args);
-					break;
-				case LogLevel.Fatal:
-                    _logger.Fatal(ordinalFormattedMessage, args);
-					break;
-				default:
-                    _logger.Info(ordinalFormattedMessage, args);
-					break;
-				}
-			}
-		}
-	}
+                        break;
+                    case LogLevel.Info:
+                        _logger.Info(ordinalFormattedMessage, args);
+                        break;
+                    case LogLevel.Warning:
+                        _logger.Warn(ordinalFormattedMessage, args);
+                        break;
+                    case LogLevel.Error:
+                        _logger.Error(ordinalFormattedMessage, args);
+                        break;
+                    case LogLevel.Fatal:
+                        _logger.Fatal(ordinalFormattedMessage, args);
+                        break;
+                    default:
+                        _logger.Info(ordinalFormattedMessage, args);
+                        break;
+                }
+            }
+        }
+    }
 }

--- a/Logging/DICOM.Serilog/LogLevelConverter.cs
+++ b/Logging/DICOM.Serilog/LogLevelConverter.cs
@@ -1,11 +1,16 @@
-﻿using Serilog.Events;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Serilog.Events;
 
 namespace Dicom.Log
 {
     internal static class LogLevelConverter
     {
-        public static LogEventLevel ToSerilog(this LogLevel dicomLogLevel) {
-            switch (dicomLogLevel) {
+        public static LogEventLevel ToSerilog(this LogLevel dicomLogLevel)
+        {
+            switch (dicomLogLevel)
+            {
                 case LogLevel.Debug:
                     return LogEventLevel.Debug;
                 case LogLevel.Info:
@@ -20,7 +25,7 @@ namespace Dicom.Log
                     //pathological case - shouldn't occur
                     return LogEventLevel.Verbose;
             }
-            
+
         }
     }
 }

--- a/Logging/DICOM.Serilog/SerilogLoggerAdapter.cs
+++ b/Logging/DICOM.Serilog/SerilogLoggerAdapter.cs
@@ -1,16 +1,21 @@
-﻿using Serilog;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Serilog;
 
 namespace Dicom.Log
 {
-    internal class SerilogLoggerAdapter :Logger
+    internal class SerilogLoggerAdapter : Logger
     {
         private readonly ILogger _serilog;
 
-        public SerilogLoggerAdapter(ILogger serilog) {
+        public SerilogLoggerAdapter(ILogger serilog)
+        {
             _serilog = serilog;
         }
 
-        public override void Log(LogLevel level, string msg, params object[] args) {
+        public override void Log(LogLevel level, string msg, params object[] args)
+        {
             _serilog.Write(level.ToSerilog(), msg, args);
         }
     }

--- a/Logging/DICOM.Serilog/SerilogManager.cs
+++ b/Logging/DICOM.Serilog/SerilogManager.cs
@@ -1,4 +1,7 @@
-﻿using Serilog;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Serilog;
 
 namespace Dicom.Log
 {
@@ -6,13 +9,15 @@ namespace Dicom.Log
     /// <summary>
     /// Directs fo-dicom's logging through Serilog
     /// </summary>
-    public class SerilogManager :LogManager{
+    public class SerilogManager : LogManager
+    {
         private readonly ILogger _serilogLogger;
 
         /// <summary>
         /// Instantiates fo-dicom Serilog logging relying on Serilog's Serilog.Log global static logger
         /// </summary>
-        public SerilogManager() {
+        public SerilogManager()
+        {
             _serilogLogger = null;
         }
 
@@ -20,7 +25,8 @@ namespace Dicom.Log
         /// Instantiates fo-dicom Serilog logging facility, sending logs through the provided ILogger instance
         /// </summary>
         /// <param name="serilogLogger"></param>
-        public SerilogManager(ILogger serilogLogger) {
+        public SerilogManager(ILogger serilogLogger)
+        {
             _serilogLogger = serilogLogger;
         }
 
@@ -30,7 +36,8 @@ namespace Dicom.Log
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public override Logger GetLogger(string name) {
+        public override Logger GetLogger(string name)
+        {
             var serilogLogger = (_serilogLogger ?? Serilog.Log.Logger).ForContext("fo-DICOM", name);
             return new SerilogLoggerAdapter(serilogLogger);
         }

--- a/Publish/fo-dicom.NLog.nuspec
+++ b/Publish/fo-dicom.NLog.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>fo-dicom.NLog</id>
-        <version>1.1.0-rc2</version>
+        <version>1.1.0</version>
         <title>Fellow Oak DICOM NLog support</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
@@ -11,7 +11,7 @@
         <description>Support library for using NLog log handler with fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
-            <dependency id="fo-dicom" version="1.1.0-rc2" />
+            <dependency id="fo-dicom" version="1.1.0" />
             <dependency id="NLog" version="3.2.1" />
         </dependencies>
     </metadata>

--- a/Publish/fo-dicom.Serilog.nuspec
+++ b/Publish/fo-dicom.Serilog.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>fo-dicom.Serilog</id>
-        <version>1.1.0-rc2</version>
+        <version>1.1.0</version>
         <title>Fellow Oak DICOM Serilog support</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
@@ -11,7 +11,7 @@
         <description>Support library for using Serilog log handler with fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
-            <dependency id="fo-dicom" version="1.1.0-rc2" />
+            <dependency id="fo-dicom" version="1.1.0" />
             <dependency id="Serilog" version="1.5.6" />
         </dependencies>
     </metadata>

--- a/Publish/fo-dicom.nuspec
+++ b/Publish/fo-dicom.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>fo-dicom</id>
-        <version>1.1.0-rc2</version>
+        <version>1.1.0</version>
         <title>Fellow Oak DICOM for .NET</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Fellow Oak DICOM for .NET
 
-[![Join the chat at https://gitter.im/fo-dicom/fo-dicom](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fo-dicom/fo-dicom?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![NuGet](https://img.shields.io/nuget/v/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/)
-[//]: # ( [![NuGet Pre Release](https://img.shields.io/nuget/vpre/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/) )
 [![Build status](https://ci.appveyor.com/api/projects/status/r3yptmhufh3dl1xc?svg=true)](https://ci.appveyor.com/project/anders9ustafsson/fo-dicom)
 [![Stories in Ready](https://badge.waffle.io/fo-dicom/fo-dicom.svg?label=ready&title=Ready)](http://waffle.io/fo-dicom/fo-dicom)
+[![Join the chat at https://gitter.im/fo-dicom/fo-dicom](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fo-dicom/fo-dicom?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[//]: # ( [![NuGet Pre Release](https://img.shields.io/nuget/vpre/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/) )
 
 ### Features
 * Targets .NET 4.5 and higher

--- a/README.md
+++ b/README.md
@@ -2,18 +2,17 @@
 
 [![Join the chat at https://gitter.im/fo-dicom/fo-dicom](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fo-dicom/fo-dicom?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![NuGet](https://img.shields.io/nuget/v/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/)
-[![NuGet Pre Release](https://img.shields.io/nuget/vpre/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/)
+[//]: # ( [![NuGet Pre Release](https://img.shields.io/nuget/vpre/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/) )
 [![Build status](https://ci.appveyor.com/api/projects/status/r3yptmhufh3dl1xc?svg=true)](https://ci.appveyor.com/project/anders9ustafsson/fo-dicom)
 [![Stories in Ready](https://badge.waffle.io/fo-dicom/fo-dicom.svg?label=ready&title=Ready)](http://waffle.io/fo-dicom/fo-dicom)
 
 ### Features
-* High-performance, fully asynchronous, .NET 4.0 API
+* Targets .NET 4.5 and higher
+* DICOM dictionary version 2015c
+* High-performance, fully asynchronous API
 * JPEG (including lossless), JPEG-LS, JPEG2000, and RLE image compression
 * Supports very large datasets with content loading on demand
 * Image rendering
-
-### Notes
-* *Development* branch targets .NET 4.5; Visual Studio 2013 required
 
 ### Examples
 
@@ -78,8 +77,8 @@ client.Send("127.0.0.1", 104, false, "SCU-AE", "SCP-AE");
 
 ### Contributors
 * [Colby Dillion](https://github.com/rcd)
-* [Hesham Desouky](https://github.com/hdesouky) (Nebras Technology)
 * [Anders Gustafsson](https://github.com/anders9ustafsson) (Cureos AB)
+* [Hesham Desouky](https://github.com/hdesouky) (Nebras Technology)
 * [Ian Yates](http://github.com/IanYates)
 * [Chris Horn](https://github.com/GMZ)
 * [Mahesh Dubey](https://github.com/mdubey82)

--- a/Tools/DICOM Compare/ListViewEx.cs
+++ b/Tools/DICOM Compare/ListViewEx.cs
@@ -1,26 +1,30 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
 using System.Windows.Forms;
 
-namespace Dicom.Compare {
-	class ListViewEx : ListView {
-		private const int WM_VSCROLL = 0x0115;
-		private const int WM_MOUSEWHEEL = 0x020A;
+namespace Dicom.Compare
+{
+    internal class ListViewEx : ListView
+    {
+        private const int WM_VSCROLL = 0x0115;
 
-		public event ScrollEventHandler Scroll;
+        private const int WM_MOUSEWHEEL = 0x020A;
 
-		protected virtual void OnScroll(ScrollEventArgs e) {
-			if (Scroll != null)
-				Scroll(this, e);
-		}
+        public event ScrollEventHandler Scroll;
 
-		protected override void WndProc(ref Message m) {
-			base.WndProc(ref m);
+        protected virtual void OnScroll(ScrollEventArgs e)
+        {
+            if (Scroll != null) Scroll(this, e);
+        }
 
-			if (m.Msg == WM_VSCROLL)
-				OnScroll(new ScrollEventArgs((ScrollEventType)(m.WParam.ToInt32() & 0xffff), 0));
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
 
-			else if (m.Msg == WM_MOUSEWHEEL)
-				OnScroll(new ScrollEventArgs(ScrollEventType.EndScroll, 0));
-		}
-	}
+            if (m.Msg == WM_VSCROLL) OnScroll(new ScrollEventArgs((ScrollEventType)(m.WParam.ToInt32() & 0xffff), 0));
+
+            else if (m.Msg == WM_MOUSEWHEEL) OnScroll(new ScrollEventArgs(ScrollEventType.EndScroll, 0));
+        }
+    }
 }

--- a/Tools/DICOM Compare/MainForm.cs
+++ b/Tools/DICOM Compare/MainForm.cs
@@ -1,469 +1,579 @@
-﻿using System;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
-using Dicom;
 using Dicom.IO.Buffer;
 
-namespace Dicom.Compare {
-	public partial class MainForm : Form {
-		private readonly static Color None = Color.Transparent;
-		private readonly static Color Green = Color.FromArgb(190, 240, 190);
-		private readonly static Color Yellow = Color.FromArgb(255, 255, 217);
-		private readonly static Color Red = Color.FromArgb(255, 200, 200);
-		private readonly static Color Gray = Color.FromArgb(200, 200, 200);
-
-		private DicomFile _file1;
-		private DicomFile _file2;
-
-		private int _level = 0;
-		private string _indent = String.Empty;
-
-		public MainForm() {
-			InitializeComponent();
-		}
-
-		public int Level {
-			get { return _level; }
-			set {
-				_level = value;
-				_indent = String.Empty;
-				for (int i = 0; i < Level; i++)
-					_indent += "    ";
-			}
-		}
-
-		private void OnClickSelect(object sender, EventArgs e) {
-			DicomFile file1 = null;
-			while (true) {
-				var ofd = new OpenFileDialog();
-				ofd.Title = "Choose first DICOM file";
-				ofd.Filter = "DICOM Files (*.dcm;*.dic)|*.dcm;*.dic|All Files (*.*)|*.*";
-
-				if (ofd.ShowDialog(this) == DialogResult.Cancel)
-					return;
-
-				try {
-					file1 = DicomFile.Open(ofd.FileName);
-					break;
-				} catch (Exception ex) {
-					MessageBox.Show(this, ex.Message, "Error opening DICOM file", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				}
-			}
-
-			DicomFile file2 = null;
-			while (true) {
-				var ofd = new OpenFileDialog();
-				ofd.Title = "Choose second DICOM file";
-				ofd.Filter = "DICOM Files (*.dcm;*.dic)|*.dcm;*.dic|All Files (*.*)|*.*";
-
-				if (ofd.ShowDialog(this) == DialogResult.Cancel)
-					return;
-
-				try {
-					file2 = DicomFile.Open(ofd.FileName);
-					break;
-				} catch (Exception ex) {
-					MessageBox.Show(this, ex.Message, "Error opening DICOM file", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				}
-			}
-
-			_file1 = file1;
-			_file2 = file2;
-
-			lblFile1.Text = _file1.File.Name;
-			lblFile2.Text = _file2.File.Name;
-
-			CompareFiles();
-		}
-
-		private void CompareFiles() {
-			Level = 0;
-
-			try {
-				lvFile1.BeginUpdate();
-				lvFile2.BeginUpdate();
-
-				lvFile1.Items.Clear();
-				lvFile2.Items.Clear();
-
-				CompareDatasets(_file1.FileMetaInfo, _file2.FileMetaInfo);
-				CompareDatasets(_file1.Dataset, _file2.Dataset);
-
-				OnSizeChanged(lvFile1, EventArgs.Empty);
-				OnSizeChanged(lvFile2, EventArgs.Empty);
-			} catch (Exception ex) {
-				MessageBox.Show(this, ex.Message, "Error comparing DICOM files", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			} finally {
-				lvFile1.EndUpdate();
-				lvFile2.EndUpdate();
-			}
-		}
-
-		private void CompareDatasets(DicomDataset d1, DicomDataset d2) {
-			var e1 = new Queue<DicomItem>(d1 ?? new DicomDataset());
-			var e2 = new Queue<DicomItem>(d2 ?? new DicomDataset());
-
-			while (e1.Count > 0 || e2.Count > 0) {
-				DicomItem i1 = null;
-				if (e1.Count > 0)
-					i1 = e1.Peek();
-
-				DicomItem i2 = null;
-				if (e2.Count > 0)
-					i2 = e2.Peek();
-
-				if (i1 != null) {
-					if (i2 != null) {
-						if (i1.Tag.Group < i2.Tag.Group) {
-							AddItem(i1, null);
-							e1.Dequeue();
-							continue;
-						}
-
-						if (i1.Tag.Group == i2.Tag.Group && i1.Tag.Element < i2.Tag.Element) {
-							AddItem(i1, null);
-							e1.Dequeue();
-							continue;
-						}
-					}
-				}
-
-				if (i2 != null) {
-					if (i1 != null) {
-						if (i2.Tag.Group < i1.Tag.Group) {
-							AddItem(null, i2);
-							e2.Dequeue();
-							continue;
-						}
-
-						if (i2.Tag.Group == i1.Tag.Group && i2.Tag.Element < i1.Tag.Element) {
-							AddItem(null, i2);
-							e2.Dequeue();
-							continue;
-						}
-					}
-				}
-
-				AddItem(i1, i2);
-
-				if (i1 != null)
-					e1.Dequeue();
-
-				if (i2 != null)
-					e2.Dequeue();
-			}
-		}
-
-		private void CompareSequences(DicomSequence s1, DicomSequence s2) {
-			if (s1 == null) {
-				AddItem(s1, lvFile1, Gray);
-				AddItem(s2, lvFile2, Green);
-			} else if (s2 == null) {
-				AddItem(s1, lvFile1, Green);
-				AddItem(s2, lvFile2, Gray);
-			} else {
-				AddItem(s1, lvFile1, None);
-				AddItem(s2, lvFile2, None);
-			}
-
-			Level++;
-
-			int count = 0;
-			if (s1 != null)
-				count = s1.Items.Count;
-			if (s2 != null && s2.Items.Count > count)
-				count = s2.Items.Count;
-
-			for (int i = 0; i < count; i++) {
-				DicomDataset d1 = null;
-				if (s1 != null && i < s1.Items.Count)
-					d1 = s1.Items[i];
-
-				DicomDataset d2 = null;
-				if (s2 != null && i < s2.Items.Count)
-					d2 = s2.Items[i];
-
-				if (d1 == null) {
-					AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile1, Gray);
-					AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile2, Green);
-				} else if (d2 == null) {
-					AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile1, Green);
-					AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile2, Gray);
-				} else {
-					AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile1, None);
-					AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile2, None);
-				}
-
-				Level++;
-				CompareDatasets(d1, d2);
-				Level--;
-			}
-
-			Level--;
-		}
-
-		private void CompareFragments(DicomItem i1, DicomItem i2) {
-			DicomFragmentSequence s1 = null;
-			DicomFragmentSequence s2 = null;
-
-			bool pixel = cbIgnorePixelData.Checked && i1.Tag == DicomTag.PixelData;
-
-			if (i1 == null) {
-				AddItem(i1, lvFile1, Gray);
-				AddItem(i2, lvFile2, Green);
-				s2 = i2 as DicomFragmentSequence;
-			} else if (i2 == null) {
-				AddItem(i1, lvFile1, Green);
-				AddItem(i2, lvFile2, Gray);
-				s1 = i1 as DicomFragmentSequence;
-			} else if (!(i1 is DicomFragmentSequence)) {
-				AddItem(i1, lvFile1, pixel ? Yellow : Red);
-				AddItem(i2, lvFile2, pixel ? Yellow : Red);
-				s2 = i2 as DicomFragmentSequence;
-			} else if (!(i2 is DicomFragmentSequence)) {
-				AddItem(i1, lvFile1, pixel ? Yellow : Red);
-				AddItem(i2, lvFile2, pixel ? Yellow : Red);
-				s1 = i1 as DicomFragmentSequence;
-			} else {
-				AddItem(i1, lvFile1, pixel ? Yellow : None);
-				AddItem(i2, lvFile2, pixel ? Yellow : None);
-				s1 = i1 as DicomFragmentSequence;
-				s2 = i2 as DicomFragmentSequence;
-			}
-
-			Level++;
-
-			if (s1 == null) {
-				AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile1, Gray);
-				AddItem(_indent + "Offset Table", (uint)s2.OffsetTable.Count * 4, String.Format("@entries={0}", s2.OffsetTable.Count), lvFile2, pixel ? Yellow : Red);
-			} else if (s2 == null) {
-				AddItem(_indent + "Offset Table", (uint)s1.OffsetTable.Count * 4, String.Format("@entries={0}", s1.OffsetTable.Count), lvFile1, pixel ? Yellow : Red);
-				AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile2, Gray);
-			} else {
-				Color c = None;
-				if (s1.OffsetTable.Count != s2.OffsetTable.Count)
-					c = Red;
-				else {
-					for (int i = 0; i < s1.OffsetTable.Count; i++) {
-						if (s1.OffsetTable[i] != s2.OffsetTable[i]) {
-							c = Red;
-							break;
-						}
-					}
-				}
-				AddItem(_indent + "Offset Table", (uint)s2.OffsetTable.Count * 4, String.Format("@entries={0}", s1.OffsetTable.Count), lvFile1, pixel ? Yellow : c);
-				AddItem(_indent + "Offset Table", (uint)s2.OffsetTable.Count * 4, String.Format("@entries={0}", s2.OffsetTable.Count), lvFile2, pixel ? Yellow : c);
-			}
-
-			int count = 0;
-			if (s1 != null)
-				count = s1.Fragments.Count;
-			if (s2 != null && s2.Fragments.Count > count)
-				count = s2.Fragments.Count;
-
-			string name = _indent + "Fragment";
-
-			for (int i = 0; i < count; i++) {
-				IByteBuffer b1 = null;
-				if (s1 != null && i < s1.Fragments.Count)
-					b1 = s1.Fragments[i];
-
-				IByteBuffer b2 = null;
-				if (s2 != null && i < s2.Fragments.Count)
-					b2 = s2.Fragments[i];
-
-				if (b1 == null) {
-					AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile1, Gray);
-					AddItem(name, b2.Size, String.Empty, lvFile2, pixel ? Yellow : Red);
-					continue;
-				} else if (b2 == null) {
-					AddItem(name, b1.Size, String.Empty, lvFile1, pixel ? Yellow : Red);
-					AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile2, Gray);
-					continue;
-				}
-
-				Color c = None;
-				if (pixel)
-					c = Yellow;
-				else if (!Compare(b1.Data, b2.Data))
-					c = Red;
-
-				AddItem(name, b1.Size, String.Empty, lvFile1, c);
-				AddItem(name, b2.Size, String.Empty, lvFile2, c);
-			}
-
-			Level--;
-		}
-
-		private string GetTagName(DicomTag t) {
-			return String.Format("{0}{1}  {2}", _indent, t.ToString().ToUpper(), t.DictionaryEntry.Name);
-		}
-
-		private void AddItem(string t, uint l, string v, ListView lv, Color c) {
-			var lvi = lv.Items.Add(t);
-			lvi.SubItems.Add(!String.IsNullOrEmpty(t) ? "--" : String.Empty);
-			if (l == UInt32.MaxValue)
-				lvi.SubItems.Add(!String.IsNullOrEmpty(t) ? "-" : String.Empty);
-			else
-				lvi.SubItems.Add(l.ToString());
-			lvi.SubItems.Add(v);
-			lvi.UseItemStyleForSubItems = true;
-			lvi.BackColor = c;
-		}
-
-		private void AddItem(DicomItem i, ListView lv, Color c) {
-			ListViewItem lvi = null;
-
-			if (i != null) {
-				var tag = GetTagName(i.Tag);
-				lvi = lv.Items.Add(tag);
-				lvi.SubItems.Add(i.ValueRepresentation.Code);
-				if (i is DicomElement) {
-					var e = i as DicomElement;
-					lvi.SubItems.Add(e.Length.ToString());
-					string value = "<large value not displayed>";
-					if (e.Length <= 2048)
-						value = String.Join("\\", e.Get<string[]>());
-					lvi.SubItems.Add(value);
-				} else {
-					lvi.SubItems.Add("-");
-					lvi.SubItems.Add(String.Empty);
-				}
-				lvi.Tag = i;
-			} else {
-				lvi = lv.Items.Add(String.Empty);
-				lvi.SubItems.Add(String.Empty);
-				lvi.SubItems.Add(String.Empty);
-				lvi.SubItems.Add(String.Empty);
-			}
-
-			lvi.UseItemStyleForSubItems = true;
-			lvi.BackColor = c;
-		}
-
-		private void AddItem(DicomItem i1, DicomItem i2) {
-			if (i1 is DicomSequence || i2 is DicomSequence) {
-				CompareSequences(i1 as DicomSequence, i2 as DicomSequence);
-				return;
-			}
-
-			if (i2 == null) {
-				AddItem(i1, lvFile1, Green);
-				AddItem(i2, lvFile2, Gray);
-				return;
-			}
-
-			if (i1 == null) {
-				AddItem(i1, lvFile1, Gray);
-				AddItem(i2, lvFile2, Green);
-				return;
-			}
-
-			if (i1 is DicomElement && i2 is DicomElement) {
-				var e1 = i1 as DicomElement;
-				var e2 = i2 as DicomElement;
-
-				var c = None;
-				if (!cbIgnoreVR.Checked && e1.ValueRepresentation != e2.ValueRepresentation)
-					c = Red;
-				else if(!Compare(e1.Buffer.Data, e2.Buffer.Data))
-					c = Red;
-
-				if (cbIgnoreGroupLengths.Checked && e1.Tag.Element == 0x0000)
-					c = Yellow;
-
-				if (cbIgnoreUIDs.Checked && e1.ValueRepresentation == DicomVR.UI) {
-					var uid = (i1 as DicomElement).Get<DicomUID>(0);
-					if (uid != null && (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown))
-						c = Yellow;
-				}
-
-				if (cbIgnorePixelData.Checked && i1.Tag == DicomTag.PixelData)
-					c = Yellow;
-
-				AddItem(i1, lvFile1, c);
-				AddItem(i2, lvFile2, c);
-				return;
-			}
-
-			if (i1 is DicomFragmentSequence || i2 is DicomFragmentSequence) {
-				CompareFragments(i1, i2);
-				return;
-			}
-
-			while (i1 is DicomElement || i2 is DicomElement) {
-				AddItem(i1, lvFile1, Red);
-				AddItem(i2, lvFile2, Red);
-				return;
-			}
-
-			AddItem(i1, lvFile1, Yellow);
-			AddItem(i2, lvFile2, Yellow);
-		}
-
-		private static bool Compare(byte[] b1, byte[] b2) {
-			if (b1.Length != b2.Length)
-				return false;
-
-			for (int i = 0; i < b1.Length; i++) {
-				if (b1[i] != b2[i])
-					return false;
-			}
-
-			return true;
-		}
-
-		private void OnScroll(object sender, ScrollEventArgs e) {
-			if (sender == lvFile1) {
-				int index = lvFile1.TopItem.Index;
-				lvFile2.TopItem = lvFile2.Items[index];
-			} else {
-				int index = lvFile2.TopItem.Index;
-				lvFile1.TopItem = lvFile1.Items[index];
-			}
-		}
-
-		private void OnSelect(object sender, EventArgs e) {
-			if (sender == lvFile1) {
-				if (lvFile1.SelectedIndices.Count > 0) {
-					int index = lvFile1.SelectedIndices[0];
-					lvFile2.Items[index].Selected = true;
-				}
-			} else {
-				if (lvFile2.SelectedIndices.Count > 0) {
-					int index = lvFile2.SelectedIndices[0];
-					lvFile1.Items[index].Selected = true;
-				}
-			}
-		}
-
-		private void OnMouseEnter(object sender, EventArgs e) {
-			((Control)sender).Focus();
-		}
-
-		private void OnSizeChanged(object sender, EventArgs e) {
-			var lv = (ListViewEx)sender;
-			var width = lv.Columns[0].Width + lv.Columns[1].Width + lv.Columns[2].Width;
-			lv.Columns[3].Width = Math.Max(lv.ClientSize.Width - width, 440);
-		}
-
-		private void OnOptionChanged(object sender, EventArgs e) {
-			int index = -1;
-			if (lvFile1.TopItem != null)
-				index = lvFile1.TopItem.Index;
-
-			CompareFiles();
-
-			if (index != -1 && index < lvFile1.Items.Count) {
-				lvFile1.TopItem = lvFile1.Items[index];
-				lvFile2.TopItem = lvFile2.Items[index];
-			}
-		}
-	}
+namespace Dicom.Compare
+{
+    public partial class MainForm : Form
+    {
+        private static readonly Color None = Color.Transparent;
+
+        private static readonly Color Green = Color.FromArgb(190, 240, 190);
+
+        private static readonly Color Yellow = Color.FromArgb(255, 255, 217);
+
+        private static readonly Color Red = Color.FromArgb(255, 200, 200);
+
+        private static readonly Color Gray = Color.FromArgb(200, 200, 200);
+
+        private DicomFile _file1;
+
+        private DicomFile _file2;
+
+        private int _level = 0;
+
+        private string _indent = String.Empty;
+
+        public MainForm()
+        {
+            InitializeComponent();
+        }
+
+        public int Level
+        {
+            get
+            {
+                return _level;
+            }
+            set
+            {
+                _level = value;
+                _indent = String.Empty;
+                for (int i = 0; i < Level; i++) _indent += "    ";
+            }
+        }
+
+        private void OnClickSelect(object sender, EventArgs e)
+        {
+            DicomFile file1 = null;
+            while (true)
+            {
+                var ofd = new OpenFileDialog();
+                ofd.Title = "Choose first DICOM file";
+                ofd.Filter = "DICOM Files (*.dcm;*.dic)|*.dcm;*.dic|All Files (*.*)|*.*";
+
+                if (ofd.ShowDialog(this) == DialogResult.Cancel) return;
+
+                try
+                {
+                    file1 = DicomFile.Open(ofd.FileName);
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        this,
+                        ex.Message,
+                        "Error opening DICOM file",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+            }
+
+            DicomFile file2 = null;
+            while (true)
+            {
+                var ofd = new OpenFileDialog();
+                ofd.Title = "Choose second DICOM file";
+                ofd.Filter = "DICOM Files (*.dcm;*.dic)|*.dcm;*.dic|All Files (*.*)|*.*";
+
+                if (ofd.ShowDialog(this) == DialogResult.Cancel) return;
+
+                try
+                {
+                    file2 = DicomFile.Open(ofd.FileName);
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        this,
+                        ex.Message,
+                        "Error opening DICOM file",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+            }
+
+            _file1 = file1;
+            _file2 = file2;
+
+            lblFile1.Text = _file1.File.Name;
+            lblFile2.Text = _file2.File.Name;
+
+            CompareFiles();
+        }
+
+        private void CompareFiles()
+        {
+            Level = 0;
+
+            try
+            {
+                lvFile1.BeginUpdate();
+                lvFile2.BeginUpdate();
+
+                lvFile1.Items.Clear();
+                lvFile2.Items.Clear();
+
+                CompareDatasets(_file1.FileMetaInfo, _file2.FileMetaInfo);
+                CompareDatasets(_file1.Dataset, _file2.Dataset);
+
+                OnSizeChanged(lvFile1, EventArgs.Empty);
+                OnSizeChanged(lvFile2, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    this,
+                    ex.Message,
+                    "Error comparing DICOM files",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            finally
+            {
+                lvFile1.EndUpdate();
+                lvFile2.EndUpdate();
+            }
+        }
+
+        private void CompareDatasets(DicomDataset d1, DicomDataset d2)
+        {
+            var e1 = new Queue<DicomItem>(d1 ?? new DicomDataset());
+            var e2 = new Queue<DicomItem>(d2 ?? new DicomDataset());
+
+            while (e1.Count > 0 || e2.Count > 0)
+            {
+                DicomItem i1 = null;
+                if (e1.Count > 0) i1 = e1.Peek();
+
+                DicomItem i2 = null;
+                if (e2.Count > 0) i2 = e2.Peek();
+
+                if (i1 != null)
+                {
+                    if (i2 != null)
+                    {
+                        if (i1.Tag.Group < i2.Tag.Group)
+                        {
+                            AddItem(i1, null);
+                            e1.Dequeue();
+                            continue;
+                        }
+
+                        if (i1.Tag.Group == i2.Tag.Group && i1.Tag.Element < i2.Tag.Element)
+                        {
+                            AddItem(i1, null);
+                            e1.Dequeue();
+                            continue;
+                        }
+                    }
+                }
+
+                if (i2 != null)
+                {
+                    if (i1 != null)
+                    {
+                        if (i2.Tag.Group < i1.Tag.Group)
+                        {
+                            AddItem(null, i2);
+                            e2.Dequeue();
+                            continue;
+                        }
+
+                        if (i2.Tag.Group == i1.Tag.Group && i2.Tag.Element < i1.Tag.Element)
+                        {
+                            AddItem(null, i2);
+                            e2.Dequeue();
+                            continue;
+                        }
+                    }
+                }
+
+                AddItem(i1, i2);
+
+                if (i1 != null) e1.Dequeue();
+
+                if (i2 != null) e2.Dequeue();
+            }
+        }
+
+        private void CompareSequences(DicomSequence s1, DicomSequence s2)
+        {
+            if (s1 == null)
+            {
+                AddItem(s1, lvFile1, Gray);
+                AddItem(s2, lvFile2, Green);
+            }
+            else if (s2 == null)
+            {
+                AddItem(s1, lvFile1, Green);
+                AddItem(s2, lvFile2, Gray);
+            }
+            else
+            {
+                AddItem(s1, lvFile1, None);
+                AddItem(s2, lvFile2, None);
+            }
+
+            Level++;
+
+            int count = 0;
+            if (s1 != null) count = s1.Items.Count;
+            if (s2 != null && s2.Items.Count > count) count = s2.Items.Count;
+
+            for (int i = 0; i < count; i++)
+            {
+                DicomDataset d1 = null;
+                if (s1 != null && i < s1.Items.Count) d1 = s1.Items[i];
+
+                DicomDataset d2 = null;
+                if (s2 != null && i < s2.Items.Count) d2 = s2.Items[i];
+
+                if (d1 == null)
+                {
+                    AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile1, Gray);
+                    AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile2, Green);
+                }
+                else if (d2 == null)
+                {
+                    AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile1, Green);
+                    AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile2, Gray);
+                }
+                else
+                {
+                    AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile1, None);
+                    AddItem(GetTagName(DicomTag.Item), UInt32.MaxValue, String.Empty, lvFile2, None);
+                }
+
+                Level++;
+                CompareDatasets(d1, d2);
+                Level--;
+            }
+
+            Level--;
+        }
+
+        private void CompareFragments(DicomItem i1, DicomItem i2)
+        {
+            DicomFragmentSequence s1 = null;
+            DicomFragmentSequence s2 = null;
+
+            bool pixel = cbIgnorePixelData.Checked && i1.Tag == DicomTag.PixelData;
+
+            if (i1 == null)
+            {
+                AddItem(i1, lvFile1, Gray);
+                AddItem(i2, lvFile2, Green);
+                s2 = i2 as DicomFragmentSequence;
+            }
+            else if (i2 == null)
+            {
+                AddItem(i1, lvFile1, Green);
+                AddItem(i2, lvFile2, Gray);
+                s1 = i1 as DicomFragmentSequence;
+            }
+            else if (!(i1 is DicomFragmentSequence))
+            {
+                AddItem(i1, lvFile1, pixel ? Yellow : Red);
+                AddItem(i2, lvFile2, pixel ? Yellow : Red);
+                s2 = i2 as DicomFragmentSequence;
+            }
+            else if (!(i2 is DicomFragmentSequence))
+            {
+                AddItem(i1, lvFile1, pixel ? Yellow : Red);
+                AddItem(i2, lvFile2, pixel ? Yellow : Red);
+                s1 = i1 as DicomFragmentSequence;
+            }
+            else
+            {
+                AddItem(i1, lvFile1, pixel ? Yellow : None);
+                AddItem(i2, lvFile2, pixel ? Yellow : None);
+                s1 = i1 as DicomFragmentSequence;
+                s2 = i2 as DicomFragmentSequence;
+            }
+
+            Level++;
+
+            if (s1 == null)
+            {
+                AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile1, Gray);
+                AddItem(
+                    _indent + "Offset Table",
+                    (uint)s2.OffsetTable.Count * 4,
+                    String.Format("@entries={0}", s2.OffsetTable.Count),
+                    lvFile2,
+                    pixel ? Yellow : Red);
+            }
+            else if (s2 == null)
+            {
+                AddItem(
+                    _indent + "Offset Table",
+                    (uint)s1.OffsetTable.Count * 4,
+                    String.Format("@entries={0}", s1.OffsetTable.Count),
+                    lvFile1,
+                    pixel ? Yellow : Red);
+                AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile2, Gray);
+            }
+            else
+            {
+                Color c = None;
+                if (s1.OffsetTable.Count != s2.OffsetTable.Count) c = Red;
+                else
+                {
+                    for (int i = 0; i < s1.OffsetTable.Count; i++)
+                    {
+                        if (s1.OffsetTable[i] != s2.OffsetTable[i])
+                        {
+                            c = Red;
+                            break;
+                        }
+                    }
+                }
+                AddItem(
+                    _indent + "Offset Table",
+                    (uint)s2.OffsetTable.Count * 4,
+                    String.Format("@entries={0}", s1.OffsetTable.Count),
+                    lvFile1,
+                    pixel ? Yellow : c);
+                AddItem(
+                    _indent + "Offset Table",
+                    (uint)s2.OffsetTable.Count * 4,
+                    String.Format("@entries={0}", s2.OffsetTable.Count),
+                    lvFile2,
+                    pixel ? Yellow : c);
+            }
+
+            int count = 0;
+            if (s1 != null) count = s1.Fragments.Count;
+            if (s2 != null && s2.Fragments.Count > count) count = s2.Fragments.Count;
+
+            string name = _indent + "Fragment";
+
+            for (int i = 0; i < count; i++)
+            {
+                IByteBuffer b1 = null;
+                if (s1 != null && i < s1.Fragments.Count) b1 = s1.Fragments[i];
+
+                IByteBuffer b2 = null;
+                if (s2 != null && i < s2.Fragments.Count) b2 = s2.Fragments[i];
+
+                if (b1 == null)
+                {
+                    AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile1, Gray);
+                    AddItem(name, b2.Size, String.Empty, lvFile2, pixel ? Yellow : Red);
+                    continue;
+                }
+                else if (b2 == null)
+                {
+                    AddItem(name, b1.Size, String.Empty, lvFile1, pixel ? Yellow : Red);
+                    AddItem(String.Empty, UInt32.MaxValue, String.Empty, lvFile2, Gray);
+                    continue;
+                }
+
+                Color c = None;
+                if (pixel) c = Yellow;
+                else if (!Compare(b1.Data, b2.Data)) c = Red;
+
+                AddItem(name, b1.Size, String.Empty, lvFile1, c);
+                AddItem(name, b2.Size, String.Empty, lvFile2, c);
+            }
+
+            Level--;
+        }
+
+        private string GetTagName(DicomTag t)
+        {
+            return String.Format("{0}{1}  {2}", _indent, t.ToString().ToUpper(), t.DictionaryEntry.Name);
+        }
+
+        private void AddItem(string t, uint l, string v, ListView lv, Color c)
+        {
+            var lvi = lv.Items.Add(t);
+            lvi.SubItems.Add(!String.IsNullOrEmpty(t) ? "--" : String.Empty);
+            if (l == UInt32.MaxValue) lvi.SubItems.Add(!String.IsNullOrEmpty(t) ? "-" : String.Empty);
+            else lvi.SubItems.Add(l.ToString());
+            lvi.SubItems.Add(v);
+            lvi.UseItemStyleForSubItems = true;
+            lvi.BackColor = c;
+        }
+
+        private void AddItem(DicomItem i, ListView lv, Color c)
+        {
+            ListViewItem lvi = null;
+
+            if (i != null)
+            {
+                var tag = GetTagName(i.Tag);
+                lvi = lv.Items.Add(tag);
+                lvi.SubItems.Add(i.ValueRepresentation.Code);
+                if (i is DicomElement)
+                {
+                    var e = i as DicomElement;
+                    lvi.SubItems.Add(e.Length.ToString());
+                    string value = "<large value not displayed>";
+                    if (e.Length <= 2048) value = String.Join("\\", e.Get<string[]>());
+                    lvi.SubItems.Add(value);
+                }
+                else
+                {
+                    lvi.SubItems.Add("-");
+                    lvi.SubItems.Add(String.Empty);
+                }
+                lvi.Tag = i;
+            }
+            else
+            {
+                lvi = lv.Items.Add(String.Empty);
+                lvi.SubItems.Add(String.Empty);
+                lvi.SubItems.Add(String.Empty);
+                lvi.SubItems.Add(String.Empty);
+            }
+
+            lvi.UseItemStyleForSubItems = true;
+            lvi.BackColor = c;
+        }
+
+        private void AddItem(DicomItem i1, DicomItem i2)
+        {
+            if (i1 is DicomSequence || i2 is DicomSequence)
+            {
+                CompareSequences(i1 as DicomSequence, i2 as DicomSequence);
+                return;
+            }
+
+            if (i2 == null)
+            {
+                AddItem(i1, lvFile1, Green);
+                AddItem(i2, lvFile2, Gray);
+                return;
+            }
+
+            if (i1 == null)
+            {
+                AddItem(i1, lvFile1, Gray);
+                AddItem(i2, lvFile2, Green);
+                return;
+            }
+
+            if (i1 is DicomElement && i2 is DicomElement)
+            {
+                var e1 = i1 as DicomElement;
+                var e2 = i2 as DicomElement;
+
+                var c = None;
+                if (!cbIgnoreVR.Checked && e1.ValueRepresentation != e2.ValueRepresentation) c = Red;
+                else if (!Compare(e1.Buffer.Data, e2.Buffer.Data)) c = Red;
+
+                if (cbIgnoreGroupLengths.Checked && e1.Tag.Element == 0x0000) c = Yellow;
+
+                if (cbIgnoreUIDs.Checked && e1.ValueRepresentation == DicomVR.UI)
+                {
+                    var uid = (i1 as DicomElement).Get<DicomUID>(0);
+                    if (uid != null && (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown)) c = Yellow;
+                }
+
+                if (cbIgnorePixelData.Checked && i1.Tag == DicomTag.PixelData) c = Yellow;
+
+                AddItem(i1, lvFile1, c);
+                AddItem(i2, lvFile2, c);
+                return;
+            }
+
+            if (i1 is DicomFragmentSequence || i2 is DicomFragmentSequence)
+            {
+                CompareFragments(i1, i2);
+                return;
+            }
+
+            while (i1 is DicomElement || i2 is DicomElement)
+            {
+                AddItem(i1, lvFile1, Red);
+                AddItem(i2, lvFile2, Red);
+                return;
+            }
+
+            AddItem(i1, lvFile1, Yellow);
+            AddItem(i2, lvFile2, Yellow);
+        }
+
+        private static bool Compare(byte[] b1, byte[] b2)
+        {
+            if (b1.Length != b2.Length) return false;
+
+            for (int i = 0; i < b1.Length; i++)
+            {
+                if (b1[i] != b2[i]) return false;
+            }
+
+            return true;
+        }
+
+        private void OnScroll(object sender, ScrollEventArgs e)
+        {
+            if (sender == lvFile1)
+            {
+                int index = lvFile1.TopItem.Index;
+                lvFile2.TopItem = lvFile2.Items[index];
+            }
+            else
+            {
+                int index = lvFile2.TopItem.Index;
+                lvFile1.TopItem = lvFile1.Items[index];
+            }
+        }
+
+        private void OnSelect(object sender, EventArgs e)
+        {
+            if (sender == lvFile1)
+            {
+                if (lvFile1.SelectedIndices.Count > 0)
+                {
+                    int index = lvFile1.SelectedIndices[0];
+                    lvFile2.Items[index].Selected = true;
+                }
+            }
+            else
+            {
+                if (lvFile2.SelectedIndices.Count > 0)
+                {
+                    int index = lvFile2.SelectedIndices[0];
+                    lvFile1.Items[index].Selected = true;
+                }
+            }
+        }
+
+        private void OnMouseEnter(object sender, EventArgs e)
+        {
+            ((Control)sender).Focus();
+        }
+
+        private void OnSizeChanged(object sender, EventArgs e)
+        {
+            var lv = (ListViewEx)sender;
+            var width = lv.Columns[0].Width + lv.Columns[1].Width + lv.Columns[2].Width;
+            lv.Columns[3].Width = Math.Max(lv.ClientSize.Width - width, 440);
+        }
+
+        private void OnOptionChanged(object sender, EventArgs e)
+        {
+            int index = -1;
+            if (lvFile1.TopItem != null) index = lvFile1.TopItem.Index;
+
+            CompareFiles();
+
+            if (index != -1 && index < lvFile1.Items.Count)
+            {
+                lvFile1.TopItem = lvFile1.Items[index];
+                lvFile2.TopItem = lvFile2.Items[index];
+            }
+        }
+    }
 }

--- a/Tools/DICOM Compare/Program.cs
+++ b/Tools/DICOM Compare/Program.cs
@@ -1,18 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Windows.Forms;
 
-namespace Dicom.Compare {
-	static class Program {
-		/// <summary>
-		/// The main entry point for the application.
-		/// </summary>
-		[STAThread]
-		static void Main() {
-			Application.EnableVisualStyles();
-			Application.SetCompatibleTextRenderingDefault(false);
-			Application.Run(new MainForm());
-		}
-	}
+namespace Dicom.Compare
+{
+    internal static class Program
+    {
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
 }

--- a/Tools/DICOM Compare/Properties/AssemblyInfo.cs
+++ b/Tools/DICOM Compare/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Tools/DICOM Dump/MainForm.cs
+++ b/Tools/DICOM Dump/MainForm.cs
@@ -1,415 +1,447 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
-using Dicom;
 using Dicom.Imaging;
 using Dicom.Imaging.Codec;
 using Dicom.IO.Buffer;
 
-namespace Dicom.Dump {
-	public partial class MainForm : Form {
-		private DicomFile _file;
-
-		public MainForm() {
-			InitializeComponent();
-		}
-
-		private void Reset() {
-			lvDicom.Items.Clear();
-			menuItemView.Enabled = false;
-		}
-
-		private delegate void AddItemDelegate(string tag, string vr, string length, string value);
-
-		private void AddItem(string tag, string vr, string length, string value) {
-			if (InvokeRequired) {
-			    BeginInvoke(new AddItemDelegate(AddItem), tag, vr, length, value);
-			    return;
-			}
-
-			var lvi = lvDicom.Items.Add(tag);
-			lvi.SubItems.Add(vr);
-			lvi.SubItems.Add(length);
-			lvi.SubItems.Add(value);
-		}
-
-		public void OpenFile(string fileName) {
-			DicomFile file = null;
-
-			try {
-				file = DicomFile.Open(fileName);
-			} catch (DicomFileException ex) {
-				file = ex.File;
-				MessageBox.Show(this, "Exception while loading DICOM file: " + ex.Message, "Error loading DICOM file", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			}
-
-			OpenFile(file);
-		}
-
-		public void OpenFile(DicomFile file) {
-			try {
-				lvDicom.BeginUpdate();
-
-				Reset();
-
-				_file = file;
-
-				new DicomDatasetWalker(_file.FileMetaInfo).Walk(new DumpWalker(this));
-				new DicomDatasetWalker(_file.Dataset).Walk(new DumpWalker(this));
-
-				if (_file.Dataset.Contains(DicomTag.PixelData))
-					menuItemView.Enabled = true;
-				menuItemSyntax.Enabled = true;
-				menuItemSave.Enabled = true;
-
-				menuItemJpegLossy.Enabled = _file.Dataset.Get<int>(DicomTag.BitsStored, 0, 16) <= 12;
-			} catch (Exception ex) {
-				MessageBox.Show(this, "Exception while loading DICOM file: " + ex.Message, "Error loading DICOM file", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			} finally {
-				lvDicom.EndUpdate();
-			}
-		}
-
-		private void OnClickOpen(object sender, EventArgs e) {
-			var ofd = new OpenFileDialog();
-			ofd.Filter = "DICOM Files (*.dcm;*.dic)|*.dcm;*.dic|All Files (*.*)|*.*";
-
-			if (ofd.ShowDialog() == DialogResult.Cancel)
-				return;
-
-			OpenFile(ofd.FileName);
-		}
-
-		private void OnClickSave(object sender, EventArgs e) {
-			var sfd = new SaveFileDialog();
-			sfd.Filter = "DICOM (*.dcm)|*.dcm|Image (*.bmp;*.jpg;*.png;*.gif)|*.bmp;*.jpg;*.png;*.gif";
-
-			if (sfd.ShowDialog() == DialogResult.Cancel)
-				return;
-
-			if (sfd.FilterIndex == 1) {
-				var file = new DicomFile(_file.Dataset);
-				file.Save(sfd.FileName);
-			} else {
-				var image = new DicomImage(_file.Dataset);
-				image.RenderImage().Save(sfd.FileName);
-			}
-		}
-
-		private class DumpWalker : IDicomDatasetWalker {
-			int _level = 0;
-
-			public DumpWalker(MainForm form) {
-				Form = form;
-				Level = 0;
-			}
-
-			public MainForm Form {
-				get;
-				set;
-			}
-
-			public int Level {
-				get { return _level; }
-				set {
-					_level = value;
-					Indent = String.Empty;
-					for (int i = 0; i < _level; i++)
-						Indent += "    ";
-				}
-			}
-
-			private string Indent {
-				get;
-				set;
-			}
-
-			public void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback) {
-			}
-
-			public bool OnElement(DicomElement element) {
-				var tag = String.Format("{0}{1}  {2}", Indent, element.Tag.ToString().ToUpper(), element.Tag.DictionaryEntry.Name);
-
-				string value = "<large value not displayed>";
-				if (element.Length <= 2048)
-					value = String.Join("\\", element.Get<string[]>());
-
-				if (element.ValueRepresentation == DicomVR.UI && element.Count > 0) {
-					var uid = element.Get<DicomUID>(0);
-					var name = uid.Name;
-					if (name != "Unknown")
-						value = String.Format("{0} ({1})", value, name);
-				}
-
-				Form.AddItem(tag, 
-					element.ValueRepresentation.Code, 
-					element.Length.ToString(), 
-					value);
-				return true;
-			}
-
-			public bool OnBeginSequence(DicomSequence sequence) {
-				var tag = String.Format("{0}{1}  {2}", Indent, sequence.Tag.ToString().ToUpper(), sequence.Tag.DictionaryEntry.Name);
-
-				Form.AddItem(tag, "SQ", String.Empty, String.Empty);
-
-				Level++;
-				return true;
-			}
-
-			public bool OnBeginSequenceItem(DicomDataset dataset) {
-				var tag = String.Format("{0}Sequence Item:", Indent);
-
-				Form.AddItem(tag, String.Empty, String.Empty, String.Empty);
-
-				Level++;
-				return true;
-			}
-
-			public bool OnEndSequenceItem() {
-				Level--;
-				return true;
-			}
-
-			public bool OnEndSequence() {
-				Level--;
-				return true;
-			}
-
-			public bool OnBeginFragment(DicomFragmentSequence fragment) {
-				var tag = String.Format("{0}{1}  {2}", Indent, fragment.Tag.ToString().ToUpper(), fragment.Tag.DictionaryEntry.Name);
-
-				Form.AddItem(tag, fragment.ValueRepresentation.Code, String.Empty, String.Empty);
-
-				Level++;
-				return true;
-			}
-
-			public bool OnFragmentItem(IByteBuffer item) {
-				var tag = String.Format("{0}Fragment", Indent);
-
-				Form.AddItem(tag, String.Empty, item.Size.ToString(), String.Empty);
-				return true;
-			}
-
-			public bool OnEndFragment() {
-				Level--;
-				return true;
-			}
-
-			public void OnEndWalk() {
-			}
-		}
-
-		private void OnClickView(object sender, EventArgs e) {
-			var form = new DisplayForm(_file);
-			form.ShowDialog(this);
-		}
-
-		private void OnContextMenuOpening(object sender, CancelEventArgs e) {
-			var point = lvDicom.PointToClient(MousePosition);
-
-			var item = lvDicom.GetItemAt(point.X, point.Y);
-			if (item == null) {
-				e.Cancel = true;
-				return;
-			}
-
-			item.Selected = true;
-		}
-
-		private void OnClickContextMenuCopyValue(object sender, EventArgs e) {
-			if (lvDicom.SelectedItems.Count == 0)
-				return;
-
-			var item = lvDicom.SelectedItems[0];
-			var value = item.SubItems[3].Text;
-
-			Clipboard.SetText(value);			
-		}
-
-		private void OnClickContextMenuCopyTag(object sender, EventArgs e) {
-			if (lvDicom.SelectedItems.Count == 0)
-				return;
-
-			var item = lvDicom.SelectedItems[0];
-			var value = item.Text.Substring(1);
-			value = value.Substring(0, value.IndexOf(')'));
-
-			Clipboard.SetText(value);
-		}
-
-		private void ChangeSyntax(DicomTransferSyntax syntax, DicomCodecParams param = null) {
-			var file = _file.ChangeTransferSyntax(syntax, param);
-			OpenFile(file);
-		}
-
-		private void OnClickExplicitVRLittleEndian(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.ExplicitVRLittleEndian);
-		}
-
-		private void OnClickImplicitVRLittleEndian(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.ImplicitVRLittleEndian);
-		}
-
-		private void OnClickExplicitVRBigEndian(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.ExplicitVRBigEndian);
-		}
-
-		private void OnClickJPEGLosslessP14(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGProcess14);
-		}
-
-		private void OnClickJPEGLosslessP14SV1(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGProcess14SV1);
-		}
-
-		private void OnClickJPEGLossyQuality100(object sender, EventArgs e) {
-			var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
-			var syntax = DicomTransferSyntax.JPEGProcess1;
-			if (bits == 16)
-				syntax = DicomTransferSyntax.JPEGProcess2_4;
-			ChangeSyntax(syntax, new DicomJpegParams {
-				Quality = 100
-			});
-		}
-
-		private void OnClickJPEGLossyQuality90(object sender, EventArgs e) {
-			var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
-			var syntax = DicomTransferSyntax.JPEGProcess1;
-			if (bits == 16)
-				syntax = DicomTransferSyntax.JPEGProcess2_4;
-			ChangeSyntax(syntax, new DicomJpegParams {
-				Quality = 90
-			});
-		}
-
-		private void OnClickJPEGLossyQuality80(object sender, EventArgs e) {
-			var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
-			var syntax = DicomTransferSyntax.JPEGProcess1;
-			if (bits == 16)
-				syntax = DicomTransferSyntax.JPEGProcess2_4;
-			ChangeSyntax(syntax, new DicomJpegParams {
-				Quality = 80
-			});
-		}
-
-		private void OnClickJPEGLossyQuality75(object sender, EventArgs e) {
-			var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
-			var syntax = DicomTransferSyntax.JPEGProcess1;
-			if (bits == 16)
-				syntax = DicomTransferSyntax.JPEGProcess2_4;
-			ChangeSyntax(syntax, new DicomJpegParams {
-				Quality = 75
-			});
-		}
-
-		private void OnClickJPEGLossyQuality70(object sender, EventArgs e) {
-			var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
-			var syntax = DicomTransferSyntax.JPEGProcess1;
-			if (bits == 16)
-				syntax = DicomTransferSyntax.JPEGProcess2_4; ;
-			ChangeSyntax(syntax, new DicomJpegParams {
-				Quality = 70
-			});
-		}
-
-		private void OnClickJPEGLossyQuality60(object sender, EventArgs e) {
-			var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
-			var syntax = DicomTransferSyntax.JPEGProcess1;
-			if (bits == 16)
-				syntax = DicomTransferSyntax.JPEGProcess2_4;
-			ChangeSyntax(syntax, new DicomJpegParams {
-				Quality = 60
-			});
-		}
-
-		private void OnClickJPEGLossyQuality50(object sender, EventArgs e) {
-			var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
-			var syntax = DicomTransferSyntax.JPEGProcess1;
-			if (bits == 16)
-				syntax = DicomTransferSyntax.JPEGProcess2_4;
-			ChangeSyntax(syntax, new DicomJpegParams {
-				Quality = 50
-			});
-		}
-
-		private void OnClickJPEG2000Lossless(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEG2000Lossless);
-		}
-
-		private void OnClickJPEG2000LossyRate5(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params {
-				Rate = 5
-			});
-		}
-
-		private void OnClickJPEG2000LossyRate10(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params {
-				Rate = 10
-			});
-		}
-
-		private void OnClickJPEG2000LossyRate20(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params {
-				Rate = 20
-			});
-		}
-
-		private void OnClickJPEG2000LossyRate40(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params {
-				Rate = 40
-			});
-		}
-
-		private void OnClickJPEG2000LossyRate80(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params {
-				Rate = 80
-			});
-		}
-
-		private void OnClickJPEGLSLossless(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGLSLossless);
-		}
-
-		private void OnClickJPEGLSNearLosslessError2(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams {
-				AllowedError = 2
-			});
-		}
-
-		private void OnClickJPEGLSNearLosslessError3(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams {
-				AllowedError = 3
-			});
-		}
-
-		private void OnClickJPEGLSNearLosslessError4(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams {
-				AllowedError = 4
-			});
-		}
-
-		private void OnClickJPEGLSNearLosslessError5(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams {
-				AllowedError = 5
-			});
-		}
-
-		private void OnClickJPEGLSNearLosslessError10(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams {
-				AllowedError = 10
-			});
-		}
-
-		private void OnClickRLELossless(object sender, EventArgs e) {
-			ChangeSyntax(DicomTransferSyntax.RLELossless);
-		}
-	}
+namespace Dicom.Dump
+{
+    public partial class MainForm : Form
+    {
+        private DicomFile _file;
+
+        public MainForm()
+        {
+            InitializeComponent();
+        }
+
+        private void Reset()
+        {
+            lvDicom.Items.Clear();
+            menuItemView.Enabled = false;
+        }
+
+        private delegate void AddItemDelegate(string tag, string vr, string length, string value);
+
+        private void AddItem(string tag, string vr, string length, string value)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(new AddItemDelegate(AddItem), tag, vr, length, value);
+                return;
+            }
+
+            var lvi = lvDicom.Items.Add(tag);
+            lvi.SubItems.Add(vr);
+            lvi.SubItems.Add(length);
+            lvi.SubItems.Add(value);
+        }
+
+        public void OpenFile(string fileName)
+        {
+            DicomFile file = null;
+
+            try
+            {
+                file = DicomFile.Open(fileName);
+            }
+            catch (DicomFileException ex)
+            {
+                file = ex.File;
+                MessageBox.Show(
+                    this,
+                    "Exception while loading DICOM file: " + ex.Message,
+                    "Error loading DICOM file",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+
+            OpenFile(file);
+        }
+
+        public void OpenFile(DicomFile file)
+        {
+            try
+            {
+                lvDicom.BeginUpdate();
+
+                Reset();
+
+                _file = file;
+
+                new DicomDatasetWalker(_file.FileMetaInfo).Walk(new DumpWalker(this));
+                new DicomDatasetWalker(_file.Dataset).Walk(new DumpWalker(this));
+
+                if (_file.Dataset.Contains(DicomTag.PixelData)) menuItemView.Enabled = true;
+                menuItemSyntax.Enabled = true;
+                menuItemSave.Enabled = true;
+
+                menuItemJpegLossy.Enabled = _file.Dataset.Get<int>(DicomTag.BitsStored, 0, 16) <= 12;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    this,
+                    "Exception while loading DICOM file: " + ex.Message,
+                    "Error loading DICOM file",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+            finally
+            {
+                lvDicom.EndUpdate();
+            }
+        }
+
+        private void OnClickOpen(object sender, EventArgs e)
+        {
+            var ofd = new OpenFileDialog();
+            ofd.Filter = "DICOM Files (*.dcm;*.dic)|*.dcm;*.dic|All Files (*.*)|*.*";
+
+            if (ofd.ShowDialog() == DialogResult.Cancel) return;
+
+            OpenFile(ofd.FileName);
+        }
+
+        private void OnClickSave(object sender, EventArgs e)
+        {
+            var sfd = new SaveFileDialog();
+            sfd.Filter = "DICOM (*.dcm)|*.dcm|Image (*.bmp;*.jpg;*.png;*.gif)|*.bmp;*.jpg;*.png;*.gif";
+
+            if (sfd.ShowDialog() == DialogResult.Cancel) return;
+
+            if (sfd.FilterIndex == 1)
+            {
+                var file = new DicomFile(_file.Dataset);
+                file.Save(sfd.FileName);
+            }
+            else
+            {
+                var image = new DicomImage(_file.Dataset);
+                image.RenderImage().Save(sfd.FileName);
+            }
+        }
+
+        private class DumpWalker : IDicomDatasetWalker
+        {
+            private int _level = 0;
+
+            public DumpWalker(MainForm form)
+            {
+                Form = form;
+                Level = 0;
+            }
+
+            public MainForm Form { get; set; }
+
+            public int Level
+            {
+                get
+                {
+                    return _level;
+                }
+                set
+                {
+                    _level = value;
+                    Indent = String.Empty;
+                    for (int i = 0; i < _level; i++) Indent += "    ";
+                }
+            }
+
+            private string Indent { get; set; }
+
+            public void OnBeginWalk(DicomDatasetWalker walker, DicomDatasetWalkerCallback callback)
+            {
+            }
+
+            public bool OnElement(DicomElement element)
+            {
+                var tag = String.Format(
+                    "{0}{1}  {2}",
+                    Indent,
+                    element.Tag.ToString().ToUpper(),
+                    element.Tag.DictionaryEntry.Name);
+
+                string value = "<large value not displayed>";
+                if (element.Length <= 2048) value = String.Join("\\", element.Get<string[]>());
+
+                if (element.ValueRepresentation == DicomVR.UI && element.Count > 0)
+                {
+                    var uid = element.Get<DicomUID>(0);
+                    var name = uid.Name;
+                    if (name != "Unknown") value = String.Format("{0} ({1})", value, name);
+                }
+
+                Form.AddItem(tag, element.ValueRepresentation.Code, element.Length.ToString(), value);
+                return true;
+            }
+
+            public bool OnBeginSequence(DicomSequence sequence)
+            {
+                var tag = String.Format(
+                    "{0}{1}  {2}",
+                    Indent,
+                    sequence.Tag.ToString().ToUpper(),
+                    sequence.Tag.DictionaryEntry.Name);
+
+                Form.AddItem(tag, "SQ", String.Empty, String.Empty);
+
+                Level++;
+                return true;
+            }
+
+            public bool OnBeginSequenceItem(DicomDataset dataset)
+            {
+                var tag = String.Format("{0}Sequence Item:", Indent);
+
+                Form.AddItem(tag, String.Empty, String.Empty, String.Empty);
+
+                Level++;
+                return true;
+            }
+
+            public bool OnEndSequenceItem()
+            {
+                Level--;
+                return true;
+            }
+
+            public bool OnEndSequence()
+            {
+                Level--;
+                return true;
+            }
+
+            public bool OnBeginFragment(DicomFragmentSequence fragment)
+            {
+                var tag = String.Format(
+                    "{0}{1}  {2}",
+                    Indent,
+                    fragment.Tag.ToString().ToUpper(),
+                    fragment.Tag.DictionaryEntry.Name);
+
+                Form.AddItem(tag, fragment.ValueRepresentation.Code, String.Empty, String.Empty);
+
+                Level++;
+                return true;
+            }
+
+            public bool OnFragmentItem(IByteBuffer item)
+            {
+                var tag = String.Format("{0}Fragment", Indent);
+
+                Form.AddItem(tag, String.Empty, item.Size.ToString(), String.Empty);
+                return true;
+            }
+
+            public bool OnEndFragment()
+            {
+                Level--;
+                return true;
+            }
+
+            public void OnEndWalk()
+            {
+            }
+        }
+
+        private void OnClickView(object sender, EventArgs e)
+        {
+            var form = new DisplayForm(_file);
+            form.ShowDialog(this);
+        }
+
+        private void OnContextMenuOpening(object sender, CancelEventArgs e)
+        {
+            var point = lvDicom.PointToClient(MousePosition);
+
+            var item = lvDicom.GetItemAt(point.X, point.Y);
+            if (item == null)
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            item.Selected = true;
+        }
+
+        private void OnClickContextMenuCopyValue(object sender, EventArgs e)
+        {
+            if (lvDicom.SelectedItems.Count == 0) return;
+
+            var item = lvDicom.SelectedItems[0];
+            var value = item.SubItems[3].Text;
+
+            Clipboard.SetText(value);
+        }
+
+        private void OnClickContextMenuCopyTag(object sender, EventArgs e)
+        {
+            if (lvDicom.SelectedItems.Count == 0) return;
+
+            var item = lvDicom.SelectedItems[0];
+            var value = item.Text.Substring(1);
+            value = value.Substring(0, value.IndexOf(')'));
+
+            Clipboard.SetText(value);
+        }
+
+        private void ChangeSyntax(DicomTransferSyntax syntax, DicomCodecParams param = null)
+        {
+            var file = _file.ChangeTransferSyntax(syntax, param);
+            OpenFile(file);
+        }
+
+        private void OnClickExplicitVRLittleEndian(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.ExplicitVRLittleEndian);
+        }
+
+        private void OnClickImplicitVRLittleEndian(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.ImplicitVRLittleEndian);
+        }
+
+        private void OnClickExplicitVRBigEndian(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.ExplicitVRBigEndian);
+        }
+
+        private void OnClickJPEGLosslessP14(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGProcess14);
+        }
+
+        private void OnClickJPEGLosslessP14SV1(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGProcess14SV1);
+        }
+
+        private void OnClickJPEGLossyQuality100(object sender, EventArgs e)
+        {
+            var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
+            var syntax = DicomTransferSyntax.JPEGProcess1;
+            if (bits == 16) syntax = DicomTransferSyntax.JPEGProcess2_4;
+            ChangeSyntax(syntax, new DicomJpegParams { Quality = 100 });
+        }
+
+        private void OnClickJPEGLossyQuality90(object sender, EventArgs e)
+        {
+            var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
+            var syntax = DicomTransferSyntax.JPEGProcess1;
+            if (bits == 16) syntax = DicomTransferSyntax.JPEGProcess2_4;
+            ChangeSyntax(syntax, new DicomJpegParams { Quality = 90 });
+        }
+
+        private void OnClickJPEGLossyQuality80(object sender, EventArgs e)
+        {
+            var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
+            var syntax = DicomTransferSyntax.JPEGProcess1;
+            if (bits == 16) syntax = DicomTransferSyntax.JPEGProcess2_4;
+            ChangeSyntax(syntax, new DicomJpegParams { Quality = 80 });
+        }
+
+        private void OnClickJPEGLossyQuality75(object sender, EventArgs e)
+        {
+            var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
+            var syntax = DicomTransferSyntax.JPEGProcess1;
+            if (bits == 16) syntax = DicomTransferSyntax.JPEGProcess2_4;
+            ChangeSyntax(syntax, new DicomJpegParams { Quality = 75 });
+        }
+
+        private void OnClickJPEGLossyQuality70(object sender, EventArgs e)
+        {
+            var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
+            var syntax = DicomTransferSyntax.JPEGProcess1;
+            if (bits == 16) syntax = DicomTransferSyntax.JPEGProcess2_4;
+            ;
+            ChangeSyntax(syntax, new DicomJpegParams { Quality = 70 });
+        }
+
+        private void OnClickJPEGLossyQuality60(object sender, EventArgs e)
+        {
+            var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
+            var syntax = DicomTransferSyntax.JPEGProcess1;
+            if (bits == 16) syntax = DicomTransferSyntax.JPEGProcess2_4;
+            ChangeSyntax(syntax, new DicomJpegParams { Quality = 60 });
+        }
+
+        private void OnClickJPEGLossyQuality50(object sender, EventArgs e)
+        {
+            var bits = _file.Dataset.Get<int>(DicomTag.BitsAllocated, 0, 8);
+            var syntax = DicomTransferSyntax.JPEGProcess1;
+            if (bits == 16) syntax = DicomTransferSyntax.JPEGProcess2_4;
+            ChangeSyntax(syntax, new DicomJpegParams { Quality = 50 });
+        }
+
+        private void OnClickJPEG2000Lossless(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEG2000Lossless);
+        }
+
+        private void OnClickJPEG2000LossyRate5(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params { Rate = 5 });
+        }
+
+        private void OnClickJPEG2000LossyRate10(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params { Rate = 10 });
+        }
+
+        private void OnClickJPEG2000LossyRate20(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params { Rate = 20 });
+        }
+
+        private void OnClickJPEG2000LossyRate40(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params { Rate = 40 });
+        }
+
+        private void OnClickJPEG2000LossyRate80(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEG2000Lossy, new DicomJpeg2000Params { Rate = 80 });
+        }
+
+        private void OnClickJPEGLSLossless(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGLSLossless);
+        }
+
+        private void OnClickJPEGLSNearLosslessError2(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams { AllowedError = 2 });
+        }
+
+        private void OnClickJPEGLSNearLosslessError3(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams { AllowedError = 3 });
+        }
+
+        private void OnClickJPEGLSNearLosslessError4(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams { AllowedError = 4 });
+        }
+
+        private void OnClickJPEGLSNearLosslessError5(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams { AllowedError = 5 });
+        }
+
+        private void OnClickJPEGLSNearLosslessError10(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.JPEGLSNearLossless, new DicomJpegLsParams { AllowedError = 10 });
+        }
+
+        private void OnClickRLELossless(object sender, EventArgs e)
+        {
+            ChangeSyntax(DicomTransferSyntax.RLELossless);
+        }
+    }
 }

--- a/Tools/DICOM Dump/Program.cs
+++ b/Tools/DICOM Dump/Program.cs
@@ -1,18 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Windows.Forms;
 
-namespace Dicom.Dump {
-	static class Program {
-		/// <summary>
-		/// The main entry point for the application.
-		/// </summary>
-		[STAThread]
-		static void Main() {
-			Application.EnableVisualStyles();
-			Application.SetCompatibleTextRenderingDefault(false);
-			Application.Run(new MainForm());
-		}
-	}
+namespace Dicom.Dump
+{
+    internal static class Program
+    {
+        /// <summary>
+        /// The main entry point for the application.
+        /// </summary>
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
 }

--- a/Tools/DICOM Dump/Properties/AssemblyInfo.cs
+++ b/Tools/DICOM Dump/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
This PR provides complete re-formatting of all C# code, plus re-formatting of the C/C++ code that is original to the *fo-dicom* project. I have not tried to re-format *LibJPEG* etc. code. The re-formatting follows these conventions:

* Smart indenting
* Tab size 4
* Indent size 4
* Insert spaces

Along with this re-formatting, I have also applied the "open-angle-bracket-on-next-line" convention in the C# code, I have removed unused `using` directives and I have inserted a tiny file header with copyright information in all C# files.

Please review.