### PR TITLE
DicomDictionary.Default setter and EnsureLoaded...() behaviour

### DIFF
--- a/DICOM.Tests/DicomDictionaryTest.cs
+++ b/DICOM.Tests/DicomDictionaryTest.cs
@@ -55,7 +55,7 @@ namespace Dicom
         }
 
         [Fact]
-        public void Throw_If_Already_Loaded()
+        public void Throws_If_Already_Loaded()
         {
             var dict = DicomDictionary.EnsureDefaultDictionariesLoaded(false);
             Assert.Throws<DicomDataException>(() => DicomDictionary.Default = new DicomDictionary());
@@ -87,6 +87,49 @@ namespace Dicom
             Assert.All(multipleSimultaneousCallsToDefault, dicomDict=>Assert.Equal(dicomDict, firstResolvedDict));
         }
 
+
+        [Fact]
+        public void Can_Call_EnsureLoaded_Multiple_Times_Including_Private()
+        {
+            DicomDictionary.EnsureDefaultDictionariesLoaded(true);
+            DicomDictionary.EnsureDefaultDictionariesLoaded(true);
+            DicomDictionary.EnsureDefaultDictionariesLoaded();
+        }
+
+
+        [Fact]
+        public void Can_Call_EnsureLoaded_Multiple_Times_Excluding_Private()
+        {
+            DicomDictionary.EnsureDefaultDictionariesLoaded(false);
+            DicomDictionary.EnsureDefaultDictionariesLoaded(false);
+            DicomDictionary.EnsureDefaultDictionariesLoaded();
+        }
+
+
+        [Fact]
+        public void Throws_If_EnsureLoaded_Called_With_And_Without_Private()
+        {
+            DicomDictionary.EnsureDefaultDictionariesLoaded(true);
+            Assert.Throws<DicomDataException>(() => DicomDictionary.EnsureDefaultDictionariesLoaded(false));
+        }
+
+
+        [Fact]
+        public void Throws_If_EnsureLoaded_Called_Without_And_With_Private()
+        {
+            DicomDictionary.EnsureDefaultDictionariesLoaded(false);
+            Assert.Throws<DicomDataException>(() => DicomDictionary.EnsureDefaultDictionariesLoaded(true));
+        }
+
+        [Fact]
+        public void EnsureLoaded_Assumes_Loading_Private_Dictionary_Data_By_Default()
+        {
+            var dict = DicomDictionary.EnsureDefaultDictionariesLoaded();
+            var secondEnsurCall = DicomDictionary.EnsureDefaultDictionariesLoaded(loadPrivateDictionary: true);
+            Assert.Equal(dict, secondEnsurCall);
+            Assert.Throws<DicomDataException>(
+                () => DicomDictionary.EnsureDefaultDictionariesLoaded(loadPrivateDictionary: false));
+        }
 
         #endregion
 

--- a/DICOM.Tests/DicomDictionaryTest.cs
+++ b/DICOM.Tests/DicomDictionaryTest.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) 2012-2015 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Drawing.Drawing2D;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Dicom
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     using Xunit;
 

--- a/DICOM/DicomDictionary.cs
+++ b/DICOM/DicomDictionary.cs
@@ -178,6 +178,10 @@ namespace Dicom
             {
                 lock (_lock)
                 {
+                    if (_default != null)
+                    {
+                        throw new DicomDataException("Cannot set Default DicomDictionary as it has already been initialised");
+                    }
                     _default = value;
                 }
             }

--- a/DICOM/DicomException.cs
+++ b/DICOM/DicomException.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Dicom
 {


### PR DESCRIPTION
This PR continues from #169.

The setter for `DicomDictionary.Default` has logic to prevent its invocation if we've already initalised the default dictionary.  Note that it doesn't check it we're calling the setter with the existing dictionary - that'd be unlikely but I'm happy to update the PR if required.  However it's probably a bit of an end-user code smell if the setter is being called multiple times anyway.

Additionally, the `EnsureDefaultDictionariesLoaded()` method now takes a nullable boolean indicating whether or not a private dictionary should be loaded.  It's nullable because the null value is used to indicate the caller will accept the already-loaded dictionary data.  If no such data exists then the previous default behaviour - to load private dictionaries - is preserved.

Unit tests confirming this behaviour are included.  There's also a test that tries to simulate multiple simultaneous calls to ensure the dictionary is loaded and validates that all calls result in the same dictionary.  There's no guarantee these are truly executing in parallel.  One way to check this would be to have verbose logging output indicate if the race to initialise was won, lost or not even necessary and ensure that only one task won and the rest either lost or didn't even race since `_default` was already non-null by the time they entered the method call.  Not sure it's worth the effort.

Finally, there are some issues running these tests in XUnit - at least with ReSharper.  The static data stays around between tests within the same test run so the dictionary appears to be initialised already in some tests.  Running them individually shows they all pass.  I don't use statics much in my own code so I don't run into this issue.  I'm looking to see whether or not we can give XUnit some attributes at the assembly, class or test method level to indicate the app domain should be completely torn down between tests.