### PR TITLE
Native binaries are not copied into the output folder. Connected to #87

### DIFF
--- a/fo-dicom.targets
+++ b/fo-dicom.targets
@@ -10,6 +10,9 @@
         <Reference Include="Dicom.Native64">
           <HintPath>$(MSBuildThisFileDirectory)\net45\Dicom.Native64.dll</HintPath>
         </Reference>
+        <None Include="$(MSBuildThisFileDirectory)\net45\Dicom.Native64.dll">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
       </ItemGroup>
     </When>
     <When Condition="'$(PlatformTarget)' == 'x86'">
@@ -17,6 +20,9 @@
         <Reference Include="Dicom.Native">
           <HintPath>$(MSBuildThisFileDirectory)\net45\Dicom.Native.dll</HintPath>
         </Reference>
+        <None Include="$(MSBuildThisFileDirectory)\net45\Dicom.Native.dll">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
       </ItemGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
**Testing**:

I checked that if the provided fix is applied to PATH\packages\fo-dicom.1.1.0\build\fo-dicom.targets then the issue is solved. 
