### PR TITLE
Linger before closing a non-exception close request. Connected to #167

### DIFF
--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -234,9 +234,18 @@ namespace Dicom.Network
             await this.SendNextPDUAsync().ConfigureAwait(false);
         }
 
-        private void CloseConnection(Exception exception)
+        private async void CloseConnection(Exception exception)
         {
             if (!_isConnected) return;
+
+            if (exception == null)
+            {
+                await Task.Delay((this.Options ?? DicomServiceOptions.Default).ThreadPoolLinger);
+                lock (this._lock)
+                {
+                    if (this._pduQueue.Count > 0 || this._msgQueue.Count > 0 || this._pending.Count > 0) return;
+                }
+            }
 
             _isConnected = false;
             try


### PR DESCRIPTION
The following modification solve the issue with failing network unit tests on the CI server, #167. 

I have re-enabled the use of the thread pool linger which was present in 1.x when asynchronous `DicomService` tasks were performed via a `ThreadPoolQueue`. In the fix here I am using this lingering time as a temporary hold-up in the `CloseConnection` method, and if no work has been placed in queue during that hold-up time, the connection is definitely closed.

I am still not entirely pleased with the solution, but it does improve the network functionality up to the level that all unit tests pass even on the CI server. Fail safety is also better than 1.x; when the same unit tests are performed on 1.1.0 with the `ThreadPoolQueue` approach, the tests fail.

Please review.