### PR TITLE
Possible fix for #195

### DIFF
--- a/DICOM/IO/Buffer/CompositeByteBuffer.cs
+++ b/DICOM/IO/Buffer/CompositeByteBuffer.cs
@@ -62,7 +62,7 @@ namespace Dicom.IO.Buffer
                 {
                     try
                     {
-                        System.Buffer.BlockCopy(Buffers[pos].Data, offset, data, offset2, remain);
+                        System.Buffer.BlockCopy(Buffers[pos].Data, offset, data, offset2, count);
                     }
                     catch (Exception)
                     {
@@ -73,8 +73,8 @@ namespace Dicom.IO.Buffer
 
                 else
                 {
-                    byte[] temp = Buffers[pos].GetByteRange(offset, remain);
-                    System.Buffer.BlockCopy(temp, 0, data, offset2, remain);
+                    byte[] temp = Buffers[pos].GetByteRange(offset, count);
+                    System.Buffer.BlockCopy(temp, 0, data, offset2, count);
                 }
 
                 count -= remain;


### PR DESCRIPTION
Tested with the problem image cited in #195 and tested this with a known working simple two-frame image and the second frame was able to be loaded fine. Further testing by others is probably warranted.
