### PR TITLE
Moved System.Drawing dependencies to separate files. Connected to #83

### DIFF
--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -71,6 +71,7 @@
     <Compile Include="Imaging\ColorTableTest.cs" />
     <Compile Include="Imaging\GrayscaleRenderOptionsTest.cs" />
     <Compile Include="Imaging\LUT\OutputLUTTest.cs" />
+    <Compile Include="Imaging\Mathematics\RectFTest.cs" />
     <Compile Include="Imaging\SpatialTransformTest.cs" />
     <Compile Include="IO\Buffer\TempFileBufferTest.cs" />
     <Compile Include="IO\DesktopFileReferenceTest.cs" />

--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -45,7 +45,6 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="xunit.abstractions">

--- a/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
+++ b/DICOM [Unit Tests]/DICOM [Unit Tests].csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="xunit.abstractions">
@@ -71,6 +72,7 @@
     <Compile Include="Imaging\ColorTableTest.cs" />
     <Compile Include="Imaging\GrayscaleRenderOptionsTest.cs" />
     <Compile Include="Imaging\LUT\OutputLUTTest.cs" />
+    <Compile Include="Imaging\SpatialTransformTest.cs" />
     <Compile Include="IO\Buffer\TempFileBufferTest.cs" />
     <Compile Include="IO\DesktopFileReferenceTest.cs" />
     <Compile Include="IO\DesktopPathTest.cs" />

--- a/DICOM [Unit Tests]/Imaging/Mathematics/RectFTest.cs
+++ b/DICOM [Unit Tests]/Imaging/Mathematics/RectFTest.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging.Mathematics
+{
+    using Xunit;
+
+    public class RectFTest
+    {
+        #region Unit tests
+
+        [Theory]
+        [InlineData(0f, 0f, 100f, 50f, 10f, 20f, -10f, -20f, 120f, 90f)]
+        [InlineData(0f, 0f, 100f, 50f, -10f, -20f, 10f, 20f, 80f, 10f)]
+        [InlineData(0f, 0f, 100f, 50f, -10f, -30f, 10f, 25f, 80f, 0f)]
+        [InlineData(0f, 0f, 100f, 50f, -100f, -20f, 50f, 20f, 0f, 10f)]
+        public void Inflate_Various_YieldCorrectNewRectangle(
+            float x0,
+            float y0,
+            float w0,
+            float h0,
+            float inflateX,
+            float inflateY,
+            float x1,
+            float y1,
+            float w1,
+            float h1)
+        {
+            var rect = new RectF(x0, y0, w0, h0);
+            rect.Inflate(inflateX, inflateY);
+            Assert.Equal(x1, rect.X);
+            Assert.Equal(y1, rect.Y);
+            Assert.Equal(w1, rect.Width);
+            Assert.Equal(h1, rect.Height);
+        }
+
+        #endregion
+    }
+}

--- a/DICOM [Unit Tests]/Imaging/Mathematics/RectFTest.cs
+++ b/DICOM [Unit Tests]/Imaging/Mathematics/RectFTest.cs
@@ -34,6 +34,18 @@ namespace Dicom.Imaging.Mathematics
             Assert.Equal(h1, rect.Height);
         }
 
+        [Fact]
+        public void Assignment_ChangeInNewInstance_DoesNotAffectOldInstance()
+        {
+            var oldRect = new RectF(10f, 20f, 30f, 40f);
+            var newRect = oldRect;
+            newRect.Inflate(10f, 10f);
+            Assert.Equal(10f, oldRect.X);
+            Assert.Equal(20f, oldRect.Y);
+            Assert.Equal(30f, oldRect.Width);
+            Assert.Equal(40f, oldRect.Height);
+        }
+
         #endregion
     }
 }

