### PR TITLE
Overlay error corrections. Connected to #138 and #110

### DIFF
--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -271,10 +271,14 @@ namespace Dicom.Imaging.Codec
             {
                 var dataTag = new DicomTag(overlay.Group, DicomTag.OverlayData.Element);
 
-                // don't run conversion on non-embedded overlays
+                // don't run conversion on non-embedded overlays; overlay considered embedded if Overlay Data tag
+                // exists or if Overlay Bits Allocated is larger than 1.
                 if (output.Contains(dataTag)) continue;
 
-                output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), (ushort)1);
+                var bitsAllocTag = new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element);
+                if (output.Get(bitsAllocTag, (ushort)0) > 1) continue;
+
+                output.Add(bitsAllocTag, (ushort)1);
                 output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitPosition.Element), (ushort)0);
 
                 var data = overlay.Data;

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -267,11 +267,6 @@ namespace Dicom.Imaging.Codec
         {
             var overlays = DicomOverlayData.FromDataset(input.InternalTransferSyntax.IsEncapsulated ? output : input);
 
-            // Overlay counter to use if overlay bit position is zero (#110)
-            var fallbackBitPosition = output.Contains(DicomTag.HighBit)
-                                          ? (ushort)(output.Get<ushort>(DicomTag.HighBit) + 1)
-                                          : (ushort)0;
-
             foreach (var overlay in overlays)
             {
                 var dataTag = new DicomTag(overlay.Group, DicomTag.OverlayData.Element);
@@ -282,13 +277,6 @@ namespace Dicom.Imaging.Codec
                 // If embedded overlay, Overlay Bits Allocated should equal Bits Allocated (#110).
                 var bitsAlloc = output.Get(DicomTag.BitsAllocated, (ushort)0);
                 output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), bitsAlloc);
-
-                // If Overlay Bit Position is zero (#110), use fallback bit position
-                var bitPosTag = new DicomTag(overlay.Group, DicomTag.OverlayBitPosition.Element);
-                if (output.Get(bitPosTag, (ushort)0) == 0 && fallbackBitPosition < bitsAlloc)
-                {
-                    output.Add(bitPosTag, fallbackBitPosition++);
-                }
 
                 var data = overlay.Data;
                 if (output.InternalTransferSyntax.IsExplicitVR) output.Add(new DicomOtherByte(dataTag, data));

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -268,7 +268,9 @@ namespace Dicom.Imaging.Codec
             var overlays = DicomOverlayData.FromDataset(input.InternalTransferSyntax.IsEncapsulated ? output : input);
 
             // Overlay counter to use if overlay bit position is zero (#110)
-            var fallbackBitPosition = output.Get(DicomTag.BitsStored, (ushort)0);
+            var fallbackBitPosition = output.Contains(DicomTag.HighBit)
+                                          ? (ushort)(output.Get<ushort>(DicomTag.HighBit) + 1)
+                                          : (ushort)0;
 
             foreach (var overlay in overlays)
             {

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -346,8 +346,8 @@ namespace Dicom.Imaging
                 // (1,1) indicates top left pixel of image
                 int ox = Math.Max(0, OriginX - 1);
                 int oy = Math.Max(0, OriginY - 1);
-                int ow = Rows - (pixels.Width - Rows - ox);
-                int oh = Columns - (pixels.Height - Columns - oy);
+                int ow = Columns - (pixels.Width - Columns - ox);
+                int oh = Rows - (pixels.Height - Rows - oy);
 
                 var frame = pixels.GetFrame(0);
 

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -355,7 +355,12 @@ namespace Dicom.Imaging
                 bits.Capacity = Rows * Columns;
                 int mask = 1 << BitPosition;
 
-                if (pixels.BitsAllocated == 8)
+                // Sanity check: do not collect overlay data if Overlay Bit Position is NOT greater than main image High Bit. (#110)
+                if (this.BitPosition <= pixels.HighBit)
+                {
+                    // Do nothing
+                }
+                else if (pixels.BitsAllocated == 8)
                 {
                     var data = IO.ByteConverter.ToArray<byte>(frame);
 

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -346,8 +346,8 @@ namespace Dicom.Imaging
                 // (1,1) indicates top left pixel of image
                 int ox = Math.Max(0, OriginX - 1);
                 int oy = Math.Max(0, OriginY - 1);
-                int ow = Columns - (pixels.Width - Columns - ox);
-                int oh = Rows - (pixels.Height - Rows - oy);
+                int ow = Columns;
+                int oh = Rows;
 
                 var frame = pixels.GetFrame(0);
 
@@ -359,11 +359,11 @@ namespace Dicom.Imaging
                 {
                     var data = IO.ByteConverter.ToArray<byte>(frame);
 
-                    for (int y = oy; y < oh; y++)
+                    for (int y = 0; y < oh; y++)
                     {
-                        int n = (y * pixels.Width) + ox;
-                        int i = (y - oy) * Columns;
-                        for (int x = ox; x < ow; x++)
+                        int n = (y + oy) * pixels.Width + ox;
+                        int i = y * Columns;
+                        for (int x = 0; x < ow; x++)
                         {
                             if ((data[n] & mask) != 0) bits[i] = true;
                             n++;
@@ -376,11 +376,11 @@ namespace Dicom.Imaging
                     // we don't really care if the pixel data is signed or not
                     var data = IO.ByteConverter.ToArray<ushort>(frame);
 
-                    for (int y = oy; y < oh; y++)
+                    for (int y = 0; y < oh; y++)
                     {
-                        int n = (y * pixels.Width) + ox;
-                        int i = (y - oy) * Columns;
-                        for (int x = ox; x < ow; x++)
+                        int n = (y + oy) * pixels.Width + ox;
+                        int i = y * Columns;
+                        for (int x = 0; x < ow; x++)
                         {
                             if ((data[n] & mask) != 0) bits[i] = true;
                             n++;


### PR DESCRIPTION
Thanks to the splendid detective work of @Ed55, I have now been able to solve both the issues brought up in #138 and #110 .

1. When looping over overlay pixels, the loop width and height was determined using overlay `Rows` and `Columns`, respectively. This order should be reversed, i.e. loop width should be determined based on overlay `Columns`, and loop height should be determined based on overlay `Rows`. This is relevant for rectangular overlays.
2. For embedded overlays, *Overlay Bits Allocated* should equal the main image *Bits Allocated*.
3. For embedded overlays, if *Overlay Bit Position* is zero, make an assumption that the overlay data is stored in the bits "above" the main image *Bits Stored*.

By handling item 1. in the list above correctly, the iteration scheme listed by @Ed55 in #138 becomes unnecessary.

Please review.