### PR TITLE
Improved handling for DicomDataset.Get methods with int arguments. Connected to #212 Connected to #231

### DIFF
--- a/DICOM.Tests/DicomDatasetTest.cs
+++ b/DICOM.Tests/DicomDatasetTest.cs
@@ -107,6 +107,30 @@ namespace Dicom
             Assert.Equal(values.Last(), data.Last());
         }
 
+        [Fact]
+        public void Get_IntWithoutArgument_ShouldThrowIfTagNonExisting()
+        {
+            var dataset = new DicomDataset();
+            var e = Record.Exception(() => dataset.Get<int>(DicomTag.MetersetRate));
+            Assert.IsType<DicomDataException>(e);
+        }
+
+        [Fact]
+        public void Get_IntWithIntArgument_ShouldThrowIfTagNonExisting()
+        {
+            var dataset = new DicomDataset();
+            var e = Record.Exception(() => dataset.Get<int>(DicomTag.MetersetRate, 20));
+            Assert.IsType<DicomDataException>(e);
+        }
+
+        [Fact]
+        public void Get_NonGenericWithIntArgument_ShouldNotThrowIfTagNonExisting()
+        {
+            var dataset = new DicomDataset();
+            var e = Record.Exception(() => Assert.Equal(20, dataset.Get(DicomTag.MetersetRate, 20)));
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support data

--- a/DICOM.Tests/DicomDatasetTest.cs
+++ b/DICOM.Tests/DicomDatasetTest.cs
@@ -153,6 +153,17 @@ namespace Dicom
             Assert.Null(e);
         }
 
+        [Fact]
+        public void Get_NullableReturnType_ReturnsDefinedValue()
+        {
+            var tag = DicomTag.SelectorULValue;
+            const uint expected = 100u;
+            var dataset = new DicomDataset { { tag, expected } };
+
+            var actual = dataset.Get<uint?>(tag).Value;
+            Assert.Equal(expected, actual);
+        }
+
         #endregion
 
         #region Support data

--- a/DICOM.Tests/DicomDatasetTest.cs
+++ b/DICOM.Tests/DicomDatasetTest.cs
@@ -108,7 +108,7 @@ namespace Dicom
         }
 
         [Fact]
-        public void Get_IntWithoutArgument_ShouldThrowIfTagNonExisting()
+        public void Get_IntWithoutArgumentTagNonExisting_ShouldThrow()
         {
             var dataset = new DicomDataset();
             var e = Record.Exception(() => dataset.Get<int>(DicomTag.MetersetRate));
@@ -116,7 +116,7 @@ namespace Dicom
         }
 
         [Fact]
-        public void Get_IntWithIntArgument_ShouldThrowIfTagNonExisting()
+        public void Get_IntWithIntArgumentTagNonExisting_ShouldThrow()
         {
             var dataset = new DicomDataset();
             var e = Record.Exception(() => dataset.Get<int>(DicomTag.MetersetRate, 20));
@@ -124,10 +124,32 @@ namespace Dicom
         }
 
         [Fact]
-        public void Get_NonGenericWithIntArgument_ShouldNotThrowIfTagNonExisting()
+        public void Get_NonGenericWithIntArgumentTagNonExisting_ShouldNotThrow()
         {
             var dataset = new DicomDataset();
             var e = Record.Exception(() => Assert.Equal(20, dataset.Get(DicomTag.MetersetRate, 20)));
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void Get_IntOutsideRange_ShouldThrow()
+        {
+            var tag = DicomTag.SelectorISValue;
+            var dataset = new DicomDataset();
+            dataset.Add(tag, 3, 4, 5);
+
+            var e = Record.Exception(() => dataset.Get<int>(tag, 10));
+            Assert.IsType<DicomDataException>(e);
+        }
+
+        [Fact]
+        public void Get_NonGenericIntArgumentEmptyElement_ShouldNotThrow()
+        {
+            var tag = DicomTag.SelectorISValue;
+            var dataset = new DicomDataset();
+            dataset.Add(tag, new int[0]);
+
+            var e = Record.Exception(() => Assert.Equal(10, dataset.Get(tag, 10)));
             Assert.Null(e);
         }
 

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -266,6 +266,12 @@ namespace Dicom
         }
 
         [Fact]
