### PR TITLE
WaitForAssociation always return true even if aborted

### DIFF
--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -258,7 +258,7 @@ namespace Dicom.Network
         {
             if (this.aborted) return;
 
-            if (this.associateNotifier != null) this.associateNotifier.TrySetResult(true);
+            if (this.associateNotifier != null) this.associateNotifier.TrySetResult(false);
             if (this.completeNotifier != null) this.completeNotifier.TrySetResult(true);
 
             if (this.networkStream != null)


### PR DESCRIPTION
I was testing WaitForAssociation method in the case of a rejection.
It is saying returns "True if association is established, false otherwise"
But it always returns true even in the case of an abort.
I think the problem comes from this line where the result should be set to false instead of true.

I am not a dicom expert and not used to fo dicom source code, so I might be totally wrong but I'd like to know what do you guys think of this?