### PR TITLE
Remove single thread limitation in unit tests. Connected to #82

### DIFF
--- a/DICOM.Tests/App.config
+++ b/DICOM.Tests/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <appSettings>
-    <add key="xunit.maxParallelThreads" value="1"/>
-  </appSettings>
-</configuration>

--- a/DICOM.Tests/DICOM.Tests.csproj
+++ b/DICOM.Tests/DICOM.Tests.csproj
@@ -163,7 +163,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
     <None Include="packages.config" />
     <None Include="Test Data\GH195.dcm">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
It appears like the latest fixes on networking unit tests and the `DicomDictionary` have solved the concurrency issues brought up in #82. Therefore it should now be possible to remove the requirement that all unit tests be run in same thread.

Please review.