+        public void DicomDecimalString_GetNullableLongArray_ReturnsArray()
+        {
+            this.TestDicomDecimalStringGetArray<long>();
+        }
+
+        [Fact]
         public void DicomDecimalString_GetStringArray_ReturnsArray()
         {
             this.TestDicomDecimalStringGetArray<string>();

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -205,6 +205,98 @@ namespace Dicom
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void DicomDecimalString_GetDecimal_ReturnsValue()
+        {
+            this.TestDicomDecimalStringGetItem<decimal>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetDouble_ReturnsValue()
+        {
+            this.TestDicomDecimalStringGetItem<double>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetSingle_ReturnsValue()
+        {
+            this.TestDicomDecimalStringGetItem<float>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetLong_ReturnsValue()
+        {
+            this.TestDicomDecimalStringGetItem<long>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetString_ReturnsValue()
+        {
+            this.TestDicomDecimalStringGetItem<string>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetObject_ReturnsValue()
+        {
+            this.TestDicomDecimalStringGetItem<object>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetDecimalArray_ReturnsArray()
+        {
+            this.TestDicomDecimalStringGetArray<decimal>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetDoubleArray_ReturnsArray()
+        {
+            this.TestDicomDecimalStringGetArray<double>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetSingleArray_ReturnsArray()
+        {
+            this.TestDicomDecimalStringGetArray<float>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetLongArray_ReturnsArray()
+        {
+            this.TestDicomDecimalStringGetArray<long>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetStringArray_ReturnsArray()
+        {
+            this.TestDicomDecimalStringGetArray<string>();
+        }
+
+        [Fact]
+        public void DicomDecimalString_GetObjectArray_ReturnsArray()
+        {
+            this.TestDicomDecimalStringGetArray<object>();
+        }
+
+        #endregion
+
+        #region Support methods
+
+        public void TestDicomDecimalStringGetItem<T>()
+        {
+            var expected = 45.0m;
+            var element = new DicomDecimalString(DicomTag.MaterialThickness, 35.0m, expected, 55.0m);
+            var actual = element.Get<T>(1);
+            Assert.Equal((T)Convert.ChangeType(expected, typeof(T)), actual);
+        }
+
+        public void TestDicomDecimalStringGetArray<T>()
+        {
+            var expected = new[] { 35.0m, 45.0m, 55.0m };
+            var element = new DicomDecimalString(DicomTag.MaterialThickness, expected);
+            var actual = element.Get<T[]>();
+            Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, typeof(T))), actual);
+        }
+
         #endregion
 
         #region Support types

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Security.RightsManagement;
+
 namespace Dicom
 {
     using System;
@@ -165,6 +167,33 @@ namespace Dicom
         {
             const MockEnum expected = MockEnum.Zero;
             var element = new DicomCodeString(DicomTag.AcquisitionStatus, expected.ToString());
+            var actual = element.Get<MockEnum>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact(DisplayName = "GH-231")]
+        public void DicomIntegerString_GetIntegerDefaultArgument_ShouldReturnFirstValue()
+        {
+            const int expected = 5;
+            var element = new DicomIntegerString(DicomTag.AcquisitionTerminationConditionData, expected, 4, 3);
+            var actual = element.Get<int>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact(DisplayName = "GH-231")]
+        public void DicomIntegerString_GetDecimalDefaultArgument_ShouldReturnFirstValue()
+        {
+            const decimal expected = 5m;
+            var element = new DicomIntegerString(DicomTag.AcquisitionTerminationConditionData, (int)expected, 4, 3);
+            var actual = element.Get<decimal>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact(DisplayName = "GH-231")]
+        public void DicomIntegerString_GetEnumDefaultArgument_ShouldReturnFirstValue()
+        {
+            const MockEnum expected = MockEnum.Two;
+            var element = new DicomIntegerString(DicomTag.AcquisitionTerminationConditionData, (int)expected, 4, 3);
             var actual = element.Get<MockEnum>();
             Assert.Equal(expected, actual);
         }

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Security.RightsManagement;
-
 namespace Dicom
 {
     using System;

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -283,6 +283,78 @@ namespace Dicom
             this.TestDicomDecimalStringGetArray<object>();
         }
 
+        [Fact]
+        public void DicomIntegerString_GetDecimal_ReturnsValue()
+        {
+            this.TestDicomIntegerStringGetItem<decimal>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetString_ReturnsValue()
+        {
+            this.TestDicomIntegerStringGetItem<string>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetNullableUnsignedLong_ReturnsValue()
+        {
+            this.TestDicomIntegerStringGetItem<ulong?>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetSingle_ReturnsValue()
+        {
+            this.TestDicomIntegerStringGetItem<float>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetObject_ReturnsValue()
+        {
+            this.TestDicomIntegerStringGetItem<object>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetIntArray_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArray<int>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetLongArray_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArray<long>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetUnsignedShortArray_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArray<ushort>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetNullableDoubleArray_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArray<double?>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetSingleArray_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArray<float>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetDecimalArray_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArray<decimal>();
+        }
+
+        [Fact]
+        public void DicomIntegerString_GetObjectArray_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArray<object>();
+        }
+
         #endregion
 
         #region Support methods
@@ -299,6 +371,22 @@ namespace Dicom
         {
             var expected = new[] { 35.0m, 45.0m, 55.0m };
             var element = new DicomDecimalString(DicomTag.MaterialThickness, expected);
+            var actual = element.Get<T[]>();
+            Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, typeof(T))), actual);
+        }
+
+        public void TestDicomIntegerStringGetItem<T>()
+        {
+            var expected = 45;
+            var element = new DicomIntegerString(DicomTag.AttachedContours, 35, expected, 55);
+            var actual = element.Get<T>(1);
+            Assert.Equal((T)Convert.ChangeType(expected, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T)), actual);
+        }
+
+        public void TestDicomIntegerStringGetArray<T>()
+        {
+            var expected = new[] { 35, 45, 55 };
+            var element = new DicomIntegerString(DicomTag.AttachedContours, expected);
             var actual = element.Get<T[]>();
             Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, typeof(T))), actual);
         }

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -106,6 +106,79 @@ namespace Dicom
           }
         }
 
+        [Fact]
+        public void DicomValueElement_HasData_GetNullableReturnsDefinedNullable()
+        {
+            const ushort expected = 1;
+            var element = new DicomUnsignedShort(DicomTag.ALinesPerFrame, expected);
+            var actual = element.Get<ushort?>().Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DicomValueElement_HasData_GetNullableEnumReturnsDefinedNullableEnum()
+        {
+            const MockEnum expected = MockEnum.Two;
+            var element = new DicomSignedLong(DicomTag.ReferencePixelX0, (int)expected);
+            var actual = element.Get<MockEnum?>().Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DicomIntegerString_HasData_GetNullableReturnsDefinedNullable()
+        {
+            const double expected = -30.0;
+            var element = new DicomIntegerString(DicomTag.EchoPeakPosition, (int)expected);
+            var actual = element.Get<double?>().Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DicomIntegerString_HasData_GetNullableEnumReturnsDefinedNullableEnum()
+        {
+            const MockEnum expected = MockEnum.One;
+            var element = new DicomIntegerString(DicomTag.NumberOfBeams, (int)expected);
+            var actual = element.Get<MockEnum?>().Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DicomDecimalString_HasData_GetNullableReturnsDefinedNullable()
+        {
+            const int expected = -30;
+            var element = new DicomDecimalString(DicomTag.ChannelOffset, expected);
+            var actual = element.Get<int?>().Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DicomCodeString_HasData_GetNullableEnumReturnsDefinedNullableEnum()
+        {
+            const MockEnum expected = MockEnum.Zero;
+            var element = new DicomCodeString(DicomTag.AcquisitionStatus, expected.ToString());
+            var actual = element.Get<MockEnum?>().Value;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DicomCodeString_HasData_GetEnumReturnsDefinedEnum()
+        {
+            const MockEnum expected = MockEnum.Zero;
+            var element = new DicomCodeString(DicomTag.AcquisitionStatus, expected.ToString());
+            var actual = element.Get<MockEnum>();
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+
+        #region Support types
+
+        private enum MockEnum
+        {
+            Zero,
+            One,
+            Two
+        }
 
         #endregion
     }

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -268,7 +268,7 @@ namespace Dicom
         [Fact]
         public void DicomDecimalString_GetNullableLongArray_ReturnsArray()
         {
-            this.TestDicomDecimalStringGetArray<long>();
+            this.TestDicomDecimalStringGetArray<long?>();
         }
 
         [Fact]
@@ -364,7 +364,7 @@ namespace Dicom
             var expected = 45.0m;
             var element = new DicomDecimalString(DicomTag.MaterialThickness, 35.0m, expected, 55.0m);
             var actual = element.Get<T>(1);
-            Assert.Equal((T)Convert.ChangeType(expected, typeof(T)), actual);
+            Assert.Equal((T)Convert.ChangeType(expected, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T)), actual);
         }
 
         public void TestDicomDecimalStringGetArray<T>()
@@ -372,7 +372,7 @@ namespace Dicom
             var expected = new[] { 35.0m, 45.0m, 55.0m };
             var element = new DicomDecimalString(DicomTag.MaterialThickness, expected);
             var actual = element.Get<T[]>();
-            Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, typeof(T))), actual);
+            Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T))), actual);
         }
 
         public void TestDicomIntegerStringGetItem<T>()
