### PR TITLE
Synchronized LogManager API with other managers. Connected to #103

### DIFF
--- a/ConsoleTest/Program.cs
+++ b/ConsoleTest/Program.cs
@@ -35,8 +35,8 @@ namespace ConsoleTest
 
                 NLog.LogManager.Configuration = config;
 
-                //Not necessary due to inclusion of the Dicom.Nlog assembly
-                //Dicom.Log.LogManager.Default = new Dicom.Log.NLogManager();
+                //Use NLog for logging.
+                Dicom.Log.LogManager.SetImplementation(Dicom.Log.NLogManager.Instance);
 
                 //var server = new DicomServer<DicomCEchoProvider>(12345);
 

--- a/DICOM [Unit Tests]/Helpers/StringLogManager.cs
+++ b/DICOM [Unit Tests]/Helpers/StringLogManager.cs
@@ -9,7 +9,7 @@ namespace Dicom.Helpers
 
     public class StringLogManager : LogManager
     {
-        public override Logger GetLogger(string name)
+        protected override Logger GetLoggerImpl(string name)
         {
             return StringLogger.Instance;
         }

--- a/DICOM [Unit Tests]/Network/DicomCEchoProviderTest.cs
+++ b/DICOM [Unit Tests]/Network/DicomCEchoProviderTest.cs
@@ -14,7 +14,7 @@ namespace Dicom.Network
         [Fact]
         public void Send_FromDicomClient_DoesNotDeadlock()
         {
-            LogManager.Default = new StringLogManager();
+            LogManager.SetImplementation(new StringLogManager());
 
             const int port = 11112;
             using (new DicomServer<DicomCEchoProvider>(port))
@@ -25,7 +25,7 @@ namespace Dicom.Network
 
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
                 
-                var log = LogManager.Default.GetLogger(null).ToString();
+                var log = LogManager.GetLogger(null).ToString();
                 Assert.True(log.Length > 0);
             }
         }

--- a/DICOM/Imaging/Codec/DicomCodecParams.cs
+++ b/DICOM/Imaging/Codec/DicomCodecParams.cs
@@ -5,13 +5,22 @@ using Dicom.Log;
 
 namespace Dicom.Imaging.Codec
 {
+    /// <summary>
+    /// Base class for DICOM codec parameters.
+    /// </summary>
     public class DicomCodecParams
     {
+        /// <summary>
+        /// Protected base class constructor.
+        /// </summary>
         protected DicomCodecParams()
         {
-            Logger = LogManager.Default.GetLogger("Dicom.Imaging.Codec");
+            this.Logger = LogManager.GetLogger("Dicom.Imaging.Codec");
         }
 
+        /// <summary>
+        /// Gets or sets the DICOM codec parameters <see cref="Logger"/>.
+        /// </summary>
         public Logger Logger { get; protected set; }
     }
 }

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -40,7 +40,7 @@ namespace Dicom.Imaging.Codec
 
             if (search == null) search = "Dicom.Native*.dll";
 
-            var log = LogManager.Default.GetLogger("Dicom.Imaging.Codec");
+            var log = LogManager.GetLogger("Dicom.Imaging.Codec");
             log.Debug("Searching {path}\\{wildcard} for Dicom codecs", path, search);
 
             var foundAnyCodecs = false;

