### PR TITLE
Cureos transfers

### DIFF
--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -703,18 +703,23 @@ namespace Dicom
             {
                 if (_formats == null)
                 {
-                    _formats = new string[11];
-                    _formats[0] = "yyyyMMddHHmmsszzz";
-                    _formats[1] = "yyyyMMddHHmmsszz";
-                    _formats[2] = "yyyyMMddHHmmssz";
-                    _formats[3] = "yyyyMMddHHmmss.fff";
-                    _formats[4] = "yyyyMMddHHmmss.ff";
-                    _formats[5] = "yyyyMMddHHmmss.f";
-                    _formats[6] = "yyyyMMddHHmmss";
-                    _formats[7] = "yyyyMMddHHmm";
-                    _formats[8] = "yyyyMMdd";
-                    _formats[9] = "yyyy.MM.dd";
-                    _formats[10] = "yyyy/MM/dd";
+                    _formats = new[]
+                    {
+                        "yyyyMMddHHmmsszzz",
+                        "yyyyMMddHHmmsszz",
+                        "yyyyMMddHHmmssz",
+                        "yyyyMMddHHmmss.ffffff",
+                        "yyyyMMddHHmmss.fffff",
+                        "yyyyMMddHHmmss.ffff",
+                        "yyyyMMddHHmmss.fff",
+                        "yyyyMMddHHmmss.ff",
+                        "yyyyMMddHHmmss.f",
+                        "yyyyMMddHHmmss",
+                        "yyyyMMddHHmm",
+                        "yyyyMMdd",
+                        "yyyy.MM.dd",
+                        "yyyy/MM/dd"
+                    };
                 }
                 return _formats;
             }

--- a/DICOM/DicomMaskedTag.cs
+++ b/DICOM/DicomMaskedTag.cs
@@ -143,7 +143,7 @@ namespace Dicom
                 ushort e = ushort.Parse(element.ToLower().Replace('x', '0'), NumberStyles.HexNumber);
                 tag.Tag = new DicomTag(g, e);
 
-                string mask = group + element;
+                string mask = (group + element).ToLowerInvariant();
                 mask =
                     mask.Replace('0', 'f')
                         .Replace('1', 'f')


### PR DESCRIPTION
There are a few very small modifications in my *Cureos* fork (originally contributed by @rickardraysearch) that have not been transferred to the main fork before. Just to make sure they are not forgotten, here is a pull request with these modifications included.

With this transfer, the *Cureos* fork should not contain any further enhancements compared to this main fork, except for the functionality requested in #173 (which needs to be made in a more consistent manner anyway due to cross-platform considerations).

Please review.