### PR TITLE
Update DICOM Dump tool with ability to ignore private tag dictionary

### DIFF
--- a/DICOM/DicomDictionary.cs
+++ b/DICOM/DicomDictionary.cs
@@ -44,7 +44,7 @@ namespace Dicom {
 		private static object _lock = new object();
 		private static DicomDictionary _default;
 
-		private static void LoadInternalDictionaries() {
+		public static void LoadInternalDictionaries(bool loadPrivateDictionary = true) {
 			lock (_lock) {
 				if (_default == null) {
 					_default = new DicomDictionary();
@@ -58,14 +58,16 @@ namespace Dicom {
 					} catch (Exception e) {
 						throw new DicomDataException("Unable to load DICOM dictionary from resources.\n\n" + e.Message, e);
 					}
-					try {
-						var assembly = Assembly.GetExecutingAssembly();
-						var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml.gz");
-						var gzip = new GZipStream(stream, CompressionMode.Decompress);
-						var reader = new DicomDictionaryReader(_default, DicomDictionaryFormat.XML, gzip);
-						reader.Process();
-					} catch (Exception e) {
-						throw new DicomDataException("Unable to load private dictionary from resources.\n\n" + e.Message, e);
+					if (loadPrivateDictionary) {
+						try {
+							var assembly = Assembly.GetExecutingAssembly();
+							var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml.gz");
+							var gzip = new GZipStream(stream, CompressionMode.Decompress);
+							var reader = new DicomDictionaryReader(_default, DicomDictionaryFormat.XML, gzip);
+							reader.Process();
+						} catch (Exception e) {
+							throw new DicomDataException("Unable to load private dictionary from resources.\n\n" + e.Message, e);
+						}
 					}
 				}
 			}

--- a/Tools/DICOM Dump/DICOM Dump.csproj
+++ b/Tools/DICOM Dump/DICOM Dump.csproj
@@ -70,6 +70,12 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReportForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ReportForm.Designer.cs">
+      <DependentUpon>ReportForm.cs</DependentUpon>
+    </Compile>
     <EmbeddedResource Include="DisplayForm.resx">
       <DependentUpon>DisplayForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -86,6 +92,9 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <EmbeddedResource Include="ReportForm.resx">
+      <DependentUpon>ReportForm.cs</DependentUpon>
+    </EmbeddedResource>
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>

--- a/Tools/DICOM Dump/MainForm.Designer.cs
+++ b/Tools/DICOM Dump/MainForm.Designer.cs
@@ -59,6 +59,7 @@
 			this.error5ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.error10ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.rLELosslessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.exportPixelDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.lvDicom = new System.Windows.Forms.ListView();
 			this.columnHeaderTag = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
 			this.columnHeaderVR = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -110,16 +111,17 @@
 			// 
 			this.menuItemTools.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuItemView,
-            this.menuItemSyntax});
+            this.menuItemSyntax,
+            this.exportPixelDataToolStripMenuItem});
 			this.menuItemTools.Name = "menuItemTools";
-			this.menuItemTools.Size = new System.Drawing.Size(48, 20);
+			this.menuItemTools.Size = new System.Drawing.Size(47, 20);
 			this.menuItemTools.Text = "&Tools";
 			// 
 			// menuItemView
 			// 
 			this.menuItemView.Enabled = false;
 			this.menuItemView.Name = "menuItemView";
-			this.menuItemView.Size = new System.Drawing.Size(152, 22);
+			this.menuItemView.Size = new System.Drawing.Size(161, 22);
 			this.menuItemView.Text = "&View";
 			this.menuItemView.Click += new System.EventHandler(this.OnClickView);
 			// 
@@ -139,7 +141,7 @@
             this.rLELosslessToolStripMenuItem});
 			this.menuItemSyntax.Enabled = false;
 			this.menuItemSyntax.Name = "menuItemSyntax";
-			this.menuItemSyntax.Size = new System.Drawing.Size(152, 22);
+			this.menuItemSyntax.Size = new System.Drawing.Size(161, 22);
 			this.menuItemSyntax.Text = "&Change Syntax";
 			// 
 			// explicitVRLittleEndianToolStripMenuItem
@@ -355,6 +357,13 @@
 			this.rLELosslessToolStripMenuItem.Text = "RLE Lossless";
 			this.rLELosslessToolStripMenuItem.Click += new System.EventHandler(this.OnClickRLELossless);
 			// 
+			// exportPixelDataToolStripMenuItem
+			// 
+			this.exportPixelDataToolStripMenuItem.Name = "exportPixelDataToolStripMenuItem";
+			this.exportPixelDataToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+			this.exportPixelDataToolStripMenuItem.Text = "Export Pixel Data";
+			this.exportPixelDataToolStripMenuItem.Click += new System.EventHandler(this.OnClickExportPixelData);
+			// 
 			// lvDicom
 			// 
 			this.lvDicom.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
@@ -398,25 +407,26 @@
             this.copyValueToolStripMenuItem,
             this.copyTagToolStripMenuItem});
 			this.cmDicom.Name = "cmDicom";