--- a/DICOM/Log/ConsoleLogger.cs
+++ b/DICOM/Log/ConsoleLogger.cs
@@ -1,23 +1,38 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-
 namespace Dicom.Log
 {
+    using System;
+
+    /// <summary>
+    /// Logger for output to the <see cref="Console"/>.
+    /// </summary>
     public class ConsoleLogger : Logger
     {
+        /// <summary>
+        /// Singleton instance of the <see cref="ConsoleLogger"/>.
+        /// </summary>
         public static readonly Logger Instance = new ConsoleLogger();
 
-        private object _lock = new object();
+        private readonly object @lock = new object();
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="ConsoleLogger"/>.
+        /// </summary>
         private ConsoleLogger()
         {
         }
 
+        /// <summary>
+        /// Log a message to the logger.
+        /// </summary>
+        /// <param name="level">Log level.</param>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public override void Log(LogLevel level, string msg, params object[] args)
         {
-            lock (_lock)
+            lock (this.@lock)
             {
                 var previous = Console.ForegroundColor;
                 switch (level)
@@ -38,7 +53,7 @@ namespace Dicom.Log
                         Console.ForegroundColor = ConsoleColor.Magenta;
                         break;
                     default:
-                        break;
+                        throw new ArgumentOutOfRangeException("level", level, null);
                 }
                 Console.WriteLine(NameFormatToPositionalFormat(msg), args);
                 Console.ForegroundColor = previous;
@@ -46,9 +61,29 @@ namespace Dicom.Log
         }
     }
 
+    /// <summary>
+    /// Manager for logging to the console.
+    /// </summary>
     public class ConsoleLogManager : LogManager
     {
-        public override Logger GetLogger(string name)
+        /// <summary>
+        /// Singleton instance of the <see cref="ConsoleLogManager"/>.
+        /// </summary>
+        public static readonly LogManager Instance = new ConsoleLogManager();
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="ConsoleLogManager"/>.
+        /// </summary>
+        private ConsoleLogManager()
+        {
+        }
+
+        /// <summary>
+        /// Get logger from the current log manager implementation.
+        /// </summary>
+        /// <param name="name">Classifier name, typically namespace or type name.</param>
+        /// <returns>Logger from the current log manager implementation.</returns>
+        protected override Logger GetLoggerImpl(string name)
         {
             return ConsoleLogger.Instance;
         }

--- a/DICOM/Log/LogManager.cs
+++ b/DICOM/Log/LogManager.cs
@@ -6,39 +6,93 @@ namespace Dicom.Log
     /// <summary>
     /// Main class for logging management.
     /// </summary>
-    public class LogManager
+    public abstract class LogManager
     {
+        #region FIELDS
+
+        private static LogManager implementation;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
         /// <summary>
-        /// Initilaizes the static fields of <see cref="LogManager"/>.
+        /// Initializes the static fields of <see cref="LogManager"/>.
         /// </summary>
         static LogManager()
         {
-            Default = new LogManager();
+            SetImplementation(NullLoggerManager.Instance);
         }
 
+        #endregion
+
+        #region METHODS
+
         /// <summary>
-        /// Initializes an instance of <see cref="LogManager"/>.
+        /// Set the log manager implementation to use for logging.
         /// </summary>
-        protected LogManager()
+        /// <param name="impl"></param>
+        public static void SetImplementation(LogManager impl)
         {
+            implementation = impl;
         }
 
         /// <summary>
-        /// Gets or sets the default log manager implementation.
-        /// </summary>
-        public static LogManager Default { get; set; }
-
-        /// <summary>
-        /// Get logger from the <see cref="Default"/> log manager implementation.
+        /// Get logger.
         /// </summary>
         /// <param name="name">Classifier name, typically namespace or type name.</param>
-        /// <returns>Logger from the <see cref="Default"/> log manager implementation.</returns>
-        public virtual Logger GetLogger(string name)
+        /// <returns>Logger from the current log manager implementation.</returns>
+        public static Logger GetLogger(string name)
         {
-            return NullLogger.Instance;
+            return implementation.GetLoggerImpl(name);
         }
 
+        /// <summary>
+        /// Get logger from the current log manager implementation.
+        /// </summary>
+        /// <param name="name">Classifier name, typically namespace or type name.</param>
+        /// <returns>Logger from the current log manager implementation.</returns>
+        protected abstract Logger GetLoggerImpl(string name);
+
+        #endregion
+
         #region INNER TYPES
+
+        /// <summary>
+        /// Manager for null ("do nothing") loggers.
+        /// </summary>
+        private class NullLoggerManager : LogManager
+        {
+            /// <summary>
+            /// Singleton instance of null logger manager.
+            /// </summary>
+            public static readonly LogManager Instance;
+
+            /// <summary>
+            /// Initializes the static fields.
+            /// </summary>
+            static NullLoggerManager()
+            {
+                Instance = new NullLoggerManager();
+            }
+
+            /// <summary>
+            /// Initializes an instance of the null logger manager.
+            /// </summary>
+            private NullLoggerManager()
+            {
+            }
+
+            /// <summary>
+            /// Get logger from the current log manager implementation.
+            /// </summary>
+            /// <param name="name">Classifier name, typically namespace or type name.</param>
+            /// <returns>Logger from the current log manager implementation.</returns>
+            protected override Logger GetLoggerImpl(string name)
+            {
+                return NullLogger.Instance;
+            }
+        }
 
         /// <summary>
         /// Null logger, provides a no-op logger implementation.
@@ -48,7 +102,7 @@ namespace Dicom.Log
             /// <summary>
             /// Singleton instance of the <see cref="NullLogger"/> class.
             /// </summary>
-            internal static readonly Logger Instance;
+            public static readonly Logger Instance;
 
             /// <summary>
             /// Initializes the static fields of <see cref="NullLogger"/>.
@@ -73,7 +127,7 @@ namespace Dicom.Log
             /// <param name="args">Arguments corresponding to the <paramref name="msg">log message</paramref>.</param>
             /// <remarks>The <see cref="NullLogger"/> Log method overloads do nothing.</remarks>
             public override void Log(LogLevel level, string msg, params object[] args)
-            {                
+            {
                 // Do nothing
             }
         }

--- a/DICOM/Log/Logger.cs
+++ b/DICOM/Log/Logger.cs
@@ -1,44 +1,77 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
-
 namespace Dicom.Log
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Abstract base class for loggers.
+    /// </summary>
     public abstract class Logger
     {
+        /// <summary>
+        /// Log a message to the logger.
+        /// </summary>
+        /// <param name="level">Log level.</param>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public abstract void Log(LogLevel level, string msg, params object[] args);
 
+        /// <summary>
+        /// Log a debug message to the logger.
+        /// </summary>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public void Debug(string msg, params object[] args)
         {
-            Log(LogLevel.Debug, msg, args);
+            this.Log(LogLevel.Debug, msg, args);
         }
 
+        /// <summary>
+        /// Log an informational message to the logger.
+        /// </summary>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public void Info(string msg, params object[] args)
         {
-            Log(LogLevel.Info, msg, args);
+            this.Log(LogLevel.Info, msg, args);
         }
 
+        /// <summary>
+        /// Log a warning message to the logger.
+        /// </summary>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public void Warn(string msg, params object[] args)
         {
-            Log(LogLevel.Warning, msg, args);
+            this.Log(LogLevel.Warning, msg, args);
         }
 
+        /// <summary>
+        /// Log an error message to the logger.
+        /// </summary>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public void Error(string msg, params object[] args)
         {
-            Log(LogLevel.Error, msg, args);
+            this.Log(LogLevel.Error, msg, args);
         }
 
+        /// <summary>
+        /// Log a fatal error message to the logger.
+        /// </summary>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public void Fatal(string msg, params object[] args)
         {
-            Log(LogLevel.Fatal, msg, args);
+            this.Log(LogLevel.Fatal, msg, args);
         }
 
-
-        private static readonly Regex _curlyBracePairRegex = new Regex(@"{.*?}");
+        private static readonly Regex CurlyBracePairRegex = new Regex(@"{.*?}");
 
         /// <summary>
         /// Called to adapt the string message before passing through
@@ -53,7 +86,7 @@ namespace Dicom.Log
         /// <returns></returns>
         protected static string NameFormatToPositionalFormat(string message)
         {
-            var matches = _curlyBracePairRegex.Matches(message).Cast<Match>();
+            var matches = CurlyBracePairRegex.Matches(message).Cast<Match>();
 
             var handledMatchNames = new Dictionary<string, int>(StringComparer.InvariantCultureIgnoreCase);
 
@@ -62,7 +95,7 @@ namespace Dicom.Log
             var positionDelta = 0;
 
             //Is every encountered match a number?  If so, we've been given a string already in positional format so it should not be amended
-            bool everyMatchIsANumber = true; //until proven otherwise
+            var everyMatchIsANumber = true; //until proven otherwise
 
             foreach (var match in matches)
             {
@@ -117,6 +150,11 @@ namespace Dicom.Log
             return updatedMessage;
         }
 
+        /// <summary>
+        /// Checks whether string represents an integer value.
+        /// </summary>
+        /// <param name="s">String potentially containing integer value.</param>
+        /// <returns>True if <paramref name="s"/> could be interpreted as integer value, false otherwise.</returns>
         internal static bool IsNumber(string s)
         {
             int dummy;

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -98,7 +98,7 @@ namespace Dicom.Network
             }
             catch (Exception e)
             {
-                if (Logger == null) Logger = LogManager.Default.GetLogger("Dicom.Network");
+                if (Logger == null) Logger = LogManager.GetLogger("Dicom.Network");
                 Logger.Error("Exception accepting client {@error}", e);
             }
             finally

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -75,7 +75,7 @@ namespace Dicom.Network
             _processQueue = new ThreadPoolQueue<int>(int.MinValue);
             _isConnected = true;
             _fallbackEncoding = fallbackEncoding;
-            Logger = log ?? LogManager.Default.GetLogger("Dicom.Network");
+            Logger = log ?? LogManager.GetLogger("Dicom.Network");
             BeginReadPDUHeader();
             Options = DicomServiceOptions.Default;
         }
@@ -265,7 +265,7 @@ namespace Dicom.Network
                             var pdu = new AAssociateRQ(Association);
                             pdu.Read(raw);
                             LogID = Association.CallingAE;
-                            if (Options.UseRemoteAEForLogName) Logger = LogManager.Default.GetLogger(LogID);
+                            if (Options.UseRemoteAEForLogName) Logger = LogManager.GetLogger(LogID);
                             Logger.Info(
                                 "{callingAE} <- Association request:\n{association}",
                                 LogID,
@@ -1302,7 +1302,7 @@ namespace Dicom.Network
         protected void SendAssociationRequest(DicomAssociation association)
         {
             LogID = association.CalledAE;
-            if (Options.UseRemoteAEForLogName) Logger = LogManager.Default.GetLogger(LogID);
+            if (Options.UseRemoteAEForLogName) Logger = LogManager.GetLogger(LogID);
             Logger.Info("{calledAE} -> Association request:\n{association}", LogID, association.ToString());
             Association = association;
             SendPDU(new AAssociateRQ(Association));

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -19,7 +19,7 @@ namespace Dicom.Printing
     {
         #region Properties and Attributes
 
-        private static readonly Logger Logger = LogManager.Default.GetLogger("Dicom.Printing");
+        private static readonly Logger Logger = LogManager.GetLogger("Dicom.Printing");
 
         private readonly FilmSession _filmSession = null;
 

--- a/Examples/Logging Serilog/Program.cs
+++ b/Examples/Logging Serilog/Program.cs
@@ -31,7 +31,7 @@ namespace Dicom.Demo.SerilogDemo
             //file.Dataset.WriteToLog(LogManager.Default.GetLogger("dumpedDataset"), LogLevel.Info);
 
             //Other logging using fo-dicom's log abstraction
-            Dicom.Log.Logger foDicomLogger = LogManager.Default.GetLogger("testLog");
+            Dicom.Log.Logger foDicomLogger = LogManager.GetLogger("testLog");
             foDicomLogger.Fatal("A fatal message at {dateTime}", DateTime.Now);
             foDicomLogger.Debug("A debug for file {filename} - info: {@metaInfo}", file.File.Name, file.FileMetaInfo);
 
@@ -51,7 +51,7 @@ namespace Dicom.Demo.SerilogDemo
             logger = logger.ForContext("Purpose", "Demonstration");
 
             //Configure fo-dicom & Serilog
-            LogManager.Default = new SerilogManager(logger);
+            LogManager.SetImplementation(new SerilogManager(logger));
 
         }
 
@@ -61,7 +61,7 @@ namespace Dicom.Demo.SerilogDemo
             ConfigureLogging();
 
             //Configure fo-dicom & Serilog
-            LogManager.Default = new SerilogManager();
+            LogManager.SetImplementation(new SerilogManager());
 
         }
 

--- a/Logging/DICOM.MetroLog/MetroLogManager.cs
+++ b/Logging/DICOM.MetroLog/MetroLogManager.cs
@@ -7,16 +7,28 @@ namespace Dicom.Log
     /// Log manager for the MetroLog logging framework.
     /// </summary>
     /// <example>
-    /// LogManager.Default = new MetroLogManager();
+    /// LogManager.SetImplementation(MetroLogManager.Instance);
     /// </example>
     public class MetroLogManager : LogManager
     {
+        /// <summary>
+        /// Singleton instance of the <see cref="MetroLogManager"/>.
+        /// </summary>
+        public static readonly LogManager Instance = new MetroLogManager();
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="MetroLogManager"/>.
+        /// </summary>
+        private MetroLogManager()
+        {
+        }
+
         /// <summary>
         /// Returns a logger for the specified (type) name.
         /// </summary>
         /// <param name="name">Name of logger, typically type or namespace name.</param>
         /// <returns>Logger for the specified name.</returns>
-        public override Logger GetLogger(string name)
+        protected override Logger GetLoggerImpl(string name)
         {
             return new MetroLogger(MetroLog.LogManagerFactory.DefaultLogManager.GetLogger(name));
         }

--- a/Logging/DICOM.NLog/NLogManager.cs
+++ b/Logging/DICOM.NLog/NLogManager.cs
@@ -7,24 +7,54 @@ namespace Dicom.Log
     /// LogManager for the NLog logging framework.
     /// </summary>
     /// <example>
-    /// LogManager.Default = new NLogManager();
+    /// LogManager.SetImplementation(NLogManager.Instance);
     /// </example>
     public class NLogManager : LogManager
     {
-        public override Logger GetLogger(string name)
+        /// <summary>
+        /// Singleton instance of <see cref="NLogManager"/>.
+        /// </summary>
+        public static readonly LogManager Instance = new NLogManager();
+
+        /// <summary>
+        /// Initializes an instance of <see cref="NLogManager"/>.
+        /// </summary>
+        private NLogManager()
+        {
+        }
+
+        /// <summary>
+        /// Get logger from the current log manager implementation.
+        /// </summary>
+        /// <param name="name">Classifier name, typically namespace or type name.</param>
+        /// <returns>Logger from the current log manager implementation.</returns>
+        protected override Logger GetLoggerImpl(string name)
         {
             return new NLogger(NLog.LogManager.GetLogger(name));
         }
 
+        /// <summary>
+        /// Implementation of a NLog logger.
+        /// </summary>
         private class NLogger : Logger
         {
-            private readonly NLog.Logger _logger;
+            private readonly NLog.Logger logger;
 
+            /// <summary>
+            /// Initializes an instance of <see cref="NLogger"/>.
+            /// </summary>
+            /// <param name="logger"></param>
             public NLogger(NLog.Logger logger)
             {
-                _logger = logger;
+                this.logger = logger;
             }
 
+            /// <summary>
+            /// Log a message to the logger.
+            /// </summary>
+            /// <param name="level">Log level.</param>
+            /// <param name="msg">Log message (format string).</param>
+            /// <param name="args">Log message arguments.</param>
             public override void Log(LogLevel level, string msg, params object[] args)
             {
                 var ordinalFormattedMessage = NameFormatToPositionalFormat(msg);
@@ -32,22 +62,22 @@ namespace Dicom.Log
                 switch (level)
                 {
                     case LogLevel.Debug:
-                        _logger.Debug(ordinalFormattedMessage, args);
+                        this.logger.Debug(ordinalFormattedMessage, args);
                         break;
                     case LogLevel.Info:
-                        _logger.Info(ordinalFormattedMessage, args);
+                        this.logger.Info(ordinalFormattedMessage, args);
                         break;
                     case LogLevel.Warning:
-                        _logger.Warn(ordinalFormattedMessage, args);
+                        this.logger.Warn(ordinalFormattedMessage, args);
                         break;
                     case LogLevel.Error:
-                        _logger.Error(ordinalFormattedMessage, args);
+                        this.logger.Error(ordinalFormattedMessage, args);
                         break;
                     case LogLevel.Fatal:
-                        _logger.Fatal(ordinalFormattedMessage, args);
+                        this.logger.Fatal(ordinalFormattedMessage, args);
                         break;
                     default:
-                        _logger.Info(ordinalFormattedMessage, args);
+                        this.logger.Info(ordinalFormattedMessage, args);
                         break;
                 }
             }

--- a/Logging/DICOM.Serilog/LogLevelConverter.cs
+++ b/Logging/DICOM.Serilog/LogLevelConverter.cs
@@ -5,8 +5,16 @@ using Serilog.Events;
 
 namespace Dicom.Log
 {
+    /// <summary>
+    /// Support for converting between <see cref="LogEventLevel"/> and <see cref="LogLevel"/>.
+    /// </summary>
     internal static class LogLevelConverter
     {
+        /// <summary>
+        /// Convert from <see cref="LogLevel"/> to <see cref="LogEventLevel"/>.
+        /// </summary>
+        /// <param name="dicomLogLevel">DICOM log level.</param>
+        /// <returns>Serilog log event level.</returns>
         public static LogEventLevel ToSerilog(this LogLevel dicomLogLevel)
         {
             switch (dicomLogLevel)

--- a/Logging/DICOM.Serilog/SerilogLoggerAdapter.cs
+++ b/Logging/DICOM.Serilog/SerilogLoggerAdapter.cs
@@ -5,18 +5,31 @@ using Serilog;
 
 namespace Dicom.Log
 {
+    /// <summary>
+    /// Implementation of <see cref="Logger"/> for Serilog.
+    /// </summary>
     internal class SerilogLoggerAdapter : Logger
     {
-        private readonly ILogger _serilog;
+        private readonly ILogger serilog;
 
+        /// <summary>
+        /// Initializes an instance of <see cref="SerilogLoggerAdapter"/>
+        /// </summary>
+        /// <param name="serilog"></param>
         public SerilogLoggerAdapter(ILogger serilog)
         {
-            _serilog = serilog;
+            this.serilog = serilog;
         }
 
+        /// <summary>
+        /// Log a message to the logger.
+        /// </summary>
+        /// <param name="level">Log level.</param>
+        /// <param name="msg">Log message (format string).</param>
+        /// <param name="args">Log message arguments.</param>
         public override void Log(LogLevel level, string msg, params object[] args)
         {
-            _serilog.Write(level.ToSerilog(), msg, args);
+            this.serilog.Write(level.ToSerilog(), msg, args);
         }
     }
 }

--- a/Logging/DICOM.Serilog/SerilogManager.cs
+++ b/Logging/DICOM.Serilog/SerilogManager.cs
@@ -24,19 +24,18 @@ namespace Dicom.Log
         /// <summary>
         /// Instantiates fo-dicom Serilog logging facility, sending logs through the provided ILogger instance
         /// </summary>
-        /// <param name="serilogLogger"></param>
+        /// <param name="serilogLogger">Specific Serilog logger to use.</param>
         public SerilogManager(ILogger serilogLogger)
         {
             _serilogLogger = serilogLogger;
         }
 
         /// <summary>
-        /// Returns a scoped instance of a Serilog logger with the fo-DICOM
-        /// property set to the given name
+        /// Get logger from the current log manager implementation.
         /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public override Logger GetLogger(string name)
+        /// <param name="name">Classifier name, typically namespace or type name.</param>
+        /// <returns>Logger from the current log manager implementation.</returns>
+        protected override Logger GetLoggerImpl(string name)
         {
             var serilogLogger = (_serilogLogger ?? Serilog.Log.Logger).ForContext("fo-DICOM", name);
             return new SerilogLoggerAdapter(serilogLogger);

--- a/Logging/DICOM.log4net/Log4NetManager.cs
+++ b/Logging/DICOM.log4net/Log4NetManager.cs
@@ -7,20 +7,28 @@ namespace Dicom.Log
     /// Log manager for the log4net logging framework.
     /// </summary>
     /// <example>
-    /// LogManager.Default = new Log4NetLogger();
+    /// LogManager.SetImplementation(Log4NetManager.Instance);
     /// </example>
     public sealed class Log4NetManager : LogManager
     {
         /// <summary>
-        /// Get a log4net based logger.
+        /// Singleton instance of the <see cref="Log4NetManager"/>.
         /// </summary>
-        /// <param name="name">
-        /// Type or namespace name.
-        /// </param>
-        /// <returns>
-        /// A log4net based <see cref="Logger"/>.
-        /// </returns>
-        public override Logger GetLogger(string name)
+        public static readonly LogManager Instance = new Log4NetManager();
+
+        /// <summary>
+        /// Initializes an instance of <see cref="Log4NetManager"/>.
+        /// </summary>
+        private Log4NetManager()
+        {
+        }
+
+        /// <summary>
+        /// Get logger from the current log manager implementation.
+        /// </summary>
+        /// <param name="name">Classifier name, typically namespace or type name.</param>
+        /// <returns>Logger from the current log manager implementation.</returns>
+        protected override Logger GetLoggerImpl(string name)
         {
             return new Log4NetLogger(log4net.LogManager.GetLogger(name));
         }
@@ -47,17 +55,11 @@ namespace Dicom.Log
             }
 
             /// <summary>
-            /// Log a message.
+            /// Log a message to the logger.
             /// </summary>
-            /// <param name="level">
-            /// Log level.
-            /// </param>
-            /// <param name="msg">
-            /// Formatted message string.
-            /// </param>
-            /// <param name="args">
-            /// Message arguments.
-            /// </param>
+            /// <param name="level">Log level.</param>
+            /// <param name="msg">Log message (format string).</param>
+            /// <param name="args">Log message arguments.</param>
             public override void Log(LogLevel level, string msg, params object[] args)
             {
                 var ordinalFormattedMessage = NameFormatToPositionalFormat(msg);


### PR DESCRIPTION
I have slightly modified the `LogManager` public API so that it is more in line with the other "manager" APIs recently implemented:

* The `Default` property is deprecated and its setter has been replaced with a static method `LogManager.SetImplementation`.
* The `GetLogger` method is now static.
* The `LogManager` implementations are exposed as singleton static `Instance` fields and are no llonger publicly instantiable (is that the right word?). Exception is the `SerilogManager` where a `Serilog.ILogger` object can be passed in the constructor.

Since #91 , the default logger is the "do-nothing" `NullLogger`. This logger and the accompanying `NullLoggerManager` are private inner classes to `LogManager`, and cannot be reset to when another `LogManager` implementation has been explicitly selected.

The above changes will have the following practical consequences.

The following is no longer supported:

~~```LogManager.Default = new NLogManager();```~~
~~```var logger = LogManager.Default.GetLogger("some name");```~~

To select a log manager implementation, use the `SetImplementation` method instead:

    LogManager.SetImplementation(NLogManager.Instance);
    LogManager.SetImplementation(ConsoleLogManager.Instance);
    LogManager.SetImplementation(new SerilogManager(someSerilogLogger));

To retrieve a logger instance, do this from now on:

    var logger = LogManager.GetLogger("some name");

Please review.