### PR TITLE
AAssociate Request/Reponse SOP Class Extended Negotiation. Connected to #241

### DIFF
--- a/DICOM.Tests/Network/PDUTest.cs
+++ b/DICOM.Tests/Network/PDUTest.cs
@@ -49,5 +49,44 @@ namespace Dicom.Network
 
             Assert.True(File.Exists(name));
         }
-    }
+
+		[Fact]
+		public void WriteReadAAssociateRQExtendedNegotiation()
+		{
+			DicomAssociation association = new DicomAssociation("testCalling", "testCalled");
+			association.ExtendedNegotiations.Add(
+				new DicomExtendedNegotiation(DicomUID.StudyRootQueryRetrieveInformationModelFIND,
+				new StudyRootQueryRetrieveInfo(1, 1, 1, 1)));
+
+			AAssociateRQ rq = new AAssociateRQ(association);
+
+			RawPDU writePdu = rq.Write();
+
+			RawPDU readPdu;
+			using (MemoryStream stream = new MemoryStream())
+			{
+				writePdu.WritePDU(stream);
+
+				int length = (int)stream.Length;
+				byte[] buffer = new byte[length];
+				stream.Seek(0, SeekOrigin.Begin);
+				stream.Read(buffer, 0, length);
+				readPdu = new RawPDU(buffer);
+			}
+
+			DicomAssociation testAssociation = new DicomAssociation();
+			AAssociateRQ rq2 = new AAssociateRQ(testAssociation);
+			rq2.Read(readPdu);
+
+			Assert.True(testAssociation.ExtendedNegotiations.Count == 1);
+			Assert.True(testAssociation.ExtendedNegotiations[0].SopClassUid == DicomUID.StudyRootQueryRetrieveInformationModelFIND);
+
+			StudyRootQueryRetrieveInfo info = testAssociation.ExtendedNegotiations[0].SubItem as StudyRootQueryRetrieveInfo;
+			Assert.True(null != info);
+			Assert.True((1 == info.DateTimeMatching)
+				&& (1 == info.FuzzySemanticMatching)
+				&& (1 == info.RelationalQueries)
+				&& (1 == info.TimezoneQueryAdjustment));
+		}
+	}
 }

--- a/DICOM.Tests/Network/PDUTest.cs
+++ b/DICOM.Tests/Network/PDUTest.cs
@@ -56,7 +56,7 @@ namespace Dicom.Network
 			DicomAssociation association = new DicomAssociation("testCalling", "testCalled");
 			association.ExtendedNegotiations.Add(
 				new DicomExtendedNegotiation(DicomUID.StudyRootQueryRetrieveInformationModelFIND,
-				new StudyRootQueryRetrieveInfo(1, 1, 1, 1)));
+				new RootQueryRetrieveInfoFind(1, 1, 1, 1, null)));
 
 			AAssociateRQ rq = new AAssociateRQ(association);
 
@@ -81,12 +81,13 @@ namespace Dicom.Network
 			Assert.True(testAssociation.ExtendedNegotiations.Count == 1);
 			Assert.True(testAssociation.ExtendedNegotiations[0].SopClassUid == DicomUID.StudyRootQueryRetrieveInformationModelFIND);
 
-			StudyRootQueryRetrieveInfo info = testAssociation.ExtendedNegotiations[0].SubItem as StudyRootQueryRetrieveInfo;
+			RootQueryRetrieveInfoFind info = testAssociation.ExtendedNegotiations[0].SubItem as RootQueryRetrieveInfoFind;
 			Assert.True(null != info);
 			Assert.True((1 == info.DateTimeMatching)
 				&& (1 == info.FuzzySemanticMatching)
 				&& (1 == info.RelationalQueries)
-				&& (1 == info.TimezoneQueryAdjustment));
+				&& (1 == info.TimezoneQueryAdjustment)
+				&& (false == info.EnhancedMultiFrameImageConversion.HasValue));
 		}
 	}
 }

--- a/DICOM/DICOM.Core.csproj
+++ b/DICOM/DICOM.Core.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Imaging\Mathematics\Geometry3D.cs" />
     <Compile Include="Imaging\Mathematics\Matrix.cs" />
     <Compile Include="Imaging\Mathematics\Point2.cs" />
+    <Compile Include="Network\DicomExtendedNegotiation.cs" />
     <Compile Include="Network\DicomPriorityRequest.cs" />
     <Compile Include="Network\IDicomNServiceProvider.cs" />
     <Compile Include="Network\DicomNDeleteRequest.cs" />
@@ -281,6 +282,7 @@
     <Compile Include="Network\INetworkStream.cs" />
     <Compile Include="Network\NetworkManager.cs" />
     <Compile Include="Network\PDU.cs" />
