### PR TITLE
Dummy call to early initialize log4net.LogManager. Connected to #244

### DIFF
--- a/Logging/DICOM.Log4Net.Desktop/Log4NetManager.cs
+++ b/Logging/DICOM.Log4Net.Desktop/Log4NetManager.cs
@@ -21,6 +21,9 @@ namespace Dicom.Log
         /// </summary>
         private Log4NetManager()
         {
+            // Perform dummy logging to ensure that [XmlConfigurator] attribute can be sufficiently employed (#244)
+            var dummy = log4net.LogManager.Exists(string.Empty);
+            dummy?.Warn("Unexpectedly found empty string logger");
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #244.

### Changes proposed in this pull request
- Make a dummy call to `log4net.LogManager`, at the earliest possible instant, to ensure that `[XmlConfigurator]` attribute can be sufficiently employed e.g. from *AssemblyInfo*.

Please review.