### PR TITLE
Fix for DicomDictionary lazy initialisation. Connected to #168

### DIFF
--- a/Tools/DICOM Dump/MainForm.cs
+++ b/Tools/DICOM Dump/MainForm.cs
@@ -26,7 +26,7 @@ namespace Dicom.Dump
 
         protected override void OnLoad(EventArgs e)
         {
-            DicomDictionary.LoadInternalDictionaries(ModifierKeys != Keys.Shift);
+            DicomDictionary.EnsureDefaultDictionariesLoaded(ModifierKeys != Keys.Shift);
 
             var args = Environment.GetCommandLineArgs();
             if (args.Length > 1)


### PR DESCRIPTION
Renamed the method to EnsureDefaultDictionariesLoaded - since we're not yet at 2.0 stable and it's probably quite rare someone's actually called the public `LoadInternalDictionaries` method.

The DICOM Dump tool does call this method so it was fixed to use the new name.

Closes #168