+    <Compile Include="Network\StudyRootQueryRetrieveInfo.cs" />
     <Compile Include="Printing\FilmBox.cs" />
     <Compile Include="Printing\FilmSession.cs" />
     <Compile Include="Printing\ImageBox.cs" />

--- a/DICOM/DICOM.Core.csproj
+++ b/DICOM/DICOM.Core.csproj
@@ -282,6 +282,7 @@
     <Compile Include="Network\INetworkStream.cs" />
     <Compile Include="Network\NetworkManager.cs" />
     <Compile Include="Network\PDU.cs" />
+    <Compile Include="Network\RootQueryRetrieveInfoMove.cs" />
     <Compile Include="Network\StudyRootQueryRetrieveInfo.cs" />
     <Compile Include="Printing\FilmBox.cs" />
     <Compile Include="Printing\FilmSession.cs" />

--- a/DICOM/Network/DicomAssociation.cs
+++ b/DICOM/Network/DicomAssociation.cs
@@ -3,12 +3,13 @@
 
 namespace Dicom.Network
 {
-    using System.Text;
+	using System.Collections.Generic;
+	using System.Text;
 
-    /// <summary>
-    /// Representation of a DICOM association.
-    /// </summary>
-    public sealed class DicomAssociation
+	/// <summary>
+	/// Representation of a DICOM association.
+	/// </summary>
+	public sealed class DicomAssociation
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DicomAssociation"/> class. 
@@ -18,7 +19,8 @@ namespace Dicom.Network
             PresentationContexts = new DicomPresentationContextCollection();
             MaxAsyncOpsInvoked = 1;
             MaxAsyncOpsPerformed = 1;
-        }
+			ExtendedNegotiations = new List<DicomExtendedNegotiation>();
+		}
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DicomAssociation"/> class.
@@ -32,7 +34,7 @@ namespace Dicom.Network
             CallingAE = callingAe;
             CalledAE = calledAe;
             MaximumPDULength = maxPduLength;
-        }
+		}
 
         /// <summary>
         /// Gets the calling application entity.
@@ -84,14 +86,19 @@ namespace Dicom.Network
         /// </summary>
         public DicomPresentationContextCollection PresentationContexts { get; private set; }
 
-        /// <summary>
-        /// Returns a string that represents the current object.
-        /// </summary>
-        /// <returns>
-        /// A string that represents the current object.
-        /// </returns>
-        /// <filterpriority>2</filterpriority>
-        public override string ToString()
+		/// <summary>
+		/// Gets supported extended negotiations
+		/// </summary>
+		public List<DicomExtendedNegotiation> ExtendedNegotiations { get; private set; }
+
+		/// <summary>
+		/// Returns a string that represents the current object.
+		/// </summary>
+		/// <returns>
+		/// A string that represents the current object.
+		/// </returns>
+		/// <filterpriority>2</filterpriority>
+		public override string ToString()
         {
             var sb = new StringBuilder();
             sb.AppendFormat("Calling AE Title:       {0}\n", CallingAE);
@@ -120,7 +127,17 @@ namespace Dicom.Network
                     sb.AppendFormat("       Transfer Syntax:  {0}\n", tx.UID.Name);
                 }
             }
-            sb.Length = sb.Length - 1;
+
+			if (ExtendedNegotiations.Count > 0)
+			{
+				sb.AppendFormat("Extended Negotiations: {0}\n", ExtendedNegotiations.Count);
+				foreach (DicomExtendedNegotiation exNeg in ExtendedNegotiations)
+				{
+					sb.AppendFormat("  Extended Negotiation: {0}\n", exNeg.SopClassUid);
+				}
+			}
+
+			sb.Length = sb.Length - 1;
             return sb.ToString();
         }
     }

--- a/DICOM/Network/DicomExtendedNegotiation.cs
+++ b/DICOM/Network/DicomExtendedNegotiation.cs
@@ -45,17 +45,20 @@ namespace Dicom.Network
 
 		public void Write(RawPDU pdu)
 		{
-			pdu.Write("Item-Type", (byte)0x56);
-			pdu.Write("Reserved", (byte)0x00);
+			if (null != SubItem)
+			{
+				pdu.Write("Item-Type", (byte)0x56);
+				pdu.Write("Reserved", (byte)0x00);
 
-			pdu.MarkLength16("Item-Length");
+				pdu.MarkLength16("Item-Length");
 
-			pdu.Write("SOP Class UID Length", (ushort)(SopClassUid.UID.Length));
-			pdu.Write("SOP Class UID", SopClassUid.UID);
+				pdu.Write("SOP Class UID Length", (ushort)(SopClassUid.UID.Length));
+				pdu.Write("SOP Class UID", SopClassUid.UID);
 
-			SubItem.Write(pdu);
+				SubItem.Write(pdu);
 
-			pdu.WriteLength16();
+				pdu.WriteLength16();
+			}
 		}
 
 		public static DicomExtendedNegotiation Create(RawPDU raw, ushort length)