-			this.cmDicom.Size = new System.Drawing.Size(153, 70);
+			this.cmDicom.Size = new System.Drawing.Size(134, 48);
 			this.cmDicom.Opening += new System.ComponentModel.CancelEventHandler(this.OnContextMenuOpening);
 			// 
 			// copyValueToolStripMenuItem
 			// 
 			this.copyValueToolStripMenuItem.Name = "copyValueToolStripMenuItem";
-			this.copyValueToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.copyValueToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
 			this.copyValueToolStripMenuItem.Text = "Copy &Value";
 			this.copyValueToolStripMenuItem.Click += new System.EventHandler(this.OnClickContextMenuCopyValue);
 			// 
 			// copyTagToolStripMenuItem
 			// 
 			this.copyTagToolStripMenuItem.Name = "copyTagToolStripMenuItem";
-			this.copyTagToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+			this.copyTagToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
 			this.copyTagToolStripMenuItem.Text = "Copy &Tag";
 			this.copyTagToolStripMenuItem.Click += new System.EventHandler(this.OnClickContextMenuCopyTag);
 			// 
 			// MainForm
 			// 
+			this.AllowDrop = true;
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.ClientSize = new System.Drawing.Size(792, 573);
@@ -425,6 +435,8 @@
 			this.MainMenuStrip = this.menuStrip1;
 			this.Name = "MainForm";
 			this.Text = "DICOM Dump";
+			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.OnDragDrop);
+			this.DragEnter += new System.Windows.Forms.DragEventHandler(this.OnDragEnter);
 			this.menuStrip1.ResumeLayout(false);
 			this.menuStrip1.PerformLayout();
 			this.cmDicom.ResumeLayout(false);
@@ -479,6 +491,7 @@
 		private System.Windows.Forms.ToolStripMenuItem quality60ToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem quality50ToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem copyTagToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem exportPixelDataToolStripMenuItem;
 	}
 }
 

--- a/Tools/DICOM Dump/ReportForm.Designer.cs
+++ b/Tools/DICOM Dump/ReportForm.Designer.cs
@@ -1,0 +1,55 @@
+﻿namespace Dicom.Dump {
+	partial class ReportForm {
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing) {
+			if (disposing && (components != null)) {
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent() {
+			this.tvReport = new System.Windows.Forms.TreeView();
+			this.SuspendLayout();
+			// 
+			// tvReport
+			// 
+			this.tvReport.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.tvReport.Location = new System.Drawing.Point(0, 0);
+			this.tvReport.Name = "tvReport";
+			this.tvReport.ShowRootLines = false;
+			this.tvReport.Size = new System.Drawing.Size(784, 561);
+			this.tvReport.TabIndex = 2;
+			// 
+			// ReportForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(784, 561);
+			this.Controls.Add(this.tvReport);
+			this.Name = "ReportForm";
+			this.ShowInTaskbar = false;
+			this.Text = "Structured Report";
+			this.ResumeLayout(false);
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.TreeView tvReport;
+	}
+}

--- a/Tools/DICOM Dump/ReportForm.cs
+++ b/Tools/DICOM Dump/ReportForm.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+using Dicom;
+using Dicom.StructuredReport;
+
+namespace Dicom.Dump {
+	public partial class ReportForm : Form {
+		private DicomFile _file;
+
+		public ReportForm(DicomFile file) {
+			_file = file;
+			InitializeComponent();
+		}
+
+		protected override void OnLoad(EventArgs e) {
+			try {
+				tvReport.BeginUpdate();
+				tvReport.Nodes.Clear();
+
+				var sr = new DicomStructuredReport(_file.Dataset);
+				var node = tvReport.Nodes.Add(sr.ToString());
+				foreach (var child in sr.Children())
+					AddTreeNode(child, node);
+
+				tvReport.ExpandAll();
+				node.EnsureVisible();
+				tvReport.EndUpdate();
+			} catch (Exception ex) {
+				OnException(ex);
+			}
+		}
+
+		private void AddTreeNode(DicomContentItem item, TreeNode parent) {
+			var node = parent.Nodes.Add(item.ToString());
+
+			foreach (var child in item.Children())
+				AddTreeNode(child, node);
+		}
+
+		private delegate void ExceptionHandler(Exception e);
+
+		protected void OnException(Exception e) {
+			if (InvokeRequired) {
+				BeginInvoke(new ExceptionHandler(OnException), e);
+				return;
+			}
+
+			MessageBox.Show(this, e.Message, "Structured Report Exception", MessageBoxButtons.OK, MessageBoxIcon.Error);
+			Close();
+		}
+	}
+}

--- a/Tools/DICOM Dump/ReportForm.resx
+++ b/Tools/DICOM Dump/ReportForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
Updates to DICOM Dump tool:
* Hold `shift` while opening program to prevent loading private dictionary
* Ability to display outline of structured reports
* Drag-and-drop files onto program to open
* Open files from command line
* Probably others that I can't remember