### PR TITLE
Proper handling of exceptions during DicomClient.Send(Async). Connected to #239

### DIFF
--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -320,10 +320,7 @@ namespace Dicom.Network
             }
             catch (AggregateException ae)
             {
-                foreach (var e in ae.Flatten().InnerExceptions)
-                {
-                    throw e;
-                }
+                throw ae.Flatten().InnerExceptions.First();
             }
             finally
             {

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -144,10 +144,8 @@ namespace Dicom.Network
                 RemoteHost = host,
                 RemotePort = port
             };
-            this.InitializeSend(this.networkStream, assoc);
 
-            this.completeNotifier.Task.Wait();
-            this.FinalizeSend();
+            this.DoSend(this.networkStream, assoc);
         }
 
         /// <summary>
@@ -159,9 +157,9 @@ namespace Dicom.Network
         /// <param name="callingAe">Calling Application Entity Title.</param>
         /// <param name="calledAe">Called Application Entity Title.</param>
         /// <returns>Awaitable task.</returns>
-        public async Task SendAsync(string host, int port, bool useTls, string callingAe, string calledAe)
+        public Task SendAsync(string host, int port, bool useTls, string callingAe, string calledAe)
         {
-            if (!this.CanSend) return;
+            if (!this.CanSend) Task.FromResult(false);   // TODO Replace with Task.CompletedTask when moving to .NET 4.6
 
             var noDelay = this.Options != null ? this.Options.TcpNoDelay : DicomServiceOptions.Default.TcpNoDelay;
             var ignoreSslPolicyErrors = (this.Options ?? DicomServiceOptions.Default).IgnoreSslPolicyErrors;
@@ -175,10 +173,8 @@ namespace Dicom.Network
                 RemoteHost = host,
                 RemotePort = port
             };
-            this.InitializeSend(this.networkStream, assoc);
 
-            await this.completeNotifier.Task.ConfigureAwait(false);
-            this.FinalizeSend();
+            return this.DoSendAsync(this.networkStream, assoc);
         }
 
         /// <summary>
@@ -198,10 +194,8 @@ namespace Dicom.Network
                 RemoteHost = stream.Host,
                 RemotePort = stream.Port
             };
-            this.InitializeSend(stream, assoc);
 
-            this.completeNotifier.Task.Wait();
-            this.FinalizeSend();
+            this.DoSend(stream, assoc);
         }
 
         /// <summary>
@@ -211,9 +205,9 @@ namespace Dicom.Network
         /// <param name="callingAe">Calling Application Entity Title.</param>
         /// <param name="calledAe">Called Application Entity Title.</param>
         /// <returns>Awaitable task.</returns>
-        public async Task SendAsync(INetworkStream stream, string callingAe, string calledAe)
+        public Task SendAsync(INetworkStream stream, string callingAe, string calledAe)
         {
-            if (!this.CanSend) return;
+            if (!this.CanSend) return Task.FromResult(false);   // TODO Replace with Task.CompletedTask when moving to .NET 4.6
 
             var assoc = new DicomAssociation(callingAe, calledAe)
             {
@@ -222,10 +216,8 @@ namespace Dicom.Network
                 RemoteHost = stream.Host,
                 RemotePort = stream.Port
             };
-            this.InitializeSend(stream, assoc);
 
-            await this.completeNotifier.Task.ConfigureAwait(false);
-            this.FinalizeSend();
+            return this.DoSendAsync(stream, assoc);
         }
 
         /// <summary>
@@ -318,6 +310,33 @@ namespace Dicom.Network
             this.networkStream = null;
 
             this.aborted = true;
+        }
+
+        private void DoSend(INetworkStream stream, DicomAssociation assoc)
+        {
+            try
+            {
+                this.InitializeSend(stream, assoc);
+                this.completeNotifier.Task.Wait();
+            }
+            catch (AggregateException ae)
+            {
+                foreach (var e in ae.Flatten().InnerExceptions)
+                {
+                    throw e;
+                }
+            }
+            finally
+            {
+                this.FinalizeSend();
+            }
+        }
+
+        private async Task DoSendAsync(INetworkStream stream, DicomAssociation assoc)
+        {
+            this.InitializeSend(stream, assoc);
+            await this.completeNotifier.Task.ConfigureAwait(false);
+            this.FinalizeSend();
         }
 
         private void InitializeSend(INetworkStream stream, DicomAssociation association)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -320,7 +320,7 @@ namespace Dicom.Network
             }
             catch (AggregateException ae)
             {
-                throw ae.Flatten().InnerExceptions.First();
+                throw ae.Flatten().InnerException;
             }
             finally
             {

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Text;
-
 namespace Dicom.Network
 {
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -125,7 +125,7 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="host">DICOM host.</param>
         /// <param name="port">Port.</param>
-        /// <param name="useTls">Treu if TLS security should be enabled, false otherwise.</param>
+        /// <param name="useTls">True if TLS security should be enabled, false otherwise.</param>
         /// <param name="callingAe">Calling Application Entity Title.</param>
         /// <param name="calledAe">Called Application Entity Title.</param>
         public void Send(string host, int port, bool useTls, string callingAe, string calledAe)
@@ -155,7 +155,7 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="host">DICOM host.</param>
         /// <param name="port">Port.</param>
-        /// <param name="useTls">Treu if TLS security should be enabled, false otherwise.</param>
+        /// <param name="useTls">True if TLS security should be enabled, false otherwise.</param>
         /// <param name="callingAe">Calling Application Entity Title.</param>
         /// <param name="calledAe">Called Application Entity Title.</param>
         /// <returns>Awaitable task.</returns>
@@ -426,8 +426,7 @@ namespace Dicom.Network
                 DicomRejectSource source,
                 DicomRejectReason reason)
             {
-                this.SetComplete();
-                throw new DicomAssociationRejectedException(result, source, reason);
+                this.SetComplete(new DicomAssociationRejectedException(result, source, reason));
             }
 
             public void OnReceiveAssociationReleaseResponse()
@@ -437,8 +436,7 @@ namespace Dicom.Network
 
             public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
             {
-                this.SetComplete();
-                throw new DicomAssociationAbortedException(source, reason);
+                this.SetComplete(new DicomAssociationAbortedException(source, reason));
             }
 
             public void OnConnectionClosed(Exception exception)
@@ -515,11 +513,18 @@ namespace Dicom.Network
                 return false;
             }
 
-            private void SetComplete()
+            private void SetComplete(Exception ex = null)
             {
                 if (this.client.completeNotifier != null)
                 {
-                    this.client.completeNotifier.TrySetResult(true);
+                    if (ex == null)
+                    {
+                        this.client.completeNotifier.TrySetResult(true);
+                    }
+                    else
+                    {
+                        this.client.completeNotifier.TrySetException(ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #239 (according to @Ed55 's proposals).

Changes proposed in this pull request:
- Re-factor `SetComplete` method to handle optional exceptions.
- Unwrap `AggregateException` and re-throw the inner exceptions in the `Send` overloads.
- Re-factor the actual send parts in the `Send` and `SendAsync` overloads to be contained in separate `DoSend(Async)` methods.

Please review.