### PR TITLE
Abstraction layer for transcoder operations. Connected to #102

### DIFF
--- a/DICOM [Unit Tests]/Imaging/Codec/DicomTranscoderTest.cs
+++ b/DICOM [Unit Tests]/Imaging/Codec/DicomTranscoderTest.cs
@@ -15,7 +15,7 @@ namespace Dicom.Imaging.Codec
         [MemberData("TransferSyntaxesNames")]
         public void GetCodec_KnownTransferSyntax_ShouldReturnCodecObject(DicomTransferSyntax transferSyntax, string expected)
         {
-            var codec = DicomTranscoder.GetCodec(transferSyntax);
+            var codec = DicomTranscoderManager.GetCodec(transferSyntax);
             var actual = codec.Name;
             Assert.Equal(expected, actual);
         }

--- a/DICOM [Unit Tests]/Network/PDUTest.cs
+++ b/DICOM [Unit Tests]/Network/PDUTest.cs
@@ -7,7 +7,6 @@ namespace Dicom.Network
 
     using Xunit;
 
-    [Collection("Network"), Trait("Category", "Network")]
     public class PDUTest
     {
         [Fact]

--- a/DICOM.sln
+++ b/DICOM.sln
@@ -34,7 +34,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documents", "Documents", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1E86A172-B9C5-4BBF-BD0F-22507432C8A5}"
 	ProjectSection(SolutionItems) = preProject
-		fo-dicom.nuspec = fo-dicom.nuspec
 		fo-dicom.targets = fo-dicom.targets
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
@@ -175,6 +174,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{16FD143D-6E25-4CD9-AEC0-B096644B0045} = {96052E4E-90EF-431F-A599-8723506A424B}
 		{8DC28743-3826-453A-B400-B0AE7B2C04E7} = {A1D10E37-DC32-4A8E-ABFF-5E5FB3A9687C}
 		{0331D451-7C7A-4DB7-A11D-61708F2E8D05} = {A1D10E37-DC32-4A8E-ABFF-5E5FB3A9687C}
 		{63088DEC-9F99-404C-B4E8-D823D2A0018F} = {A1D10E37-DC32-4A8E-ABFF-5E5FB3A9687C}

--- a/DICOM/DICOM.csproj
+++ b/DICOM/DICOM.csproj
@@ -66,7 +66,9 @@
     <Compile Include="AsyncFactory.cs" />
     <Compile Include="DicomFile.Async.cs" />
     <Compile Include="DicomFileExtensions.Async.cs" />
+    <Compile Include="Imaging\Codec\DesktopTranscoderManager.cs" />
     <Compile Include="Imaging\Codec\IDicomTranscoder.cs" />
+    <Compile Include="Imaging\Codec\DicomTranscoderManager.cs" />
     <Compile Include="Imaging\DicomOverlayDataFactory.cs" />
     <Compile Include="Imaging\WinFormsImage.cs" />
     <Compile Include="Imaging\WinFormsImageManager.cs" />

--- a/DICOM/DICOM.csproj
+++ b/DICOM/DICOM.csproj
@@ -66,6 +66,7 @@
     <Compile Include="AsyncFactory.cs" />
     <Compile Include="DicomFile.Async.cs" />
     <Compile Include="DicomFileExtensions.Async.cs" />
+    <Compile Include="Imaging\Codec\IDicomTranscoder.cs" />
     <Compile Include="Imaging\DicomOverlayDataFactory.cs" />
     <Compile Include="Imaging\WinFormsImage.cs" />
     <Compile Include="Imaging\WinFormsImageManager.cs" />
@@ -330,7 +331,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" BuildVersion_UseGlobalSettings="True" />
+      <UserProperties BuildVersion_UseGlobalSettings="True" BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" />
     </VisualStudio>
   </ProjectExtensions>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/DICOM/Imaging/Codec/DesktopTranscoderManager.cs
+++ b/DICOM/Imaging/Codec/DesktopTranscoderManager.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging.Codec
+{
+    using System;
+    using System.ComponentModel.Composition.Hosting;
+    using System.Reflection;
+
+    using Dicom.IO;
+    using Dicom.Log;
+
+    /// <summary>
+    /// Implementation of <see cref="DicomTranscoderManager"/> for Windows desktop (.NET) applications.
+    /// </summary>
+    public sealed class DesktopTranscoderManager : DicomTranscoderManager
+    {
+        #region FIELDS
+
+        /// <summary>
+        /// Singleton instance of the <see cref="DesktopTranscoderManager"/>.
+        /// </summary>
+        public static readonly DicomTranscoderManager Instance;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes the static fields of <see cref="DesktopTranscoderManager"/>.
+        /// </summary>
+        static DesktopTranscoderManager()
+        {
+            Instance = new DesktopTranscoderManager();
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="DesktopTranscoderManager"/>.
+        /// </summary>
+        private DesktopTranscoderManager()
+        {
+            this.LoadCodecsImpl(null, null);
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Implementation of method to load codecs from assembly(ies) at the specified <paramref name="path"/> and 
+        /// with the specified <paramref name="search"/> pattern.
+        /// </summary>
+        /// <param name="path">Directory path to codec assemblies.</param>
+        /// <param name="search">Search pattern for codec assemblies.</param>
+        protected override void LoadCodecsImpl(string path, string search)
+        {
+            if (path == null) path = IOManager.Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
+
+            if (search == null) search = "Dicom.Native*.dll";
+
+            var log = LogManager.GetLogger("Dicom.Imaging.Codec");
+            log.Debug("Searching {path}\\{wildcard} for Dicom codecs", path, search);
+
+            var foundAnyCodecs = false;
+
+            DirectoryCatalog catalog;
+            try
+            {
+                catalog = new DirectoryCatalog(path, search);
+            }
+            catch (Exception ex)
+            {
+                log.Error(
+                    "Error encountered creating new DirectCatalog({path}, {search}) - {@exception}",
+                    path,
+                    search,
+                    ex);
+                throw;
+            }
+
+            var container = new CompositionContainer(catalog);
+            foreach (var lazy in container.GetExports<IDicomCodec>())
+            {
+                foundAnyCodecs = true;
+                var codec = lazy.Value;
+                log.Debug("Codec: {codecName}", codec.TransferSyntax.UID.Name);
+                Codecs[codec.TransferSyntax] = codec;
+            }
+
+            if (!foundAnyCodecs)
+            {
+                log.Warn("No Dicom codecs were found after searching {path}\\{wildcard}", path, search);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/Codec/DicomCodecExtensions.cs
+++ b/DICOM/Imaging/Codec/DicomCodecExtensions.cs
@@ -3,27 +3,40 @@
 
 namespace Dicom.Imaging.Codec
 {
+    /// <summary>
+    /// Extension methods associated with DICOM transfer syntax change.
+    /// </summary>
     public static class DicomCodecExtensions
     {
+        /// <summary>
+        /// Create a copy of the specified DICOM file with requested transfer syntax.
+        /// </summary>
+        /// <param name="file">DICOM file to copy.</param>
+        /// <param name="syntax">Requested transfer syntax for the created DICOM file.</param>
+        /// <param name="parameters">Codec parameters.</param>
+        /// <returns>DICOM file with modified transfer syntax.</returns>
         public static DicomFile ChangeTransferSyntax(
             this DicomFile file,
             DicomTransferSyntax syntax,
             DicomCodecParams parameters = null)
         {
-            DicomTranscoder transcoder = new DicomTranscoder(file.FileMetaInfo.TransferSyntax, syntax);
-            transcoder.InputCodecParams = parameters;
-            transcoder.OutputCodecParams = parameters;
+            var transcoder = new DicomTranscoder(file.FileMetaInfo.TransferSyntax, syntax, parameters, parameters);
             return transcoder.Transcode(file);
         }
 
+        /// <summary>
+        /// Create a copy of the specified DICOM dataset with requested transfer syntax.
+        /// </summary>
+        /// <param name="dataset">DICOM dataset to copy.</param>
+        /// <param name="syntax">Requested transfer syntax for the created DICOM dataset.</param>
+        /// <param name="parameters">Codec parameters.</param>
+        /// <returns>DICOM dataset with modified transfer syntax.</returns>
         public static DicomDataset ChangeTransferSyntax(
             this DicomDataset dataset,
             DicomTransferSyntax syntax,
             DicomCodecParams parameters = null)
         {
-            DicomTranscoder transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, syntax);
-            transcoder.InputCodecParams = parameters;
-            transcoder.OutputCodecParams = parameters;
+            var transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, syntax, parameters, parameters);
             return transcoder.Transcode(dataset);
         }
     }

--- a/DICOM/Imaging/Codec/DicomTranscoderManager.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoderManager.cs
@@ -1,0 +1,81 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging.Codec
+{
+    using System.Collections.Generic;
+
+    public abstract class DicomTranscoderManager
+    {
+        #region FIELDS
+
+        /// <summary>
+        /// Selected DICOM transcoder implementation.
+        /// </summary>
+        private static DicomTranscoderManager implementation;
+
+        /// <summary>
+        /// Collection of known transfer syntaxes and their associated codecs.
+        /// </summary>
+        protected static readonly Dictionary<DicomTransferSyntax, IDicomCodec> Codecs =
+            new Dictionary<DicomTransferSyntax, IDicomCodec>();
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes the static fields of <see cref="DicomTranscoderManager"/>.
+        /// </summary>
+        static DicomTranscoderManager()
+        {
+            SetImplementation(DesktopTranscoderManager.Instance);
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Set the implementation to use for DICOM transcoder management.
+        /// </summary>
+        /// <param name="impl"></param>
+        public static void SetImplementation(DicomTranscoderManager impl)
+        {
+            implementation = impl;
+        }
+
+        /// <summary>
+        /// Get codec associated with specified DICOM transfer syntax.
+        /// </summary>
+        /// <param name="syntax">Transfer syntax.</param>
+        /// <returns>Codec associated with <paramref name="syntax"/>.</returns>
+        /// <exception cref="DicomCodecException">if no codec is available for the specified <paramref name="syntax"/>.</exception>
+        public static IDicomCodec GetCodec(DicomTransferSyntax syntax)
+        {
+            IDicomCodec codec;
+            if (!Codecs.TryGetValue(syntax, out codec)) throw new DicomCodecException("No codec registered for tranfer syntax: {0}", syntax);
+            return codec;
+        }
+
+        /// <summary>
+        /// Load codecs from assembly(ies) at the specified <paramref name="path"/> and with the specified <paramref name="search"/> pattern.
+        /// </summary>
+        /// <param name="path">Directory path to codec assemblies.</param>
+        /// <param name="search">Search pattern for codec assemblies.</param>
+        public static void LoadCodecs(string path = null, string search = null)
+        {
+            implementation.LoadCodecsImpl(path, search);
+        }
+
+        /// <summary>
+        /// Implementation of method to load codecs from assembly(ies) at the specified <paramref name="path"/> and 
+        /// with the specified <paramref name="search"/> pattern.
+        /// </summary>
+        /// <param name="path">Directory path to codec assemblies.</param>
+        /// <param name="search">Search pattern for codec assemblies.</param>
+        protected abstract void LoadCodecsImpl(string path, string search);
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/Codec/IDicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/IDicomTranscoder.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging.Codec
+{
+    using Dicom.Imaging.Render;
+    using Dicom.IO.Buffer;
+
+    /// <summary>
+    /// DICOM transcoder interface.
+    /// </summary>
+    public interface IDicomTranscoder
+    {
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the transfer syntax of the input codec.
+        /// </summary>
+        DicomTransferSyntax InputSyntax { get; }
+
+        /// <summary>
+        /// Gets the parameters associated with the input codec.
+        /// </summary>
+        DicomCodecParams InputCodecParams { get; }
+
+        /// <summary>
+        /// Gets the transfer syntax of the output codec.
+        /// </summary>
+        DicomTransferSyntax OutputSyntax { get; }
+
+        /// <summary>
+        /// Gets the parameters associated with the output codec.
+        /// </summary>
+        DicomCodecParams OutputCodecParams { get; }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Transcode a <see cref="DicomFile"/> from <see cref="InputSyntax"/> to <see cref="OutputSyntax"/>.
+        /// </summary>
+        /// <param name="file">DICOM file.</param>
+        /// <returns>New, transcoded, DICOM file.</returns>
+        DicomFile Transcode(DicomFile file);
+
+        /// <summary>
+        /// Transcode a <see cref="DicomDataset"/> from <see cref="InputSyntax"/> to <see cref="OutputSyntax"/>.
+        /// </summary>
+        /// <param name="dataset">DICOM dataset.</param>
+        /// <returns>New, transcoded, DICOM dataset.</returns>
+        DicomDataset Transcode(DicomDataset dataset);
+
+        /// <summary>
+        /// Decompress single frame from DICOM dataset and return uncompressed frame buffer.
+        /// </summary>
+        /// <param name="dataset">DICOM dataset.</param>
+        /// <param name="frame">Frame number.</param>
+        /// <returns>Uncompressed frame buffer.</returns>
+        IByteBuffer DecodeFrame(DicomDataset dataset, int frame);
+
+        /// <summary>
+        /// Decompress pixel data from DICOM dataset and return uncompressed pixel data.
+        /// </summary>
+        /// <param name="dataset">DICOM dataset.</param>
+        /// <param name="frame">Frame number.</param>
+        /// <returns>Uncompressed pixel data.</returns>
+        IPixelData DecodePixelData(DicomDataset dataset, int frame);
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -263,10 +263,10 @@ namespace Dicom.Imaging
                 }
 
                 var transcoder = new DicomTranscoder(
-                    Dataset.InternalTransferSyntax,
-                    DicomTransferSyntax.ExplicitVRLittleEndian);
-                transcoder.InputCodecParams = cparams;
-                transcoder.OutputCodecParams = cparams;
+                    this.Dataset.InternalTransferSyntax,
+                    DicomTransferSyntax.ExplicitVRLittleEndian,
+                    cparams,
+                    cparams);
                 var buffer = transcoder.DecodeFrame(Dataset, frame);
 
                 // clone the dataset because modifying the pixel data modifies the dataset


### PR DESCRIPTION
I have now moved the codec loading from `DicomTranscoder` to an abstract `DicomTranscoderManager` class. The implementations of this class (currently the `DesktopTranscoderManager` for the .NET platform) are responsible for loading the codecs, using the assembly (or whatever) tools that are available on the current platform. 

To implement codec loading specific for e.g. the *Universal Windows Platform*, the procedure has now become as simple as replacing the `DesktopTranscoderManager` implementation with for example a `UWPTranscoderManager` that implements the protected `LoadCodecsImpl` method. 

The same principles would apply to any other platform as well, for example Xamarin iOS/Android or the related *Mono* platform (see also issue #13).

To set the relevant transcoder manager implementation for the specific platform, use:

    DicomTranscoderManager.SetImplementation(PlatformSpecificTranscoderManager.Instance);

(provided a singleton `Instance` field is defined). Right now while the *DICOM* library still only targets .NET, the `DesktopTranscoderManager` implementation is automatically selected.

The public API has changed minimally with this implementation; the `GetCodec` and `LoadCodecs` static methods have been moved from `DicomTranscoder` to `DicomTranscoderManager`. Method signatures remain the same.

I have also taken the opportunity to improve XML documentation and cleanup the `DicomTranscoder` instance API. For potential future needs, I have also extracted an `IDicomTranscoder` interface.

Finally, I have made some minuscule cleanups in the solution and one unit test class.

Please review.