--- a/DICOM [Unit Tests]/Imaging/SpatialTransformTest.cs
+++ b/DICOM [Unit Tests]/Imaging/SpatialTransformTest.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Imaging
 {
-    using System.Drawing;
+    using Dicom.Imaging.Mathematics;
 
     using Xunit;
 
@@ -14,14 +14,14 @@ namespace Dicom.Imaging
         [Fact]
         public void IsTransformed_PanNonZero_IsTrue()
         {
-            var transform = new SpatialTransform { Pan = new Point(5, -7) };
+            var transform = new SpatialTransform { Pan = new Point2(5, -7) };
             Assert.True(transform.IsTransformed);
         }
 
         [Fact]
         public void IsTransformed_ScaleUnity_RotateZeroPanZero_IsFalse()
         {
-            var transform = new SpatialTransform { Scale = 1.0, Rotation = 0, Pan = new Point(0, 0) };
+            var transform = new SpatialTransform { Scale = 1.0, Rotation = 0, Pan = new Point2(0, 0) };
             Assert.False(transform.IsTransformed);
         }
 

--- a/DICOM [Unit Tests]/Imaging/SpatialTransformTest.cs
+++ b/DICOM [Unit Tests]/Imaging/SpatialTransformTest.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging
+{
+    using System.Drawing;
+
+    using Xunit;
+
+    public class SpatialTransformTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void IsTransformed_PanNonZero_IsTrue()
+        {
+            var transform = new SpatialTransform { Pan = new Point(5, -7) };
+            Assert.True(transform.IsTransformed);
+        }
+
+        [Fact]
+        public void IsTransformed_ScaleUnity_RotateZeroPanZero_IsFalse()
+        {
+            var transform = new SpatialTransform { Scale = 1.0, Rotation = 0, Pan = new Point(0, 0) };
+            Assert.False(transform.IsTransformed);
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/DICOM.csproj
+++ b/DICOM/DICOM.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Printing\FilmBoxExtensions.cs" />
     <Compile Include="Printing\FilmSession.cs" />
     <Compile Include="Printing\ImageBox.cs" />
+    <Compile Include="Printing\ImageBoxExtensions.cs" />
     <Compile Include="Printing\PresentationLut.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringExtensions.cs" />

--- a/DICOM/DICOM.csproj
+++ b/DICOM/DICOM.csproj
@@ -270,6 +270,7 @@
     <Compile Include="Network\IDicomServiceUser.cs" />
     <Compile Include="Network\PDU.cs" />
     <Compile Include="Printing\FilmBox.cs" />
+    <Compile Include="Printing\FilmBoxExtensions.cs" />
     <Compile Include="Printing\FilmSession.cs" />
     <Compile Include="Printing\ImageBox.cs" />
     <Compile Include="Printing\PresentationLut.cs" />

--- a/DICOM/DICOM.csproj
+++ b/DICOM/DICOM.csproj
@@ -62,6 +62,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DatabaseQueryTransformRule.cs" />
+    <Compile Include="Imaging\Mathematics\RectF.cs" />
     <Compile Include="IO\DesktopPath.cs" />
     <Compile Include="DicomDataException.cs" />
     <Compile Include="DicomDataset.cs" />
@@ -318,7 +319,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_UseGlobalSettings="True" BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" />
+      <UserProperties BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" BuildVersion_UseGlobalSettings="True" />
     </VisualStudio>
   </ProjectExtensions>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/DICOM/DICOM.csproj
+++ b/DICOM/DICOM.csproj
@@ -62,6 +62,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DatabaseQueryTransformRule.cs" />
+    <Compile Include="Imaging\DicomOverlayDataFactory.cs" />
     <Compile Include="Imaging\Mathematics\RectF.cs" />
     <Compile Include="IO\DesktopPath.cs" />
     <Compile Include="DicomDataException.cs" />
@@ -321,7 +322,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" BuildVersion_UseGlobalSettings="True" />
+      <UserProperties BuildVersion_UseGlobalSettings="True" BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" />
     </VisualStudio>
   </ProjectExtensions>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 
 using Dicom.Imaging.Mathematics;
@@ -301,47 +300,6 @@ namespace Dicom.Imaging
                 }
             }
             return overlays.ToArray();
-        }
-
-        /// <summary>
-        /// Creates a DICOM overlay from a GDI+ Bitmap.
-        /// </summary>
-        /// <param name="ds">Dataset</param>
-        /// <param name="bitmap">Bitmap</param>
-        /// <param name="mask">Color mask for overlay</param>
-        /// <returns>DICOM overlay</returns>
-        public static DicomOverlayData FromBitmap(DicomDataset ds, Bitmap bitmap, Color mask)
-        {
-            ushort group = 0x6000;
-            while (ds.Contains(new DicomTag(group, DicomTag.OverlayBitPosition.Element))) group += 2;
-
-            var overlay = new DicomOverlayData(ds, group);
-            overlay.Type = DicomOverlayType.Graphics;
-            overlay.Rows = bitmap.Height;
-            overlay.Columns = bitmap.Width;
-            overlay.OriginX = 1;
-            overlay.OriginY = 1;
-            overlay.BitsAllocated = 1;
-            overlay.BitPosition = 1;
-
-            var count = overlay.Rows * overlay.Columns / 8;
-            if ((overlay.Rows * overlay.Columns) % 8 > 0) count++;
-
-            var array = new BitList();
-            array.Capacity = overlay.Rows * overlay.Columns;
-
-            int p = 0;
-            for (int y = 0; y < bitmap.Height; y++)
-            {
-                for (int x = 0; x < bitmap.Width; x++, p++)
-                {
-                    if (bitmap.GetPixel(x, y).ToArgb() == mask.ToArgb()) array[p] = true;
-                }
-            }
-
-            overlay.Data = EvenLengthBuffer.Create(new MemoryByteBuffer(array.Array));
-
-            return overlay;
         }
 
         public static bool HasEmbeddedOverlays(DicomDataset ds)