--- a/DICOM/Network/DicomExtendedNegotiation.cs
+++ b/DICOM/Network/DicomExtendedNegotiation.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+	public interface IExtendedNegotiationSubItem
+	{
+		void Write(RawPDU pdu);
+	}
+
+	public delegate IExtendedNegotiationSubItem CreateIExtendedNegotiationSubItemDelegate(RawPDU raw, out int bytesRead);
+
+	public class DicomExtendedNegotiation
+	{
+		private static Dictionary<DicomUID, CreateIExtendedNegotiationSubItemDelegate> subItemCreators = new Dictionary<DicomUID, CreateIExtendedNegotiationSubItemDelegate>();
+
+		public DicomUID SopClassUid { get; private set; }
+
+		public IExtendedNegotiationSubItem SubItem { get; private set; }
+
+		static DicomExtendedNegotiation()
+		{
+			AddSubItemCreator(DicomUID.StudyRootQueryRetrieveInformationModelFIND, StudyRootQueryRetrieveInfo.Create);
+		}
+
+		public static void AddSubItemCreator(DicomUID uid, CreateIExtendedNegotiationSubItemDelegate creator)
+		{
+			if (false == subItemCreators.ContainsKey(uid))
+			{
+				subItemCreators.Add(uid, creator);
+			}
+		}
+
+		public DicomExtendedNegotiation(DicomUID sopClassUid, IExtendedNegotiationSubItem subItem)
+		{
+			SopClassUid = sopClassUid;
+			SubItem = subItem;
+		}
+
+		public void Write(RawPDU pdu)
+		{
+			pdu.Write("Item-Type", (byte)0x56);
+			pdu.Write("Reserved", (byte)0x00);
+
+			pdu.MarkLength16("Item-Length");
+
+			pdu.Write("SOP Class UID Length", (ushort)(SopClassUid.UID.Length));
+			pdu.Write("SOP Class UID", SopClassUid.UID);
+
+			SubItem.Write(pdu);
+
+			pdu.WriteLength16();
+		}
+
+		public static DicomExtendedNegotiation Create(RawPDU raw, ushort length)
+		{
+			ushort uidLen = raw.ReadUInt16("SOP Class UID Length");
+			string uidStr = raw.ReadString("SOP Class UID", uidLen);
+
+			DicomUID uid = DicomUID.Parse(uidStr);
+			IExtendedNegotiationSubItem subItem = null;
+			int subItemSize = 0;
+
+			if (subItemCreators.ContainsKey(uid))
+			{
+				subItem = subItemCreators[uid](raw, out subItemSize);
+			}
+
+			int remaining = length - uidLen - subItemSize - 2;
+			if (remaining > 0)
+			{
+				raw.SkipBytes("Unread bytes", remaining);
+			}
+
+			return new DicomExtendedNegotiation(uid, subItem);
+		}
+	}
+}

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -508,7 +508,12 @@ namespace Dicom.Network
             pdu.Write("Implementation Version", DicomImplementation.Version);
             pdu.WriteLength16();
 
-            pdu.WriteLength16();
+			foreach (DicomExtendedNegotiation exNeg in _assoc.ExtendedNegotiations)
+			{
+				exNeg.Write(pdu);
+			}
+
+			pdu.WriteLength16();
 
             return pdu;
         }
@@ -614,7 +619,11 @@ namespace Dicom.Network
                                     raw.ReadByte();		// SCP role
                                     */
                         }
-                        else
+						else if (ut == 0x56)
+						{
+							_assoc.ExtendedNegotiations.Add(DicomExtendedNegotiation.Create(raw, ul));
+						}
+						else
                         {
                             //Debug.Log.Error("Unhandled user item: 0x{0:x2} ({1} + 4 bytes)", ut, ul);
                             raw.SkipBytes("Unhandled User Item", ul);

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -738,7 +738,12 @@ namespace Dicom.Network
             pdu.Write("Implementation Version", DicomImplementation.Version);
             pdu.WriteLength16();
 
-            pdu.WriteLength16();
+			foreach (DicomExtendedNegotiation exNeg in _assoc.ExtendedNegotiations)
+			{
+				exNeg.Write(pdu);
+			}
+
+			pdu.WriteLength16();
 
             return pdu;
         }
