### PR TITLE
Include remote host and port in DicomAssociation. Connected to #173

### DIFF
--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -327,7 +327,7 @@ namespace Dicom.Network
 
         public class MockCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
         {
-            public MockCEchoProvider(Stream stream, Logger log)
+            public MockCEchoProvider(INetworkStream stream, Logger log)
                 : base(stream, log)
             {
             }

--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -4,7 +4,6 @@
 namespace Dicom.Network
 {
     using System;
-    using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -15,6 +14,24 @@ namespace Dicom.Network
     [Collection("Network"), Trait("Category", "Network")]
     public class DicomClientTest
     {
+        #region Fields
+
+        private static string remoteHost;
+
+        private static int remotePort;
+
+        #endregion
+
+        #region Constructors
+
+        public DicomClientTest()
+        {
+            remoteHost = null;
+            remotePort = 0;
+        }
+
+        #endregion
+
         #region Unit tests
 
         [Fact]
@@ -321,6 +338,21 @@ namespace Dicom.Network
             }
         }
 
+        [Fact]
+        public void Send_RecordAssociationData_AssociationContainsHostAndPort()
+        {
+            int port = Ports.GetNext();
+            using (new DicomServer<MockCEchoProvider>(port))
+            {
+                var client = new DicomClient();
+                client.AddRequest(new DicomCEchoRequest());
+                client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
+
+                Assert.NotNull(remoteHost);
+                Assert.NotEqual(port, remotePort);
+            }
+        }
+
         #endregion
 
         #region Support classes
@@ -335,6 +367,8 @@ namespace Dicom.Network
             public void OnReceiveAssociationRequest(DicomAssociation association)
             {
                 Thread.Sleep(1000);
+                DicomClientTest.remoteHost = association.RemoteHost;
+                DicomClientTest.remotePort = association.RemotePort;
                 this.SendAssociationAccept(association);
             }
 

--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -360,7 +360,7 @@ namespace Dicom.Network
         public class MockCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
         {
             public MockCEchoProvider(INetworkStream stream, Logger log)
-                : base(stream, log)
+                : base(stream, DicomEncoding.Default, log)
             {
             }
 

--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -4,6 +4,7 @@
 namespace Dicom.Network
 {
     using System;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -359,8 +360,8 @@ namespace Dicom.Network
 
         public class MockCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
         {
-            public MockCEchoProvider(INetworkStream stream, Logger log)
-                : base(stream, DicomEncoding.Default, log)
+            public MockCEchoProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+                : base(stream, fallbackEncoding, log)
             {
             }
 

--- a/DICOM.Tests/Network/DicomClientTest.cs
+++ b/DICOM.Tests/Network/DicomClientTest.cs
@@ -350,6 +350,7 @@ namespace Dicom.Network
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
                 Assert.NotNull(remoteHost);
+                Assert.True(remotePort > 0);
                 Assert.NotEqual(port, remotePort);
             }
         }

--- a/DICOM.Tests/Network/DicomServiceTest.cs
+++ b/DICOM.Tests/Network/DicomServiceTest.cs
@@ -5,6 +5,7 @@ namespace Dicom.Network
 {
     using System;
     using System.IO;
+    using System.Text;
     using System.Threading.Tasks;
 
     using Dicom.Log;
@@ -104,8 +105,8 @@ namespace Dicom.Network
                     DicomTransferSyntax.ImplicitVRLittleEndian
                 };
 
-            public SimpleCStoreProvider(INetworkStream stream, Logger log)
-                : base(stream, DicomEncoding.Default, log)
+            public SimpleCStoreProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+                : base(stream, fallbackEncoding, log)
             {
             }
 

--- a/DICOM.Tests/Network/DicomServiceTest.cs
+++ b/DICOM.Tests/Network/DicomServiceTest.cs
@@ -104,7 +104,7 @@ namespace Dicom.Network
                     DicomTransferSyntax.ImplicitVRLittleEndian
                 };
 
-            public SimpleCStoreProvider(Stream stream, Logger log)
+            public SimpleCStoreProvider(INetworkStream stream, Logger log)
                 : base(stream, log)
             {
             }

--- a/DICOM.Tests/Network/DicomServiceTest.cs
+++ b/DICOM.Tests/Network/DicomServiceTest.cs
@@ -105,7 +105,7 @@ namespace Dicom.Network
                 };
 
             public SimpleCStoreProvider(INetworkStream stream, Logger log)
