### PR TITLE
Dataset stop tag extended to tag/depth criterion. Connected to #136

### DIFF
--- a/DICOM.Tests/DicomFileTest.cs
+++ b/DICOM.Tests/DicomFileTest.cs
@@ -3,6 +3,7 @@
 
 namespace Dicom
 {
+    using System;
     using System.IO;
     using System.IO.MemoryMappedFiles;
     using System.Threading.Tasks;
@@ -150,6 +151,38 @@ namespace Dicom
         {
             var validHeader = DicomFile.HasValidHeader(@".\Test Data\CT1_J2KI");
             Assert.True(validHeader);
+        }
+
+        [Fact]
+        public void Open_StopAtOperatorsNameTag_OperatorsNameExcluded()
+        {
+            Func<DicomTag, int, bool> criterion = (tag, depth) => tag.CompareTo(DicomTag.OperatorsName) >= 0;
+            var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
+            Assert.False(file.Dataset.Contains(DicomTag.OperatorsName));
+        }
+
+        [Fact]
+        public void Open_StopAfterOperatorsNameTag_OperatorsNameIncluded()
+        {
+            Func<DicomTag, int, bool> criterion = (tag, depth) => tag.CompareTo(DicomTag.OperatorsName) > 0;
+            var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
+            Assert.True(file.Dataset.Contains(DicomTag.OperatorsName));
+        }
+
+        [Fact]
+        public void Open_StopAfterInstanceNumberTag_SequenceDepth0InstanceNumberExcluded()
+        {
+            Func<DicomTag, int, bool> criterion = (tag, depth) => tag.CompareTo(DicomTag.InstanceNumber) > 0;
+            var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
+            Assert.False(file.Dataset.Contains(DicomTag.InstanceNumber));
+        }
+
+        [Fact]
+        public void Open_StopAfterInstanceNumberTagAtDepth0_SequenceDepth0InstanceNumberIncluded()
+        {
+            Func<DicomTag, int, bool> criterion = (tag, depth) => depth == 0 && tag.CompareTo(DicomTag.InstanceNumber) > 0;
+            var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
+            Assert.True(file.Dataset.Contains(DicomTag.InstanceNumber));
         }
 
         #endregion

--- a/DICOM.Tests/DicomFileTest.cs
+++ b/DICOM.Tests/DicomFileTest.cs
@@ -156,7 +156,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAtOperatorsNameTag_OperatorsNameExcluded()
         {
-            Func<DicomTag, object, bool> criterion = (tag, state) => tag.CompareTo(DicomTag.OperatorsName) >= 0;
+            Func<ParseState, bool> criterion = state => state.Tag.CompareTo(DicomTag.OperatorsName) >= 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.False(file.Dataset.Contains(DicomTag.OperatorsName));
         }
@@ -164,7 +164,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAfterOperatorsNameTag_OperatorsNameIncluded()
         {
-            Func<DicomTag, object, bool> criterion = (tag, state) => tag.CompareTo(DicomTag.OperatorsName) > 0;
+            Func<ParseState, bool> criterion = state => state.Tag.CompareTo(DicomTag.OperatorsName) > 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.True(file.Dataset.Contains(DicomTag.OperatorsName));
         }
@@ -172,7 +172,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAfterInstanceNumberTag_SequenceDepth0InstanceNumberExcluded()
         {
-            Func<DicomTag, object, bool> criterion = (tag, state) => tag.CompareTo(DicomTag.InstanceNumber) > 0;
+            Func<ParseState, bool> criterion = state => state.Tag.CompareTo(DicomTag.InstanceNumber) > 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.False(file.Dataset.Contains(DicomTag.InstanceNumber));
         }
@@ -180,7 +180,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAfterInstanceNumberTagAtDepth0_SequenceDepth0InstanceNumberIncluded()
         {
-            Func<DicomTag, object, bool> criterion = (tag, depth) => (int)depth == 0 && tag.CompareTo(DicomTag.InstanceNumber) > 0;
+            Func<ParseState, bool> criterion = state => state.SequenceDepth == 0 && state.Tag.CompareTo(DicomTag.InstanceNumber) > 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.True(file.Dataset.Contains(DicomTag.InstanceNumber));
         }

--- a/DICOM.Tests/DicomFileTest.cs
+++ b/DICOM.Tests/DicomFileTest.cs
@@ -156,7 +156,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAtOperatorsNameTag_OperatorsNameExcluded()
         {
-            Func<DicomTag, int, bool> criterion = (tag, depth) => tag.CompareTo(DicomTag.OperatorsName) >= 0;
+            Func<DicomTag, object, bool> criterion = (tag, state) => tag.CompareTo(DicomTag.OperatorsName) >= 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.False(file.Dataset.Contains(DicomTag.OperatorsName));
         }
@@ -164,7 +164,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAfterOperatorsNameTag_OperatorsNameIncluded()
         {
-            Func<DicomTag, int, bool> criterion = (tag, depth) => tag.CompareTo(DicomTag.OperatorsName) > 0;
+            Func<DicomTag, object, bool> criterion = (tag, state) => tag.CompareTo(DicomTag.OperatorsName) > 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.True(file.Dataset.Contains(DicomTag.OperatorsName));
         }
@@ -172,7 +172,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAfterInstanceNumberTag_SequenceDepth0InstanceNumberExcluded()
         {
-            Func<DicomTag, int, bool> criterion = (tag, depth) => tag.CompareTo(DicomTag.InstanceNumber) > 0;
+            Func<DicomTag, object, bool> criterion = (tag, state) => tag.CompareTo(DicomTag.InstanceNumber) > 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.False(file.Dataset.Contains(DicomTag.InstanceNumber));
         }
@@ -180,7 +180,7 @@ namespace Dicom
         [Fact]
         public void Open_StopAfterInstanceNumberTagAtDepth0_SequenceDepth0InstanceNumberIncluded()
         {
-            Func<DicomTag, int, bool> criterion = (tag, depth) => depth == 0 && tag.CompareTo(DicomTag.InstanceNumber) > 0;
+            Func<DicomTag, object, bool> criterion = (tag, depth) => (int)depth == 0 && tag.CompareTo(DicomTag.InstanceNumber) > 0;
             var file = DicomFile.Open(@"Test Data\GH064.dcm", DicomEncoding.Default, criterion);
             Assert.True(file.Dataset.Contains(DicomTag.InstanceNumber));
         }

--- a/DICOM/DicomFile.cs
+++ b/DICOM/DicomFile.cs
@@ -189,8 +189,9 @@ namespace Dicom
         /// </summary>
         /// <param name="fileName">The filename of the DICOM file</param>
         /// <param name="fallbackEncoding">Encoding to apply when attribute Specific Character Set is not available.</param>
+        /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>DicomFile instance</returns>
-        public static DicomFile Open(string fileName, Encoding fallbackEncoding)
+        public static DicomFile Open(string fileName, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -204,11 +205,12 @@ namespace Dicom
 
                 using (var source = new FileByteSource(df.File))
                 {
-                    DicomFileReader reader = new DicomFileReader();
+                    var reader = new DicomFileReader();
                     if (reader.Read(
                         source,
                         new DicomDatasetReaderObserver(df.FileMetaInfo),
-                        new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding)) == DicomReaderResult.Error)
+                        new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding),
+                        stop) == DicomReaderResult.Error)
                     {
                         return null;
                     }