--- a/DICOM/Imaging/DicomOverlayDataFactory.cs
+++ b/DICOM/Imaging/DicomOverlayDataFactory.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging
+{
+    using System.Drawing;
+
+    using Dicom.Imaging.Mathematics;
+    using Dicom.IO.Buffer;
+
+    /// <summary>
+    /// Bitmap related factory methods for <see cref="DicomOverlayData"/>.
+    /// </summary>
+    public class DicomOverlayDataFactory
+    {
+        #region METHODS
+
+        /// <summary>
+        /// Creates a DICOM overlay from a GDI+ Bitmap.
+        /// </summary>
+        /// <param name="ds">Dataset</param>
+        /// <param name="bitmap">Bitmap</param>
+        /// <param name="mask">Color mask for overlay</param>
+        /// <returns>DICOM overlay</returns>
+        public static DicomOverlayData FromBitmap(DicomDataset ds, Bitmap bitmap, Color mask)
+        {
+            ushort group = 0x6000;
+            while (ds.Contains(new DicomTag(group, DicomTag.OverlayBitPosition.Element))) group += 2;
+
+            var overlay = new DicomOverlayData(ds, group)
+                              {
+                                  Type = DicomOverlayType.Graphics,
+                                  Rows = bitmap.Height,
+                                  Columns = bitmap.Width,
+                                  OriginX = 1,
+                                  OriginY = 1,
+                                  BitsAllocated = 1,
+                                  BitPosition = 1
+                              };
+
+            var array = new BitList { Capacity = overlay.Rows * overlay.Columns };
+
+            int p = 0;
+            for (var y = 0; y < bitmap.Height; y++)
+            {
+                for (var x = 0; x < bitmap.Width; x++, p++)
+                {
+                    if (bitmap.GetPixel(x, y).ToArgb() == mask.ToArgb()) array[p] = true;
+                }
+            }
+
+            overlay.Data = EvenLengthBuffer.Create(new MemoryByteBuffer(array.Array));
+
+            return overlay;
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/Mathematics/RectF.cs
+++ b/DICOM/Imaging/Mathematics/RectF.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging.Mathematics
+{
+    using System;
+
+    /// <summary>
+    /// Representation of a floating-point rectangle.
+    /// </summary>
+    public struct RectF
+    {
+        #region FIELDS
+
+        private float x;
+
+        private float y;
+
+        private float width;
+
+        private float height;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of <see cref="RectF"/>.
+        /// </summary>
+        /// <param name="x">The start x coordinate.</param>
+        /// <param name="y">The start y coordinate.</param>
+        /// <param name="width">The width.</param>
+        /// <param name="height">The height.</param>
+        public RectF(float x, float y, float width, float height)
+        {
+            if (width < 0f)
+            {
+                throw new ArgumentOutOfRangeException("width", "Negative width not supported.");
+            }
+            if (height < 0f)
+            {
+                throw new ArgumentOutOfRangeException("height", "Negative height not supported.");
+            }
+            this.x = x;
+            this.y = y;
+            this.width = width;
+            this.height = height;
+        }
+
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the rectangle start coordinate in X direction.
+        /// </summary>
+        public float X
+        {
+            get
+            {
+                return this.x;
+            }
+            set
+            {
+                this.x = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the rectangle start coordinate in Y direction.
+        /// </summary>
+        public float Y
+        {
+            get
+            {
+                return this.y;
+            }
+            set
+            {
+                this.y = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the rectangle width.
+        /// </summary>
+        public float Width
+        {
+            get
+            {
+                return this.width;
+            }
+            set
+            {
+                this.width = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the rectangle height.
+        /// </summary>
+        public float Height
+        {
+            get
+            {
+                return this.height;
+            }
+            set
+            {
+                this.height = value;
+            }
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Enlarges this <see cref="RectF"/> structure by the specified amount.
+        /// </summary>
+        /// <param name="x">The amount to inflate this <see cref="RectF"/> structure horizontally.</param>
+        /// <param name="y">The amount to inflate this <see cref="RectF"/> structure vertically.</param>
+        public void Inflate(float x, float y)
+        {
+            if (x < -this.width / 2.0f)
+            {
+                x = -this.width / 2.0f;
+            }
+            if (y < -this.height / 2.0f)
+            {
+                y = -this.height / 2.0f;
+            }
+
+            this.x -= x;
+            this.y -= y;
+            this.width += 2.0f * x;
+            this.height += 2.0f * y;
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/SpatialTransform.cs
+++ b/DICOM/Imaging/SpatialTransform.cs
@@ -97,7 +97,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                return _scale != 1.0f || _rotate != 0.0f || _pan == Point.Empty;
+                return _scale != 1.0f || _rotate != 0.0f || _pan != Point.Empty;
             }
         }
 

--- a/DICOM/Imaging/SpatialTransform.cs
+++ b/DICOM/Imaging/SpatialTransform.cs
@@ -5,24 +5,22 @@ using System.Drawing;
 
 namespace Dicom.Imaging
 {
+    /// <summary>
+    /// Representation of a spatial 2D transform.
+    /// </summary>
     public class SpatialTransform
     {
         #region Private Members
-
-        private double _scale;
-
-        private int _rotate;
-
-        private bool _flipx;
-
-        private bool _flipy;
 
         private Point _pan;
 
         #endregion
 
         #region Public Constructors
-
+        
+        /// <summary>
+        /// Initializes an instance of <see cref="SpatialTransform"/>.
+        /// </summary>
         public SpatialTransform()
         {
             _pan = new Point(0, 0);
@@ -33,54 +31,29 @@ namespace Dicom.Imaging
 
         #region Public Properties
 
-        public double Scale
-        {
-            get
-            {
-                return _scale;
-            }
-            set
-            {
-                _scale = value;
-            }
-        }
+        /// <summary>
+        /// Gets or sets the scale of the transform.
+        /// </summary>
+        public double Scale { get; set; }
 
-        public int Rotation
-        {
-            get
-            {
-                return _rotate;
-            }
-            set
-            {
-                _rotate = value;
-            }
-        }
+        /// <summary>
+        /// Gets or sets the rotation of the transform.
+        /// </summary>
+        public int Rotation { get; set; }
 
-        public bool FlipX
-        {
-            get
-            {
-                return _flipx;
-            }
-            set
-            {
-                _flipx = value;
-            }
-        }
+        /// <summary>
+        /// Gets or sets whether to flip in X direction.
+        /// </summary>
+        public bool FlipX { get; set; }
 
-        public bool FlipY
-        {
-            get
-            {
-                return _flipy;
-            }
-            set
-            {
-                _flipy = value;
-            }
-        }
+        /// <summary>
+        /// Gets or sets whether to flip in Y direction.
+        /// </summary>
+        public bool FlipY { get; set; }
 
+        /// <summary>
+        /// Gets or sets the pan of the transform.
+        /// </summary>
         public Point Pan
         {
             get
@@ -93,11 +66,14 @@ namespace Dicom.Imaging
             }
         }
 
+        /// <summary>
+        /// Gets whether the transform is set or reset.
+        /// </summary>
         public bool IsTransformed
         {
             get
             {
-                return _scale != 1.0f || _rotate != 0.0f || _pan != Point.Empty;
+                return this.Scale != 1.0 || this.Rotation != 0 || this.Pan != Point.Empty;
             }
         }
 
@@ -105,17 +81,24 @@ namespace Dicom.Imaging
 
         #region Public Members
 
+        /// <summary>
+        /// Add further rotation to the transform.
+        /// </summary>
+        /// <param name="angle">Angle with which to rotate.</param>
         public void Rotate(int angle)
         {
-            _rotate += angle;
+            this.Rotation += angle;
         }
 
+        /// <summary>
+        /// Reset the transform.
+        /// </summary>
         public void Reset()
         {
-            _scale = 1.0;
-            _rotate = 0;
-            _flipx = false;
-            _flipy = false;
+            this.Scale = 1.0;
+            this.Rotation = 0;
+            this.FlipX = false;
+            this.FlipY = false;
             _pan.X = 0;
             _pan.Y = 0;
         }

--- a/DICOM/Imaging/SpatialTransform.cs
+++ b/DICOM/Imaging/SpatialTransform.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Drawing;
-
 namespace Dicom.Imaging
 {
+    using Dicom.Imaging.Mathematics;
+
     /// <summary>
     /// Representation of a spatial 2D transform.
     /// </summary>
@@ -12,7 +12,7 @@ namespace Dicom.Imaging
     {
         #region Private Members
 
-        private Point _pan;
+        private Point2 _pan;
 
         #endregion
 
@@ -23,7 +23,7 @@ namespace Dicom.Imaging
         /// </summary>
         public SpatialTransform()
         {
-            _pan = new Point(0, 0);
+            _pan = new Point2(0, 0);
             Reset();
         }
 
@@ -54,7 +54,7 @@ namespace Dicom.Imaging
         /// <summary>
         /// Gets or sets the pan of the transform.
         /// </summary>
-        public Point Pan
+        public Point2 Pan
         {
             get
             {
@@ -73,7 +73,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                return this.Scale != 1.0 || this.Rotation != 0 || this.Pan != Point.Empty;
+                return this.Scale != 1.0 || this.Rotation != 0 || !this.Pan.Equals(Point2.Origin);
             }
         }
 

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -741,7 +741,13 @@ namespace Dicom.Printing
             }
         }
 
-        protected RectF[] PrintColumnFormat(string[] parts, RectF marginBounds)
+        /// <summary>
+        /// Generate rectangles arranged in column format.
+        /// </summary>
+        /// <param name="parts">Display format data.</param>
+        /// <param name="marginBounds">Margin bounds.</param>
+        /// <returns>Rectangles arranged in column format.</returns>
+        public static RectF[] PrintColumnFormat(string[] parts, RectF marginBounds)
         {
             if (parts.Length >= 2)
             {
@@ -775,7 +781,13 @@ namespace Dicom.Printing
             return null;
         }
 
-        protected RectF[] PrintRowFormat(string[] parts, RectF marginBounds)
+        /// <summary>
+        /// Generate rectangles arranged in row format.
+        /// </summary>
+        /// <param name="parts">Display format data.</param>
+        /// <param name="marginBounds">Margin bounds.</param>
+        /// <returns>Rectangles arranged in row format.</returns>
+        public static RectF[] PrintRowFormat(string[] parts, RectF marginBounds)
         {
             if (parts.Length >= 2)
             {
@@ -809,7 +821,13 @@ namespace Dicom.Printing
             return null;
         }
 
-        protected RectF[] PrintStandardFormat(string[] parts, RectF marginBounds)
+        /// <summary>
+        /// Generate rectangles arranged in standard format.
+        /// </summary>
+        /// <param name="parts">Display format data.</param>
+        /// <param name="marginBounds">Margin bounds.</param>
+        /// <returns>Rectangles arranged in standard format.</returns>
+        public static RectF[] PrintStandardFormat(string[] parts, RectF marginBounds)
         {
             if (parts.Length >= 3)
             {

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -9,16 +9,18 @@ namespace Dicom.Printing
     using System.Linq;
     using System.Drawing;
 
-    using Dicom.Log;
     using Dicom.Imaging.Mathematics;
     using Dicom.IO;
+    using Dicom.Log;
 
     /// <summary>
     /// Basic film box
     /// </summary>
     public class FilmBox : DicomDataset
     {
-        #region Properites and Attributes
+        #region Properties and Attributes
+
+        private static readonly Logger Logger = LogManager.Default.GetLogger("Dicom.Printing");
 
         private readonly FilmSession _filmSession = null;
 
@@ -562,11 +564,11 @@ namespace Dicom.Printing
             {
                 if (string.IsNullOrEmpty(ImageDisplayFormat))
                 {
-                    //Log.Logger.Error("No display format present in N-CREATE Basic Film Box dataset");
+                    Logger.Error("No display format present in N-CREATE Basic Film Box dataset");
                     return false;
                 }
 
-                //Core.Logger.Info("Applying display format {0} for film box {1}", ImageDisplayFormat, SOPInstanceUID);
+                Logger.Info("Applying display format {0} for film box {1}", ImageDisplayFormat, SOPInstanceUID);
 
                 var parts = ImageDisplayFormat.Split('\\');
 
@@ -607,9 +609,8 @@ namespace Dicom.Printing
             }
             catch (Exception ex)
             {
-                //Core.Logger.Error("FilmBox.Initialize", ex);
+                Logger.Error("FilmBox.Initialize, exception message: {0}", ex.Message);
             }
-            //Core.Logger.Error("Unsupported image display format \"{0}\"", ImageDisplayFormat);
             return false;
         }
 

--- a/DICOM/Printing/FilmBoxExtensions.cs
+++ b/DICOM/Printing/FilmBoxExtensions.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Printing
+{
+    using System;
+    using System.Drawing;
+
+    using Dicom.Imaging.Mathematics;
+
+    /// <summary>
+    /// Extension methods on instance of the <see cref="FilmBox"/> class.
+    /// </summary>
+    public static class FilmBoxExtensions
+    {
+        #region METHODS
+
+        /// <summary>
+        /// Get the film box size in inches.
+        /// </summary>
+        /// <param name="filmBox">Film box object.</param>
+        /// <returns>Size in inches of film box.</returns>
+        public static SizeF GetSizeInInch(this FilmBox filmBox)
+        {
+            // ReSharper disable once InconsistentNaming
+            const float CM_PER_INCH = 2.54f;
+            var filmSizeId = filmBox.FilmSizeID;
+
+            if (filmSizeId.Contains("IN"))
+            {
+                var parts = filmSizeId.Split(new[] { "IN" }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2)
+                {
+                    var width = parts[0].Replace('_', '.');
+                    var height = parts[1].TrimStart('X').Replace('_', '.');
+
+                    return new SizeF(Single.Parse(width), Single.Parse(height));
+                }
+            }
+            else if (filmSizeId.Contains("CM"))
+            {
+                var parts = filmSizeId.Split(new[] { "CM" }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2)
+                {
+                    var width = parts[0].Replace('_', '.');
+                    var height = parts[1].TrimStart('X').Replace('_', '.');
+
+                    return new SizeF(Single.Parse(width) / CM_PER_INCH, Single.Parse(height) / CM_PER_INCH);
+                }
+            }
+            else if (filmSizeId == "A3")
+            {
+                return new SizeF(29.7f / CM_PER_INCH, 42.0f / CM_PER_INCH);
+            }
+
+            return new SizeF(210 / CM_PER_INCH, 297 / CM_PER_INCH);
+        }
+
+        /// <summary>
+        /// Print a film box on specified graphics.
+        /// </summary>
+        /// <param name="filmBox">Film box.</param>
+        /// <param name="graphics">Graphics on which to draw the film box.</param>
+        /// <param name="marginBounds">Margin bounds.</param>
+        /// <param name="imageResolution">Image resolution.</param>
+        public static void Print(this FilmBox filmBox, Graphics graphics, Rectangle marginBounds, int imageResolution)
+        {
+            var parts = filmBox.ImageDisplayFormat.Split('\\', ',');
+
+            if (parts.Length > 0)
+            {
+                RectF[] boxes = null;
+                if (parts[0] == "STANDARD")
+                {
+                    boxes = FilmBox.PrintStandardFormat(parts, ToRectF(marginBounds));
+                }
+                else if (parts[0] == "ROW")
+                {
+                    boxes = FilmBox.PrintRowFormat(parts, ToRectF(marginBounds));
+                }
+                else if (parts[0] == "COL")
+                {
+                    boxes = FilmBox.PrintColumnFormat(parts, ToRectF(marginBounds));
+                }
+
+                if (boxes == null)
+                {
+                    throw new InvalidOperationException(
+                        string.Format("ImageDisplayFormat {0} invalid", filmBox.ImageDisplayFormat));
+                }
+
+                for (var i = 0; i < filmBox.BasicImageBoxes.Count; i++)
+                {
+                    filmBox.BasicImageBoxes[i].Print(graphics, boxes[i], imageResolution);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Convert <see cref="Rectangle"/> object into <see cref="RectF"/> object.
+        /// </summary>
+        /// <param name="rectangle">Rectangle to convert.</param>
+        /// <returns>Rectangle expressed as <see cref="RectF"/>.</returns>
+        private static RectF ToRectF(Rectangle rectangle)
+        {
+            return new RectF(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Printing/ImageBox.cs
+++ b/DICOM/Printing/ImageBox.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Drawing;
-
-using Dicom.Log;
-
 namespace Dicom.Printing
 {
+    using System;
+    using System.Drawing;
     using System.IO;
 
+    using Dicom.Imaging.Mathematics;
     using Dicom.IO;
+    using Dicom.Log;
 
     /// <summary>
     /// Color or gray scale basic image box
@@ -339,7 +338,7 @@ namespace Dicom.Printing
 
         #region Printing
 
-        public void Print(Graphics graphics, RectangleF box, int imageResolution)
+        public void Print(Graphics graphics, RectF box, int imageResolution)
         {
             var state = graphics.Save();
 
@@ -359,10 +358,9 @@ namespace Dicom.Printing
                     var image = new Dicom.Imaging.DicomImage(ImageSequence);
                     var frame = image.RenderImage(0);
 
-                    bitmap = frame; // new Bitmap(frame);
-                    //frame.Dispose();
+                    bitmap = frame;
 
-                    DrawBitmap(graphics, box, bitmap, imageResolution);
+                    DrawBitmap(graphics, imageBox, bitmap, imageResolution);
                 }
                 finally
                 {
@@ -376,37 +374,35 @@ namespace Dicom.Printing
             graphics.Restore(state);
         }
 
-        private void FillBox(RectangleF box, Graphics graphics)
+        private void FillBox(RectF box, Graphics graphics)
         {
             if (FilmBox.EmptyImageDensity == "BLACK")
             {
-                RectangleF fillBox = box;
+                RectF fillBox = box;
                 if (FilmBox.BorderDensity == "WHITE" && FilmBox.Trim == "YES")
                 {
                     fillBox.Inflate(-BORDER, -BORDER);
                 }
                 using (var brush = new SolidBrush(Color.Black))
                 {
-                    graphics.FillRectangle(brush, fillBox);
+                    graphics.FillRectangle(brush, fillBox.X, fillBox.Y, fillBox.Width, fillBox.Height);
                 }
             }
         }
 
-        private void DrawBitmap(Graphics graphics, RectangleF box, Image bitmap, int imageResolution)
+        private void DrawBitmap(Graphics graphics, RectF box, Image bitmap, int imageResolution)
         {
-            var imageSizeInInch = new SizeF(100 * bitmap.Width / imageResolution, 100 * bitmap.Height / imageResolution);
-            double factor = Math.Min(box.Height / imageSizeInInch.Height, box.Width / imageSizeInInch.Width);
+            var imageWidthInInch = 100 * bitmap.Width / imageResolution;
+            var imageHeightInInch = 100 * bitmap.Height / imageResolution;
+            double factor = Math.Min(box.Height / imageHeightInInch, box.Width / imageWidthInInch);
 
             if (factor > 1)
             {
-                var targetSize = new Size
-                                     {
-                                         Width = (int)(imageResolution * box.Width / 100),
-                                         Height = (int)(imageResolution * box.Height / 100)
-                                     };
+                var targetWidth = (int)(imageResolution * box.Width / 100);
+                                         var targetHeight = (int)(imageResolution * box.Height / 100);
 
 
-                using (var membmp = new Bitmap(targetSize.Width, targetSize.Height))
+                using (var membmp = new Bitmap(targetWidth, targetHeight))
                 {
                     membmp.SetResolution(imageResolution, imageResolution);
 
@@ -420,50 +416,32 @@ namespace Dicom.Printing
                         {
                             using (var brush = new SolidBrush(Color.Black))
                             {
-                                memg.FillRectangle(brush, 0, 0, targetSize.Width, targetSize.Height);
+                                memg.FillRectangle(brush, 0, 0, targetWidth, targetHeight);
                             }
                         }
 
                         factor = Math.Min(
-                            targetSize.Height / (double)bitmap.Height,
-                            targetSize.Width / (double)bitmap.Width);
+                            targetHeight / (double)bitmap.Height,
+                            targetWidth / (double)bitmap.Width);
 
-                        RectangleF srcRect = new RectangleF(0, 0, bitmap.Width, bitmap.Height);
-                        RectangleF dstRect = new RectangleF
-                                                 {
-                                                     X =
-                                                         (float)
-                                                         ((targetSize.Width - bitmap.Width * factor) / 2.0f),
-                                                     Y =
-                                                         (float)
-                                                         ((targetSize.Height - bitmap.Height * factor) / 2.0f),
-                                                     Width = (float)(bitmap.Width * factor),
-                                                     Height = (float)(bitmap.Height * factor),
-                                                 };
-                        memg.DrawImage(bitmap, dstRect, srcRect, GraphicsUnit.Pixel);
+                        var x = (float)((targetWidth - bitmap.Width * factor) / 2.0f);
+                        var y = (float)((targetHeight - bitmap.Height * factor) / 2.0f);
+                        var width = (float)(bitmap.Width * factor);
+                        var height = (float)(bitmap.Height * factor);
+
+                        memg.DrawImage(bitmap, x, y, width, height);
                     }
                     graphics.DrawImage(membmp, box.X, box.Y, box.Width, box.Height);
                 }
             }
             else
             {
-                //var bmp = new Bitmap(bitmap);
-                //bmp.SetResolution(imageResolution, imageResolution);
-                RectangleF dstRect = new RectangleF
-                                         {
-                                             X =
-                                                 box.X
-                                                 + (float)(box.Width - imageSizeInInch.Width * factor) / 2.0f,
-                                             Y =
-                                                 box.Y
-                                                 + (float)(box.Height - imageSizeInInch.Height * factor)
-                                                 / 2.0f,
-                                             Width = (float)(imageSizeInInch.Width * factor),
-                                             Height = (float)(imageSizeInInch.Height * factor),
-                                         };
+                var x = box.X + (float)(box.Width - imageWidthInInch * factor) / 2.0f;
+                var y = box.Y + (float)(box.Height - imageHeightInInch * factor) / 2.0f;
+                var width = (float)(imageWidthInInch * factor);
+                var height = (float)(imageHeightInInch * factor);
 
-                graphics.DrawImage(bitmap, dstRect);
-                //bmp.Dispose();
+                graphics.DrawImage(bitmap, x, y, width, height);
             }
 
         }

--- a/DICOM/Printing/ImageBoxExtensions.cs
+++ b/DICOM/Printing/ImageBoxExtensions.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Printing
+{
+    using System;
+    using System.Drawing;
+
+    using Dicom.Imaging;
+    using Dicom.Imaging.Mathematics;
+
+    /// <summary>
+    /// Extension methods to support <see cref="ImageBox"/> class.
+    /// </summary>
+    public static class ImageBoxExtensions
+    {
+        #region FIELDS
+
+        //border in 100th of inches
+        private const float BORDER = (float)(100 * 2 / 25.4);
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Prints an image box onto the specified graphics.
+        /// </summary>
+        /// <param name="imageBox">Image box to print.</param>
+        /// <param name="graphics">Graphics in which image box should be contained.</param>
+        /// <param name="box">Rectangle within which the image box should be contained.</param>
+        /// <param name="imageResolution">Image resolution.</param>
+        public static void Print(this ImageBox imageBox, Graphics graphics, RectF box, int imageResolution)
+        {
+            var state = graphics.Save();
+
+            FillBox(imageBox.FilmBox, box, graphics);
+
+            var boxCopy = box;
+            if (imageBox.FilmBox.Trim == "YES")
+            {
+                boxCopy.Inflate(-BORDER, -BORDER);
+            }
+
+            if (imageBox.ImageSequence != null && imageBox.ImageSequence.Contains(DicomTag.PixelData))
+            {
+                Image bitmap = null;
+                try
+                {
+                    var image = new DicomImage(imageBox.ImageSequence);
+                    var frame = image.RenderImage();
+
+                    bitmap = frame;
+
+                    DrawBitmap(graphics, boxCopy, bitmap, imageResolution, imageBox.FilmBox.EmptyImageDensity);
+                }
+                finally
+                {
+                    if (bitmap != null)
+                    {
+                        bitmap.Dispose();
+                    }
+                }
+            }
+
+            graphics.Restore(state);
+        }
+
+        /// <summary>
+        /// If requested, fill the box with black color.
+        /// </summary>
+        /// <param name="filmBox">Film box.</param>
+        /// <param name="box">Rectangle.</param>
+        /// <param name="graphics">Graphics.</param>
+        private static void FillBox(FilmBox filmBox, RectF box, Graphics graphics)
+        {
+            if (filmBox.EmptyImageDensity == "BLACK")
+            {
+                RectF fillBox = box;
+                if (filmBox.BorderDensity == "WHITE" && filmBox.Trim == "YES")
+                {
+                    fillBox.Inflate(-BORDER, -BORDER);
+                }
+                using (var brush = new SolidBrush(Color.Black))
+                {
+                    graphics.FillRectangle(brush, fillBox.X, fillBox.Y, fillBox.Width, fillBox.Height);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Draw image bitmap in the specified rectangle.
+        /// </summary>
+        /// <param name="graphics">Graphics.</param>
+        /// <param name="box">Rectangle in which to draw.</param>
+        /// <param name="bitmap">Image to draw.</param>
+        /// <param name="imageResolution">Image resolution.</param>
+        /// <param name="emptyImageDensity">Empty image density.</param>
+        private static void DrawBitmap(Graphics graphics, RectF box, Image bitmap, int imageResolution, string emptyImageDensity)
+        {
+            var imageWidthInInch = 100 * bitmap.Width / imageResolution;
+            var imageHeightInInch = 100 * bitmap.Height / imageResolution;
+            double factor = Math.Min(box.Height / imageHeightInInch, box.Width / imageWidthInInch);
+
+            if (factor > 1)
+            {
+                var targetWidth = (int)(imageResolution * box.Width / 100);
+                var targetHeight = (int)(imageResolution * box.Height / 100);
+
+
+                using (var membmp = new Bitmap(targetWidth, targetHeight))
+                {
+                    membmp.SetResolution(imageResolution, imageResolution);
+
+                    using (var memg = Graphics.FromImage(membmp))
+                    {
+
+                        memg.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.Bicubic;
+                        memg.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+
+                        if (emptyImageDensity == "BLACK")
+                        {
+                            using (var brush = new SolidBrush(Color.Black))
+                            {
+                                memg.FillRectangle(brush, 0, 0, targetWidth, targetHeight);
+                            }
+                        }
+
+                        factor = Math.Min(
+                            targetHeight / (double)bitmap.Height,
+                            targetWidth / (double)bitmap.Width);
+
+                        var x = (float)((targetWidth - bitmap.Width * factor) / 2.0f);
+                        var y = (float)((targetHeight - bitmap.Height * factor) / 2.0f);
+                        var width = (float)(bitmap.Width * factor);
+                        var height = (float)(bitmap.Height * factor);
+
+                        memg.DrawImage(bitmap, x, y, width, height);
+                    }
+                    graphics.DrawImage(membmp, box.X, box.Y, box.Width, box.Height);
+                }
+            }
+            else
+            {
+                var x = box.X + (float)(box.Width - imageWidthInInch * factor) / 2.0f;
+                var y = box.Y + (float)(box.Height - imageHeightInInch * factor) / 2.0f;
+                var width = (float)(imageWidthInInch * factor);
+                var height = (float)(imageHeightInInch * factor);
+
+                graphics.DrawImage(bitmap, x, y, width, height);
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
I have made a few changes to reduce and isolate the dependency on the `System.Drawing` namespace, in order to facilitate transfer of *fo-dicom* to portable class libraries.

In brief, I have done the following in the *DICOM* assembly:

* Refactored the `Print` methods in `FilmBox` and `ImageBox` and `FilmBox.GetSizeInInch` to extension methods and moved these methods together with associated private methods into separate static extension classes.
* Moved static method `DicomOverlayData.FromBitmap` to separate factory class `DicomOverlayDataFactory`.
* Limited the use of geometric types from `System.Drawing` (`Point`, `SizeF`, `RectangleF` etc.) to a minimum so that classes `SpatialTransform`, `FilmBox`, `ImageBox` and `DicomOverlayData` no longer contain dependencies to the `System.Drawing` namespace.

These refactorings allow for improved separation of concerns; the main functionality of the aforementioned classes can be maintained in a core library, whereas the `Bitmap` dependent can be moved to a (.NET) platform specific library. At the same time, this opens up for alternative implementations in other platform specific libraries, where print functionality and overlay data generation from existing images can be implemented for the platform specific graphics engine.

The `FilmBox.GetSizeInInch`, `FilmBox.Print` and `ImageBox.Print` methods have been replaced with extension methods with the same convenience signature as the original methods, so client code does not need to be modified (although it will have to be re-compiled). The `DicomOverlayData.FromBitmap` has been moved to another class, which will require a minuscule change in any client code using that method. The `SpatialTransform.Pan` property is now of type `System.Imaging.Mathematics.Point2`. Otherwise, the public API is untouched by this PR.

Please review and comment.