### PR TITLE
Runtime directives file included as Embedded Resource. Connected to #237

### DIFF
--- a/DICOM.Platform/Windows/DICOM.Windows.csproj
+++ b/DICOM.Platform/Windows/DICOM.Windows.csproj
@@ -170,7 +170,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Content Include="Properties\Dicom.Platform.rd.xml" />
+    <EmbeddedResource Include="Properties\Dicom.Platform.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DICOM.Native\Windows\DICOM.Native.Windows.vcxproj">

--- a/Setup/fo-dicom.Universal.nuspec
+++ b/Setup/fo-dicom.Universal.nuspec
@@ -25,20 +25,17 @@
         <file src="..\DICOM.Native\bin\x86\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.dll" target="runtimes\win10-x86\native" />
         <file src="..\DICOM.Native\bin\x86\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.pdb" target="runtimes\win10-x86\native" />
         <file src="..\DICOM.Native\bin\x86\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.pri" target="runtimes\win10-x86\native" />
-        <file src="..\DICOM.Platform\Windows\Properties\Dicom.Platform.rd.xml" target="runtimes\win10-x86\native\Dicom.Platform\Properties" />
         <file src="..\DICOM.Platform\Windows\bin\x64\Release\Dicom.Platform.dll" target="runtimes\win10-x64\lib\uap" />
         <file src="..\DICOM.Platform\Windows\bin\x64\Release\Dicom.Platform.pdb" target="runtimes\win10-x64\native" />
         <file src="..\DICOM.Platform\Windows\bin\x64\Release\Dicom.Platform.pri" target="runtimes\win10-x64\native" />
         <file src="..\DICOM.Native\bin\x64\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.dll" target="runtimes\win10-x64\native" />
         <file src="..\DICOM.Native\bin\x64\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.pdb" target="runtimes\win10-x64\native" />
         <file src="..\DICOM.Native\bin\x64\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.pri" target="runtimes\win10-x64\native" />
-        <file src="..\DICOM.Platform\Windows\Properties\Dicom.Platform.rd.xml" target="runtimes\win10-x64\native\Dicom.Platform\Properties" />
         <file src="..\DICOM.Platform\Windows\bin\ARM\Release\Dicom.Platform.dll" target="runtimes\win10-arm\lib\uap" />
         <file src="..\DICOM.Platform\Windows\bin\ARM\Release\Dicom.Platform.pdb" target="runtimes\win10-arm\native" />
         <file src="..\DICOM.Platform\Windows\bin\ARM\Release\Dicom.Platform.pri" target="runtimes\win10-arm\native" />
         <file src="..\DICOM.Native\bin\ARM\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.dll" target="runtimes\win10-arm\native" />
         <file src="..\DICOM.Native\bin\ARM\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.pdb" target="runtimes\win10-arm\native" />
         <file src="..\DICOM.Native\bin\ARM\Release\DICOM.Native.Windows\Dicom.Imaging.Codec.pri" target="runtimes\win10-arm\native" />
-        <file src="..\DICOM.Platform\Windows\Properties\Dicom.Platform.rd.xml" target="runtimes\win10-arm\native\Dicom.Platform\Properties" />
     </files>
 </package>


### PR DESCRIPTION
Fixes #237 .

Changes proposed in this pull request:
- *Dicom.Platform.rd.xml* file included in UWP project as *Embedded Resource* instead of as *Content*.
- *Dicom.Platform.rd.xml* removed from *UWP* platform NuGet file.

Please review.