@@ -241,8 +243,9 @@ namespace Dicom
         /// </summary>
         /// <param name="stream">Stream to read.</param>
         /// <param name="fallbackEncoding">Encoding to use if encoding cannot be obtained from DICOM file.</param>
+        /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Read <see cref="DicomFile"/>.</returns>
-        public static DicomFile Open(Stream stream, Encoding fallbackEncoding)
+        public static DicomFile Open(Stream stream, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -258,7 +261,8 @@ namespace Dicom
                 if (reader.Read(
                     source,
                     new DicomDatasetReaderObserver(df.FileMetaInfo),
-                    new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding)) == DicomReaderResult.Error)
+                    new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding),
+                    stop) == DicomReaderResult.Error)
                 {
                     return null;
                 }
@@ -294,8 +298,9 @@ namespace Dicom
         /// </summary>
         /// <param name="fileName">The filename of the DICOM file</param>
         /// <param name="fallbackEncoding">Encoding to apply when attribute Specific Character Set is not available.</param>
+        /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomFile"/> instance.</returns>
-        public static async Task<DicomFile> OpenAsync(string fileName, Encoding fallbackEncoding)
+        public static async Task<DicomFile> OpenAsync(string fileName, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -315,7 +320,8 @@ namespace Dicom
                         reader.ReadAsync(
                             source,
                             new DicomDatasetReaderObserver(df.FileMetaInfo),
-                            new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding)).ConfigureAwait(false);
+                            new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding),
+                            stop).ConfigureAwait(false);
 
                     if (result == DicomReaderResult.Error)
                     {
@@ -349,8 +355,9 @@ namespace Dicom
         /// </summary>
         /// <param name="stream">Stream to read.</param>
         /// <param name="fallbackEncoding">Encoding to use if encoding cannot be obtained from DICOM file.</param>
+        /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomFile"/> instance.</returns>
-        public static async Task<DicomFile> OpenAsync(Stream stream, Encoding fallbackEncoding)
+        public static async Task<DicomFile> OpenAsync(Stream stream, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -368,7 +375,8 @@ namespace Dicom
                     reader.ReadAsync(
                         source,
                         new DicomDatasetReaderObserver(df.FileMetaInfo),
-                        new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding)).ConfigureAwait(false);
+                        new DicomDatasetReaderObserver(df.Dataset, fallbackEncoding),
+                        stop).ConfigureAwait(false);
 
                 if (result == DicomReaderResult.Error)
                 {

--- a/DICOM/DicomFile.cs
+++ b/DICOM/DicomFile.cs
@@ -13,6 +13,26 @@ namespace Dicom
     using Dicom.IO.Writer;
 
     /// <summary>
+    /// Container class for DICOM file parsing states.
+    /// </summary>
+    public sealed class ParseState
+    {
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets or sets the DICOM tag associated with the parse state.
+        /// </summary>
+        public DicomTag Tag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the sequence depth (zero-based) associated with the parse state.
+        /// </summary>
+        public int SequenceDepth { get; set; }
+
+        #endregion
+    }
+
+    /// <summary>
     /// Representation of one DICOM file.
     /// </summary>
     public partial class DicomFile
@@ -191,7 +211,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to apply when attribute Specific Character Set is not available.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>DicomFile instance</returns>
-        public static DicomFile Open(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
+        public static DicomFile Open(string fileName, Encoding fallbackEncoding, Func<ParseState, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -245,7 +265,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to use if encoding cannot be obtained from DICOM file.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Read <see cref="DicomFile"/>.</returns>
-        public static DicomFile Open(Stream stream, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
+        public static DicomFile Open(Stream stream, Encoding fallbackEncoding, Func<ParseState, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -300,7 +320,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to apply when attribute Specific Character Set is not available.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomFile"/> instance.</returns>
-        public static async Task<DicomFile> OpenAsync(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
+        public static async Task<DicomFile> OpenAsync(string fileName, Encoding fallbackEncoding, Func<ParseState, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -357,7 +377,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to use if encoding cannot be obtained from DICOM file.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomFile"/> instance.</returns>
-        public static async Task<DicomFile> OpenAsync(Stream stream, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
+        public static async Task<DicomFile> OpenAsync(Stream stream, Encoding fallbackEncoding, Func<ParseState, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {

--- a/DICOM/DicomFile.cs
+++ b/DICOM/DicomFile.cs
@@ -191,7 +191,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to apply when attribute Specific Character Set is not available.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>DicomFile instance</returns>
-        public static DicomFile Open(string fileName, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
+        public static DicomFile Open(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -245,7 +245,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to use if encoding cannot be obtained from DICOM file.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Read <see cref="DicomFile"/>.</returns>
-        public static DicomFile Open(Stream stream, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
+        public static DicomFile Open(Stream stream, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -300,7 +300,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to apply when attribute Specific Character Set is not available.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomFile"/> instance.</returns>
-        public static async Task<DicomFile> OpenAsync(string fileName, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
+        public static async Task<DicomFile> OpenAsync(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -357,7 +357,7 @@ namespace Dicom
         /// <param name="fallbackEncoding">Encoding to use if encoding cannot be obtained from DICOM file.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomFile"/> instance.</returns>
-        public static async Task<DicomFile> OpenAsync(Stream stream, Encoding fallbackEncoding, Func<DicomTag, int, bool> stop = null)
+        public static async Task<DicomFile> OpenAsync(Stream stream, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {

--- a/DICOM/IO/Reader/DicomFileReader.cs
+++ b/DICOM/IO/Reader/DicomFileReader.cs
@@ -16,6 +16,9 @@ namespace Dicom.IO.Reader
 
         private static readonly DicomTag FileMetaInfoStopTag = new DicomTag(0x0002, 0xffff);
 
+        private static readonly Func<DicomTag, int, bool> FileMetaInfoStopCriterion =
+            (tag, depth) => tag.CompareTo(FileMetaInfoStopTag) >= 0;
+
         private DicomFileFormat fileFormat;
 
         private DicomTransferSyntax syntax;
@@ -284,7 +287,7 @@ namespace Dicom.IO.Reader
             }
             else
             {
-                if (reader.Read(source, new DicomReaderMultiObserver(obs, fileMetasetInfoObserver), FileMetaInfoStopTag)
+                if (reader.Read(source, new DicomReaderMultiObserver(obs, fileMetasetInfoObserver), FileMetaInfoStopCriterion)
                     != DicomReaderResult.Stopped)
                 {
                     throw new DicomReaderException("DICOM File Meta Info ended prematurely");
@@ -358,7 +361,7 @@ namespace Dicom.IO.Reader
                     reader.ReadAsync(
                         source,
                         new DicomReaderMultiObserver(obs, fileMetasetInfoObserver),
-                        FileMetaInfoStopTag).ConfigureAwait(false) != DicomReaderResult.Stopped)
+                        FileMetaInfoStopCriterion).ConfigureAwait(false) != DicomReaderResult.Stopped)
                 {
                     throw new DicomReaderException("DICOM File Meta Info ended prematurely");
                 }

--- a/DICOM/IO/Reader/DicomFileReader.cs
+++ b/DICOM/IO/Reader/DicomFileReader.cs
@@ -16,8 +16,8 @@ namespace Dicom.IO.Reader
 
         private static readonly DicomTag FileMetaInfoStopTag = new DicomTag(0x0002, 0xffff);
 
-        private static readonly Func<DicomTag, object, bool> FileMetaInfoStopCriterion =
-            (tag, state) => tag.CompareTo(FileMetaInfoStopTag) >= 0;
+        private static readonly Func<ParseState, bool> FileMetaInfoStopCriterion =
+            state => state.Tag.CompareTo(FileMetaInfoStopTag) >= 0;
 
         private DicomFileFormat fileFormat;
 
@@ -81,7 +81,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetaInfo,
             IDicomReaderObserver dataset,
-            Func<DicomTag, object, bool> stop = null)
+            Func<ParseState, bool> stop = null)
         {
             var parse = Parse(source, fileMetaInfo, dataset, stop);
             lock (this.locker)
@@ -104,7 +104,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetaInfo,
             IDicomReaderObserver dataset,
-            Func<DicomTag, object, bool> stop = null)
+            Func<ParseState, bool> stop = null)
         {
             var parse = await ParseAsync(source, fileMetaInfo, dataset, stop).ConfigureAwait(false);
             lock (this.locker)
@@ -119,7 +119,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, object, bool> stop)
+            Func<ParseState, bool> stop)
         {
             if (!source.Require(132))
             {
@@ -146,7 +146,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, object, bool> stop)
+            Func<ParseState, bool> stop)
         {
             if (!source.Require(132))
             {
@@ -251,7 +251,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, object, bool> stop,
+            Func<ParseState, bool> stop,
             ref DicomTransferSyntax syntax,
             ref DicomFileFormat fileFormat)
         {
@@ -319,7 +319,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, object, bool> stop,
+            Func<ParseState, bool> stop,
             DicomTransferSyntax syntax,
             DicomFileFormat fileFormat)
         {

--- a/DICOM/IO/Reader/DicomFileReader.cs
+++ b/DICOM/IO/Reader/DicomFileReader.cs
@@ -16,8 +16,8 @@ namespace Dicom.IO.Reader
 
         private static readonly DicomTag FileMetaInfoStopTag = new DicomTag(0x0002, 0xffff);
 
-        private static readonly Func<DicomTag, int, bool> FileMetaInfoStopCriterion =
-            (tag, depth) => tag.CompareTo(FileMetaInfoStopTag) >= 0;
+        private static readonly Func<DicomTag, object, bool> FileMetaInfoStopCriterion =
+            (tag, state) => tag.CompareTo(FileMetaInfoStopTag) >= 0;
 
         private DicomFileFormat fileFormat;
 
@@ -81,7 +81,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetaInfo,
             IDicomReaderObserver dataset,
-            Func<DicomTag, int, bool> stop = null)
+            Func<DicomTag, object, bool> stop = null)
         {
             var parse = Parse(source, fileMetaInfo, dataset, stop);
             lock (this.locker)
@@ -104,7 +104,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetaInfo,
             IDicomReaderObserver dataset,
-            Func<DicomTag, int, bool> stop = null)
+            Func<DicomTag, object, bool> stop = null)
         {
             var parse = await ParseAsync(source, fileMetaInfo, dataset, stop).ConfigureAwait(false);
             lock (this.locker)
@@ -119,7 +119,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, int, bool> stop)
+            Func<DicomTag, object, bool> stop)
         {
             if (!source.Require(132))
             {
@@ -146,7 +146,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, int, bool> stop)
+            Func<DicomTag, object, bool> stop)
         {
             if (!source.Require(132))
             {
@@ -251,7 +251,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, int, bool> stop,
+            Func<DicomTag, object, bool> stop,
             ref DicomTransferSyntax syntax,
             ref DicomFileFormat fileFormat)
         {
@@ -319,7 +319,7 @@ namespace Dicom.IO.Reader
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
             IDicomReaderObserver datasetObserver,
-            Func<DicomTag, int, bool> stop,
+            Func<DicomTag, object, bool> stop,
             DicomTransferSyntax syntax,
             DicomFileFormat fileFormat)
         {

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -60,7 +60,7 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Reader resulting status.</returns>
-        public DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null)
+        public DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null)
         {
             var worker = new DicomReaderWorker(observer, stop, this.Dictionary, this.IsExplicitVR, this._private);
             return worker.DoWork(source);
@@ -73,7 +73,7 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Awaitable reader resulting status.</returns>
-        public Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null)
+        public Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null)
         {
             var worker = new DicomReaderWorker(observer, stop, this.Dictionary, this.IsExplicitVR, this._private);
             return worker.DoWorkAsync(source);
@@ -111,7 +111,7 @@ namespace Dicom.IO.Reader
 
             private readonly IDicomReaderObserver observer;
 
-            private readonly Func<DicomTag, object, bool> stop;
+            private readonly Func<ParseState, bool> stop;
 
             private readonly DicomDictionary dictionary;
 
@@ -150,7 +150,7 @@ namespace Dicom.IO.Reader
             /// </summary>
             internal DicomReaderWorker(
                 IDicomReaderObserver observer,
-                Func<DicomTag, object, bool> stop,
+                Func<ParseState, bool> stop,
                 DicomDictionary dictionary,
                 bool isExplicitVR,
                 Dictionary<uint, string> @private)
@@ -278,7 +278,8 @@ namespace Dicom.IO.Reader
                         this._tag = this._entry.Tag; // Use dictionary tag
                     }
 
-                    if (this.stop != null && this.stop(this._tag, this.sequenceDepth))
+                    if (this.stop != null
+                        && this.stop(new ParseState { Tag = this._tag, SequenceDepth = this.sequenceDepth }))
                     {
                         this.result = DicomReaderResult.Stopped;
                         return false;

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -60,7 +60,7 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Reader resulting status.</returns>
-        public DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, int, bool> stop = null)
+        public DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null)
         {
             var worker = new DicomReaderWorker(observer, stop, this.Dictionary, this.IsExplicitVR, this._private);
             return worker.DoWork(source);
@@ -73,7 +73,7 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Awaitable reader resulting status.</returns>
-        public Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, int, bool> stop = null)
+        public Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null)
         {
             var worker = new DicomReaderWorker(observer, stop, this.Dictionary, this.IsExplicitVR, this._private);
             return worker.DoWorkAsync(source);
@@ -111,7 +111,7 @@ namespace Dicom.IO.Reader
 
             private readonly IDicomReaderObserver observer;
 
-            private readonly Func<DicomTag, int, bool> stop;
+            private readonly Func<DicomTag, object, bool> stop;
 
             private readonly DicomDictionary dictionary;
 
@@ -150,7 +150,7 @@ namespace Dicom.IO.Reader
             /// </summary>
             internal DicomReaderWorker(
                 IDicomReaderObserver observer,
-                Func<DicomTag, int, bool> stop,
+                Func<DicomTag, object, bool> stop,
                 DicomDictionary dictionary,
                 bool isExplicitVR,
                 Dictionary<uint, string> @private)

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -44,7 +44,7 @@ namespace Dicom.IO.Reader
         public bool IsExplicitVR { get; set; }
 
         /// <summary>
-        /// Gets or sets the DICOM dictionary to be used by the reader..
+        /// Gets or sets the DICOM dictionary to be used by the reader.
         /// </summary>
         public DicomDictionary Dictionary { get; set; }
 

--- a/DICOM/IO/Reader/DicomReaderExtensions.cs
+++ b/DICOM/IO/Reader/DicomReaderExtensions.cs
@@ -17,7 +17,7 @@ namespace Dicom.IO.Reader
         /// <param name="this"><see cref="DicomReader"/> object performing the read operation.</param>
         /// <param name="source">Byte source to read.</param>
         /// <param name="observer">Reader observer.</param>
-        /// <param name="stop">Tag at which to stop.</param>
+        /// <param name="stop">Criterion at which to stop.</param>
         /// <param name="callback">Asynchronous callback.</param>
         /// <param name="state">Asynchronous state.</param>
         /// <returns>Asynchronous result handle to be managed by <see cref="EndRead"/>.</returns>
@@ -26,7 +26,7 @@ namespace Dicom.IO.Reader
             this DicomReader @this,
             IByteSource source,
             IDicomReaderObserver observer,
-            DicomTag stop,
+            Func<DicomTag, int, bool> stop,
             AsyncCallback callback,
             object state)
         {

--- a/DICOM/IO/Reader/DicomReaderExtensions.cs
+++ b/DICOM/IO/Reader/DicomReaderExtensions.cs
@@ -26,7 +26,7 @@ namespace Dicom.IO.Reader
             this DicomReader @this,
             IByteSource source,
             IDicomReaderObserver observer,
-            Func<DicomTag, object, bool> stop,
+            Func<ParseState, bool> stop,
             AsyncCallback callback,
             object state)
         {

--- a/DICOM/IO/Reader/DicomReaderExtensions.cs
+++ b/DICOM/IO/Reader/DicomReaderExtensions.cs
@@ -26,7 +26,7 @@ namespace Dicom.IO.Reader
             this DicomReader @this,
             IByteSource source,
             IDicomReaderObserver observer,
-            Func<DicomTag, int, bool> stop,
+            Func<DicomTag, object, bool> stop,
             AsyncCallback callback,
             object state)
         {

--- a/DICOM/IO/Reader/IDicomReader.cs
+++ b/DICOM/IO/Reader/IDicomReader.cs
@@ -3,6 +3,7 @@
 
 namespace Dicom.IO.Reader
 {
+    using System;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -56,17 +57,17 @@ namespace Dicom.IO.Reader
         /// </summary>
         /// <param name="source">Byte source to read.</param>
         /// <param name="observer">Reader observer.</param>
-        /// <param name="stop">Tag at which to stop.</param>
+        /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Reader resulting status.</returns>
-        DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, DicomTag stop = null);
+        DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, int, bool> stop = null);
 
         /// <summary>
         /// Asynchronously perform DICOM reading of a byte source.
         /// </summary>
         /// <param name="source">Byte source to read.</param>
         /// <param name="observer">Reader observer.</param>
-        /// <param name="stop">Tag at which to stop.</param>
+        /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Awaitable reader resulting status.</returns>
-        Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, DicomTag stop = null);
+        Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, int, bool> stop = null);
     }
 }

--- a/DICOM/IO/Reader/IDicomReader.cs
+++ b/DICOM/IO/Reader/IDicomReader.cs
@@ -3,6 +3,8 @@
 
 namespace Dicom.IO.Reader
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Possible DICOM reader results.
     /// </summary>
@@ -45,6 +47,11 @@ namespace Dicom.IO.Reader
         bool IsExplicitVR { get; set; }
 
         /// <summary>
+        /// Gets or sets the DICOM dictionary to be used by the reader.
+        /// </summary>
+        DicomDictionary Dictionary { get; set; }
+
+        /// <summary>
         /// Perform DICOM reading of a byte source.
         /// </summary>
         /// <param name="source">Byte source to read.</param>
@@ -52,5 +59,14 @@ namespace Dicom.IO.Reader
         /// <param name="stop">Tag at which to stop.</param>
         /// <returns>Reader resulting status.</returns>
         DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, DicomTag stop = null);
+
+        /// <summary>
+        /// Asynchronously perform DICOM reading of a byte source.
+        /// </summary>
+        /// <param name="source">Byte source to read.</param>
+        /// <param name="observer">Reader observer.</param>
+        /// <param name="stop">Tag at which to stop.</param>
+        /// <returns>Awaitable reader resulting status.</returns>
+        Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, DicomTag stop = null);
     }
 }

