### PR TITLE
Ability to cancel server listening prematurely. Connected to #158

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@
 * Xamarin Android platform library with imaging cabability (#113 #117)
 * Xamarin iOS platform library with imaging cabability (#111 #112)
 * Portable Core and platform-specific assemblies, including basic Mono implementation (#13 #93 #94 #60 #109)
-* Network abstraction layer (#86 #106 #156 #159 #160)
+* Network abstraction layer (#86 #106 #156 #159 #160 #157 #164 #158 #165)
 * Transcoder abstraction layer (#102 #105)
 * Synchronized LogManager API with other managers (#103 #104)
 * Image abstraction layer (#83 #85 #92 #101 #144 #145 #150)

--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -37,9 +37,9 @@ namespace Dicom.Network
 
         [Theory]
         [InlineData(2)]
-        [InlineData(5)]
         [InlineData(20)]
         [InlineData(100)]
+        [InlineData(1000)]
         public void Send_MultipleRequests_AllRecognized(int expected)
         {
             int port = Ports.GetNext();
@@ -58,6 +58,7 @@ namespace Dicom.Network
 
         [Theory]
         [InlineData(20)]
+        [InlineData(200)]
         public void Send_MultipleTimes_AllRecognized(int expected)
         {
             int port = Ports.GetNext();
@@ -97,9 +98,9 @@ namespace Dicom.Network
 
         [Theory]
         [InlineData(2)]
-        [InlineData(5)]
         [InlineData(20)]
         [InlineData(100)]
+        [InlineData(1000)]
         public async Task SendAsync_MultipleRequests_AllRecognized(int expected)
         {
             int port = Ports.GetNext();
@@ -119,6 +120,7 @@ namespace Dicom.Network
 
         [Theory]
         [InlineData(20)]
+        [InlineData(200)]
         public async Task SendAsync_MultipleTimes_AllRecognized(int expected)
         {
             int port = Ports.GetNext();

--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -62,6 +62,8 @@ namespace Dicom.Network
         public void Send_MultipleTimes_AllRecognized(int expected)
         {
             int port = Ports.GetNext();
+            var @lock = new object();
+
             using (new DicomServer<DicomCEchoProvider>(port))
             {
                 var actual = 0;
@@ -69,7 +71,7 @@ namespace Dicom.Network
                 var client = new DicomClient();
                 for (var i = 0; i < expected; ++i)
                 {
-                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { ++actual; } });
+                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { lock (@lock) ++actual; } });
                     client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
                 }
 
@@ -124,6 +126,8 @@ namespace Dicom.Network
         public async Task SendAsync_MultipleTimes_AllRecognized(int expected)
         {
             int port = Ports.GetNext();
+            var @lock = new object();
+
             using (new DicomServer<DicomCEchoProvider>(port))
             {
                 var actual = 0;
@@ -131,7 +135,7 @@ namespace Dicom.Network
                 var client = new DicomClient();
                 for (var i = 0; i < expected; ++i)
                 {
-                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { ++actual; } });
+                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { lock (@lock) ++actual; } });
                     var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
                     await Task.WhenAny(task, Task.Delay(1000));
                 }

--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -69,7 +69,7 @@ namespace Dicom.Network
                 var client = new DicomClient();
                 for (var i = 0; i < expected; ++i)
                 {
-                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { lock (client) ++actual; } });
+                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { ++actual; } });
                     client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
                 }
 
@@ -131,7 +131,7 @@ namespace Dicom.Network
                 var client = new DicomClient();
                 for (var i = 0; i < expected; ++i)
                 {
-                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { lock (client) ++actual; } });
+                    client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => { ++actual; } });
                     var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
                     await Task.WhenAny(task, Task.Delay(1000));
                 }

--- a/DICOM.Tests/Network/DicomServerTest.cs
+++ b/DICOM.Tests/Network/DicomServerTest.cs
@@ -27,5 +27,25 @@ namespace Dicom.Network
             Assert.False(server2.IsListening);
             Assert.IsType<SocketException>(server2.Exception);
         }
+
+        [Fact]
+        public void Stop_IsListening_TrueUntilStopRequested()
+        {
+            var port = Ports.GetNext();
+
+            var server = new DicomServer<DicomCEchoProvider>(port);
+            while (!server.IsListening) Thread.Sleep(10);
+
+            for (var i = 0; i < 10; ++i)
+            {
+                Thread.Sleep(500);
+                Assert.True(server.IsListening);
+            }
+
+            server.Stop();
+            Thread.Sleep(500);
+
+            Assert.False(server.IsListening);
+        }
     }
 }

--- a/DICOM.Tests/Network/DicomServerTest.cs
+++ b/DICOM.Tests/Network/DicomServerTest.cs
@@ -17,7 +17,7 @@ namespace Dicom.Network
             var port = Ports.GetNext();
 
             var server1 = new DicomServer<DicomCEchoProvider>(port);
-            Thread.Sleep(500);  // Allow for server1 to start listening
+            while (!server1.IsListening) Thread.Sleep(10);
             var server2 = new DicomServer<DicomCEchoProvider>(port);
             Thread.Sleep(500);  // Allow for server2 to attempt listening
 

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -6,6 +6,7 @@ namespace Dicom.Network
     using System.Net;
     using System.Net.Sockets;
     using System.Security.Cryptography.X509Certificates;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// .NET implementation of the <see cref="INetworkListener"/>.
