### PR TITLE
IImage now implements IDisposable.  Fixes WinFormsImage disposal issues. Connected to #144

### DIFF
--- a/DICOM.Platform/Desktop/DICOM.Desktop.csproj
+++ b/DICOM.Platform/Desktop/DICOM.Desktop.csproj
@@ -108,6 +108,7 @@
     <Compile Include="..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Imaging\DesktopImagingExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DICOM.Platform/Desktop/Imaging/DesktopImagingExtensions.cs
+++ b/DICOM.Platform/Desktop/Imaging/DesktopImagingExtensions.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace Dicom.Imaging
+{
+    public static class DesktopImagingExtensions
+    {
+        /// <summary>
+        /// Convenience method to access WinForms IImage instance as as WinForms Bitmap
+        /// The returned Bitmap will be disposed when the IImage is disposed
+        /// </summary>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        public static Bitmap AsBitmap(this IImage image)
+        {
+            return image.As<Bitmap>();
+        }
+
+        /// <summary>
+        /// Convenience method to access WinForms IImage instance as as WinForms Bitmap
+        /// The caller is responsible for disposal of the returned Bitmap
+        /// </summary>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        public static Bitmap AsBitmapCopy(this IImage image)
+        {
+            return (Bitmap)image.AsBitmap().Clone();
+        }
+
+        /// <summary>
+        /// Convenience method to access WPF IImage instance as a WPF WriteableBitmap
+        /// The WriteableBitmap will be disposed when the IImage is disposed
+        /// </summary>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        public static WriteableBitmap AsWriteableBitmap(this IImage image)
+        {
+            return image.As<WriteableBitmap>();
+        }
+
+        /// <summary>
+        /// Convenience method to access WPF IImage instance as a WPF WriteableBitmap
+        /// The caller is responsible for disposal of the returned WriteableBitmap
+        /// </summary>
+        /// <param name="image"></param>
+        /// <returns></returns>
+        public static WriteableBitmap AsWriteableBitmapCopy(this IImage image)
+        {
+            return image.AsWriteableBitmap().Clone();
+        }
+    }
+}

--- a/DICOM.Tests/Imaging/DicomImageTest.cs
+++ b/DICOM.Tests/Imaging/DicomImageTest.cs
@@ -30,6 +30,16 @@ namespace Dicom.Imaging
             }
         }
 
