### PR TITLE
Removed Modality Dicom Tag in Study Request

### DIFF
--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -79,7 +79,6 @@ namespace Dicom.Network
             dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
             dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             dimse.Dataset.Add(DicomTag.ModalitiesInStudy, modalitiesInStudy);
-            dimse.Dataset.Add(DicomTag.Modality, modalitiesInStudy);
             dimse.Dataset.Add(DicomTag.StudyID, studyId);
             dimse.Dataset.Add(DicomTag.AccessionNumber, accession);
             dimse.Dataset.Add(DicomTag.StudyDate, studyDateTime);


### PR DESCRIPTION
According to the [official specification] (http://dicom.nema.org/dicom/2013/output/chtml/part04/sect_C.6.html),
for a study level query, Modalities in Study should be used but Modality should not as it's Series specific.
Another source : ftp://medical.nema.org/medical/dicom/final/cp071_ft.pdf

What do you think?