### PR TITLE
Improved DICOM parameter validation in GrayscaleRenderOptions. Connected to #161

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
-#### v2.0.0 (Beta 3, 11/20/2015)
+#### v2.0.0 (Release Candidate, 12/XX/2015)
+* Checking for valid Window Center and Window Width values before using in GrayscaleRenderOptions (#161 #163)
 * Initialize managers automatically via reflection (#148 #149)
 * Message Command Field Priority invalid for C-ECHO and all DIMSE-N Requests (#141 #143)
 * Overlay data error corrections (#110 #138 #140)

--- a/DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
+++ b/DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
@@ -27,6 +27,167 @@ namespace Dicom.Imaging
             Assert.Same(ColorTable.Monochrome1, options.ColorMap);
         }
 
+        [Theory]
+        [InlineData((ushort)16, (ushort)12, (ushort)0, 1.0, 0.0, 500.0, 20.0, "LINEAR")]
+        public void FromWindowLevel_ValidInput_CorrectOutput(
+            ushort bitsAllocated,
+            ushort bitsStored,
+            ushort pixelRepresentation,
+            double rescaleSlope,
+            double rescaleIntercept,
+            double windowWidth,
+            double windowCenter,
+            string voiLutFunction)
+        {
+            var dataset = new DicomDataset(
+                new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
+                new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, pixelRepresentation),
+                new DicomDecimalString(DicomTag.RescaleSlope, (decimal)rescaleSlope),
+                new DicomDecimalString(DicomTag.RescaleIntercept, (decimal)rescaleIntercept),
+                new DicomDecimalString(DicomTag.WindowWidth, (decimal)windowWidth),
+                new DicomDecimalString(DicomTag.WindowCenter, (decimal)windowCenter),
+                new DicomCodeString(DicomTag.VOILUTFunction, voiLutFunction));
+
+            var actual = GrayscaleRenderOptions.FromWindowLevel(dataset);
+
+            Assert.Equal(windowWidth, actual.WindowWidth);
+            Assert.Equal(windowCenter, actual.WindowCenter);
+        }
+
+        [Theory]
+        [InlineData((ushort)16, (ushort)12, (ushort)0, 1.0, 0.0, 500.0, 20.0, "LINEAR")]
+        public void FromDataset_WindowCenterWidth_ReturnsSameAsFromWindowLevel(
+            ushort bitsAllocated,
+            ushort bitsStored,
+            ushort pixelRepresentation,
+            double rescaleSlope,
+            double rescaleIntercept,
+            double windowWidth,
+            double windowCenter,
+            string voiLutFunction)
+        {
+            var dataset = new DicomDataset(
+                new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
+                new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, pixelRepresentation),
+                new DicomDecimalString(DicomTag.RescaleSlope, (decimal)rescaleSlope),
+                new DicomDecimalString(DicomTag.RescaleIntercept, (decimal)rescaleIntercept),
+                new DicomDecimalString(DicomTag.WindowWidth, (decimal)windowWidth),
+                new DicomDecimalString(DicomTag.WindowCenter, (decimal)windowCenter),
+                new DicomCodeString(DicomTag.VOILUTFunction, voiLutFunction));
+
+            var expected = GrayscaleRenderOptions.FromWindowLevel(dataset);
+            var actual = GrayscaleRenderOptions.FromDataset(dataset);
+
+            Assert.Equal(expected.WindowWidth, actual.WindowWidth);
+            Assert.Equal(expected.WindowCenter, actual.WindowCenter);
+        }
+
+        [Theory]
+        [InlineData((ushort)16, (ushort)12, 1.0, 0.0, (short)-150, (short)1050, "LINEAR", 1200.0, 450.0)]
+        public void FromImagePixelValueTags_ValidSignedInput_CorrectOutput(
+            ushort bitsAllocated,
+            ushort bitsStored,
+            double rescaleSlope,
+            double rescaleIntercept,
+            short smallestImagePixelValue,
+            short largestImagePixelValue,
+            string voiLutFunction,
+            double expectedWindowWidth,
+            double expectedWindowCenter)
+        {
+            var dataset = new DicomDataset(
+                new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
+                new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, 1),
+                new DicomDecimalString(DicomTag.RescaleSlope, (decimal)rescaleSlope),
+                new DicomDecimalString(DicomTag.RescaleIntercept, (decimal)rescaleIntercept),
+                new DicomSignedShort(DicomTag.SmallestImagePixelValue, smallestImagePixelValue),
+                new DicomSignedShort(DicomTag.LargestImagePixelValue, largestImagePixelValue),
+                new DicomCodeString(DicomTag.VOILUTFunction, voiLutFunction));
+
+            var actual = GrayscaleRenderOptions.FromImagePixelValueTags(dataset);
+
+            Assert.Equal(expectedWindowWidth, actual.WindowWidth);
+            Assert.Equal(expectedWindowCenter, actual.WindowCenter);
+        }
+
+        [Theory]
+        [InlineData((ushort)16, (ushort)12, 1.0, 0.0, (short)-150, (short)1050, "LINEAR", 1200.0, 450.0)]
+        public void FromDataset_PixelLimits_ReturnsSameAsFromImagePixelValueTags(
+            ushort bitsAllocated,
+            ushort bitsStored,
+            double rescaleSlope,
+            double rescaleIntercept,
+            short smallestImagePixelValue,
+            short largestImagePixelValue,
+            string voiLutFunction,
+            double expectedWindowWidth,
+            double expectedWindowCenter)
+        {
+            var dataset = new DicomDataset(
+                new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
+                new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, 1),
+                new DicomDecimalString(DicomTag.RescaleSlope, (decimal)rescaleSlope),
+                new DicomDecimalString(DicomTag.RescaleIntercept, (decimal)rescaleIntercept),
+                new DicomSignedShort(DicomTag.SmallestImagePixelValue, smallestImagePixelValue),
+                new DicomSignedShort(DicomTag.LargestImagePixelValue, largestImagePixelValue),
+                new DicomCodeString(DicomTag.VOILUTFunction, voiLutFunction));
+
+            var expected = GrayscaleRenderOptions.FromImagePixelValueTags(dataset);
+            var actual = GrayscaleRenderOptions.FromDataset(dataset);
+
+            Assert.Equal(expected.WindowWidth, actual.WindowWidth);
+            Assert.Equal(expected.WindowCenter, actual.WindowCenter);
+        }
+
+        [Theory]
+        [InlineData((ushort)16, (ushort)12, 1.0, 0.0, (ushort)150, (ushort)1050, "LINEAR", 900.0, 600.0)]
+        public void FromImagePixelValueTags_ValidUnsignedInput_CorrectOutput(
+            ushort bitsAllocated,
+            ushort bitsStored,
+            double rescaleSlope,
+            double rescaleIntercept,
+            ushort smallestImagePixelValue,
+            ushort largestImagePixelValue,
+            string voiLutFunction,
+            double expectedWindowWidth,
+            double expectedWindowCenter)
+        {
+            var dataset = new DicomDataset(
+                new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
+                new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, 0),
+                new DicomDecimalString(DicomTag.RescaleSlope, (decimal)rescaleSlope),
+                new DicomDecimalString(DicomTag.RescaleIntercept, (decimal)rescaleIntercept),
+                new DicomUnsignedShort(DicomTag.SmallestImagePixelValue, smallestImagePixelValue),
+                new DicomUnsignedShort(DicomTag.LargestImagePixelValue, largestImagePixelValue),
+                new DicomCodeString(DicomTag.VOILUTFunction, voiLutFunction));
+
+            var actual = GrayscaleRenderOptions.FromImagePixelValueTags(dataset);
+
+            Assert.Equal(expectedWindowWidth, actual.WindowWidth);
+            Assert.Equal(expectedWindowCenter, actual.WindowCenter);
+        }
+
+        [Fact]
+        public void FromImagePixelValueTags_SmallestGreaterThanLargest_Throws()
+        {
+            var dataset = new DicomDataset(
+                new DicomUnsignedShort(DicomTag.BitsAllocated, 8),
+                new DicomUnsignedShort(DicomTag.BitsStored, 8),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, 0),
+                new DicomDecimalString(DicomTag.RescaleSlope, (decimal)1),
+                new DicomDecimalString(DicomTag.RescaleIntercept, (decimal)0),
+                new DicomUnsignedShort(DicomTag.SmallestImagePixelValue, 180),
+                new DicomUnsignedShort(DicomTag.LargestImagePixelValue, 90),
+                new DicomCodeString(DicomTag.VOILUTFunction, "LINEAR"));
+
+            Assert.Throws<DicomImagingException>(() => GrayscaleRenderOptions.FromImagePixelValueTags(dataset));
+        }
+
         #endregion
     }
 }

--- a/Setup/version.cmd
+++ b/Setup/version.cmd
@@ -1,1 +1,1 @@
-set version=2.0.0-beta3
+set version=2.0.0-rc

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -17,6 +17,6 @@ using System.Resources;
 [assembly: AssemblyCultureAttribute("")]
 [assembly: NeutralResourcesLanguage("en")]
 
-[assembly: AssemblyVersionAttribute("1.9.5")]
-[assembly: AssemblyFileVersion("1.9.5.3")]
-[assembly: AssemblyInformationalVersionAttribute("1.9.5")]
+[assembly: AssemblyVersionAttribute("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.1")]
+[assembly: AssemblyInformationalVersionAttribute("2.0.0")]


### PR DESCRIPTION
* In `FromDataset`, add check that window width is at least 1 and that window center before requesting calculation using these parameters.
* In `FromDataset` add check that smallest pixel value is not greater than largest pixel value before requesting calculation using these parameters.
* In `FromImagePixelValueTags`, if smallest pixel value is greater than largest pixel value, throw `DicomImagingException`.

Added a few unit tests to verify a sub-set of functionality.

Please review.