### PR TITLE
Implemented network abstraction layer. Connected to #86

### DIFF
--- a/DICOM [Unit Tests]/Network/DicomCEchoProviderTest.cs
+++ b/DICOM [Unit Tests]/Network/DicomCEchoProviderTest.cs
@@ -16,7 +16,7 @@ namespace Dicom.Network
         {
             LogManager.SetImplementation(new StringLogManager());
 
-            const int port = 11112;
+            const int port = 12345;
             using (new DicomServer<DicomCEchoProvider>(port))
             {
                 var client = new DicomClient();

--- a/DICOM/DICOM.csproj
+++ b/DICOM/DICOM.csproj
@@ -234,6 +234,9 @@
     <Compile Include="Imaging\Mathematics\Geometry3D.cs" />
     <Compile Include="Imaging\Mathematics\Matrix.cs" />
     <Compile Include="Imaging\Mathematics\Point2.cs" />
+    <Compile Include="Network\DesktopNetworkListener.cs" />
+    <Compile Include="Network\DesktopNetworkManager.cs" />
+    <Compile Include="Network\DesktopNetworkStream.cs" />
     <Compile Include="Network\DicomClientExtensions.cs" />
     <Compile Include="Network\IDicomNServiceProvider.cs" />
     <Compile Include="Network\DicomNDeleteRequest.cs" />
@@ -281,6 +284,9 @@
     <Compile Include="Network\IDicomCStoreProvider.cs" />
     <Compile Include="Network\IDicomServiceProvider.cs" />
     <Compile Include="Network\IDicomServiceUser.cs" />
+    <Compile Include="Network\INetworkListener.cs" />
+    <Compile Include="Network\INetworkStream.cs" />
+    <Compile Include="Network\NetworkManager.cs" />
     <Compile Include="Network\PDU.cs" />
     <Compile Include="Printing\FilmBox.cs" />
     <Compile Include="Printing\FilmBoxExtensions.cs" />
@@ -330,7 +336,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" BuildVersion_UseGlobalSettings="True" />
+      <UserProperties BuildVersion_UseGlobalSettings="True" BuildVersion_BuildVersioningStyle="None.None.Increment.YearDayOfYear" />
     </VisualStudio>
   </ProjectExtensions>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/DICOM/DicomUIDGenerator.cs
+++ b/DICOM/DicomUIDGenerator.cs
@@ -1,114 +1,139 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Net.NetworkInformation;
-using System.Text;
-using System.Threading;
-
 namespace Dicom
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// Class for generating DICOM UIDs.
+    /// </summary>
     public class DicomUIDGenerator
     {
-        private static volatile DicomUID _instanceRootUid = null;
+        #region FIELDS
+
+        private static volatile DicomUID instanceRootUid = null;
+
+        private static long lastTicks = 0;
+
+        private static readonly object GenerateUidLock = new object();
+
+        private static readonly DateTime Y2K = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        private readonly Dictionary<string, DicomUID> uidMap = new Dictionary<string, DicomUID>();
+
+        #endregion
+
+        #region PROPERTIES
 
         private static DicomUID InstanceRootUID
         {
             get
             {
-                if (_instanceRootUid == null)
+                if (instanceRootUid == null)
                 {
                     lock (GenerateUidLock)
                     {
-                        if (_instanceRootUid == null)
+                        if (instanceRootUid == null)
                         {
-                            NetworkInterface[] interfaces = NetworkInterface.GetAllNetworkInterfaces();
-                            for (int i = 0; i < interfaces.Length; i++)
-                            {
-                                if (NetworkInterface.LoopbackInterfaceIndex != i
-                                    && interfaces[i].OperationalStatus == OperationalStatus.Up)
-                                {
-                                    string hex = interfaces[i].GetPhysicalAddress().ToString();
-                                    if (!String.IsNullOrEmpty(hex))
-                                    {
-                                        try
-                                        {
-                                            long mac = long.Parse(
-                                                hex,
-                                                NumberStyles.HexNumber,
-                                                CultureInfo.InvariantCulture);
-                                            return DicomUID.Append(DicomImplementation.ClassUID, mac);
-                                        }
-                                        catch
-                                        {
-                                        }
-                                    }
-                                }
-                            }
+                            DicomUID dicomUid;
+                            if (TryGetNetworkUid(out dicomUid)) return dicomUid;
 
-                            _instanceRootUid = DicomUID.Append(DicomImplementation.ClassUID, Environment.TickCount);
+                            instanceRootUid = DicomUID.Append(DicomImplementation.ClassUID, Environment.TickCount);
                         }
                     }
                 }
-                return _instanceRootUid;
-            }
-            set
-            {
-                _instanceRootUid = value;
+                return instanceRootUid;
             }
         }
 
-        private static long LastTicks = 0;
+        #endregion
 
-        private static object GenerateUidLock = new object();
+        #region METHODS
 
-        private static DateTime Y2K = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-        private Dictionary<string, DicomUID> _uidMap = new Dictionary<string, DicomUID>();
-
+        /// <summary>
+        /// Generate a new DICOM UID.
+        /// </summary>
+        /// <param name="sourceUid">Source UID.</param>
+        /// <returns>Generated UID.</returns>
         public DicomUID Generate(DicomUID sourceUid = null)
         {
             lock (GenerateUidLock)
             {
                 DicomUID destinationUid;
-                if (sourceUid != null && _uidMap.TryGetValue(sourceUid.UID, out destinationUid)) return destinationUid;
+                if (sourceUid != null && this.uidMap.TryGetValue(sourceUid.UID, out destinationUid)) return destinationUid;
 
-                long ticks = DateTime.UtcNow.Subtract(Y2K).Ticks;
-                if (ticks == LastTicks) ++ticks;
-                LastTicks = ticks;
+                var ticks = DateTime.UtcNow.Subtract(Y2K).Ticks;
+                if (ticks == lastTicks) ++ticks;
+                lastTicks = ticks;
 
-                string str = ticks.ToString();
+                var str = ticks.ToString();
                 if (str.EndsWith("0000")) str = str.Substring(0, str.Length - 4);
 
-                StringBuilder uid = new StringBuilder();
+                var uid = new StringBuilder();
                 uid.Append(InstanceRootUID.UID).Append('.').Append(str);
 
                 destinationUid = new DicomUID(uid.ToString(), "SOP Instance UID", DicomUidType.SOPInstance);
 
-                if (sourceUid != null) _uidMap.Add(sourceUid.UID, destinationUid);
+                if (sourceUid != null) this.uidMap.Add(sourceUid.UID, destinationUid);
 
                 return destinationUid;
             }
         }
 
+        /// <summary>
+        /// Regenerate all UIDs in a DICOM dataset.
+        /// </summary>
+        /// <param name="dataset">Dataset in which UIDs should be regenerated.</param>
         public void RegenerateAll(DicomDataset dataset)
         {
             foreach (var ui in dataset.Where(x => x.ValueRepresentation == DicomVR.UI).ToArray())
             {
                 var uid = dataset.Get<DicomUID>(ui.Tag);
-                if (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown) dataset.Add(ui.Tag, Generate(uid));
+                if (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown) dataset.Add(ui.Tag, this.Generate(uid));
             }
 
             foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>().ToArray())
             {
                 foreach (var item in sq)
                 {
-                    RegenerateAll(item);
+                    this.RegenerateAll(item);
                 }
             }
         }
+
+        private static bool TryGetNetworkUid(out DicomUID dicomUid)
+        {
+            var interfaces = System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
+            for (var i = 0; i < interfaces.Length; i++)
+            {
+                if (System.Net.NetworkInformation.NetworkInterface.LoopbackInterfaceIndex == i
+                    || interfaces[i].OperationalStatus != System.Net.NetworkInformation.OperationalStatus.Up) continue;
+
+                var hex = interfaces[i].GetPhysicalAddress().ToString();
+                if (string.IsNullOrEmpty(hex)) continue;
+
+                try
+                {
+                    var mac = long.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                    {
+                        dicomUid = DicomUID.Append(DicomImplementation.ClassUID, mac);
+                        return true;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            dicomUid = null;
+            return false;
+        }
+
+        #endregion
     }
 }

--- a/DICOM/DicomUIDGenerator.cs
+++ b/DICOM/DicomUIDGenerator.cs
@@ -5,9 +5,10 @@ namespace Dicom
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
     using System.Text;
+
+    using Dicom.Network;
 
     /// <summary>
     /// Class for generating DICOM UIDs.
@@ -41,7 +42,7 @@ namespace Dicom
                         if (instanceRootUid == null)
                         {
                             DicomUID dicomUid;
-                            if (TryGetNetworkUid(out dicomUid)) return dicomUid;
+                            if (NetworkManager.TryGetNetworkIdentifier(out dicomUid)) return dicomUid;
 
                             instanceRootUid = DicomUID.Append(DicomImplementation.ClassUID, Environment.TickCount);
                         }
@@ -104,34 +105,6 @@ namespace Dicom
                     this.RegenerateAll(item);
                 }
             }
-        }
-
-        private static bool TryGetNetworkUid(out DicomUID dicomUid)
-        {
-            var interfaces = System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
-            for (var i = 0; i < interfaces.Length; i++)
-            {
-                if (System.Net.NetworkInformation.NetworkInterface.LoopbackInterfaceIndex == i
-                    || interfaces[i].OperationalStatus != System.Net.NetworkInformation.OperationalStatus.Up) continue;
-
-                var hex = interfaces[i].GetPhysicalAddress().ToString();
-                if (string.IsNullOrEmpty(hex)) continue;
-
-                try
-                {
-                    var mac = long.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-                    {
-                        dicomUid = DicomUID.Append(DicomImplementation.ClassUID, mac);
-                        return true;
-                    }
-                }
-                catch
-                {
-                }
-            }
-
-            dicomUid = null;
-            return false;
         }
 
         #endregion

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -54,11 +54,10 @@ namespace Dicom.Network
         /// <summary>
         /// Wait until a network stream is trying to connect, and return the accepted stream.
         /// </summary>