@@ -23,9 +24,11 @@ namespace Dicom.Network
         #region CONSTRUCTORS
 
         /// <summary>
-        /// Initializes an instance of <see cref="DesktopNetworkListener"/>.
+        /// Initializes a new instance of the <see cref="DesktopNetworkListener"/> class. 
         /// </summary>
-        /// <param name="port"></param>
+        /// <param name="port">
+        /// TCP/IP port to listen to.
+        /// </param>
         internal DesktopNetworkListener(int port)
         {
             this.listener = new TcpListener(IPAddress.Any, port);
@@ -38,9 +41,11 @@ namespace Dicom.Network
         /// <summary>
         /// Start listening.
         /// </summary>
-        public void Start()
+        /// <returns>An await:able <see cref="Task"/>.</returns>
+        public Task StartAsync()
         {
             this.listener.Start();
+            return Task.FromResult(0);
         }
 
         /// <summary>

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -62,12 +62,15 @@ namespace Dicom.Network
         /// <param name="certificateName">Certificate name of authenticated connections.</param>
         /// <param name="noDelay">No delay?</param>
         /// <returns>Connected network stream.</returns>
-        public INetworkStream AcceptNetworkStream(string certificateName, bool noDelay)
+        public async Task<INetworkStream> AcceptNetworkStreamAsync(string certificateName, bool noDelay)
         {
-            var tcpClient = this.listener.AcceptTcpClient();
+            var tcpClient = await this.listener.AcceptTcpClientAsync().ConfigureAwait(false);
             tcpClient.NoDelay = noDelay;
 
-            if (!string.IsNullOrEmpty(certificateName) && this.certificate == null) this.certificate = GetX509Certificate(certificateName);
+            if (!string.IsNullOrEmpty(certificateName) && this.certificate == null)
+            {
+                this.certificate = GetX509Certificate(certificateName);
+            }
 
             return new DesktopNetworkStream(tcpClient, this.certificate);
         }

--- a/DICOM/Network/INetworkListener.cs
+++ b/DICOM/Network/INetworkListener.cs
@@ -27,6 +27,6 @@ namespace Dicom.Network
         /// <param name="certificateName">Certificate name of authenticated connections.</param>
         /// <param name="noDelay">No delay?</param>
         /// <returns>Connected network stream.</returns>
-        INetworkStream AcceptNetworkStream(string certificateName, bool noDelay);
+        Task<INetworkStream> AcceptNetworkStreamAsync(string certificateName, bool noDelay);
     }
 }

--- a/DICOM/Network/INetworkListener.cs
+++ b/DICOM/Network/INetworkListener.cs
@@ -3,6 +3,8 @@
 
 namespace Dicom.Network
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Interface for listening to network stream connections.
     /// </summary>
@@ -11,7 +13,8 @@ namespace Dicom.Network
         /// <summary>
         /// Start listening.
         /// </summary>
-        void Start();
+        /// <returns>An await:able <see cref="Task"/>.</returns>
+        Task StartAsync();
 
         /// <summary>
         /// Stop listening.

--- a/DICOM/Network/INetworkListener.cs
+++ b/DICOM/Network/INetworkListener.cs
@@ -3,6 +3,7 @@
 
 namespace Dicom.Network
 {
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -26,7 +27,8 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="certificateName">Certificate name of authenticated connections.</param>
         /// <param name="noDelay">No delay?</param>
+        /// <param name="token">Cancellation token.</param>
         /// <returns>Connected network stream.</returns>
-        Task<INetworkStream> AcceptNetworkStreamAsync(string certificateName, bool noDelay);
+        Task<INetworkStream> AcceptNetworkStreamAsync(string certificateName, bool noDelay, CancellationToken token);
     }
 }

--- a/DICOM/Network/WindowsNetworkListener.cs
+++ b/DICOM/Network/WindowsNetworkListener.cs
@@ -6,6 +6,7 @@ namespace Dicom.Network
     using System;
     using System.Globalization;
     using System.Threading;
+    using System.Threading.Tasks;
 
     using Windows.Networking.Sockets;
     using Windows.Security.Cryptography.Certificates;
@@ -30,9 +31,9 @@ namespace Dicom.Network
         #region CONSTRUCTORS
 
         /// <summary>
-        /// Initializes an instance of <see cref="WindowsNetworkListener"/>.
+        /// Initializes a new instance of the <see cref="WindowsNetworkListener"/> class. 
         /// </summary>
-        /// <param name="port"></param>
+        /// <param name="port">TCP/IP port to listen to.</param>
         internal WindowsNetworkListener(int port)
         {
             this.port = port.ToString(CultureInfo.InvariantCulture);
@@ -46,7 +47,8 @@ namespace Dicom.Network
         /// <summary>
         /// Start listening.
         /// </summary>
-        public async void Start()
+        /// <returns>An await:able <see cref="Task"/>.</returns>
+        public async Task StartAsync()
         {
             this.listener = new StreamSocketListener();
             this.listener.ConnectionReceived += this.OnConnectionReceived;


### PR DESCRIPTION
@IanYates again sorry for barging in, but while I was at it I thought I'd deal with this issue too.

I have added asynchronous behavior to `INetworkListener`, and thereby enabled the ability to cancel the listening procedure before a network stream connection is established.

Due to these changes the `Server` class is substantially refactored, but the unit tests indicates that the new implementation has improved reliability.

Please review.