### PR TITLE
Change grayscale color map via DicomImage. Connected to #79

### DIFF
--- a/DICOM [Unit Tests]/App.config
+++ b/DICOM [Unit Tests]/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.maxParallelThreads" value="1"/>
+  </appSettings>
+</configuration>

--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -111,6 +111,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
     <None Include="Test Data\CT1_J2KI">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -69,6 +69,8 @@
     <Compile Include="DicomDatasetTest.cs" />
     <Compile Include="DicomDictionaryTest.cs" />
     <Compile Include="Imaging\ColorTableTest.cs" />
+    <Compile Include="Imaging\GrayscaleRenderOptionsTest.cs" />
+    <Compile Include="Imaging\LUT\OutputLUTTest.cs" />
     <Compile Include="IO\Buffer\TempFileBufferTest.cs" />
     <Compile Include="IO\DesktopFileReferenceTest.cs" />
     <Compile Include="IO\DesktopPathTest.cs" />

--- a/DICOM [Unit Tests]/Imaging/GrayscaleRenderOptionsTest.cs
+++ b/DICOM [Unit Tests]/Imaging/GrayscaleRenderOptionsTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging
+{
+    using Xunit;
+
+    public class GrayscaleRenderOptionsTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void ColorMap_Monochrome2ImageOptions_ReturnsMonochrome2ColorMap()
+        {
+            var file = DicomFile.Open(@".\Test Data\CT1_J2KI");
+            var options = GrayscaleRenderOptions.FromDataset(file.Dataset);
+            Assert.Same(ColorTable.Monochrome2, options.ColorMap);
+        }
+
+        [Fact]
+        public void ColorMap_Setter_ReturnsSetColorMap()
+        {
+            var file = DicomFile.Open(@".\Test Data\CT1_J2KI");
+            var options = GrayscaleRenderOptions.FromDataset(file.Dataset);
+            options.ColorMap = ColorTable.Monochrome1;
+            Assert.Same(ColorTable.Monochrome1, options.ColorMap);
+        }
+
+        #endregion
+    }
+}

