### PR TITLE
Implement NullLogger as default logger. Connected to #89

### DIFF
--- a/DICOM/Log/LogManager.cs
+++ b/DICOM/Log/LogManager.cs
@@ -3,15 +3,81 @@
 
 namespace Dicom.Log
 {
-    public abstract class LogManager
+    /// <summary>
+    /// Main class for logging management.
+    /// </summary>
+    public class LogManager
     {
+        /// <summary>
+        /// Initilaizes the static fields of <see cref="LogManager"/>.
+        /// </summary>
         static LogManager()
         {
-            Default = new ConsoleLogManager();
+            Default = new LogManager();
         }
 
+        /// <summary>
+        /// Initializes an instance of <see cref="LogManager"/>.
+        /// </summary>
+        protected LogManager()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the default log manager implementation.
+        /// </summary>
         public static LogManager Default { get; set; }
 
-        public abstract Logger GetLogger(string name);
+        /// <summary>
+        /// Get logger from the <see cref="Default"/> log manager implementation.
+        /// </summary>
+        /// <param name="name">Classifier name, typically namespace or type name.</param>
+        /// <returns>Logger from the <see cref="Default"/> log manager implementation.</returns>
+        public virtual Logger GetLogger(string name)
+        {
+            return NullLogger.Instance;
+        }
+
+        #region INNER TYPES
+
+        /// <summary>
+        /// Null logger, provides a no-op logger implementation.
+        /// </summary>
+        private class NullLogger : Logger
+        {
+            /// <summary>
+            /// Singleton instance of the <see cref="NullLogger"/> class.
+            /// </summary>
+            internal static readonly Logger Instance;
+
+            /// <summary>
+            /// Initializes the static fields of <see cref="NullLogger"/>.
+            /// </summary>
+            static NullLogger()
+            {
+                Instance = new NullLogger();
+            }
+
+            /// <summary>
+            /// Initializes an instance of <see cref="NullLogger"/>.
+            /// </summary>
+            private NullLogger()
+            {
+            }
+
+            /// <summary>
+            /// Dispatch a log message.
+            /// </summary>
+            /// <param name="level">Log level.</param>
+            /// <param name="msg">Log message format string.</param>
+            /// <param name="args">Arguments corresponding to the <paramref name="msg">log message</paramref>.</param>
+            /// <remarks>The <see cref="NullLogger"/> Log method overloads do nothing.</remarks>
+            public override void Log(LogLevel level, string msg, params object[] args)
+            {                
+                // Do nothing
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Here is a pull request providing a `NullLogger` class, i.e. a logger class that logs nothing. I have made this the default logger class of `LogManager`, instead of the `ConsoleLogger`.

I see two obvious benefits:

1. This is a working (well...) logger implementation that will also function in a portable class library.
2. The logger provides a quiet alternative for those applications where no logging is desired.

The `NullLogger` class is a private inner class of `LogManager`, and will be the initial logger that will be provided by the `GetLogger()` method. To enable logging output it will henceforth be required to explicitly set any other log manager, for example `ConsoleLogManager`, `NLogManager`, `Log4NetManager` etc.

Many thanks, @pircjernej for coming up with this idea.

Please review.