### PR TITLE
Added Xamarin iOS (Unified API) project. Connected to #111

### DIFF
--- a/DICOM.iOS/DICOM.iOS.csproj
+++ b/DICOM.iOS/DICOM.iOS.csproj
@@ -25,7 +25,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/DICOM.iOS/DICOM.iOS.csproj
+++ b/DICOM.iOS/DICOM.iOS.csproj
@@ -33,6 +33,12 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\DICOM\fo-dicom.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\DICOM\DatabaseQueryTransformRule.cs">
       <Link>DatabaseQueryTransformRule.cs</Link>

--- a/DICOM.iOS/DICOM.iOS.csproj
+++ b/DICOM.iOS/DICOM.iOS.csproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{322DD2FF-C0B7-4CBF-BE95-F0032FD94E02}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Dicom</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>Dicom.Platform</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\DICOM\DatabaseQueryTransformRule.cs">
+      <Link>DatabaseQueryTransformRule.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Imaging\Codec\IOSTranscoderManager.cs">
+      <Link>Imaging\Codec\IOSTranscoderManager.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Imaging\IOSImage.cs">
+      <Link>Imaging\IOSImage.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Imaging\IOSImageManager.cs">
+      <Link>Imaging\IOSImageManager.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\IO\DesktopDirectoryReference.cs">
+      <Link>IO\DesktopDirectoryReference.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\IO\DesktopFileReference.cs">
+      <Link>IO\DesktopFileReference.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\IO\DesktopIOManager.cs">
+      <Link>IO\DesktopIOManager.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\IO\DesktopPath.cs">
+      <Link>IO\DesktopPath.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Log\ConsoleExtensions.cs">
+      <Link>Log\ConsoleExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Log\ConsoleLogger.cs">
+      <Link>Log\ConsoleLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Managers.cs">
+      <Link>Managers.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Managers.iOS.cs">
+      <Link>Managers.iOS.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Network\DesktopNetworkListener.cs">
+      <Link>Network\DesktopNetworkListener.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Network\DesktopNetworkManager.cs">
+      <Link>Network\DesktopNetworkManager.cs</Link>
+    </Compile>
+    <Compile Include="..\DICOM\Network\DesktopNetworkStream.cs">
+      <Link>Network\DesktopNetworkStream.cs</Link>
+    </Compile>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DICOM\DICOM.Core.csproj">
+      <Project>{a661d347-cf7d-4f36-8101-0544ae85eeec}</Project>
+      <Name>DICOM.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+</Project>

--- a/DICOM.iOS/DICOM.iOS.csproj
+++ b/DICOM.iOS/DICOM.iOS.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -27,7 +27,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\Release</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/DICOM.iOS/Properties/AssemblyInfo.cs
+++ b/DICOM.iOS/Properties/AssemblyInfo.cs
@@ -7,5 +7,5 @@ using System.Reflection;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Dicom.Platform")]
-[assembly: AssemblyDescription(".NET specific assembly for fo-dicom")]
+[assembly: AssemblyDescription("iOS specific assembly for fo-dicom")]
 [assembly: AssemblyConfiguration("")]

--- a/DICOM.sln
+++ b/DICOM.sln
@@ -81,6 +81,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DICOM.Tests", "DICOM.Tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleTest", "Examples\ConsoleTest\ConsoleTest.csproj", "{16FD143D-6E25-4CD9-AEC0-B096644B0045}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DICOM.iOS", "DICOM.iOS\DICOM.iOS.csproj", "{322DD2FF-C0B7-4CBF-BE95-F0032FD94E02}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,10 @@ Global
 		{16FD143D-6E25-4CD9-AEC0-B096644B0045}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16FD143D-6E25-4CD9-AEC0-B096644B0045}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16FD143D-6E25-4CD9-AEC0-B096644B0045}.Release|Any CPU.Build.0 = Release|Any CPU
