### PR TITLE
Handle Abort correctly in WaitForAssociation. Connected to #159

### DIFF
--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -210,6 +210,23 @@ namespace Dicom.Network
         }
 
         [Fact]
+        public void WaitForAssociation_Aborted_ReturnsFalse()
+        {
+            int port = Ports.GetNext();
+            using (new DicomServer<MockCEchoProvider>(port))
+            {
+                var client = new DicomClient();
+                client.AddRequest(new DicomCEchoRequest());
+                var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
+
+                client.Abort();
+                var actual = client.WaitForAssociation(500);
+
+                Assert.Equal(false, actual);
+            }
+        }
+
+        [Fact]
         public async Task WaitForAssociationAsync_WithinTimeout_ReturnsTrue()
         {
             int port = Ports.GetNext();
@@ -237,6 +254,23 @@ namespace Dicom.Network
 
                 var actual = await client.WaitForAssociationAsync(1);
                 task.Wait(10000);
+                Assert.Equal(false, actual);
+            }
+        }
+
+        [Fact]
+        public async Task WaitForAssociationAsync_Aborted_ReturnsFalse()
+        {
+            int port = Ports.GetNext();
+            using (new DicomServer<MockCEchoProvider>(port))
+            {
+                var client = new DicomClient();
+                client.AddRequest(new DicomCEchoRequest());
+                var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
+                client.Abort();
+
+                var actual = await client.WaitForAssociationAsync(500);
+
                 Assert.Equal(false, actual);
             }
         }

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -259,7 +259,10 @@ namespace Dicom.Network
         {
             if (this.aborted) return;
 
-            if (this.associateNotifier != null) this.associateNotifier.TrySetResult(false);
+            if (this.associateNotifier != null && !this.associateNotifier.Task.IsCompleted)
+            {
+                this.associateNotifier.TrySetResult(false);
+            }
             if (this.completeNotifier != null) this.completeNotifier.TrySetResult(true);
 
             if (this.networkStream != null)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -197,7 +197,8 @@ namespace Dicom.Network
         /// <returns>True if association is established, false otherwise.</returns>
         public bool WaitForAssociation(int millisecondsTimeout = 5000)
         {
-            return this.associateNotifier != null && this.associateNotifier.Task.Wait(millisecondsTimeout);
+            return this.associateNotifier != null && this.associateNotifier.Task.Wait(millisecondsTimeout)
+                   && this.associateNotifier.Task.Result;
         }
 
         /// <summary>
@@ -209,7 +210,7 @@ namespace Dicom.Network
         {
             if (this.associateNotifier == null) return false;
             var task = await Task.WhenAny(this.associateNotifier.Task, Task.Delay(millisecondsTimeout)).ConfigureAwait(false);
-            return task is Task<bool>;
+            return task is Task<bool> && ((Task<bool>)task).Result;
         }
 
         /// <summary>
@@ -258,7 +259,7 @@ namespace Dicom.Network
         {
             if (this.aborted) return;
 
-            if (this.associateNotifier != null) this.associateNotifier.TrySetResult(true);
+            if (this.associateNotifier != null) this.associateNotifier.TrySetResult(false);
             if (this.completeNotifier != null) this.completeNotifier.TrySetResult(true);
 
             if (this.networkStream != null)
@@ -302,7 +303,10 @@ namespace Dicom.Network
 
         private void FinalizeSend()
         {
-            this.associateNotifier.TrySetResult(true);
+            if (!this.associateNotifier.Task.IsCompleted)
+            {
+                this.associateNotifier.TrySetResult(true);
+            }
 
             if (this.networkStream != null)
             {


### PR DESCRIPTION
As superbly noted by @do0om in PR #156, there are issues with `WaitForAssociation` returning `true` even if the association request is aborted beforehand.

This is now solved by setting task return value to `false` upon abort, and subsequently checking for the task return value in the `WaitForAssociation` and `WaitForAssociationAsync` methods.

Please review.