@@ -833,7 +838,11 @@ namespace Dicom.Network
                         {
                             _assoc.RemoteImplementationVersion = raw.ReadString("Implementation Version", ul);
                         }
-                        else
+						else if (ut == 0x56)
+						{
+							_assoc.ExtendedNegotiations.Add(DicomExtendedNegotiation.Create(raw, ul));
+						}
+						else
                         {
                             raw.SkipBytes("User Item Value", (int)ul);
                         }

--- a/DICOM/Network/RootQueryRetrieveInfoMove.cs
+++ b/DICOM/Network/RootQueryRetrieveInfoMove.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+	public class RootQueryRetrieveInfoMove : IExtendedNegotiationSubItem
+	{
+		public byte? RelationalRetrieval { get; private set; }
+
+		public RootQueryRetrieveInfoMove(byte? relationalRetrieval)
+		{
+			RelationalRetrieval = relationalRetrieval;
+		}
+
+		public static RootQueryRetrieveInfoMove Create(RawPDU pdu, int itemSize, out int bytesRead)
+		{
+			bytesRead = 0;
+			byte? relationalRetrieval = null;
+			if (itemSize > 0)
+			{
+				relationalRetrieval = pdu.ReadByte("Relational Retrieval");
+
+				bytesRead = 1;
+			}
+
+			return new RootQueryRetrieveInfoMove(relationalRetrieval);
+		}
+
+		public void Write(RawPDU pdu)
+		{
+			if (RelationalRetrieval.HasValue)
+			{
+				pdu.Write("Relational RelationalRetrieval", RelationalRetrieval.Value);
+			}
+		}
+	}
+}

--- a/DICOM/Network/StudyRootQueryRetrieveInfo.cs
+++ b/DICOM/Network/StudyRootQueryRetrieveInfo.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Dicom.Network
+{
+	public class StudyRootQueryRetrieveInfo : IExtendedNegotiationSubItem
+	{
+		public byte RelationalQueries { get; private set; }
+
+		public byte DateTimeMatching { get; private set; }
+
+		public byte FuzzySemanticMatching { get; private set; }
+
+		public byte TimezoneQueryAdjustment { get; private set; }
+
+		public StudyRootQueryRetrieveInfo(byte relationalQueries, byte dateTimeMatching, byte fuzzySemanticMatching, byte timezoneQueryAdjustment)
+		{
+			RelationalQueries = relationalQueries;
+			DateTimeMatching = dateTimeMatching;
+			FuzzySemanticMatching = fuzzySemanticMatching;
+			TimezoneQueryAdjustment = timezoneQueryAdjustment;
+		}
+
+		public static StudyRootQueryRetrieveInfo Create(RawPDU raw, out int bytesRead)
+		{
+			byte relationalQueries = raw.ReadByte("Relational-queries");
+			byte dateTimeMatching = raw.ReadByte("Date-Time matching");
+			byte fuzzySemanticMatching = raw.ReadByte("Fuzzy semantic matching");
+			byte timezoneQueryAdjustment = raw.ReadByte("Timezone query adjustment");
+
+			bytesRead = 4;
+			return new StudyRootQueryRetrieveInfo(relationalQueries, dateTimeMatching, fuzzySemanticMatching, timezoneQueryAdjustment);
+		}
+
+		public void Write(RawPDU pdu)
+		{
+			pdu.Write("Relational-queries", RelationalQueries);
+			pdu.Write("Date-Time matching", DateTimeMatching);
+			pdu.Write("Fuzzy semantic matching", FuzzySemanticMatching);
+			pdu.Write("Timezone query adjustment", TimezoneQueryAdjustment);
+		}
+	}
+
+}

