### PR TITLE
Expose listening task status and errors. Connected to #157

### DIFF
--- a/DICOM.Tests/DICOM.Tests.csproj
+++ b/DICOM.Tests/DICOM.Tests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Media\DicomFileScannerTest.cs" />
     <Compile Include="Network\DicomCEchoProviderTest.cs" />
     <Compile Include="Network\DicomClientTest.cs" />
+    <Compile Include="Network\DicomServerTest.cs" />
     <Compile Include="Network\DicomServiceTest.cs" />
     <Compile Include="Network\PDUTest.cs" />
     <Compile Include="Logging\MessageNameFormatToOrdinalFormatTests.cs" />

--- a/DICOM.Tests/Network/DicomServerTest.cs
+++ b/DICOM.Tests/Network/DicomServerTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2012-2015 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System.Net.Sockets;
+    using System.Threading;
+
+    using Xunit;
+
+    [Collection("Network"), Trait("Category", "Network")]
+    public class DicomServerTest
+    {
+        [Fact]
+        public void Constructor_EstablishTwoWithSamePort_ShouldYieldAccessibleException()
+        {
+            var port = Ports.GetNext();
+
+            var server1 = new DicomServer<DicomCEchoProvider>(port);
+            Thread.Sleep(500);  // Allow for server1 to start listening
+            var server2 = new DicomServer<DicomCEchoProvider>(port);
+            Thread.Sleep(500);  // Allow for server2 to attempt listening
+
+            Assert.True(server1.IsListening);
+            Assert.Null(server1.Exception);
+
+            Assert.False(server2.IsListening);
+            Assert.IsType<SocketException>(server2.Exception);
+        }
+    }
+}

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -130,6 +130,7 @@ namespace Dicom.Network
             {
                 this.Stop();
                 this.cancellationSource.Dispose();
+                this.clients.Clear();
             }
 
             this.disposed = true;


### PR DESCRIPTION
@IanYates I couldn't keep my hands away from this one, sorry :-)

In this PR, I have made the listening task a class member, allowing me to expose the task completion status and potential exception.

I have also lifted the `CancellationTokenSource` object to become a class member and using this field to control the termination of the listening process. Instead of calling `Dispose`, the user can instead call the added `Stop()` method, which calls the `CancellationTokenSource.Cancel` method.

Even though this is not a 1-to-1 correspondence with version 1.x, I hope that these modifications should expose the properties necessary to validate the server status, and that the class has also become more maintainable at the same time.

@IanYates @BobSter3000 and others, please review.

I thought it best to complete this issue before moving on to #158 . I hope you all agree.