--- a/DICOM [Unit Tests]/Imaging/LUT/OutputLUTTest.cs
+++ b/DICOM [Unit Tests]/Imaging/LUT/OutputLUTTest.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging.LUT
+{
+    using Xunit;
+
+    public class OutputLUTTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void ColorMap_Monochrome2ImageOptions_ReturnsMonochrome2ColorMap()
+        {
+            var file = DicomFile.Open(@".\Test Data\CT1_J2KI");
+            var options = GrayscaleRenderOptions.FromDataset(file.Dataset);
+            var lut = new OutputLUT(options);
+            Assert.Same(ColorTable.Monochrome2, lut.ColorMap);
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -13,7 +13,7 @@ using Dicom.Imaging.Render;
 namespace Dicom.Imaging
 {
     /// <summary>
-    /// DICOM Image calss with capability of
+    /// DICOM Image class for image rendering.
     /// </summary>
     public class DicomImage
     {
@@ -150,6 +150,30 @@ namespace Dicom.Imaging
                 if (_pipeline is GenericGrayscalePipeline)
                 {
                     _renderOptions.WindowCenter = value;
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the color map to be applied when rendering grayscale images.</summary>
+        public virtual Color32[] GrayscaleColorMap
+        {
+            get
+            {
+                if (_pipeline == null)
+                {
+                    CreatePipeline();
+                }
+                return _pipeline is GenericGrayscalePipeline ? _renderOptions.ColorMap : null;
+            }
+            set
+            {
+                if (_pipeline == null)
+                {
+                    CreatePipeline();
+                }
+                if (_pipeline is GenericGrayscalePipeline)
+                {
+                    _renderOptions.ColorMap = value;
                 }
             }
         }
@@ -330,7 +354,10 @@ namespace Dicom.Imaging
 
             CurrentFrame = frame;
 
-            CreatePipeline();
+            if (_pipeline == null)
+            {
+                CreatePipeline();
+            }
         }
 
         /// <summary>
@@ -338,8 +365,6 @@ namespace Dicom.Imaging
         /// </summary>
         private void CreatePipeline()
         {
-            if (_pipeline != null) return;
-
             var pi = Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation);
             var samples = Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 0, 0);
 

--- a/DICOM/Imaging/LUT/OutputLUT.cs
+++ b/DICOM/Imaging/LUT/OutputLUT.cs
@@ -11,7 +11,7 @@ namespace Dicom.Imaging.LUT
     {
         #region Private Members
 
-        private Color32[] _lut;
+        private readonly GrayscaleRenderOptions _options;
 
         #endregion
 
@@ -20,10 +20,10 @@ namespace Dicom.Imaging.LUT
         /// <summary>
         /// Initialize new instance of <seealso cref="OutputLUT"/> 
         /// </summary>
-        /// <param name="lut">The color palette map to use for the output</param>
-        public OutputLUT(Color32[] lut)
+        /// <param name="options">The grayscale render options containing the grayscale color map.</param>
+        public OutputLUT(GrayscaleRenderOptions options)
         {
-            ColorMap = lut;
+            _options = options;
         }
 
         #endregion
@@ -31,21 +31,19 @@ namespace Dicom.Imaging.LUT
         #region Public Properties
 
         /// <summary>
-        /// The color map
+        /// Gets the color map
         /// </summary>
         public Color32[] ColorMap
         {
             get
             {
-                return _lut;
-            }
-            set
-            {
-                if (value == null || value.Length != 256) throw new DicomImagingException("Expected 256 entry color map");
-                _lut = value;
+                return _options.ColorMap;
             }
         }
 
+        /// <summary>
+        /// Get the minimum output value
+        /// </summary>
         public int MinimumOutputValue
         {
             get
@@ -54,6 +52,9 @@ namespace Dicom.Imaging.LUT
             }
         }
 
+        /// <summary>
+        /// Get the maximum output value
+        /// </summary>
         public int MaximumOutputValue
         {
             get
@@ -62,23 +63,31 @@ namespace Dicom.Imaging.LUT
             }
         }
 
+        /// <summary>
+        /// Returns true if the lookup table is valid
+        /// </summary>
         public bool IsValid
         {
             get
             {
-                return _lut != null;
+                return this._options != null;
             }
         }
 
+        /// <summary>
+        /// Indexer to transform input value into output value
+        /// </summary>
+        /// <param name="value">Input value</param>
+        /// <returns>Output value</returns>
         public int this[int value]
         {
             get
             {
                 unchecked
                 {
-                    if (value < 0) return _lut[0].Value;
-                    if (value > 255) return _lut[255].Value;
-                    return _lut[value].Value;
+                    if (value < 0) return _options.ColorMap[0].Value;
+                    if (value > 255) return _options.ColorMap[255].Value;
+                    return _options.ColorMap[value].Value;
                 }
             }
         }
@@ -87,6 +96,9 @@ namespace Dicom.Imaging.LUT
 
         #region Public Methods
 
+        /// <summary>
+        /// Force the recalculation of LUT
+        /// </summary>
         public void Recalculate()
         {
         }

--- a/DICOM/Imaging/Render/GenericGrayscalePipeline.cs
+++ b/DICOM/Imaging/Render/GenericGrayscalePipeline.cs
@@ -14,15 +14,15 @@ namespace Dicom.Imaging.Render
 
         private CompositeLUT _lut;
 
-        private ModalityLUT _rescaleLut;
+        private readonly ModalityLUT _rescaleLut;
 
-        private VOILUT _voiLut;
+        private readonly VOILUT _voiLut;
 
-        private OutputLUT _outputLut;
+        private readonly OutputLUT _outputLut;
 
-        private InvertLUT _invertLut;
+        private readonly InvertLUT _invertLut;
 
-        private GrayscaleRenderOptions _options;
+        private readonly GrayscaleRenderOptions _options;
 
         #endregion
 
@@ -38,7 +38,7 @@ namespace Dicom.Imaging.Render
             _options = options;
             if (_options.RescaleSlope != 1.0 || _options.RescaleIntercept != 0.0) _rescaleLut = new ModalityLUT(_options);
             _voiLut = VOILUT.Create(_options);
-            _outputLut = new OutputLUT(_options.Monochrome1 ? ColorTable.Monochrome1 : ColorTable.Monochrome2);
+            _outputLut = new OutputLUT(_options);
             if (_options.Invert) _invertLut = new InvertLUT(_outputLut.MinimumOutputValue, _outputLut.MaximumOutputValue);
         }
 
@@ -47,7 +47,7 @@ namespace Dicom.Imaging.Render
         #region Public Properties
 
         /// <summary>
-        /// Get <seealso cref="CompositeLUT"/> of avaliavble LUTs available in this pipeline instance
+        /// Get <seealso cref="CompositeLUT"/> of LUTs available in this pipeline instance
         /// </summary>
         public ILUT LUT
         {


### PR DESCRIPTION
Here is a "quick fix" to the issue for applying a color table different from `Monochrome1` and `Monochrome2` onto a grayscale image.

The relevant API change is that I have added the `Color32[]` property `GrayscaleColorMap` to the `DicomImage` class. By default, the color map is selected based on the Photometric Interpretation of the associated dataset (Monochrome 1 or 2), but it can be set to any 256 item `Color32` array prior to rendering the image.

This approach is analogous to what is already implemented for `WindowCenter` and `WindowWidth` properties in `DicomImage`.

Example of applying arbitrary color map and then render image:

    var di = new DicomImage(dicomFileName);
    di.GrayscaleColorMap = ColorTable.LoadLUT(lutFileName);
    var image = di.RenderImage();

I have also taken some time to clean up code and add XML documentation in files affected by this enhancement.

Please review.