-                : base(stream, log)
+                : base(stream, DicomEncoding.Default, log)
             {
             }
 

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Net;
-
 namespace Dicom.Network
 {
     using System;
     using System.IO;
+    using System.Net;
     using System.Net.Security;
     using System.Net.Sockets;
     using System.Security.Authentication;

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Net;
+
 namespace Dicom.Network
 {
     using System;
@@ -37,6 +39,8 @@ namespace Dicom.Network
         /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
         internal DesktopNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
+            this.Host = host;
+            this.Port = port;
             this.tcpClient = new TcpClient(host, port) { NoDelay = noDelay };
 
             Stream stream = this.tcpClient.GetStream();
@@ -63,6 +67,9 @@ namespace Dicom.Network
         /// is initialized with this server-side constructor.</remarks>
         internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate)
         {
+            this.Host = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
+            this.Port = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Port;
+
             Stream stream = tcpClient.GetStream();
             if (certificate != null)
             {
@@ -81,6 +88,20 @@ namespace Dicom.Network
         {
             this.Dispose(false);
         }
+
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the host of the network stream.
+        /// </summary>
+        public string Host { get; }
+
+        /// <summary>
+        /// Gets the port of the network stream.
+        /// </summary>
+        public int Port { get; }
 
         #endregion
 

--- a/DICOM/Network/DicomAssociation.cs
+++ b/DICOM/Network/DicomAssociation.cs
@@ -30,7 +30,7 @@ namespace Dicom.Network
 
         public int MaxAsyncOpsPerformed { get; set; }
 
-        public DicomUID RemoteImplemetationClassUID { get; internal set; }
+        public DicomUID RemoteImplementationClassUID { get; internal set; }
 
         public string RemoteImplementationVersion { get; internal set; }
 
@@ -45,7 +45,7 @@ namespace Dicom.Network
             sb.AppendFormat("Called AE Title:        {0}\n", CalledAE);
             sb.AppendFormat(
                 "Implementation Class:   {0}\n",
-                RemoteImplemetationClassUID ?? DicomImplementation.ClassUID);
+                this.RemoteImplementationClassUID ?? DicomImplementation.ClassUID);
             sb.AppendFormat("Implementation Version: {0}\n", RemoteImplementationVersion ?? DicomImplementation.Version);
             sb.AppendFormat("Maximum PDU Length:     {0}\n", MaximumPDULength);
             sb.AppendFormat("Async Ops Invoked:      {0}\n", MaxAsyncOpsInvoked);

--- a/DICOM/Network/DicomAssociation.cs
+++ b/DICOM/Network/DicomAssociation.cs
@@ -55,6 +55,16 @@ namespace Dicom.Network
         public int MaxAsyncOpsPerformed { get; set; }
 
         /// <summary>
+        /// Gets the remote host.
+        /// </summary>
+        public string RemoteHost { get; internal set; }
+
+        /// <summary>
+        /// Gets the remote port.
+        /// </summary>
+        public int RemotePort { get; internal set; }
+
+        /// <summary>
         /// Gets the remote implementation class UID.
         /// </summary>
         public DicomUID RemoteImplementationClassUID { get; internal set; }
@@ -69,6 +79,9 @@ namespace Dicom.Network
         /// </summary>
         public uint MaximumPDULength { get; internal set; }
 
+        /// <summary>
+        /// Gets the supported presentation contexts.
+        /// </summary>
         public DicomPresentationContextCollection PresentationContexts { get; private set; }
 
         /// <summary>
@@ -83,6 +96,8 @@ namespace Dicom.Network
             var sb = new StringBuilder();
             sb.AppendFormat("Calling AE Title:       {0}\n", CallingAE);
             sb.AppendFormat("Called AE Title:        {0}\n", CalledAE);
+            sb.AppendFormat("Remote host:            {0}\n", RemoteHost);
+            sb.AppendFormat("Remote port:            {0}\n", RemotePort);
             sb.AppendFormat(
                 "Implementation Class:   {0}\n",
                 this.RemoteImplementationClassUID ?? DicomImplementation.ClassUID);

--- a/DICOM/Network/DicomAssociation.cs
+++ b/DICOM/Network/DicomAssociation.cs
@@ -1,12 +1,18 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Text;
-
 namespace Dicom.Network
 {
+    using System.Text;
+
+    /// <summary>
+    /// Representation of a DICOM association.
+    /// </summary>
     public sealed class DicomAssociation
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomAssociation"/> class. 
+        /// </summary>
         public DicomAssociation()
         {
             PresentationContexts = new DicomPresentationContextCollection();
@@ -14,6 +20,12 @@ namespace Dicom.Network
             MaxAsyncOpsPerformed = 1;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomAssociation"/> class.
+        /// </summary>
+        /// <param name="callingAe">The calling Application Entity.</param>
+        /// <param name="calledAe">The called Application Entity.</param>
+        /// <param name="maxPduLength">Maximum PDU length.</param>
         public DicomAssociation(string callingAe, string calledAe, uint maxPduLength = 16384)
             : this()
         {
@@ -22,22 +34,50 @@ namespace Dicom.Network
             MaximumPDULength = maxPduLength;
         }
 
+        /// <summary>
+        /// Gets the calling application entity.
+        /// </summary>
         public string CallingAE { get; internal set; }
 
+        /// <summary>
+        /// Gets the called application entity.
+        /// </summary>
         public string CalledAE { get; internal set; }
 
+        /// <summary>
+        /// Gets or sets the supported maximum number of asynchronous operations invoked.
+        /// </summary>
         public int MaxAsyncOpsInvoked { get; set; }
 
+        /// <summary>
+        /// Gets or sets the supported maximum number of asynchronous operations performed.
+        /// </summary>
         public int MaxAsyncOpsPerformed { get; set; }
 
+        /// <summary>
+        /// Gets the remote implementation class UID.
+        /// </summary>
         public DicomUID RemoteImplementationClassUID { get; internal set; }
 
+        /// <summary>
+        /// Gets the remote implementation version.
+        /// </summary>
         public string RemoteImplementationVersion { get; internal set; }
 
+        /// <summary>
+        /// Gets the maximum PDU length.
+        /// </summary>
         public uint MaximumPDULength { get; internal set; }
 
         public DicomPresentationContextCollection PresentationContexts { get; private set; }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.IO;
-
-using Dicom.Log;
-
 namespace Dicom.Network
 {
+    using System;
+
+    using Dicom.Log;
+
     public class DicomCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
     {
         public DicomCEchoProvider(INetworkStream stream, Logger log)

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Text;
+
 namespace Dicom.Network
 {
     using System;
@@ -9,8 +11,8 @@ namespace Dicom.Network
 
     public class DicomCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
     {
-        public DicomCEchoProvider(INetworkStream stream, Logger log)
-            : base(stream, log)
+        public DicomCEchoProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
         {
         }
 

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -10,7 +10,7 @@ namespace Dicom.Network
 {
     public class DicomCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
     {
-        public DicomCEchoProvider(Stream stream, Logger log)
+        public DicomCEchoProvider(INetworkStream stream, Logger log)
             : base(stream, log)
         {
         }

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -138,7 +138,7 @@ namespace Dicom.Network
                 RemoteHost = host,
                 RemotePort = port
             };
-            this.InitializeSend(this.networkStream.AsStream(), assoc);
+            this.InitializeSend(this.networkStream, assoc);
 
             this.completeNotifier.Task.Wait();
             this.FinalizeSend();
@@ -169,7 +169,7 @@ namespace Dicom.Network
                 RemoteHost = host,
                 RemotePort = port
             };
-            this.InitializeSend(this.networkStream.AsStream(), assoc);
+            this.InitializeSend(this.networkStream, assoc);
 
             await this.completeNotifier.Task.ConfigureAwait(false);
             this.FinalizeSend();
@@ -181,7 +181,7 @@ namespace Dicom.Network
         /// <param name="stream">Established network stream.</param>
         /// <param name="callingAe">Calling Application Entity Title.</param>
         /// <param name="calledAe">Called Application Entity Title.</param>
-        public void Send(Stream stream, string callingAe, string calledAe)
+        public void Send(INetworkStream stream, string callingAe, string calledAe)
         {
             if (!this.CanSend) return;
 
@@ -203,7 +203,7 @@ namespace Dicom.Network
         /// <param name="callingAe">Calling Application Entity Title.</param>
         /// <param name="calledAe">Called Application Entity Title.</param>
         /// <returns>Awaitable task.</returns>
-        public async Task SendAsync(Stream stream, string callingAe, string calledAe)
+        public async Task SendAsync(INetworkStream stream, string callingAe, string calledAe)
         {
             if (!this.CanSend) return;
 
@@ -310,7 +310,7 @@ namespace Dicom.Network
             this.aborted = true;
         }
 
-        private void InitializeSend(Stream stream, DicomAssociation association)
+        private void InitializeSend(INetworkStream stream, DicomAssociation association)
         {
             foreach (var request in this.requests)
             {
@@ -369,7 +369,7 @@ namespace Dicom.Network
 
             internal DicomServiceUser(
                 DicomClient client,
-                Stream stream,
+                INetworkStream stream,
                 DicomAssociation association,
                 DicomServiceOptions options,
                 Logger log)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -5,7 +5,6 @@ namespace Dicom.Network
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -194,7 +194,9 @@ namespace Dicom.Network
             var assoc = new DicomAssociation(callingAe, calledAe)
             {
                 MaxAsyncOpsInvoked = this.asyncInvoked,
-                MaxAsyncOpsPerformed = this.asyncPerformed
+                MaxAsyncOpsPerformed = this.asyncPerformed,
+                RemoteHost = stream.Host,
+                RemotePort = stream.Port
             };
             this.InitializeSend(stream, assoc);
 
@@ -216,7 +218,9 @@ namespace Dicom.Network
             var assoc = new DicomAssociation(callingAe, calledAe)
             {
                 MaxAsyncOpsInvoked = this.asyncInvoked,
-                MaxAsyncOpsPerformed = this.asyncPerformed
+                MaxAsyncOpsPerformed = this.asyncPerformed,
+                RemoteHost = stream.Host,
+                RemotePort = stream.Port
             };
             this.InitializeSend(stream, assoc);
 

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Text;
+
 namespace Dicom.Network
 {
     using System;
@@ -58,6 +60,11 @@ namespace Dicom.Network
         /// Gets or sets time in milliseconds to keep connection alive for additional requests.
         /// </summary>
         public int Linger { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fallback encoding.
+        /// </summary>
+        public Encoding FallbackEncoding { get; set; }
 
         /// <summary>
         /// Gets or sets logger that is passed to the underlying <see cref="DicomService"/> implementation.
@@ -323,7 +330,7 @@ namespace Dicom.Network
             this.associateNotifier = new TaskCompletionSource<bool>();
             this.completeNotifier = new TaskCompletionSource<bool>();
 
-            this.service = new DicomServiceUser(this, stream, association, this.Options, this.Logger);
+            this.service = new DicomServiceUser(this, stream, association, this.Options, this.FallbackEncoding, this.Logger);
         }
 
         private void FinalizeSend()
@@ -371,8 +378,9 @@ namespace Dicom.Network
                 INetworkStream stream,
                 DicomAssociation association,
                 DicomServiceOptions options,
+                Encoding fallbackEncoding,
                 Logger log)
-                : base(stream, log)
+                : base(stream, fallbackEncoding, log)
             {
                 this.client = client;
                 this.isLingering = false;

--- a/DICOM/Network/DicomClientExtensions.cs
+++ b/DICOM/Network/DicomClientExtensions.cs
@@ -4,7 +4,6 @@
 namespace Dicom.Network
 {
     using System;
-    using System.IO;
 
     public static class DicomClientExtensions
     {

--- a/DICOM/Network/DicomClientExtensions.cs
+++ b/DICOM/Network/DicomClientExtensions.cs
@@ -25,7 +25,7 @@ namespace Dicom.Network
         [Obsolete]
         public static IAsyncResult BeginSend(
             this DicomClient @this,
-            Stream stream,
+            INetworkStream stream,
             string callingAe,
             string calledAe,
             AsyncCallback callback,

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -5,6 +5,7 @@ namespace Dicom.Network
 {
     using System;
     using System.Collections.Generic;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -25,9 +26,12 @@ namespace Dicom.Network
 
         private readonly string certificateName;
 
+        private readonly Encoding fallbackEncoding;
+
         private readonly CancellationTokenSource cancellationSource;
 
         private readonly List<T> clients;
+
 
         #endregion
 
@@ -39,11 +43,13 @@ namespace Dicom.Network
         /// <param name="port">Port to listen to.</param>
         /// <param name="certificateName">Certificate name for authenticated connections.</param>
         /// <param name="options">Service options.</param>
+        /// <param name="fallbackEncoding">Fallback encoding.</param>
         /// <param name="logger">Logger.</param>
-        public DicomServer(int port, string certificateName = null, DicomServiceOptions options = null, Logger logger = null)
+        public DicomServer(int port, string certificateName = null, DicomServiceOptions options = null, Encoding fallbackEncoding = null, Logger logger = null)
         {
             this.port = port;
             this.certificateName = certificateName;
+            this.fallbackEncoding = fallbackEncoding;
             this.cancellationSource = new CancellationTokenSource();
             this.clients = new List<T>();
 
@@ -142,7 +148,7 @@ namespace Dicom.Network
         /// <returns>An instance of the DICOM service class.</returns>
         protected virtual T CreateScp(INetworkStream stream)
         {
-            return (T)Activator.CreateInstance(typeof(T), stream, this.Logger);
+            return (T)Activator.CreateInstance(typeof(T), stream, this.fallbackEncoding, this.Logger);
         }
 
         /// <summary>

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -5,7 +5,6 @@ namespace Dicom.Network
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
 

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -141,7 +141,7 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="stream">Network stream.</param>
         /// <returns>An instance of the DICOM service class.</returns>
-        protected virtual T CreateScp(Stream stream)
+        protected virtual T CreateScp(INetworkStream stream)
         {
             return (T)Activator.CreateInstance(typeof(T), stream, this.Logger);
         }
@@ -168,7 +168,7 @@ namespace Dicom.Network
 
                     if (networkStream != null)
                     {
-                        var scp = this.CreateScp(networkStream.AsStream());
+                        var scp = this.CreateScp(networkStream);
                         if (this.Options != null)
                         {
                             scp.Options = this.Options;

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -57,25 +57,10 @@ namespace Dicom.Network
         /// Initializes a new instance of the <see cref="DicomService"/> class.
         /// </summary>
         /// <param name="stream">Network stream.</param>
-        /// <param name="log">Logger</param>
-        protected DicomService(INetworkStream stream, Logger log)
-            : this(stream, DicomEncoding.Default, log)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DicomService"/> class.
-        /// </summary>
-        /// <param name="stream">Network stream.</param>
         /// <param name="fallbackEncoding">Fallback encoding.</param>
         /// <param name="log">Logger</param>
         protected DicomService(INetworkStream stream, Encoding fallbackEncoding, Logger log)
         {
-            if (fallbackEncoding == null)
-            {
-                throw new ArgumentNullException("fallbackEncoding");
-            }
-
             _network = stream;
             _lock = new object();
             _pduQueue = new Queue<PDU>();
@@ -83,7 +68,7 @@ namespace Dicom.Network
             _msgQueue = new Queue<DicomMessage>();
             _pending = new List<DicomRequest>();
             _isConnected = true;
-            _fallbackEncoding = fallbackEncoding;
+            _fallbackEncoding = fallbackEncoding ?? DicomEncoding.Default;
             Logger = log ?? LogManager.GetLogger("Dicom.Network");
             Options = DicomServiceOptions.Default;
 

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -475,7 +475,7 @@ namespace Dicom.Network
                                 file.FileMetaInfo.MediaStorageSOPInstanceUID =
                                     _dimse.Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
                                 file.FileMetaInfo.TransferSyntax = pc.AcceptedTransferSyntax;
-                                file.FileMetaInfo.ImplementationClassUID = Association.RemoteImplemetationClassUID;
+                                file.FileMetaInfo.ImplementationClassUID = Association.RemoteImplementationClassUID;
                                 file.FileMetaInfo.ImplementationVersionName = Association.RemoteImplementationVersion;
                                 file.FileMetaInfo.SourceApplicationEntityTitle = Association.CallingAE;
 

--- a/DICOM/Network/INetworkStream.cs
+++ b/DICOM/Network/INetworkStream.cs
@@ -11,10 +11,28 @@ namespace Dicom.Network
     /// </summary>
     public interface INetworkStream : IDisposable
     {
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the host of the network stream.
+        /// </summary>
+        string Host { get; }
+
+        /// <summary>
+        /// Gets the port of the network stream.
+        /// </summary>
+        int Port { get; }
+
+        #endregion
+
+        #region METHODS
+
         /// <summary>
         /// Get corresponding <see cref="Stream"/> object.
         /// </summary>
         /// <returns>Network stream as <see cref="Stream"/> object.</returns>
         Stream AsStream();
+
+        #endregion
     }
 }

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -586,7 +586,7 @@ namespace Dicom.Network
                         }
                         else if (ut == 0x52)
                         {
-                            _assoc.RemoteImplemetationClassUID =
+                            _assoc.RemoteImplementationClassUID =
                                 new DicomUID(
                                     raw.ReadString("Implementation Class UID", ul),
                                     "Implementation Class UID",
@@ -812,7 +812,7 @@ namespace Dicom.Network
                         }
                         else if (ut == 0x52)
                         {
-                            _assoc.RemoteImplemetationClassUID =
+                            _assoc.RemoteImplementationClassUID =
                                 DicomUID.Parse(raw.ReadString("Implementation Class UID", ul));
                         }
                         else if (ut == 0x53)

--- a/DICOM/Network/WindowsNetworkStream.cs
+++ b/DICOM/Network/WindowsNetworkStream.cs
@@ -10,12 +10,12 @@ namespace Dicom.Network
     using System.Threading;
     using System.Threading.Tasks;
 
+    using Dicom.IO;
+
     using Windows.Networking;
     using Windows.Networking.Sockets;
     using Windows.Security.Cryptography.Certificates;
     using Windows.Storage.Streams;
-
-    using Dicom.IO;
 
     /// <summary>
     /// Universal Windows Platform implementation of <see cref="INetworkStream"/>.

--- a/DICOM/Network/WindowsNetworkStream.cs
+++ b/DICOM/Network/WindowsNetworkStream.cs
@@ -46,6 +46,8 @@ namespace Dicom.Network
         /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
         internal WindowsNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
+            this.Host = host;
+            this.Port = port;
             this.socket = new StreamSocket();
             this.canDisposeSocket = true;
 
@@ -71,6 +73,8 @@ namespace Dicom.Network
         /// is initialized with this server-side constructor.</remarks>
         internal WindowsNetworkStream(StreamSocket socket)
         {
+            this.Host = socket.Information.RemoteAddress.DisplayName;
+            this.Port = int.Parse(socket.Information.RemotePort, CultureInfo.InvariantCulture);
             this.socket = socket;
             this.canDisposeSocket = false;
             this.isConnected = true;
@@ -83,6 +87,20 @@ namespace Dicom.Network
         {
             this.Dispose(false);
         }
+
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the host of the network stream.
+        /// </summary>
+        public string Host { get; }
+
+        /// <summary>
+        /// Gets the port of the network stream.
+        /// </summary>
+        public int Port { get; }
 
         #endregion
 


### PR DESCRIPTION
I have now implemented `RemoteHost` (`string`) and `RemotePort` (`int`) properties in `DicomAssociation`. An example of where the host and port are accessed is given in the unit test `DicomClientTest.Send_RecordAssociationData_AssociationContainsHostAndPort()`.

To enable that host and port are always identified, the `INetworkStream` interface has been extended.

Furthermore, I have been "forced" to make an API modification that will affect the implementation of `DicomService` subclasses. For `DicomServer<T>` where `T` is a subclass of `DicomService` to work sufficiently, it is a *must* requirement that the service implementation defines a constructor with a specific signature. This signature has in the past been the following:

<strike>
```
DicomServiceImpl(Stream stream, Logger log) { }
```
</strike>

To ensure that remote host and port can be sufficiently registered, I have now changed the required signature to be:

    DicomServiceImpl(INetworkStream stream, Encoding fallbackEncoding, Logger log) { }

This is of course a **breaking change** for existing DICOM server implementations, but it should hopefully only have a limited impact on the code base; in many cases it would suffice to update the invocation of the base constructor:

    public DicomServiceImpl(INetworkStream stream, Encoding fallbackEncoding, Logger log)
      : base(stream, fallbackEncoding, log) { ... }

Note that I took the opportunity of adding `fallbackEncoding` to the required signature as well. This has been a minor inconsistency since PR #57 which I have now fixed since the signature needed to be modified anyway.

@do0om @HelderMPinhal @IanYates and others, please review. Is this the functionality you asked for and expected?