--- a/DICOM/IO/Reader/IDicomReader.cs
+++ b/DICOM/IO/Reader/IDicomReader.cs
@@ -59,7 +59,7 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Reader resulting status.</returns>
-        DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, int, bool> stop = null);
+        DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null);
 
         /// <summary>
         /// Asynchronously perform DICOM reading of a byte source.
@@ -68,6 +68,6 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Awaitable reader resulting status.</returns>
-        Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, int, bool> stop = null);
+        Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null);
     }
 }

--- a/DICOM/IO/Reader/IDicomReader.cs
+++ b/DICOM/IO/Reader/IDicomReader.cs
@@ -59,7 +59,7 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Reader resulting status.</returns>
-        DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null);
+        DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null);
 
         /// <summary>
         /// Asynchronously perform DICOM reading of a byte source.
@@ -68,6 +68,6 @@ namespace Dicom.IO.Reader
         /// <param name="observer">Reader observer.</param>
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Awaitable reader resulting status.</returns>
-        Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<DicomTag, object, bool> stop = null);
+        Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null);
     }
 }

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -179,8 +179,9 @@ namespace Dicom.Media
         /// </summary>
         /// <param name="fileName">File name.</param>
         /// <param name="fallbackEncoding">Encoding to apply if it cannot be identified from DICOM directory.</param>
