### PR TITLE
Explicitly include DICOM.Core project in DICOM.Mono solution.

### DIFF
--- a/DICOM.Mono.sln
+++ b/DICOM.Mono.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "C-Store SCP.Mono", "Example
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DICOM.Mono", "DICOM.Platform\Mono\DICOM.Mono.csproj", "{0E451E9D-3F37-46C1-98D3-3090743061CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DICOM.Core", "DICOM\DICOM.Core.csproj", "{A661D347-CF7D-4F36-8101-0544AE85EEEC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,6 +27,10 @@ Global
 		{8C433ABF-AFE5-4A76-BEBC-74116EC3460E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8C433ABF-AFE5-4A76-BEBC-74116EC3460E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C433ABF-AFE5-4A76-BEBC-74116EC3460E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A661D347-CF7D-4F36-8101-0544AE85EEEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A661D347-CF7D-4F36-8101-0544AE85EEEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A661D347-CF7D-4F36-8101-0544AE85EEEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A661D347-CF7D-4F36-8101-0544AE85EEEC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D9AF008C-EE25-49B3-96F6-E81B8A59D017}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D9AF008C-EE25-49B3-96F6-E81B8A59D017}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9AF008C-EE25-49B3-96F6-E81B8A59D017}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/DICOM.Platform/Mono/DICOM.Mono.csproj
+++ b/DICOM.Platform/Mono/DICOM.Mono.csproj
@@ -37,9 +37,6 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="Dicom.Core">
-      <HintPath>..\..\packages\fo-dicom.Core.2.0.0-beta1\lib\portable-net45+netcore45+wpa81\Dicom.Core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -105,6 +102,9 @@
     <Folder Include="Imaging\Codec\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <ProjectReference Include="..\..\DICOM\DICOM.Core.csproj">
+      <Project>{A661D347-CF7D-4F36-8101-0544AE85EEEC}</Project>
+      <Name>DICOM.Core</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/DICOM.Platform/Mono/packages.config
+++ b/DICOM.Platform/Mono/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="fo-dicom.Core" version="2.0.0-beta1" targetFramework="net45" />
-</packages>

--- a/Examples/C-Store SCP/C-Store SCP.Mono.csproj
+++ b/Examples/C-Store SCP/C-Store SCP.Mono.csproj
@@ -47,9 +47,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Dicom.Core">
-      <HintPath>..\..\packages\fo-dicom.Core.2.0.0-beta1\lib\portable-net45+netcore45+wpa81\Dicom.Core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">
@@ -62,7 +59,6 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
@@ -83,6 +79,10 @@
     <ProjectReference Include="..\..\DICOM.Platform\Mono\DICOM.Mono.csproj">
       <Project>{0E451E9D-3F37-46C1-98D3-3090743061CF}</Project>
       <Name>DICOM.Mono</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DICOM\DICOM.Core.csproj">
+      <Project>{A661D347-CF7D-4F36-8101-0544AE85EEEC}</Project>
+      <Name>DICOM.Core</Name>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/Examples/C-Store SCP/packages.config
+++ b/Examples/C-Store SCP/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="fo-dicom.Core" version="2.0.0-beta1" targetFramework="net45" />
-</packages>

--- a/Tools/DICOM Dump/DICOM Dump.Mono.csproj
+++ b/Tools/DICOM Dump/DICOM Dump.Mono.csproj
@@ -48,9 +48,6 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="Dicom.Core">
-      <HintPath>..\..\packages\fo-dicom.Core.2.0.0-beta1\lib\portable-net45+netcore45+wpa81\Dicom.Core.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">
@@ -107,7 +104,6 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
@@ -121,6 +117,10 @@
     <ProjectReference Include="..\..\DICOM.Platform\Mono\DICOM.Mono.csproj">
       <Project>{0E451E9D-3F37-46C1-98D3-3090743061CF}</Project>
       <Name>DICOM.Mono</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\DICOM\DICOM.Core.csproj">
+      <Project>{A661D347-CF7D-4F36-8101-0544AE85EEEC}</Project>
+      <Name>DICOM.Core</Name>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/Tools/DICOM Dump/packages.config
+++ b/Tools/DICOM Dump/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="fo-dicom.Core" version="2.0.0-beta1" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
This is an alternative PR to the one made in #171, intended to be less intrusive than the original PR.

NuGet packages are no longer used, instead the *DICOM.Core* project is included explicitly in the solution.

When opening the *DICOM.Mono* solution with *DICOM.Core* included, the *.csproj* file will be undesirably updated. This update is **not** included in the commit, since it is an artefact of *Xamarin Studio* and I don’t want it to interfere with the use of the project in *Visual Studio*.

@HelderMPinhal and others, please review.