+		{322DD2FF-C0B7-4CBF-BE95-F0032FD94E02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{322DD2FF-C0B7-4CBF-BE95-F0032FD94E02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{322DD2FF-C0B7-4CBF-BE95-F0032FD94E02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{322DD2FF-C0B7-4CBF-BE95-F0032FD94E02}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DICOM/DatabaseQueryTransformRule.cs
+++ b/DICOM/DatabaseQueryTransformRule.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+#if !__IOS__
 using System.Data.Odbc;
+#endif
 using System.Data.SqlClient;
 
 namespace Dicom
@@ -134,9 +136,10 @@ namespace Dicom
 
             try
             {
-                if (_dbType == DatabaseType.Odbc) connection = new OdbcConnection(_connectionString);
-                else if (_dbType == DatabaseType.MsSql) connection = new SqlConnection(_connectionString);
-
+                if (_dbType == DatabaseType.MsSql) connection = new SqlConnection(_connectionString);
+#if !__IOS__
+                else if (_dbType == DatabaseType.Odbc) connection = new OdbcConnection(_connectionString);
+#endif
                 using (IDbCommand command = connection.CreateCommand())
                 {
                     command.Connection = connection;

--- a/DICOM/Imaging/Codec/IOSTranscoderManager.cs
+++ b/DICOM/Imaging/Codec/IOSTranscoderManager.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging.Codec
+{
+    using System;
+    //using System.ComponentModel.Composition.Hosting;
+    using System.IO;
+    using System.Reflection;
+
+    using Dicom.Log;
+
+    /// <summary>
+    /// Implementation of <see cref="TranscoderManager"/> for iOS applications.
+    /// </summary>
+    public sealed class IOSTranscoderManager : TranscoderManager
+    {
+        #region FIELDS
+
+        /// <summary>
+        /// Singleton instance of the <see cref="DesktopTranscoderManager"/>.
+        /// </summary>
+        public static readonly TranscoderManager Instance;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes the static fields of <see cref="IOSTranscoderManager"/>.
+        /// </summary>
+        static IOSTranscoderManager()
+        {
+            Instance = new IOSTranscoderManager();
+        }
+
+        /// <summary>
+        /// Initializes an instance of <see cref="IOSTranscoderManager"/>.
+        /// </summary>
+        private IOSTranscoderManager()
+        {
+            this.LoadCodecsImpl(null, null);
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Implementation of method to load codecs from assembly(ies) at the specified <paramref name="path"/> and 
+        /// with the specified <paramref name="search"/> pattern.
+        /// </summary>
+        /// <param name="path">Directory path to codec assemblies.</param>
+        /// <param name="search">Search pattern for codec assemblies.</param>
+        /// <remarks>Not yet implemented for iOS.</remarks>
+        protected override void LoadCodecsImpl(string path, string search)
+        {
+            if (path == null) path = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
+
+            if (search == null) search = "Dicom.Native*.dll";
+
+            var log = LogManager.GetLogger("Dicom.Imaging.Codec");
+            log.Warn("Codec loading for iOS not yet implemented.");
+
+/*
+            log.Debug("Searching {path}\\{wildcard} for Dicom codecs", path, search);
+
+            var foundAnyCodecs = false;
+
+            DirectoryCatalog catalog;
+            try
+            {
+                catalog = new DirectoryCatalog(path, search);
+            }
+            catch (Exception ex)
+            {
+                log.Error(
+                    "Error encountered creating new DirectCatalog({path}, {search}) - {@exception}",
+                    path,
+                    search,
+                    ex);
+                throw;
+            }
+
+            var container = new CompositionContainer(catalog);
+            foreach (var lazy in container.GetExports<IDicomCodec>())
+            {
+                foundAnyCodecs = true;
+                var codec = lazy.Value;
+                log.Debug("Codec: {codecName}", codec.TransferSyntax.UID.Name);
+                Codecs[codec.TransferSyntax] = codec;
+            }
+
+            if (!foundAnyCodecs)
+            {
+                log.Warn("No Dicom codecs were found after searching {path}\\{wildcard}", path, search);
+            }
+*/
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/IOSImage.cs
+++ b/DICOM/Imaging/IOSImage.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging
+{
+    using System;
+    using System.Collections.Generic;
+
+    using CoreGraphics;
+
+    using CoreImage;
+
+    using Dicom.Imaging.Render;
+    using Dicom.IO;
+
+    using UIKit;
+
+    /// <summary>
+    /// <see cref="IImage"/> implementation of a Windows Forms <see cref="CGImage"/>.
+    /// </summary>
+    public sealed class IOSImage : IImage
+    {
+        #region FIELDS
+
+        private CGImage image;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="IOSImage"/> object.
+        /// </summary>
+        /// <param name="width">Image width.</param>
+        /// <param name="height">Image height.</param>
+        /// <param name="components">Number of components.</param>
+        /// <param name="flipX">Flip image in X direction?</param>
+        /// <param name="flipY">Flip image in Y direction?</param>
+        /// <param name="rotation">Image rotation.</param>
+        /// <param name="pixels">Array of pixels.</param>
+        public IOSImage(int width, int height, int components, bool flipX, bool flipY, int rotation, PinnedIntArray pixels)
+        {
+            using (
+                var context = new CGBitmapContext(
+                    pixels.Pointer,
+                    width,
+                    height,
+                    8,
+                    4 * width,
+                    CGColorSpace.CreateDeviceRGB(),
+                    CGImageAlphaInfo.PremultipliedLast))
+            {
+                var transform = CGAffineTransform.MakeRotation((float)(rotation * Math.PI / 180.0));
+                transform.Scale(flipX ? -1.0f : 1.0f, flipY ? -1.0f : 1.0f);
+                transform.Translate(flipX ? width : 0.0f, flipY ? height : 0.0f);
+                context.ConcatCTM(transform);
+
+                this.image = context.ToImage();
+            }
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Cast <see cref="IImage"/> object to specific (real image) type.
+        /// </summary>
+        /// <typeparam name="T">Real image type to cast to.</typeparam>
+        /// <returns><see cref="IImage"/> object as specific (real image) type.</returns>
+        public T As<T>()
+        {
+            if (typeof(T) == typeof(UIImage))
+            {
+                return (T)(object)new UIImage(this.image);
+            }
+            if (typeof(T) == typeof(CIImage))
+            {
+                return (T)(object)new CIImage(this.image);
+            }
+            return (T)(object)this.image;
+        }
+
+        /// <summary>
+        /// Draw graphics onto existing image.
+        /// </summary>
+        /// <param name="graphics">Graphics to draw.</param>
+        public void DrawGraphics(IEnumerable<IGraphic> graphics)
+        {
+            using (
+                var context = new CGBitmapContext(
+                    IntPtr.Zero,
+                    this.image.Width,
+                    this.image.Height,
+                    this.image.BitsPerComponent,
+                    this.image.BytesPerRow,
+                    this.image.ColorSpace,
+                    this.image.AlphaInfo))
+            {
+                context.DrawImage(new CGRect(0.0, 0.0, this.image.Width, this.image.Height), this.image);
+
+                foreach (var graphic in graphics)
+                {
+                    var layer = graphic.RenderImage(null).As<CGImage>();
+                    context.DrawImage(
+                        new CGRect(
+                            graphic.ScaledOffsetX,
+                            graphic.ScaledOffsetY,
+                            graphic.ScaledWidth,
+                            graphic.ScaledHeight),
+                        layer);
+                }
+
+                this.image = context.ToImage();
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Imaging/IOSImageManager.cs
+++ b/DICOM/Imaging/IOSImageManager.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Imaging
+{
+    using Dicom.IO;
+
+    /// <summary>
+    /// Windows Forms-based image manager implementation.
+    /// </summary>
+    public sealed class IOSImageManager : ImageManager
+    {
+        #region FIELDS
+
+        /// <summary>
+        /// Single instance of the Windows Forms image manager.
+        /// </summary>
+        public static readonly ImageManager Instance;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes the static fields of <see cref="IOSImageManager"/>
+        /// </summary>
+        static IOSImageManager()
+        {
+            Instance = new IOSImageManager();
+        }
+
+        /// <summary>
+        /// Initializes a <see cref="IOSImageManager"/> object.
+        /// </summary>
+        private IOSImageManager()
+        {
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Create <see cref="IImage"/> object using the current implementation.
+        /// </summary>
+        /// <param name="width">Image width.</param>
+        /// <param name="height">Image height.</param>
+        /// <param name="components">Number of components.</param>
+        /// <param name="flipX">Flip image in X direction?</param>
+        /// <param name="flipY">Flip image in Y direction?</param>
+        /// <param name="rotation">Image rotation.</param>
+        /// <param name="pixels">Array of pixels.</param>
+        /// <returns><see cref="IImage"/> object using the current implementation.</returns>
+        protected override IImage CreateImageImpl(int width, int height, int components, bool flipX, bool flipY, int rotation, PinnedIntArray pixels)
+        {
+            return new IOSImage(width, height, components, flipX, flipY, rotation, pixels);
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Log/ConsoleLogger.cs
+++ b/DICOM/Log/ConsoleLogger.cs
@@ -34,29 +34,51 @@ namespace Dicom.Log
         {
             lock (this.@lock)
             {
-                var previous = Console.ForegroundColor;
+                var previous = ConsoleForegroundColor;
                 switch (level)
                 {
                     case LogLevel.Debug:
-                        Console.ForegroundColor = ConsoleColor.Blue;
+                        ConsoleForegroundColor = ConsoleColor.Blue;
                         break;
                     case LogLevel.Info:
-                        Console.ForegroundColor = ConsoleColor.White;
+                        ConsoleForegroundColor = ConsoleColor.White;
                         break;
                     case LogLevel.Warning:
-                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        ConsoleForegroundColor = ConsoleColor.Yellow;
                         break;
                     case LogLevel.Error:
-                        Console.ForegroundColor = ConsoleColor.Red;
+                        ConsoleForegroundColor = ConsoleColor.Red;
                         break;
                     case LogLevel.Fatal:
-                        Console.ForegroundColor = ConsoleColor.Magenta;
+                        ConsoleForegroundColor = ConsoleColor.Magenta;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException("level", level, null);
                 }
                 Console.WriteLine(NameFormatToPositionalFormat(msg), args);
-                Console.ForegroundColor = previous;
+                ConsoleForegroundColor = previous;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the console foreground color.
+        /// </summary>
+        /// <remarks>Dispatcher method to allow for platform-specific handling.</remarks>
+        private static ConsoleColor ConsoleForegroundColor
+        {
+            get
+            {
+#if __IOS__
+                return ConsoleColor.Black;
+#else
+                return Console.ForegroundColor;
+#endif
+            }
+            set
+            {
+#if !__IOS__
+                Console.ForegroundColor = value;
+#endif
             }
         }
     }

--- a/DICOM/Managers.cs
+++ b/DICOM/Managers.cs
@@ -16,7 +16,7 @@ namespace Dicom
     {
         #region FIELDS
 
-        protected static readonly LogManager PlatformLogManagerImpl;
+        protected static LogManager PlatformLogManagerImpl;
 
         protected static readonly IOManager PlatformIOManagerImpl;
 
@@ -24,7 +24,7 @@ namespace Dicom
 
         protected static readonly TranscoderManager PlatformTranscoderManagerImpl;
 
-        protected static readonly ImageManager PlatformImageManagerImpl;
+        protected static ImageManager PlatformImageManagerImpl;
 
         #endregion
 
@@ -59,6 +59,9 @@ namespace Dicom
         /// <param name="imageManagerImpl">Selected image manager implementation.</param>
         public static void Setup(LogManager logManagerImpl, ImageManager imageManagerImpl)
         {
+            if (logManagerImpl != null) PlatformLogManagerImpl = logManagerImpl;
+            if (imageManagerImpl != null) PlatformImageManagerImpl = imageManagerImpl;
+
             Setup(
                 logManagerImpl,
                 PlatformIOManagerImpl,
@@ -73,6 +76,8 @@ namespace Dicom
         /// <param name="logManagerImpl">Selected log manager implementation.</param>
         public static void Setup(LogManager logManagerImpl)
         {
+            if (logManagerImpl != null) PlatformLogManagerImpl = logManagerImpl;
+
             Setup(
                 logManagerImpl,
                 PlatformIOManagerImpl,
@@ -87,6 +92,8 @@ namespace Dicom
         /// <param name="imageManagerImpl">Selected image manager implementation.</param>
         public static void Setup(ImageManager imageManagerImpl)
         {
+            if (imageManagerImpl != null) PlatformImageManagerImpl = imageManagerImpl;
+
             Setup(
                 PlatformLogManagerImpl,
                 PlatformIOManagerImpl,

--- a/DICOM/Managers.iOS.cs
+++ b/DICOM/Managers.iOS.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
+{
+    using Dicom.Imaging;
+    using Dicom.Imaging.Codec;
+    using Dicom.IO;
+    using Dicom.Network;
+
+    /// <summary>
+    /// Convenience class for enabling desktop managers.
+    /// </summary>
+    public partial class Managers
+    {
+        /// <summary>
+        /// Set standard implementations for .NET desktop applications.
+        /// </summary>
+        static Managers()
+        {
+            PlatformLogManagerImpl = null;
+            PlatformIOManagerImpl = DesktopIOManager.Instance;
+            PlatformNetworkManagerImpl = DesktopNetworkManager.Instance;
+            PlatformTranscoderManagerImpl = IOSTranscoderManager.Instance;
+            PlatformImageManagerImpl = IOSImageManager.Instance;
+        }
+    }
+}

--- a/Setup/fo-dicom.Core.nuspec
+++ b/Setup/fo-dicom.Core.nuspec
@@ -9,7 +9,7 @@
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>A Portable DICOM library</description>
+        <description>The core portable DICOM library for .NET, Universal Windows Platform, Xamarin iOS and Xamarin Android.</description>
         <language>en-US</language>
     </metadata>
     <files>

--- a/Setup/fo-dicom.Legacy.nuspec
+++ b/Setup/fo-dicom.Legacy.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.Legacy</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM Legacy Support</title>
+        <title>Fellow Oak DICOM Legacy Library</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>A DICOM library, legacy support</description>
+        <description>Legacy methods associated with 1.x releases of fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
             <dependency id="fo-dicom.Core" version="$version$" />

--- a/Setup/fo-dicom.MetroLog.nuspec
+++ b/Setup/fo-dicom.MetroLog.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.MetroLog</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM MetroLog support</title>
+        <title>Fellow Oak DICOM MetroLog connector</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Support library for using MetroLog log handler with fo-dicom.</description>
+        <description>Support library for connecting MetroLog log handler to fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
             <dependency id="fo-dicom.Core" version="$version$" />

--- a/Setup/fo-dicom.NLog.nuspec
+++ b/Setup/fo-dicom.NLog.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.NLog</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM NLog support</title>
+        <title>Fellow Oak DICOM NLog connector</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Support library for using NLog log handler with fo-dicom.</description>
+        <description>Support library for connecting NLog log handler to fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
             <dependency id="fo-dicom.Core" version="$version$" />

--- a/Setup/fo-dicom.Platform.nuspec
+++ b/Setup/fo-dicom.Platform.nuspec
@@ -21,5 +21,7 @@
         <file src="..\fo-dicom.targets" target="build\fo-dicom.Platform.targets" />
         <file src="..\DICOM.Desktop\bin\Release\Dicom.Platform.dll" target="lib\net45" />
         <file src="..\DICOM.Desktop\bin\Release\Dicom.Platform.pdb" target="lib\net45" />
+        <file src="..\DICOM.iOS\bin\Release\Dicom.Platform.dll" target="lib\Xamarin.iOS10" />
+        <file src="..\DICOM.iOS\bin\Release\Dicom.Platform.pdb" target="lib\Xamarin.iOS10" />
     </files>
 </package>

--- a/Setup/fo-dicom.Platform.nuspec
+++ b/Setup/fo-dicom.Platform.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.Platform</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM Platform support</title>
+        <title>Fellow Oak DICOM Platform Libraries</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>A DICOM library, platform support</description>
+        <description>Platform specific libraries for fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
             <dependency id="fo-dicom.Core" version="$version$" />

--- a/Setup/fo-dicom.Serilog.nuspec
+++ b/Setup/fo-dicom.Serilog.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.Serilog</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM Serilog support</title>
+        <title>Fellow Oak DICOM Serilog connector</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Support library for using Serilog log handler with fo-dicom.</description>
+        <description>Support library for connecting Serilog log handler to fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
             <dependency id="fo-dicom.Core" version="$version$" />

--- a/Setup/fo-dicom.log4net.nuspec
+++ b/Setup/fo-dicom.log4net.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.log4net</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM log4net support</title>
+        <title>Fellow Oak DICOM log4net connector</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Support library for using log4net log handler with fo-dicom.</description>
+        <description>Support library for connecting log4net log handler to fo-dicom.</description>
         <language>en-US</language>
         <dependencies>
             <dependency id="fo-dicom.Core" version="$version$" />

--- a/Setup/fo-dicom.nuspec
+++ b/Setup/fo-dicom.nuspec
@@ -9,7 +9,7 @@
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>A DICOM library</description>
+        <description>A portable DICOM library for .NET, Universal Windows Platform, Xamarin iOS and Xamarin Android.</description>
         <language>en-US</language>
         <dependencies>
             <dependency id="fo-dicom.Legacy" version="$version$" />

--- a/fo-dicom.targets
+++ b/fo-dicom.targets
@@ -5,7 +5,7 @@
     <Message Importance="high" Text="Change '$(MSBuildProjectName)' Platform Target Build Project Property from '$(PlatformTarget)' to either x86 or x64 to remove this message." />
   </Target>
   <Choose>
-    <When Condition="'$(PlatformTarget)' == 'x64'">
+    <When Condition="'$(TargetFrameworkVersion)' == 'v4.5' And '$(PlatformTarget)' == 'x64'">
       <ItemGroup>
         <Reference Include="Dicom.Native64">
           <HintPath>$(MSBuildThisFileDirectory)\net45\Dicom.Native64.dll</HintPath>
@@ -15,7 +15,7 @@
         </None>
       </ItemGroup>
     </When>
-    <When Condition="'$(PlatformTarget)' == 'x86'">
+    <When Condition="'$(TargetFrameworkVersion)' == 'v4.5' And '$(PlatformTarget)' == 'x86'">
       <ItemGroup>
         <Reference Include="Dicom.Native">
           <HintPath>$(MSBuildThisFileDirectory)\net45\Dicom.Native.dll</HintPath>
@@ -25,13 +25,13 @@
         </None>
       </ItemGroup>
     </When>
-    <Otherwise>
+    <When Condition="'$(TargetFrameworkVersion)' == 'v4.5' And '$(PlatformTarget)' != 'x64' And '$(PlatformTarget)' != 'x86'">
       <PropertyGroup>
         <BuildDependsOn>
           $(BuildDependsOn);
           Warn-fo-dicom-platform
         </BuildDependsOn>
       </PropertyGroup>
-    </Otherwise>
+    </When>
   </Choose>
 </Project>


### PR DESCRIPTION
As a first proof-of-concept that the PCLification of *fo-dicom* facilitates the adoption to other platforms, I have now added a platform specific library for *Xamarin iOS* (Unified API).

The library re-uses the `DesktopIOManager`, `DesktopNetworkManager`, `ConsoleLogManager` and associated classes, but implements its own `IOSIMageManager` for `CGImage` based images. Transcoding is not (yet) implemented.

Apart from the missing transcoding support, the iOS specific library also does not implement the `FilmBox` and `ImageBox` `Print` extension methods, since these methods rely on the `System.Drawing` assembly. Likewise, the `DicomOverlayDataFactory.FromBitmap` method is not included. On the other hand, the `DatabaseQueryTransformRule` class **is** included and fully functional, except for database connection via ODBC.

Please review.