-        /// <param name="port">Port to listen to.</param>
         /// <param name="certificateName">Certificate name of authenticated connections.</param>
         /// <param name="noDelay">No delay?</param>
         /// <returns>Connected network stream.</returns>
-        public INetworkStream AcceptNetworkStream(int port, string certificateName, bool noDelay)
+        public INetworkStream AcceptNetworkStream(string certificateName, bool noDelay)
         {
             var tcpClient = this.listener.AcceptTcpClient();
             tcpClient.NoDelay = noDelay;

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -7,6 +7,9 @@ namespace Dicom.Network
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
 
+    /// <summary>
+    /// .NET implementation of the <see cref="INetworkListener"/>.
+    /// </summary>
     public class DesktopNetworkListener : INetworkListener
     {
         #region FIELDS
@@ -19,6 +22,10 @@ namespace Dicom.Network
 
         #region CONSTRUCTORS
 
+        /// <summary>
+        /// Initializes an instance of <see cref="DesktopNetworkListener"/>.
+        /// </summary>
+        /// <param name="port"></param>
         internal DesktopNetworkListener(int port)
         {
             this.listener = new TcpListener(IPAddress.Any, port);
@@ -28,16 +35,29 @@ namespace Dicom.Network
 
         #region METHODS
 
+        /// <summary>
+        /// Start listening.
+        /// </summary>
         public void Start()
         {
             this.listener.Start();
         }
 
+        /// <summary>
+        /// Stop listening.
+        /// </summary>
         public void Stop()
         {
             this.listener.Stop();
         }
 
+        /// <summary>
+        /// Wait until a network stream is trying to connect, and return the accepted stream.
+        /// </summary>
+        /// <param name="port">Port to listen to.</param>
+        /// <param name="certificateName">Certificate name of authenticated connections.</param>
+        /// <param name="noDelay">No delay?</param>
+        /// <returns>Connected network stream.</returns>
         public INetworkStream AcceptNetworkStream(int port, string certificateName, bool noDelay)
         {
             var tcpClient = this.listener.AcceptTcpClient();

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    public class DesktopNetworkListener : INetworkListener
+    {
+        public void Start()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void Stop()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public INetworkStream AcceptNetworkStream(int port, string certificateName, bool noDelay)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -3,21 +3,72 @@
 
 namespace Dicom.Network
 {
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Security.Cryptography.X509Certificates;
+
     public class DesktopNetworkListener : INetworkListener
     {
+        #region FIELDS
+
+        private readonly TcpListener listener;
+
+        private X509Certificate certificate = null;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        internal DesktopNetworkListener(int port)
+        {
+            this.listener = new TcpListener(IPAddress.Any, port);
+        }
+
+        #endregion
+
+        #region METHODS
+
         public void Start()
         {
-            throw new System.NotImplementedException();
+            this.listener.Start();
         }
 
         public void Stop()
         {
-            throw new System.NotImplementedException();
+            this.listener.Stop();
         }
 
         public INetworkStream AcceptNetworkStream(int port, string certificateName, bool noDelay)
         {
-            throw new System.NotImplementedException();
+            var tcpClient = this.listener.AcceptTcpClient();
+            tcpClient.NoDelay = noDelay;
+
+            if (!string.IsNullOrEmpty(certificateName) && this.certificate == null) this.certificate = GetX509Certificate(certificateName);
+
+            return new DesktopNetworkStream(tcpClient, this.certificate);
         }
+
+        /// <summary>
+        /// Get X509 certificate from the certificate store.
+        /// </summary>
+        /// <param name="certificateName">Certificate name.</param>
+        /// <returns>Certificate with the specified name.</returns>
+        private static X509Certificate GetX509Certificate(string certificateName)
+        {
+            var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+
+            store.Open(OpenFlags.ReadOnly);
+            var certs = store.Certificates.Find(X509FindType.FindBySubjectName, certificateName, false);
+            store.Close();
+
+            if (certs.Count == 0)
+            {
+                throw new DicomNetworkException("Unable to find certificate for " + certificateName);
+            }
+
+            return certs[0];
+        }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DesktopNetworkManager.cs
+++ b/DICOM/Network/DesktopNetworkManager.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System;
+    using System.Globalization;
+    using System.Net.NetworkInformation;
+    using System.Net.Sockets;
+
+    public class DesktopNetworkManager : NetworkManager
+    {
+        #region FIELDS
+
+        public static readonly NetworkManager Instance;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        static DesktopNetworkManager()
+        {
+            Instance = new DesktopNetworkManager();
+        }
+
+        private DesktopNetworkManager()
+        {
+        }
+
+        #endregion
+
+        #region METHODS
+
+        protected override INetworkListener CreateNetworkListenerImpl(int port)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        protected override INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        protected override bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor)
+        {
+            var socketEx = exception as SocketException;
+            if (socketEx != null)
+            {
+                errorCode = socketEx.ErrorCode;
+                errorDescriptor = socketEx.SocketErrorCode.ToString();
+                return true;
+            }
+
+            errorCode = -1;
+            errorDescriptor = null;
+            return false;
+        }
+
+        protected override bool TryGetNetworkIdentifierImpl(out DicomUID identifier)
+        {
+            var interfaces = NetworkInterface.GetAllNetworkInterfaces();
+            for (var i = 0; i < interfaces.Length; i++)
+            {
+                if (NetworkInterface.LoopbackInterfaceIndex == i
+                    || interfaces[i].OperationalStatus != OperationalStatus.Up) continue;
+
+                var hex = interfaces[i].GetPhysicalAddress().ToString();
+                if (string.IsNullOrEmpty(hex)) continue;
+
+                try
+                {
+                    var mac = long.Parse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                    {
+                        identifier = DicomUID.Append(DicomImplementation.ClassUID, mac);
+                        return true;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            identifier = null;
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Network/DesktopNetworkManager.cs
+++ b/DICOM/Network/DesktopNetworkManager.cs
@@ -33,12 +33,12 @@ namespace Dicom.Network
 
         protected override INetworkListener CreateNetworkListenerImpl(int port)
         {
-            throw new System.NotImplementedException();
+            return new DesktopNetworkListener(port);
         }
 
-        protected override INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay)
+        protected override INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
-            throw new System.NotImplementedException();
+            return new DesktopNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
 
         protected override bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor)

--- a/DICOM/Network/DesktopNetworkManager.cs
+++ b/DICOM/Network/DesktopNetworkManager.cs
@@ -8,21 +8,33 @@ namespace Dicom.Network
     using System.Net.NetworkInformation;
     using System.Net.Sockets;
 
+    /// <summary>
+    /// .NET implementation of <see cref="NetworkManager"/>.
+    /// </summary>
     public class DesktopNetworkManager : NetworkManager
     {
         #region FIELDS
 
+        /// <summary>
+        /// Singleton instance of <see cref="DesktopNetworkManager"/>.
+        /// </summary>
         public static readonly NetworkManager Instance;
 
         #endregion
 
         #region CONSTRUCTORS
 
+        /// <summary>
+        /// Initializes the static fields of <see cref="DesktopNetworkManager"/>.
+        /// </summary>
         static DesktopNetworkManager()
         {
             Instance = new DesktopNetworkManager();
         }
 
+        /// <summary>
+        /// Initializes an instance of <see cref="DesktopNetworkManager"/>.
+        /// </summary>
         private DesktopNetworkManager()
         {
         }
@@ -31,16 +43,37 @@ namespace Dicom.Network
 
         #region METHODS
 
+        /// <summary>
+        /// Platform-specific implementation to create a network listener object.
+        /// </summary>
+        /// <param name="port">Network port to listen to.</param>
+        /// <returns>Network listener implementation.</returns>
         protected override INetworkListener CreateNetworkListenerImpl(int port)
         {
             return new DesktopNetworkListener(port);
         }
 
+        /// <summary>
+        /// Platform-specific implementation to create a network stream object.
+        /// </summary>
+        /// <param name="host">Network host.</param>
+        /// <param name="port">Network port.</param>
+        /// <param name="useTls">Use TLS layer?</param>
+        /// <param name="noDelay">No delay?</param>
+        /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
+        /// <returns>Network stream implementation.</returns>
         protected override INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
             return new DesktopNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
 
+        /// <summary>
+        /// Platform-specific implementation to check whether specified <paramref name="exception"/> represents a socket exception.
+        /// </summary>
+        /// <param name="exception">Exception to validate.</param>
+        /// <param name="errorCode">Error code, valid if <paramref name="exception"/> is socket exception.</param>
+        /// <param name="errorDescriptor">Error descriptor, valid if <paramref name="exception"/> is socket exception.</param>
+        /// <returns>True if <paramref name="exception"/> is socket exception, false otherwise.</returns>
         protected override bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor)
         {
             var socketEx = exception as SocketException;
@@ -56,6 +89,11 @@ namespace Dicom.Network
             return false;
         }
 
+        /// <summary>
+        /// Platform-specific implementation to attempt to obtain a unique network identifier, e.g. based on a MAC address.
+        /// </summary>
+        /// <param name="identifier">Unique network identifier, if found.</param>
+        /// <returns>True if network identifier could be obtained, false otherwise.</returns>
         protected override bool TryGetNetworkIdentifierImpl(out DicomUID identifier)
         {
             var interfaces = NetworkInterface.GetAllNetworkInterfaces();

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -10,6 +10,9 @@ namespace Dicom.Network
     using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
 
+    /// <summary>
+    /// .NET implementation of <see cref="INetworkStream"/>.
+    /// </summary>
     public sealed class DesktopNetworkStream : INetworkStream
     {
         #region FIELDS
@@ -24,6 +27,14 @@ namespace Dicom.Network
 
         #region CONSTRUCTORS
 
+        /// <summary>
+        /// Initializes a client instance of <see cref="DesktopNetworkStream"/>.
+        /// </summary>
+        /// <param name="host">Network host.</param>
+        /// <param name="port">Network port.</param>
+        /// <param name="useTls">Use TLS layer?</param>
+        /// <param name="noDelay">No delay?</param>
+        /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
         internal DesktopNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
             this.tcpClient = new TcpClient(host, port) { NoDelay = noDelay };
@@ -43,6 +54,11 @@ namespace Dicom.Network
             this.networkStream = stream;
         }
 
+        /// <summary>
+        /// Initializes a server instance of <see cref="DesktopNetworkStream"/>.
+        /// </summary>
+        /// <param name="tcpClient">TCP client.</param>
+        /// <param name="certificate">Certificate for authenticated connection.</param>
         internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate)
         {
             this.tcpClient = tcpClient;
@@ -57,6 +73,9 @@ namespace Dicom.Network
             this.networkStream = stream;
         }
 
+        /// <summary>
+        /// Destrutor.
+        /// </summary>
         ~DesktopNetworkStream()
         {
             this.Dispose(false);
@@ -66,17 +85,28 @@ namespace Dicom.Network
 
         #region METHODS
 
+        /// <summary>
+        /// Get corresponding <see cref="Stream"/> object.
+        /// </summary>
+        /// <returns>Network stream as <see cref="Stream"/> object.</returns>
         public Stream AsStream()
         {
             return this.networkStream;
         }
 
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Do the actual disposal.
+        /// </summary>
+        /// <param name="disposing">True if called from <see cref="Dispose"/>, false otherwise.</param>
         private void Dispose(bool disposing)
         {
             if (this.disposed) return;

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System;
+    using System.IO;
+
+    public sealed class DesktopNetworkStream : INetworkStream
+    {
+        #region FIELDS
+
+        private bool disposed = false;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        ~DesktopNetworkStream()
+        {
+            this.Dispose(false);
+        }
+
+        #endregion
+
+        #region METHODS
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        public Stream AsStream()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (this.disposed) return;
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -5,6 +5,10 @@ namespace Dicom.Network
 {
     using System;
     using System.IO;
+    using System.Net.Security;
+    using System.Net.Sockets;
+    using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
 
     public sealed class DesktopNetworkStream : INetworkStream
     {
@@ -12,9 +16,46 @@ namespace Dicom.Network
 
         private bool disposed = false;
 
+        private readonly TcpClient tcpClient;
+
+        private readonly Stream networkStream;
+
         #endregion
 
         #region CONSTRUCTORS
+
+        internal DesktopNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
+        {
+            this.tcpClient = new TcpClient(host, port) { NoDelay = noDelay };
+
+            Stream stream = this.tcpClient.GetStream();
+
+            if (useTls)
+            {
+                var ssl = new SslStream(
+                    stream,
+                    false,
+                    (sender, certificate, chain, errors) => errors == SslPolicyErrors.None || ignoreSslPolicyErrors);
+                ssl.AuthenticateAsClient(host);
+                stream = ssl;
+            }
+
+            this.networkStream = stream;
+        }
+
+        internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate)
+        {
+            this.tcpClient = tcpClient;
+
+            Stream stream = this.tcpClient.GetStream();
+            if (certificate != null)
+            {
+                var ssl = new SslStream(stream, false);
+                ssl.AuthenticateAsServer(certificate, false, SslProtocols.Tls, false);
+                stream = ssl;
+            }
+            this.networkStream = stream;
+        }
 
         ~DesktopNetworkStream()
         {
@@ -25,19 +66,25 @@ namespace Dicom.Network
 
         #region METHODS
 
+        public Stream AsStream()
+        {
+            return this.networkStream;
+        }
+
         public void Dispose()
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
-        public Stream AsStream()
-        {
-            throw new System.NotImplementedException();
-        }
 
         private void Dispose(bool disposing)
         {
             if (this.disposed) return;
+
+            this.networkStream.Dispose();
+            this.tcpClient.Close();
+
+            this.disposed = true;
         }
 
         #endregion

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -258,14 +258,7 @@ namespace Dicom.Network
             finally
             {
                 this.networkStream = null;
-                try
-                {
-                    this.completeNotifier.TrySetResult(true);
-                }
-                catch
-                {
-                }
-                this.completeNotifier = null;
+                if (this.completeNotifier != null) this.completeNotifier.TrySetResult(true);
             }
         }
 
@@ -292,7 +285,7 @@ namespace Dicom.Network
 
         private void FinalizeSend()
         {
-            if (this.associateNotifier != null) this.associateNotifier.SetResult(true);
+            this.associateNotifier.TrySetResult(true);
 
             if (this.networkStream != null)
             {
@@ -307,8 +300,6 @@ namespace Dicom.Network
 
             this.service = null;
             this.networkStream = null;
-            this.completeNotifier = null;
-            this.associateNotifier = null;
         }
 
         #endregion
@@ -347,7 +338,6 @@ namespace Dicom.Network
             public void OnReceiveAssociationAccept(DicomAssociation association)
             {
                 this.client.associateNotifier.TrySetResult(true);
-                this.client.associateNotifier = null;
 
                 foreach (var request in this.client.requests) base.SendRequest(request);
                 this.client.requests.Clear();

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -7,9 +7,6 @@ namespace Dicom.Network
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Net.Sockets;
-    using System.Net.Security;
-    using System.Security.Cryptography.X509Certificates;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -34,7 +31,7 @@ namespace Dicom.Network
 
         private int asyncPerformed;
 
-        private TcpClient tcpClient;
+        private INetworkStream networkStream;
 
         private bool abort;
 
@@ -118,8 +115,12 @@ namespace Dicom.Network
         {
             if (this.requests.Count == 0) return;
 
-            var stream = this.CreateSendStream(host, port, useTls);
-            this.InitializeSend(stream, callingAe, calledAe);
+            var noDelay = this.Options != null ? this.Options.TcpNoDelay : DicomServiceOptions.Default.TcpNoDelay;
+            var ignoreSslPolicyErrors = (this.Options ?? DicomServiceOptions.Default).IgnoreSslPolicyErrors;
+
+            this.networkStream = NetworkManager.CreateNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
+            this.InitializeSend(this.networkStream.AsStream(), callingAe, calledAe);
+
             this.completeNotifier.Task.Wait();
             this.FinalizeSend();
         }
@@ -137,8 +138,12 @@ namespace Dicom.Network
         {
             if (this.requests.Count == 0) return;
 
-            var stream = this.CreateSendStream(host, port, useTls);
-            this.InitializeSend(stream, callingAe, calledAe);
+            var noDelay = this.Options != null ? this.Options.TcpNoDelay : DicomServiceOptions.Default.TcpNoDelay;
+            var ignoreSslPolicyErrors = (this.Options ?? DicomServiceOptions.Default).IgnoreSslPolicyErrors;
+
+            this.networkStream = NetworkManager.CreateNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
+            this.InitializeSend(this.networkStream.AsStream(), callingAe, calledAe);
+
             await this.completeNotifier.Task.ConfigureAwait(false);
             this.FinalizeSend();
         }
@@ -245,14 +250,14 @@ namespace Dicom.Network
             try
             {
                 this.abort = true;
-                this.tcpClient.Close();
+                this.networkStream.Dispose();
             }
             catch
             {
             }
             finally
             {
-                this.tcpClient = null;
+                this.networkStream = null;
                 try
                 {
                     this.completeNotifier.TrySetResult(true);
@@ -262,38 +267,6 @@ namespace Dicom.Network
                 }
                 this.completeNotifier = null;
             }
-        }
-
-        private bool ValidateServerCertificate(
-            object sender,
-            X509Certificate certificate,
-            X509Chain chain,
-            SslPolicyErrors sslPolicyErrors)
-        {
-            return sslPolicyErrors == SslPolicyErrors.None
-                   || (this.Options ?? DicomServiceOptions.Default).IgnoreSslPolicyErrors;
-        }
-
-        private Stream CreateSendStream(string host, int port, bool useTls)
-        {
-            this.tcpClient = new TcpClient(host, port)
-                                 {
-                                     NoDelay =
-                                         this.Options != null
-                                             ? this.Options.TcpNoDelay
-                                             : DicomServiceOptions.Default.TcpNoDelay
-                                 };
-
-            Stream stream = this.tcpClient.GetStream();
-
-            if (useTls)
-            {
-                var ssl = new SslStream(stream, false, this.ValidateServerCertificate);
-                ssl.AuthenticateAsClient(host);
-                stream = ssl;
-            }
-
-            return stream;
         }
 
         private void InitializeSend(Stream stream, string callingAe, string calledAe)
@@ -321,11 +294,11 @@ namespace Dicom.Network
         {
             if (this.associateNotifier != null) this.associateNotifier.SetResult(true);
 
-            if (this.tcpClient != null)
+            if (this.networkStream != null)
             {
                 try
                 {
-                    this.tcpClient.Close();
+                    this.networkStream.Dispose();
                 }
                 catch
                 {
@@ -333,7 +306,7 @@ namespace Dicom.Network
             }
 
             this.service = null;
-            this.tcpClient = null;
+            this.networkStream = null;
             this.completeNotifier = null;
             this.associateNotifier = null;
         }

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -192,8 +192,8 @@ namespace Dicom.Network
         public async Task<bool> WaitForAssociationAsync(int millisecondsTimeout = 5000)
         {
             if (this.associateNotifier == null) return false;
-            await Task.WhenAny(this.associateNotifier.Task, Task.Delay(millisecondsTimeout)).ConfigureAwait(false);
-            return this.associateNotifier.Task.IsCompleted;
+            var task = await Task.WhenAny(this.associateNotifier.Task, Task.Delay(millisecondsTimeout)).ConfigureAwait(false);
+            return task is Task<bool>;
         }
 
         /// <summary>

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -1,139 +1,213 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Net.Sockets;
-using System.Net.Security;
-using System.Security.Authentication;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-
-using Dicom.Log;
-
 namespace Dicom.Network
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Net.Security;
+    using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Dicom.Log;
+
+    /// <summary>
+    /// DICOM server class.
+    /// </summary>
+    /// <typeparam name="T">DICOM service that the server should manage.</typeparam>
     public class DicomServer<T> : IDisposable
         where T : DicomService, IDicomServiceProvider
     {
-        private X509Certificate _cert;
+        #region FIELDS
 
-        private TcpListener _listener;
+        private X509Certificate cert;
 
-        private List<T> _clients;
+        private bool disposed = false;
 
-        private Timer _timer;
+        private readonly List<T> clients = new List<T>();
 
-        private object _synchRoot = new object();
+        #endregion
 
-        public DicomServer(int port, string certificateName = null)
-        {
-            _clients = new List<T>();
-
-            if (certificateName != null)
-            {
-                var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
-                store.Open(OpenFlags.ReadOnly);
-
-                var certs = store.Certificates.Find(X509FindType.FindBySubjectName, certificateName, false);
-
-                if (certs.Count == 0) throw new DicomNetworkException("Unable to find certificate for " + certificateName);
-
-                _cert = certs[0];
-
-                store.Close();
-            }
-
-            _listener = new TcpListener(IPAddress.Any, port);
-            _listener.Start();
-            _listener.BeginAcceptTcpClient(OnAcceptTcpClient, null);
-
-            _timer = new Timer(OnTimerTick, false, 1000, 1000);
-        }
-
-        public Logger Logger { get; set; }
+        #region CONSTRUCTORS
 
         /// <summary>
-        /// Options to control behavior of <see cref="DicomService"/> base class.
+        /// Initializes an instance of <see cref="DicomServer{T}"/>, that starts listening for connections in the background.
         /// </summary>
-        public DicomServiceOptions Options { get; set; }
-
-        private void OnAcceptTcpClient(IAsyncResult result)
+        /// <param name="port">Port to listen to.</param>
+        /// <param name="certificateName">Certificate name for authenticated connections.</param>
+        /// <param name="options">Service options.</param>
+        /// <param name="logger">Logger.</param>
+        public DicomServer(int port, string certificateName = null, DicomServiceOptions options = null, Logger logger = null)
         {
-            try
-            {
+            this.Options = options;
+            this.Logger = logger ?? LogManager.GetLogger("Dicom.Network");
 
-                TcpClient client = null;
-                lock (_synchRoot)
+            Task.Factory.StartNew(
+                () => this.Listen(port, certificateName),
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+        }
+
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the logger used by <see cref="DicomServer{T}"/>
+        /// </summary>
+        public Logger Logger { get; private set; }
+
+        /// <summary>
+        /// Gets the options to control behavior of <see cref="DicomService"/> base class.
+        /// </summary>
+        public DicomServiceOptions Options { get; private set; }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+        }
+
+        /// <summary>
+        /// Execute the disposal.
+        /// </summary>
+        /// <param name="disposing">True if called from <see cref="Dispose"/>, false otherwise.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            this.disposed = true;
+        }
+
+        /// <summary>
+        /// Create an instance of the DICOM service class.
+        /// </summary>
+        /// <param name="stream">Network stream.</param>
+        /// <returns>An instance of the DICOM service class.</returns>
+        protected virtual T CreateScp(Stream stream)
+        {
+            return (T)Activator.CreateInstance(typeof(T), stream, this.Logger);
+        }
+
+        /// <summary>
+        /// Listen indefinitely for network connections on the specified <paramref name="port"/>.
+        /// </summary>
+        /// <param name="port">Port to listen to.</param>
+        /// <param name="certificateName">Certificate name for authenticated connections.</param>
+        private void Listen(int port, string certificateName)
+        {
+            var noDelay = this.Options != null ? this.Options.TcpNoDelay : DicomServiceOptions.Default.TcpNoDelay;
+
+            using (new Timer(this.OnTimerTick, false, 1000, 1000))
+            {
+                TcpListener listener = null;
+                do
                 {
-                    if (_listener == null)
+                    try
                     {
-                        return;
+                        var stream = ListenForNetworkStream(out listener, port, noDelay, certificateName, ref this.cert);
+
+                        var scp = this.CreateScp(stream);
+                        if (this.Options != null) scp.Options = this.Options;
+
+                        this.clients.Add(scp);
                     }
-                    client = _listener.EndAcceptTcpClient(result);
+                    catch (Exception e)
+                    {
+                        this.Logger.Error("Exception accepting client {@error}", e);
+                    }
                 }
+                while (!this.disposed);
 
-
-
-                if (Options != null) client.NoDelay = Options.TcpNoDelay;
-                else client.NoDelay = DicomServiceOptions.Default.TcpNoDelay;
-
-                Stream stream = client.GetStream();
-
-                if (_cert != null)
+                if (listener != null)
                 {
-                    var ssl = new SslStream(stream, false);
-                    ssl.AuthenticateAsServer(_cert, false, SslProtocols.Tls, false);
-
-                    stream = ssl;
-                }
-
-                T scp = CreateScp(stream);
-
-                if (Options != null) scp.Options = Options;
-
-                _clients.Add(scp);
-            }
-            catch (Exception e)
-            {
-                if (Logger == null) Logger = LogManager.GetLogger("Dicom.Network");
-                Logger.Error("Exception accepting client {@error}", e);
-            }
-            finally
-            {
-                lock (_synchRoot)
-                {
-                    if (_listener != null) _listener.BeginAcceptTcpClient(OnAcceptTcpClient, null);
-
+                    listener.Stop();
                 }
             }
         }
 
+        /// <summary>
+        /// Start listening for a new network stream, and return stream when obtained.
+        /// </summary>
+        /// <param name="listener">Network listener.</param>
+        /// <param name="port">Port to listen to.</param>
+        /// <param name="noDelay">True if no delay in connection, false otherwise.</param>
+        /// <param name="certificateName">Certificate name for authenticated connections.</param>
+        /// <param name="certificate">X509 certificate, if <paramref name="certificateName"/> exists.</param>
+        /// <returns>Network stream.</returns>
+        private static Stream ListenForNetworkStream(
+            out TcpListener listener,
+            int port,
+            bool noDelay,
+            string certificateName,
+            ref X509Certificate certificate)
+        {
+            listener = new TcpListener(IPAddress.Any, port);
+            listener.Start();
+            var client = listener.AcceptTcpClient();
+
+            client.NoDelay = noDelay;
+
+            Stream stream = client.GetStream();
+            if (string.IsNullOrEmpty(certificateName)) return stream;
+
+            var ssl = new SslStream(stream, false);
+            ssl.AuthenticateAsServer(
+                certificate ?? (certificate = GetX509Certificate(certificateName)),
+                false,
+                SslProtocols.Tls,
+                false);
+            stream = ssl;
+
+            return stream;
+        }
+
+        /// <summary>
+        /// Remove no longer used client connections.
+        /// </summary>
+        /// <param name="state">Object state.</param>
         private void OnTimerTick(object state)
         {
             try
             {
-                for (int i = 0; i < _clients.Count; i++) if (!_clients[i].IsConnected) _clients.RemoveAt(i--);
+                this.clients.RemoveAll(client => !client.IsConnected);
             }
             catch
             {
             }
         }
 
-        public void Dispose()
+        /// <summary>
+        /// Get X509 certificate from the certificate store.
+        /// </summary>
+        /// <param name="certificateName">Certificate name.</param>
+        /// <returns>Certificate with the specified name.</returns>
+        private static X509Certificate GetX509Certificate(string certificateName)
         {
-            lock (_synchRoot)
+            var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+
+            store.Open(OpenFlags.ReadOnly);
+            var certs = store.Certificates.Find(X509FindType.FindBySubjectName, certificateName, false);
+            store.Close();
+
+            if (certs.Count == 0)
             {
-                _listener.Stop();
-                _listener = null;
+                throw new DicomNetworkException("Unable to find certificate for " + certificateName);
             }
+
+            return certs[0];
         }
 
-        protected virtual T CreateScp(Stream stream)
-        {
-            return (T)Activator.CreateInstance(typeof(T), stream, Logger);
-        }
+        #endregion
     }
 }

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -739,7 +739,7 @@ namespace Dicom.Network
 
         protected void SendPDU(PDU pdu)
         {
-            using (var flag = new ManualResetEvent(false))
+            var flag = new ManualResetEvent(false);
             using (new Timer(
                 obj =>
                     {

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -741,15 +741,15 @@ namespace Dicom.Network
         {
             using (var flag = new ManualResetEvent(false))
             using (new Timer(
-                state =>
+                obj =>
                     {
                         if (this._pduQueue.Count >= this.MaximumPDUsInQueue) return;
                         lock (this._lock)
                         {
-                            this._pduQueue.Enqueue((PDU)state);
-                            flag.Set();
+                            this._pduQueue.Enqueue(pdu);
+                            ((ManualResetEvent)obj).Set();
                         }
-                    }, pdu, 0, 10))
+                    }, flag, 0, 10))
             {
                 flag.WaitOne();
             }

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -1325,15 +1325,16 @@ namespace Dicom.Network
 
         #region Helper methods
 
-        private static void LogIOException(Logger logger, IOException e, bool reading)
+        private static void LogIOException(Logger logger, Exception e, bool reading)
         {
             var socketFmt = string.Format(@"Socket error {0} PDU: {{socketErrorCode}} [{{errorCode}}]", reading ? "reading" : "writing");
             var otherFmt = string.Format(@"IO exception while {0} PDU: {{@error}}", reading ? "reading" : "writing");
 
-            var socketEx = e.InnerException as System.Net.Sockets.SocketException;
-            if (socketEx != null)
+            int errorCode;
+            string errorDescriptor;
+            if (NetworkManager.IsSocketException(e, out errorCode, out errorDescriptor))
             {
-                logger.Error(socketFmt, socketEx.SocketErrorCode, socketEx.ErrorCode);
+                logger.Error(socketFmt, errorDescriptor, errorCode);
             }
             else if (!(e.InnerException is ObjectDisposedException))
             {

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -1,23 +1,22 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading;
-
-using Dicom.Imaging.Codec;
-using Dicom.IO;
-using Dicom.IO.Reader;
-using Dicom.IO.Writer;
-using Dicom.Log;
-using Dicom.Threading;
-
 namespace Dicom.Network
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+
+    using Dicom.Imaging.Codec;
+    using Dicom.IO;
+    using Dicom.IO.Reader;
+    using Dicom.IO.Writer;
+    using Dicom.Log;
+    using Dicom.Threading;
+
     /// <summary>
     /// Base class for DICOM network services.
     /// </summary>
@@ -160,15 +159,7 @@ namespace Dicom.Network
             }
             catch (IOException e)
             {
-                if (e.InnerException is SocketException)
-                {
-                    Logger.Error(
-                        "Socket error while reading PDU: {socketErrorCode} [{errorCode}]",
-                        (e.InnerException as SocketException).SocketErrorCode,
-                        (e.InnerException as SocketException).ErrorCode);
-                }
-                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while reading PDU: {@error}", e);
-
+                LogIOException(this.Logger, e, true);
                 CloseConnection(e);
             }
         }
@@ -216,15 +207,7 @@ namespace Dicom.Network
             }
             catch (IOException e)
             {
-                if (e.InnerException is SocketException)
-                {
-                    Logger.Error(
-                        "Socket error while reading PDU: {socketErrorCode} [{errorCode}]",
-                        (e.InnerException as SocketException).SocketErrorCode,
-                        (e.InnerException as SocketException).ErrorCode);
-                }
-                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while reading PDU: {@error}", e);
-
+                LogIOException(this.Logger, e, true);
                 CloseConnection(e);
             }
             catch (Exception e)
@@ -349,15 +332,7 @@ namespace Dicom.Network
             }
             catch (IOException e)
             {
-                if (e.InnerException is SocketException)
-                {
-                    Logger.Error(
-                        "Socket error while reading PDU: {socketErrorCode} [{errorCode}]",
-                        (e.InnerException as SocketException).SocketErrorCode,
-                        (e.InnerException as SocketException).ErrorCode);
-                }
-                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while reading PDU: {@error}", e);
-
+                LogIOException(this.Logger, e, true);
                 CloseConnection(e);
             }
             catch (NullReferenceException)
@@ -812,15 +787,7 @@ namespace Dicom.Network
             }
             catch (IOException e)
             {
-                if (e.InnerException is SocketException)
-                {
-                    Logger.Error(
-                        "Socket error while writing PDU: {socketErrorCode} [{errorCode}]",
-                        (e.InnerException as SocketException).SocketErrorCode,
-                        (e.InnerException as SocketException).ErrorCode);
-                }
-                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while writing PDU: {@error}", e);
-
+                LogIOException(this.Logger, e, false);
                 CloseConnection(e);
             }
         }
@@ -835,15 +802,7 @@ namespace Dicom.Network
             }
             catch (IOException e)
             {
-                if (e.InnerException is SocketException)
-                {
-                    Logger.Error(
-                        "Socket error while writing PDU: {socketErrorCode} [{errorCode}]",
-                        (e.InnerException as SocketException).SocketErrorCode,
-                        (e.InnerException as SocketException).ErrorCode);
-                }
-                else if (!(e.InnerException is ObjectDisposedException)) Logger.Error("IO exception while writing PDU: {@error}", e);
-
+                LogIOException(this.Logger, e, false);
                 CloseConnection(e);
             }
             catch
@@ -1360,6 +1319,26 @@ namespace Dicom.Network
 
         protected virtual void OnSendQueueEmpty()
         {
+        }
+
+        #endregion
+
+        #region Helper methods
+
+        private static void LogIOException(Logger logger, IOException e, bool reading)
+        {
+            var socketFmt = string.Format(@"Socket error {0} PDU: {{socketErrorCode}} [{{errorCode}}]", reading ? "reading" : "writing");
+            var otherFmt = string.Format(@"IO exception while {0} PDU: {{@error}}", reading ? "reading" : "writing");
+
+            var socketEx = e.InnerException as System.Net.Sockets.SocketException;
+            if (socketEx != null)
+            {
+                logger.Error(socketFmt, socketEx.SocketErrorCode, socketEx.ErrorCode);
+            }
+            else if (!(e.InnerException is ObjectDisposedException))
+            {
+                logger.Error(otherFmt, e);
+            }
         }
 
         #endregion

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -22,19 +22,19 @@ namespace Dicom.Network
     /// </summary>
     public abstract class DicomService
     {
-        private Stream _network;
+        private readonly Stream _network;
 
-        private object _lock;
+        private readonly object _lock;
 
         private volatile bool _writing;
 
         private volatile bool _sending;
 
-        private Queue<PDU> _pduQueue;
+        private readonly Queue<PDU> _pduQueue;
 
-        private Queue<DicomMessage> _msgQueue;
+        private readonly Queue<DicomMessage> _msgQueue;
 
-        private List<DicomRequest> _pending;
+        private readonly List<DicomRequest> _pending;
 
         private DicomMessage _dimse;
 
@@ -48,7 +48,7 @@ namespace Dicom.Network
 
         private bool _isConnected;
 
-        private ThreadPoolQueue<int> _processQueue;
+        private readonly ThreadPoolQueue<int> _processQueue;
 
         private DicomServiceOptions _options;
 
@@ -125,7 +125,7 @@ namespace Dicom.Network
             _isConnected = false;
             try
             {
-                _network.Close();
+                _network.Dispose();
             }
             catch
             {

--- a/DICOM/Network/INetworkListener.cs
+++ b/DICOM/Network/INetworkListener.cs
@@ -21,10 +21,9 @@ namespace Dicom.Network
         /// <summary>
         /// Wait until a network stream is trying to connect, and return the accepted stream.
         /// </summary>
-        /// <param name="port">Port to listen to.</param>
         /// <param name="certificateName">Certificate name of authenticated connections.</param>
         /// <param name="noDelay">No delay?</param>
         /// <returns>Connected network stream.</returns>
-        INetworkStream AcceptNetworkStream(int port, string certificateName, bool noDelay);
+        INetworkStream AcceptNetworkStream(string certificateName, bool noDelay);
     }
 }

--- a/DICOM/Network/INetworkListener.cs
+++ b/DICOM/Network/INetworkListener.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    public interface INetworkListener
+    {
+        void Start();
+
+        void Stop();
+
+        INetworkStream AcceptNetworkStream(int port, string certificateName, bool noDelay);
+    }
+}

--- a/DICOM/Network/INetworkListener.cs
+++ b/DICOM/Network/INetworkListener.cs
@@ -3,12 +3,28 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Interface for listening to network stream connections.
+    /// </summary>
     public interface INetworkListener
     {
+        /// <summary>
+        /// Start listening.
+        /// </summary>
         void Start();
 
+        /// <summary>
+        /// Stop listening.
+        /// </summary>
         void Stop();
 
+        /// <summary>
+        /// Wait until a network stream is trying to connect, and return the accepted stream.
+        /// </summary>
+        /// <param name="port">Port to listen to.</param>
+        /// <param name="certificateName">Certificate name of authenticated connections.</param>
+        /// <param name="noDelay">No delay?</param>
+        /// <returns>Connected network stream.</returns>
         INetworkStream AcceptNetworkStream(int port, string certificateName, bool noDelay);
     }
 }

--- a/DICOM/Network/INetworkStream.cs
+++ b/DICOM/Network/INetworkStream.cs
@@ -6,8 +6,15 @@ namespace Dicom.Network
     using System;
     using System.IO;
 
+    /// <summary>
+    /// Interface representing a network stream.
+    /// </summary>
     public interface INetworkStream : IDisposable
     {
+        /// <summary>
+        /// Get corresponding <see cref="Stream"/> object.
+        /// </summary>
+        /// <returns>Network stream as <see cref="Stream"/> object.</returns>
         Stream AsStream();
     }
 }

--- a/DICOM/Network/INetworkStream.cs
+++ b/DICOM/Network/INetworkStream.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System;
+    using System.IO;
+
+    public interface INetworkStream : IDisposable
+    {
+        Stream AsStream();
+    }
+}

--- a/DICOM/Network/NetworkManager.cs
+++ b/DICOM/Network/NetworkManager.cs
@@ -34,9 +34,9 @@ namespace Dicom.Network
             return implementation.CreateNetworkListenerImpl(port);
         }
 
-        public static INetworkStream CreateNetworkStream(string host, int port, bool useTls, bool noDelay)
+        public static INetworkStream CreateNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
-            return implementation.CreateNetworkStreamImpl(host, port, useTls, noDelay);
+            return implementation.CreateNetworkStreamImpl(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
 
         public static bool IsSocketException(Exception exception, out int errorCode, out string errorDescriptor)
@@ -51,7 +51,7 @@ namespace Dicom.Network
 
         protected abstract INetworkListener CreateNetworkListenerImpl(int port);
 
-        protected abstract INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay);
+        protected abstract INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors);
 
         protected abstract bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor);
 

--- a/DICOM/Network/NetworkManager.cs
+++ b/DICOM/Network/NetworkManager.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System;
+
+    public abstract class NetworkManager
+    {
+        #region FIELDS
+
+        private static NetworkManager implementation;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        static NetworkManager()
+        {
+            SetImplementation(DesktopNetworkManager.Instance);
+        }
+
+        #endregion
+
+        #region METHODS
+
+        public static void SetImplementation(NetworkManager impl)
+        {
+            implementation = impl;
+        }
+
+        public static INetworkListener CreateNetworkListener(int port)
+        {
+            return implementation.CreateNetworkListenerImpl(port);
+        }
+
+        public static INetworkStream CreateNetworkStream(string host, int port, bool useTls, bool noDelay)
+        {
+            return implementation.CreateNetworkStreamImpl(host, port, useTls, noDelay);
+        }
+
+        public static bool IsSocketException(Exception exception, out int errorCode, out string errorDescriptor)
+        {
+            return implementation.IsSocketExceptionImpl(exception, out errorCode, out errorDescriptor);
+        }
+
+        public static bool TryGetNetworkIdentifier(out DicomUID identifier)
+        {
+            return implementation.TryGetNetworkIdentifierImpl(out identifier);
+        }
+
+        protected abstract INetworkListener CreateNetworkListenerImpl(int port);
+
+        protected abstract INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay);
+
+        protected abstract bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor);
+
+        protected abstract bool TryGetNetworkIdentifierImpl(out DicomUID identifier);
+
+        #endregion
+    }
+}

--- a/DICOM/Network/NetworkManager.cs
+++ b/DICOM/Network/NetworkManager.cs
@@ -5,16 +5,25 @@ namespace Dicom.Network
 {
     using System;
 
+    /// <summary>
+    /// Abstract manager class for network operations.
+    /// </summary>
     public abstract class NetworkManager
     {
         #region FIELDS
 
+        /// <summary>
+        /// Network manager implementation in current use.
+        /// </summary>
         private static NetworkManager implementation;
 
         #endregion
 
         #region CONSTRUCTORS
 
+        /// <summary>
+        /// Initializes the static fields of <see cref="NetworkManager"/>.
+        /// </summary>
         static NetworkManager()
         {
             SetImplementation(DesktopNetworkManager.Instance);
@@ -24,37 +33,93 @@ namespace Dicom.Network
 
         #region METHODS
 
+        /// <summary>
+        /// Sets the network manager implementation to use.
+        /// </summary>
+        /// <param name="impl">Network manager implementation.</param>
         public static void SetImplementation(NetworkManager impl)
         {
             implementation = impl;
         }
 
+        /// <summary>
+        /// Create a network listener object.
+        /// </summary>
+        /// <param name="port">Network port to listen to.</param>
+        /// <returns>Network listener implementation.</returns>
         public static INetworkListener CreateNetworkListener(int port)
         {
             return implementation.CreateNetworkListenerImpl(port);
         }
 
+        /// <summary>
+        /// Create a network stream object.
+        /// </summary>
+        /// <param name="host">Network host.</param>
+        /// <param name="port">Network port.</param>
+        /// <param name="useTls">Use TLS layer?</param>
+        /// <param name="noDelay">No delay?</param>
+        /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
+        /// <returns>Network stream implementation.</returns>
         public static INetworkStream CreateNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
             return implementation.CreateNetworkStreamImpl(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
 
+        /// <summary>
+        /// Checks whether specified <paramref name="exception"/> represents a socket exception.
+        /// </summary>
+        /// <param name="exception">Exception to validate.</param>
+        /// <param name="errorCode">Error code, valid if <paramref name="exception"/> is socket exception.</param>
+        /// <param name="errorDescriptor">Error descriptor, valid if <paramref name="exception"/> is socket exception.</param>
+        /// <returns>True if <paramref name="exception"/> is socket exception, false otherwise.</returns>
         public static bool IsSocketException(Exception exception, out int errorCode, out string errorDescriptor)
         {
             return implementation.IsSocketExceptionImpl(exception, out errorCode, out errorDescriptor);
         }
 
+        /// <summary>
+        /// Attempt to obtain a unique network identifier, e.g. based on a MAC address.
+        /// </summary>
+        /// <param name="identifier">Unique network identifier, if found.</param>
+        /// <returns>True if network identifier could be obtained, false otherwise.</returns>
         public static bool TryGetNetworkIdentifier(out DicomUID identifier)
         {
             return implementation.TryGetNetworkIdentifierImpl(out identifier);
         }
 
+        /// <summary>
+        /// Platform-specific implementation to create a network listener object.
+        /// </summary>
+        /// <param name="port">Network port to listen to.</param>
+        /// <returns>Network listener implementation.</returns>
         protected abstract INetworkListener CreateNetworkListenerImpl(int port);
 
+        /// <summary>
+        /// Platform-specific implementation to create a network stream object.
+        /// </summary>
+        /// <param name="host">Network host.</param>
+        /// <param name="port">Network port.</param>
+        /// <param name="useTls">Use TLS layer?</param>
+        /// <param name="noDelay">No delay?</param>
+        /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
+        /// <returns>Network stream implementation.</returns>
         protected abstract INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors);
 
+        /// <summary>
+        /// Platform-specific implementation to check whether specified <paramref name="exception"/> represents a socket exception.
+        /// </summary>
+        /// <param name="exception">Exception to validate.</param>
+        /// <param name="errorCode">Error code, valid if <paramref name="exception"/> is socket exception.</param>
+        /// <param name="errorDescriptor">Error descriptor, valid if <paramref name="exception"/> is socket exception.</param>
+        /// <returns>True if <paramref name="exception"/> is socket exception, false otherwise.</returns>
         protected abstract bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor);
 
+        /// <summary>
+        /// Platform-specific implementation to attempt to obtain a unique network identifier, e.g. based on a MAC address.
+        /// </summary>
+        /// <param name="identifier">Unique network identifier, if found.</param>
+        /// <returns>True if network identifier could be obtained, false otherwise.</returns>
         protected abstract bool TryGetNetworkIdentifierImpl(out DicomUID identifier);
 
         #endregion

--- a/DICOM/Threading/ThreadPoolQueue.cs
+++ b/DICOM/Threading/ThreadPoolQueue.cs
@@ -230,7 +230,7 @@ namespace Dicom.Threading
 
                 if (empty)
                 {
-                    using (var flag = new ManualResetEvent(false))
+                    var flag = new ManualResetEvent(false);
                     using (new Timer(obj =>
                         {
                             lock (group.Lock)


### PR DESCRIPTION
In line with previous abstractions to facilitate porting of *fo-dicom* to non-.NET platform targets, here is now the (hopefully) last abstraction layer implementation, this time related to networking.

After examining all code using `System.Net` and `System.Security` namespaces and refactoring the `DicomServer` code so that the background process is performed as a `Task` instead of using the `Begin`/`End` *Asynchronous Programming Model*, it was clear that the network abstraction could be limited to two interfaces, `INetworkListener` and `INetworkStream`, and two additional helper methods:

    interface INetworkListener {
      void Start();
      void Stop();
      INetworkStream AcceptNetworkStream(string certificateName, bool noDelay);
    }

    interface INetworkStream {
      Stream AsStream();
    }

    abstract class NetworkManager {
      abstract bool IsSocketExceptionImpl(out int errorCode, out string errorDescriptor);
      abstract bool TryGetNetworkIdentifierImpl(out DicomUID identifier);
    }

The pull request contains implementations of these interfaces and base class intended for .NET platforms (or more accurately, all platforms that implement the full `System.Net` and `System.Security` namespaces). These implementations are denoted `DesktopNetworkListener`, `DesktopNetworkStream` and `DesktopNetworkManager`, respectively.

All network operations internal to the *fo-dicom* library/ies are managed via static methods in `NetworkManager`. `NetworkManager` is responsible for calling the corresponding methods in the `NetworkManager` implementations on respective platform.

For other platforms, this refactoring makes it considerably easier to enable the *fo-dicom* network functionality as well. The only issue will be to provide platform specific implementations for `INetworkListener`, `INetworkStream` and `NetworkManager`. 

Please review.