--- a/DICOM/Network/StudyRootQueryRetrieveInfo.cs
+++ b/DICOM/Network/StudyRootQueryRetrieveInfo.cs
@@ -2,41 +2,93 @@
 
 namespace Dicom.Network
 {
-	public class StudyRootQueryRetrieveInfo : IExtendedNegotiationSubItem
+	public class RootQueryRetrieveInfoFind : IExtendedNegotiationSubItem
 	{
-		public byte RelationalQueries { get; private set; }
+		public byte? RelationalQueries { get; private set; }
 
-		public byte DateTimeMatching { get; private set; }
+		public byte? DateTimeMatching { get; private set; }
 
-		public byte FuzzySemanticMatching { get; private set; }
+		public byte? FuzzySemanticMatching { get; private set; }
 
-		public byte TimezoneQueryAdjustment { get; private set; }
+		public byte? TimezoneQueryAdjustment { get; private set; }
 
-		public StudyRootQueryRetrieveInfo(byte relationalQueries, byte dateTimeMatching, byte fuzzySemanticMatching, byte timezoneQueryAdjustment)
+		public byte? EnhancedMultiFrameImageConversion { get; private set; }
+
+		public RootQueryRetrieveInfoFind(byte? relationalQueries, byte? dateTimeMatching, byte? fuzzySemanticMatching, byte? timezoneQueryAdjustment, byte? enhancedMultiFrameImageConversion)
 		{
 			RelationalQueries = relationalQueries;
 			DateTimeMatching = dateTimeMatching;
 			FuzzySemanticMatching = fuzzySemanticMatching;
 			TimezoneQueryAdjustment = timezoneQueryAdjustment;
+			EnhancedMultiFrameImageConversion = enhancedMultiFrameImageConversion;
 		}
 
-		public static StudyRootQueryRetrieveInfo Create(RawPDU raw, out int bytesRead)
+		public static RootQueryRetrieveInfoFind Create(RawPDU raw, int itemSize, out int bytesRead)
 		{
-			byte relationalQueries = raw.ReadByte("Relational-queries");
-			byte dateTimeMatching = raw.ReadByte("Date-Time matching");
-			byte fuzzySemanticMatching = raw.ReadByte("Fuzzy semantic matching");
-			byte timezoneQueryAdjustment = raw.ReadByte("Timezone query adjustment");
+			byte? relationalQueries = null;
+			byte? dateTimeMatching = null;
+			byte? fuzzySemanticMatching = null;
+			byte? timezoneQueryAdjustment = null;
+			byte? enhancedMultiFrameImageConversion = null;
 
-			bytesRead = 4;
-			return new StudyRootQueryRetrieveInfo(relationalQueries, dateTimeMatching, fuzzySemanticMatching, timezoneQueryAdjustment);
+			bytesRead = 0;
+			if (itemSize > 0)
+			{
+				relationalQueries = raw.ReadByte("Relational-queries");
+				bytesRead++;
+
+				if (itemSize > 1)
+				{
+					dateTimeMatching = raw.ReadByte("Date-Time matching");
+					bytesRead++;
+
+					if (itemSize > 2)
+					{
+						fuzzySemanticMatching = raw.ReadByte("Fuzzy semantic matching");
+						bytesRead++;
+
+						if (itemSize > 3)
+						{
+							timezoneQueryAdjustment = raw.ReadByte("Timezone query adjustment");
+							bytesRead++;
+
+							if (itemSize > 4)
+							{
+								enhancedMultiFrameImageConversion = raw.ReadByte("Enhanced Multi-Frame Image Conversion");
+								bytesRead++;
+							}
+						}
+					}
+				}
+			}
+
+			return new RootQueryRetrieveInfoFind(relationalQueries, dateTimeMatching, fuzzySemanticMatching, timezoneQueryAdjustment, enhancedMultiFrameImageConversion);
 		}
 
 		public void Write(RawPDU pdu)
 		{
-			pdu.Write("Relational-queries", RelationalQueries);
-			pdu.Write("Date-Time matching", DateTimeMatching);
-			pdu.Write("Fuzzy semantic matching", FuzzySemanticMatching);
-			pdu.Write("Timezone query adjustment", TimezoneQueryAdjustment);
+			if (RelationalQueries.HasValue)
+			{
+				pdu.Write("Relational-queries", RelationalQueries.Value);
+
+				if (DateTimeMatching.HasValue)
+				{
+					pdu.Write("Date-Time matching", DateTimeMatching.Value);
+					if (FuzzySemanticMatching.HasValue)
+					{
+						pdu.Write("Fuzzy semantic matching", FuzzySemanticMatching.Value);
+						if (TimezoneQueryAdjustment.HasValue)
+						{
+							pdu.Write("Timezone query adjustment", TimezoneQueryAdjustment.Value);
+
+							if (EnhancedMultiFrameImageConversion.HasValue)
+							{
+								pdu.Write("Enhanced Multi-Frame Image Conversion", EnhancedMultiFrameImageConversion.Value);
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Implements Issue #241 

Changes proposed in this pull request:
- Add a collection of Extended Negotiaion objects to DicomAssociation
- Write/read Extended Negotiation to/from RawPDU (current support for StudyRootQueryRetrieveInformationModelFIND, PatientRootQueryRetrieveInformationModelFIND, StudyRootQueryRetrieveInformationModelMOVE, PatientRootQueryRetrieveInformationModelMOVE, with a pattern for implementing more.
- Allow users to implement new extended negotiation sub items at their service level through DicomExtendedNegotiation.AddSubItemCreator()