+        public void RenderImage_WinFormsManager_AsReturnsBitmap()
+        {
+            lock (this.@lock)
+            {
+                ImageManager.SetImplementation(WinFormsImageManager.Instance);
+                var image = new DicomImage(@".\Test Data\CT-MONO2-16-ankle").RenderImage();
+                Assert.IsAssignableFrom<Bitmap>(image.As<Bitmap>());
+            }
+        }
+
         [Fact]
         public void RenderImage_WPFManager_AsReturnsImageSource()
         {

--- a/DICOM.Tests/Imaging/WPFImageTest.cs
+++ b/DICOM.Tests/Imaging/WPFImageTest.cs
@@ -27,7 +27,7 @@ namespace Dicom.Imaging
         public void As_Bitmap_Throws()
         {
             var image = new WPFImage(100, 100, 3, false, false, 0, new PinnedIntArray(100 * 100));
-            Assert.Throws(typeof(InvalidCastException), () => image.As<Bitmap>());
+            Assert.Throws(typeof(DicomImagingException), () => image.As<Bitmap>());
         }
 
         #endregion

--- a/DICOM.Tests/Imaging/WinFormsImageTest.cs
+++ b/DICOM.Tests/Imaging/WinFormsImageTest.cs
@@ -27,7 +27,7 @@ namespace Dicom.Imaging
         public void As_ImageSource_Throws()
         {
             var image = new WinFormsImage(100, 100, 3, false, false, 0, new PinnedIntArray(100 * 100));
-            Assert.Throws(typeof(InvalidCastException), () => image.As<ImageSource>());
+            Assert.Throws(typeof(DicomImagingException), () => image.As<ImageSource>());
         }
 
         #endregion

--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -198,10 +198,8 @@ namespace Dicom.Imaging
         {
             if (frame != CurrentFrame || _pixelData == null) Load(Dataset, frame);
 
-            var graphic = new ImageGraphic(_pixelData);
-
-            try
-            {
+            using (var graphic = new ImageGraphic(_pixelData))
+            {   
                 if (ShowOverlays)
                 {
                     foreach (var overlay in _overlays)
@@ -220,13 +218,6 @@ namespace Dicom.Imaging
                 }
 
                 return graphic.RenderImage(this._pipeline.LUT);
-            }
-            finally
-            {
-                if (graphic != null)
-                {
-                    graphic.Dispose();
-                }
             }
         }
 

--- a/DICOM/Imaging/IImage.cs
+++ b/DICOM/Imaging/IImage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System;
+
 namespace Dicom.Imaging
 {
     using System.Collections.Generic;
@@ -10,7 +12,7 @@ namespace Dicom.Imaging
     /// <summary>
     /// Image interface.
     /// </summary>
-    public interface IImage
+    public interface IImage: IDisposable
     {
         #region METHODS
 

--- a/DICOM/Imaging/WPFImage.cs
+++ b/DICOM/Imaging/WPFImage.cs
@@ -54,7 +54,7 @@ namespace Dicom.Imaging
         /// <returns><see cref="IImage"/> object as specific (real image) type.</returns>
         public T As<T>()
         {
-            if (typeof (T) != typeof (WriteableBitmap))
+            if (!typeof (T).IsAssignableFrom(typeof(WriteableBitmap)))
             {
                 throw new DicomImagingException("WPFImage cannot return images in format other than WriteableBitmap");
             }

--- a/DICOM/Imaging/WPFImage.cs
+++ b/DICOM/Imaging/WPFImage.cs
@@ -54,6 +54,10 @@ namespace Dicom.Imaging
         /// <returns><see cref="IImage"/> object as specific (real image) type.</returns>
         public T As<T>()
         {
+            if (typeof (T) != typeof (WriteableBitmap))
+            {
+                throw new DicomImagingException("WPFImage cannot return images in format other than WriteableBitmap");
+            }
             return (T)(object)this.image;
         }
 
@@ -117,5 +121,10 @@ namespace Dicom.Imaging
         }
 
         #endregion
+
+        public void Dispose()
+        {
+            //nothing to dispose
+        }
     }
 }

--- a/DICOM/Imaging/WinFormsImage.cs
+++ b/DICOM/Imaging/WinFormsImage.cs
@@ -16,14 +16,13 @@ namespace Dicom.Imaging
     /// <summary>
     /// <see cref="IImage"/> implementation of a Windows Forms <see cref="Image"/>.
     /// </summary>
-    public sealed class WinFormsImage : IImage, IDisposable
+    public sealed class WinFormsImage : IImage
     {
         #region FIELDS
 
         private PinnedIntArray pixelsCopy;
         private Bitmap image;
         private bool disposed;
-        private readonly Logger logger;
 
         #endregion
 
@@ -69,7 +68,7 @@ namespace Dicom.Imaging
         /// <returns><see cref="IImage"/> object as specific (real image) type.</returns>
         public T As<T>()
         {
-            if (typeof(T) != typeof(Bitmap) || typeof(T) != typeof(Image))
+            if (!typeof(T).IsAssignableFrom(typeof(Bitmap)))
             {
                 throw new DicomImagingException("WinFormsImage cannot return images in format other than Bitmap or Image");
             }
@@ -86,7 +85,7 @@ namespace Dicom.Imaging
             {
                 foreach (var graphic in graphics)
                 {
-                    var layer = graphic.RenderImage(null).As<Bitmap>();
+                    var layer = graphic.RenderImage(null).As<Image>();
                     g.DrawImage(layer, graphic.ScaledOffsetX, graphic.ScaledOffsetY, graphic.ScaledWidth, graphic.ScaledHeight);
                 }
             }

--- a/DICOM/Imaging/WinFormsImage.cs
+++ b/DICOM/Imaging/WinFormsImage.cs
@@ -41,8 +41,7 @@ namespace Dicom.Imaging
         public WinFormsImage(int width, int height, int components, bool flipX, bool flipY, int rotation, PinnedIntArray pixels)
         {
             this.disposed = false;
-            this.logger = LogManager.GetLogger("DICOM.Imaging.WinFormsImage");
-
+            
             var format = components == 4 ? PixelFormat.Format32bppArgb : PixelFormat.Format32bppRgb;
             var stride = GetStride(width, format);
 


### PR DESCRIPTION
See issue #144 

IImage now implements IDisposable

Both WinFormsImage and WPFImage were updated.  I don't have Xaramin installed on this machine so non-Desktop files have not been updated.  Sorry :(

Convenience methods added in a static extension methods class to avoid the As<> syntax.  I toyed with changing IImage to IImage<T> but that wasn't really workable.  The extension methods make the conversion to a WPF WriteableBitmap or a WinForms Bitmap/Image more discoverable.