@@ -388,7 +388,7 @@ namespace Dicom
             var expected = new[] { 35, 45, 55 };
             var element = new DicomIntegerString(DicomTag.AttachedContours, expected);
             var actual = element.Get<T[]>();
-            Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, typeof(T))), actual);
+            Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T))), actual);
         }
 
         #endregion

--- a/DICOM.Tests/DicomElementTest.cs
+++ b/DICOM.Tests/DicomElementTest.cs
@@ -109,6 +109,15 @@ namespace Dicom
         }
 
         [Fact]
+        public void DicomValueElement_GetEnum_ReturnsEnum()
+        {
+            const MockEnum expected = MockEnum.One;
+            var element = new DicomSignedShort(DicomTag.ALinesPerFrame, (short)expected);
+            var actual = element.Get<MockEnum>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void DicomValueElement_HasData_GetNullableReturnsDefinedNullable()
         {
             const ushort expected = 1;

--- a/DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
+++ b/DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
@@ -40,6 +40,7 @@ namespace Dicom.Imaging
             string voiLutFunction)
         {
             var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME1"),
                 new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
                 new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
                 new DicomUnsignedShort(DicomTag.PixelRepresentation, pixelRepresentation),
@@ -68,6 +69,7 @@ namespace Dicom.Imaging
             string voiLutFunction)
         {
             var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME1"),
                 new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
                 new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
                 new DicomUnsignedShort(DicomTag.PixelRepresentation, pixelRepresentation),
@@ -98,6 +100,7 @@ namespace Dicom.Imaging
             double expectedWindowCenter)
         {
             var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME1"),
                 new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
                 new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
                 new DicomUnsignedShort(DicomTag.PixelRepresentation, 1),
@@ -127,6 +130,7 @@ namespace Dicom.Imaging
             double expectedWindowCenter)
         {
             var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME1"),
                 new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
                 new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
                 new DicomUnsignedShort(DicomTag.PixelRepresentation, 1),
@@ -157,6 +161,7 @@ namespace Dicom.Imaging
             double expectedWindowCenter)
         {
             var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME1"),
                 new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
                 new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
                 new DicomUnsignedShort(DicomTag.PixelRepresentation, 0),
@@ -176,6 +181,7 @@ namespace Dicom.Imaging
         public void FromImagePixelValueTags_SmallestGreaterThanLargest_Throws()
         {
             var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME1"),
                 new DicomUnsignedShort(DicomTag.BitsAllocated, 8),
                 new DicomUnsignedShort(DicomTag.BitsStored, 8),
                 new DicomUnsignedShort(DicomTag.PixelRepresentation, 0),

--- a/DICOM.Tests/Imaging/Render/PixelDataTest.cs
+++ b/DICOM.Tests/Imaging/Render/PixelDataTest.cs
@@ -136,13 +136,14 @@ namespace Dicom.Imaging.Render
       return PixelDataFactory.Create(
         DicomPixelData.Create(new DicomDataset
         {
+          { DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome1.Value },
           { DicomTag.BitsAllocated, bitsAllocated },
           { DicomTag.BitsStored, bitsStored },
           { DicomTag.HighBit, highBit },
           { DicomTag.PixelData, data.SelectMany(getBytes).ToArray() },
           { DicomTag.PixelRepresentation, pixelRepresentation },
           { DicomTag.Columns, (ushort)1 },
-          { DicomTag.Rows, (ushort)data.Length },
+          { DicomTag.Rows, (ushort)data.Length }
         }),
         0);
     }

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -12,18 +12,28 @@ namespace Dicom
 {
     using System.Reflection;
 
+    /// <summary>
+    /// A collection of <see cref="DicomItem">DICOM items</see>.
+    /// </summary>
     public class DicomDataset : IEnumerable<DicomItem>
     {
         private IDictionary<DicomTag, DicomItem> _items;
 
         private DicomTransferSyntax _syntax;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomDataset"/> class.
+        /// </summary>
         public DicomDataset()
         {
             _items = new SortedDictionary<DicomTag, DicomItem>();
             InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomDataset"/> class.
+        /// </summary>
+        /// <param name="items">A collection of DICOM items.</param>
         public DicomDataset(params DicomItem[] items)
             : this()
         {
@@ -33,6 +43,10 @@ namespace Dicom
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomDataset"/> class.
+        /// </summary>
+        /// <param name="items">A collection of DICOM items.</param>
         public DicomDataset(IEnumerable<DicomItem> items)
             : this()
         {
@@ -42,7 +56,7 @@ namespace Dicom
             }
         }
 
-        /// <summary>DICOM transfer syntax of this dataset.</summary>
+        /// <summary>Gets the DICOM transfer syntax of this dataset.</summary>
         public DicomTransferSyntax InternalTransferSyntax
         {
             get
@@ -64,22 +78,54 @@ namespace Dicom
             }
         }
 
-
+        /// <summary>
+        /// Gets the item or element value of the specified <paramref name="tag"/>. 
+        /// </summary>
+        /// <typeparam name="T">Type of the return value.</typeparam>
+        /// <param name="tag">Requested DICOM tag.</param>
+        /// <param name="n">Item index (for multi-valued elements).</param>
+        /// <returns>Item or element value corresponding to <paramref name="tag"/>.</returns>
+        /// <exception cref="DicomDataException">If the dataset does not contain <paramref name="tag"/> or if the specified 
+        /// <paramref name="n">item index</paramref> is out-of-range.</exception>
         public T Get<T>(DicomTag tag, int n = 0)
         {
             return Get<T>(tag, n, false, default(T));
         }
 
+        /// <summary>
+        /// Gets the integer element value of the specified <paramref name="tag"/>, or default value if dataset does not contain <paramref name="tag"/>. 
+        /// </summary>
+        /// <param name="tag">Requested DICOM tag.</param>
+        /// <param name="defaultValue">Default value to apply if <paramref name="tag"/> is not contained in dataset.</param>
+        /// <returns>Element value corresponding to <paramref name="tag"/>.</returns>
+        /// <exception cref="DicomDataException">If the element corresponding to <paramref name="tag"/> cannot be converted to an integer.</exception>
         public int Get(DicomTag tag, int defaultValue)
         {
             return Get<int>(tag, 0, true, defaultValue);
         }
 
+        /// <summary>
+        /// Gets the item or element value of the specified <paramref name="tag"/>, or default value if dataset does not contain <paramref name="tag"/>. 
+        /// </summary>
+        /// <typeparam name="T">Type of the return value.</typeparam>
+        /// <param name="tag">Requested DICOM tag.</param>
+        /// <param name="defaultValue">Default value to apply if <paramref name="tag"/> is not contained in dataset.</param>
+        /// <returns>Item or element value corresponding to <paramref name="tag"/>.</returns>
+        /// <remarks>In code, consider to use this method with implicit type specification, since <typeparamref name="T"/> can be inferred from
+        /// <paramref name="defaultValue"/>, e.g. prefer <code>dataset.Get(tag, "Default")</code> over <code>dataset.Get&lt;string&gt;(tag, "Default")</code>.</remarks>
         public T Get<T>(DicomTag tag, T defaultValue)
         {
             return Get<T>(tag, 0, true, defaultValue);
         }
 
+        /// <summary>
+        /// Gets the item or element value of the specified <paramref name="tag"/>, or default value if dataset does not contain <paramref name="tag"/>. 
+        /// </summary>
+        /// <typeparam name="T">Type of the return value.</typeparam>
+        /// <param name="tag">Requested DICOM tag.</param>
+        /// <param name="n">Item index (for multi-valued elements).</param>
+        /// <param name="defaultValue">Default value to apply if <paramref name="tag"/> is not contained in dataset.</param>
+        /// <returns>Item or element value corresponding to <paramref name="tag"/>.</returns>
         public T Get<T>(DicomTag tag, int n, T defaultValue)
         {
             return Get<T>(tag, n, true, defaultValue);
@@ -121,6 +167,11 @@ namespace Dicom
             return new DicomTag(tag.Group, (ushort)((group << 8) + (tag.Element & 0xff)), tag.PrivateCreator);
         }
 
+        /// <summary>
+        /// Add a collection of DICOM items to the dataset (replace existing).
+        /// </summary>
+        /// <param name="items">Collection of DICOM items to add.</param>
+        /// <returns>The dataset instance.</returns>
         public DicomDataset Add(params DicomItem[] items)
         {
             if (items != null)
@@ -137,6 +188,11 @@ namespace Dicom
             return this;
         }
 
+        /// <summary>
+        /// Add a collection of DICOM items to the dataset (replace existing).
+        /// </summary>
+        /// <param name="items">Collection of DICOM items to add.</param>
+        /// <returns>The dataset instance.</returns>
         public DicomDataset Add(IEnumerable<DicomItem> items)
         {
             if (items != null)
@@ -153,6 +209,13 @@ namespace Dicom
             return this;
         }
 
+        /// <summary>
+        /// Add single DICOM item given by <paramref name="tag"/> and <paramref name="values"/>. Replace existing item.
+        /// </summary>
+        /// <typeparam name="T">Type of added values.</typeparam>
+        /// <param name="tag">DICOM tag of the added item.</param>
+        /// <param name="values">Values of the added item.</param>
+        /// <returns>The dataset instance.</returns>
         public DicomDataset Add<T>(DicomTag tag, params T[] values)
         {
             var entry = DicomDictionary.Default[tag];
@@ -472,11 +535,27 @@ namespace Dicom
             return _items.Values.GetEnumerator();
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
             return String.Format("DICOM Dataset [{0} items]", _items.Count);
         }
 
+        /// <summary>
+        /// Gets the item or element value of the specified <paramref name="tag"/>. 
+        /// </summary>
+        /// <typeparam name="T">Type of the return value.</typeparam>
+        /// <param name="tag">Requested DICOM tag.</param>
+        /// <param name="n">Item index (for multi-valued elements).</param>
+        /// <param name="useDefault">Indicates whether to use default value (true) or throw (false) if <paramref name="tag"/> is not contained in dataset.</param>
+        /// <param name="defaultValue">Default value to apply if <paramref name="tag"/> is not contained in dataset and <paramref name="useDefault"/> is true.</param>
+        /// <returns>Item or element value corresponding to <paramref name="tag"/>.</returns>
         private T Get<T>(DicomTag tag, int n, bool useDefault, T defaultValue)
         {
             DicomItem item = null;

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -641,21 +641,39 @@ namespace Dicom
                         .ToArray();
             }
 
-            if (typeof(T) == typeof(decimal) || typeof(T) == typeof(object))
+            if (typeof(T).GetTypeInfo().IsArray)
             {
-                return (T)(object)_values[Math.Max(item, 0)];
+                var t = typeof(T).GetElementType();
+
+                if (t == typeof(decimal)) return (T)(object)_values;
+
+                var tmp = _values.Select(x => Convert.ChangeType(x, t));
+
+                if (t == typeof(object)) return (T)(object)tmp.ToArray();
+                if (t == typeof(double)) return (T)(object)tmp.Cast<double>().ToArray();
+                if (t == typeof(float)) return (T)(object)tmp.Cast<float>().ToArray();
+                if (t == typeof(long)) return (T)(object)tmp.Cast<long>().ToArray();
+                if (t == typeof(int)) return (T)(object)tmp.Cast<int>().ToArray();
+                if (t == typeof(short)) return (T)(object)tmp.Cast<short>().ToArray();
+                if (t == typeof(decimal?)) return (T)(object)tmp.Cast<decimal?>().ToArray();
+                if (t == typeof(double?)) return (T)(object)tmp.Cast<double?>().ToArray();
+                if (t == typeof(float?)) return (T)(object)tmp.Cast<float?>().ToArray();
+                if (t == typeof(long?)) return (T)(object)tmp.Cast<long?>().ToArray();
+                if (t == typeof(int?)) return (T)(object)tmp.Cast<int?>().ToArray();
+                if (t == typeof(short?)) return (T)(object)tmp.Cast<short?>().ToArray();
+
+                return base.Get<T>(item);
             }
 
-            if (typeof(T) == typeof(decimal[]) || typeof(T) == typeof(object[]))
+            if (item == -1) item = 0;
+            if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+
             {
-                return (T)(object)_values;
+                // If nullable, need to apply conversions on underlying type (#212)
+                var t = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+                return (T)Convert.ChangeType(_values[item], t);
             }
-
-            if (typeof(T) == typeof(double)) return (T)(object)Convert.ToDouble(_values[Math.Max(item, 0)]);
-
-            if (typeof(T) == typeof(double[])) return (T)(object)_values.Select(x => Convert.ToDouble(x)).ToArray();
-
-            return base.Get<T>(item);
         }
 
         #endregion

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -160,9 +160,13 @@ namespace Dicom
 
             if (typeof(T) == typeof(string[]) || typeof(T) == typeof(object[])) return (T)(object)_values;
 
+            if (item == -1) item = 0;
+            if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+
             if (typeof(T).GetTypeInfo().IsSubclassOf(typeof(DicomParseable))) return (T)DicomParseable.Parse<T>(_values[item]);
 
-            if (typeof(T).GetTypeInfo().IsEnum) return (T)Enum.Parse(typeof(T), _values[item], true);
+            var t = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+            if (t.GetTypeInfo().IsEnum) return (T)Enum.Parse(t, _values[item], true);
 
             throw new InvalidCastException(
                 "Unable to convert DICOM " + ValueRepresentation.Code + " value to '" + typeof(T).Name + "'");

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -833,6 +833,12 @@ namespace Dicom
             // no need to parse values if returning string(s)
             if (typeof(T) == typeof(string) || typeof(T) == typeof(string[])) return base.Get<T>(item);
 
+            // Normalize item argument if necessary (#231)
+            if (item == -1)
+            {
+                item = 0;
+            }
+
             if (_values == null)
             {
                 _values = base.Get<string[]>().Select(x => int.Parse(x, CultureInfo.InvariantCulture)).ToArray();
@@ -840,7 +846,7 @@ namespace Dicom
 
             if (typeof(T) == typeof(int) || typeof(T) == typeof(object))
             {
-                return (T)(object)_values[Math.Max(item, 0)];
+                return (T)(object)_values[item];
             }
 
             if (typeof(T) == typeof(int[]) || typeof(T) == typeof(object[]))

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -647,7 +647,8 @@ namespace Dicom
 
                 if (t == typeof(decimal)) return (T)(object)_values;
 
-                var tmp = _values.Select(x => Convert.ChangeType(x, t));
+                var tu = Nullable.GetUnderlyingType(t) ?? t;
+                var tmp = _values.Select(x => Convert.ChangeType(x, tu));
 
                 if (t == typeof(object)) return (T)(object)tmp.ToArray();
                 if (t == typeof(double)) return (T)(object)tmp.Cast<double>().ToArray();
@@ -868,12 +869,38 @@ namespace Dicom
                 return (T)(object)_values[item];
             }
 
-            if (typeof(T) == typeof(int[]) || typeof(T) == typeof(object[]))
+            if (typeof(T).GetTypeInfo().IsArray)
             {
-                return (T)(object)_values;
-            }
+                var t = typeof(T).GetElementType();
 
-            if (typeof(T).GetTypeInfo().IsValueType)
+                if (t == typeof(int)) return (T)(object)_values;
+
+                var tu = Nullable.GetUnderlyingType(t) ?? t;
+                var tmp = _values.Select(x => Convert.ChangeType(x, tu));
+
+                if (t == typeof(object)) return (T)(object)tmp.ToArray();
+                if (t == typeof(decimal)) return (T)(object)tmp.Cast<decimal>().ToArray();
+                if (t == typeof(double)) return (T)(object)tmp.Cast<double>().ToArray();
+                if (t == typeof(float)) return (T)(object)tmp.Cast<float>().ToArray();
+                if (t == typeof(long)) return (T)(object)tmp.Cast<long>().ToArray();
+                if (t == typeof(int)) return (T)(object)tmp.Cast<int>().ToArray();
+                if (t == typeof(short)) return (T)(object)tmp.Cast<short>().ToArray();
+                if (t == typeof(byte)) return (T)(object)tmp.Cast<byte>().ToArray();
+                if (t == typeof(ulong)) return (T)(object)tmp.Cast<ulong>().ToArray();
+                if (t == typeof(uint)) return (T)(object)tmp.Cast<uint>().ToArray();
+                if (t == typeof(ushort)) return (T)(object)tmp.Cast<ushort>().ToArray();
+                if (t == typeof(decimal?)) return (T)(object)tmp.Cast<decimal?>().ToArray();
+                if (t == typeof(double?)) return (T)(object)tmp.Cast<double?>().ToArray();
+                if (t == typeof(float?)) return (T)(object)tmp.Cast<float?>().ToArray();
+                if (t == typeof(long?)) return (T)(object)tmp.Cast<long?>().ToArray();
+                if (t == typeof(int?)) return (T)(object)tmp.Cast<int?>().ToArray();
+                if (t == typeof(short?)) return (T)(object)tmp.Cast<short?>().ToArray();
+                if (t == typeof(byte?)) return (T)(object)tmp.Cast<byte?>().ToArray();
+                if (t == typeof(ulong?)) return (T)(object)tmp.Cast<ulong?>().ToArray();
+                if (t == typeof(uint?)) return (T)(object)tmp.Cast<uint?>().ToArray();
+                if (t == typeof(ushort?)) return (T)(object)tmp.Cast<ushort?>().ToArray();
+            }
+            else if (typeof(T).GetTypeInfo().IsValueType)
             {
                 if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -855,18 +855,19 @@ namespace Dicom
                 return (T)(object)_values;
             }
 
-            if (typeof(T).GetTypeInfo().IsEnum)
-            {
-                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
-
-                return (T)(object)_values[item];
-            }
-
             if (typeof(T).GetTypeInfo().IsValueType)
             {
                 if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
 
-                return (T)Convert.ChangeType(_values[item], typeof(T));
+                // If nullable, need to apply conversions on underlying type (#212)
+                var t = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+                if (t.GetTypeInfo().IsEnum)
+                {
+                    return (T)Enum.ToObject(t, _values[item]);
+                }
+
+                return (T)Convert.ChangeType(_values[item], t);
             }
 
             return base.Get<T>(item);

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -661,19 +661,19 @@ namespace Dicom
                 if (t == typeof(long?)) return (T)(object)tmp.Cast<long?>().ToArray();
                 if (t == typeof(int?)) return (T)(object)tmp.Cast<int?>().ToArray();
                 if (t == typeof(short?)) return (T)(object)tmp.Cast<short?>().ToArray();
-
-                return base.Get<T>(item);
             }
-
-            if (item == -1) item = 0;
-            if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
-
+            else if (typeof(T).GetTypeInfo().IsValueType || typeof(T) == typeof(object))
             {
+                if (item == -1) item = 0;
+                if (item < 0 || item >= Count) throw new ArgumentOutOfRangeException("item", "Index is outside the range of available value items");
+
                 // If nullable, need to apply conversions on underlying type (#212)
                 var t = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
 
                 return (T)Convert.ChangeType(_values[item], t);
             }
+
+            return base.Get<T>(item);
         }
 
         #endregion

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -192,7 +192,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                return Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation, null);
+                return Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation);
             }
             set
             {

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -177,7 +177,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                return Dataset.Get<PlanarConfiguration>(DicomTag.PlanarConfiguration);
+                return Dataset.Get(DicomTag.PlanarConfiguration, PlanarConfiguration.Interleaved);
             }
             set
             {
@@ -192,7 +192,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                return Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation);
+                return Dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation, null);
             }
             set
             {

--- a/DICOM/Imaging/GrayscaleRenderOptions.cs
+++ b/DICOM/Imaging/GrayscaleRenderOptions.cs
@@ -282,7 +282,7 @@ namespace Dicom.Imaging
         /// <returns>Color map associated with the identified Photometric Interpretation.</returns>
         private static Color32[] GetColorMap(DicomDataset dataset)
         {
-            return dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation, null)
+            return dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
                    == PhotometricInterpretation.Monochrome1
                        ? ColorTable.Monochrome1
                        : ColorTable.Monochrome2;

--- a/DICOM/Imaging/GrayscaleRenderOptions.cs
+++ b/DICOM/Imaging/GrayscaleRenderOptions.cs
@@ -282,7 +282,7 @@ namespace Dicom.Imaging
         /// <returns>Color map associated with the identified Photometric Interpretation.</returns>
         private static Color32[] GetColorMap(DicomDataset dataset)
         {
-            return dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation)
+            return dataset.Get<PhotometricInterpretation>(DicomTag.PhotometricInterpretation, null)
                    == PhotometricInterpretation.Monochrome1
                        ? ColorTable.Monochrome1
                        : ColorTable.Monochrome2;

--- a/DICOM/Network/DicomCFindResponse.cs
+++ b/DICOM/Network/DicomCFindResponse.cs
@@ -22,7 +22,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, (ushort)0);
             }
             set
             {
@@ -34,7 +34,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, (ushort)0);
             }
             set
             {
@@ -46,7 +46,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, (ushort)0);
             }
             set
             {
@@ -58,7 +58,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, (ushort)0);
             }
             set
             {

--- a/DICOM/Network/DicomCMoveResponse.cs
+++ b/DICOM/Network/DicomCMoveResponse.cs
@@ -22,7 +22,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfRemainingSuboperations, (ushort)0);
             }
             set
             {
@@ -34,7 +34,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfCompletedSuboperations, (ushort)0);
             }
             set
             {
@@ -46,7 +46,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfWarningSuboperations, (ushort)0);
             }
             set
             {
@@ -58,7 +58,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, 0);
+                return Command.Get<ushort>(DicomTag.NumberOfFailedSuboperations, (ushort)0);
             }
             set
             {

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -209,7 +209,7 @@ namespace Dicom.Printing
         {
             get
             {
-                return this.Get<ushort>(DicomTag.MaxDensity, 0);
+                return this.Get<ushort>(DicomTag.MaxDensity, (ushort)0);
             }
             set
             {
@@ -226,7 +226,7 @@ namespace Dicom.Printing
         {
             get
             {
-                return this.Get<ushort>(DicomTag.MinDensity, 0);
+                return this.Get<ushort>(DicomTag.MinDensity, (ushort)0);
             }
             set
             {
@@ -383,7 +383,7 @@ namespace Dicom.Printing
         {
             get
             {
-                return this.Get<ushort>(DicomTag.Illumination, 0);
+                return this.Get<ushort>(DicomTag.Illumination, (ushort)0);
             }
             set
             {
@@ -399,7 +399,7 @@ namespace Dicom.Printing
         {
             get
             {
-                return this.Get<ushort>(DicomTag.ReflectedAmbientLight, 0);
+                return this.Get<ushort>(DicomTag.ReflectedAmbientLight, (ushort)0);
             }
             set
             {


### PR DESCRIPTION
@MacL3an @IanYates and others, here is my take on issue #212.

It is suggested as an alternative solution to #213, so it could be good to also have that PR in mind when reviewing.

I agree with the request that `DicomDataset.Get` should throw if tag is missing or an invalid array index has been given, if a default value has not been specified. One problem is then `DicomDataset.Get<int>` with two arguments and second argument `int`, where it cannot be deduced whether this `int` represents an index or a default value. So far, so "good".

My suggestion is to keep the API as intact as possible. I have implemented a private worker method which handles both the scenario when a default value should be used and one where it should not be used, and let *all* public `Get` methods call this worker method. The implemented rules are, when specified tag is not found or index is outside range of element array:

    T Get<T>(DicomTag tag, int index)             // throw
    T Get<T>(DicomTag tag, T defaultValue)        // return default value
    T Get<T>(DicomTag tag, int, T defaultValue)   // return default value

Through C# precedence rules, calling `Get<int>(DicomTag, int)` will invoke the `Get<T>(DicomTag, int)` implementation. In the case where you want to apply an integer default value instead, I have added this non-generic overload:

    int Get(DicomTag tag, int defaultValue)       // return default value

In source code this means that `Get<int>(DicomTag, int)` will throw if tag is not existing, whereas `Get(DicomTag, int)` will not. Thus, be explicit about the return type if you don't want a default value to be applied.

Generally when using `Get<T>(DicomTag, T)` the type can be inferred from the default value argument and does not need to be explicit, for example `Get(DicomTag.X, 3.0)` or `Get(DicomTag.Y, "some default")`. Hopefully the non-generic `Get(DicomTag, int)` will blend well into existing code bases relying on type inference.

Please share your thoughts around this proposal, both by its own merits and limitations and compared to #213.

**NOTE** There are some failing unit tests due to this implementation as well. I will try to sort them out as soon as possible and post complementary commits for those fixes.

**UPDATE** I have modified the code to ensure that all unit tests pass. It will however be neccessary to revisit all `DicomDataset.Get<T>(DicomTag, int = 0)` calls in the *Dicom.Core* code and add defaults where appropriate. But I'll hold that effort until a decision on how to move forward has been made :-)

**NOTE 2** It should be pointed out that the modified implementation might lead to breaking changes in existing code bases, since the behavior of the `Get<T>(DicomTag, int)` method is changed. Previously it returned `default(T)` upon non-detection which for value types would be a valid value (0, `true` or similar). With the PR changes this method will now throw if the specified tag is not detected. Furthermore, it is also common that the `Get<T>(DicomTag, int)` method is used with default value 0 on the second argument, so all `Get<T>(DicomTag)` calls will also have to be reviewed in case they rely on default value returns.