+        /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns><see cref="DicomDirectory"/> instance.</returns>
-        public static new DicomDirectory Open(string fileName, Encoding fallbackEncoding)
+        public static new DicomDirectory Open(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -206,7 +207,8 @@ namespace Dicom.Media
                     var result = reader.Read(
                         source,
                         new DicomDatasetReaderObserver(df.FileMetaInfo),
-                        new DicomReaderMultiObserver(datasetObserver, dirObserver));
+                        new DicomReaderMultiObserver(datasetObserver, dirObserver),
+                        stop);
 
                     if (result == DicomReaderResult.Error)
                     {
@@ -244,8 +246,9 @@ namespace Dicom.Media
         /// </summary>
         /// <param name="fileName">File name.</param>
         /// <param name="fallbackEncoding">Encoding to apply if it cannot be identified from DICOM directory.</param>
+        /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomDirectory"/> instance.</returns>
-        public static new async Task<DicomDirectory> OpenAsync(string fileName, Encoding fallbackEncoding)
+        public static new async Task<DicomDirectory> OpenAsync(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -273,7 +276,8 @@ namespace Dicom.Media
                         reader.ReadAsync(
                             source,
                             new DicomDatasetReaderObserver(df.FileMetaInfo),
-                            new DicomReaderMultiObserver(datasetObserver, dirObserver)).ConfigureAwait(false);
+                            new DicomReaderMultiObserver(datasetObserver, dirObserver),
+                            stop).ConfigureAwait(false);
 
                     if (result == DicomReaderResult.Error)
                     {

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -181,7 +181,7 @@ namespace Dicom.Media
         /// <param name="fallbackEncoding">Encoding to apply if it cannot be identified from DICOM directory.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns><see cref="DicomDirectory"/> instance.</returns>
-        public static new DicomDirectory Open(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
+        public static new DicomDirectory Open(string fileName, Encoding fallbackEncoding, Func<ParseState, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {
@@ -248,7 +248,7 @@ namespace Dicom.Media
         /// <param name="fallbackEncoding">Encoding to apply if it cannot be identified from DICOM directory.</param>
         /// <param name="stop">Stop criterion in dataset.</param>
         /// <returns>Awaitable <see cref="DicomDirectory"/> instance.</returns>
-        public static new async Task<DicomDirectory> OpenAsync(string fileName, Encoding fallbackEncoding, Func<DicomTag, object, bool> stop = null)
+        public static new async Task<DicomDirectory> OpenAsync(string fileName, Encoding fallbackEncoding, Func<ParseState, bool> stop = null)
         {
             if (fallbackEncoding == null)
             {


### PR DESCRIPTION
I have now implemented a slightly more general "stop parse" handling in `DicomReader.Read` along the lines discussed by @Ed55 and @IanYates in #136 . Instead of a stop tag there is now a stop *criterion*, taking as in arguments the current parse tag and sequence depth, and returning `true` or `false`. Some example usages can be found in the included unit tests.

To make this functionality more accessible to end users, I have also propagated the stop criterion upwards in the call chain, so it is now an optional argument in a subset of the `DicomFile.Open` and `DicomFile.OpenAsync` overloads. 

Please note that the stop criterion only affects the main dataset parsing, file metaset information parsing is not affected.

Please review.