### PR TITLE
Added DicomServer class for retrieving server instances from specified port. Connected to #191

### DIFF
--- a/DICOM.Tests/Network/DicomServerTest.cs
+++ b/DICOM.Tests/Network/DicomServerTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-
 namespace Dicom.Network
 {
     using System.Linq;

--- a/DICOM.Tests/Network/DicomServerTest.cs
+++ b/DICOM.Tests/Network/DicomServerTest.cs
@@ -124,7 +124,8 @@ namespace Dicom.Network
 
             foreach (var port in ports)
             {
-                DicomServer.Create<DicomCEchoProvider>(port);
+                var server = DicomServer.Create<DicomCEchoProvider>(port);
+                while (!server.IsListening) Thread.Sleep(10);
             }
 
             foreach (var port in ports)

--- a/DICOM.Tests/Network/DicomServerTest.cs
+++ b/DICOM.Tests/Network/DicomServerTest.cs
@@ -74,6 +74,26 @@ namespace Dicom.Network
         }
 
         [Fact]
+        public void Create_TwiceOnSamePortWithDisposalInBetween_DoesNotThrow()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<DicomCEchoProvider>(port))
+            {
+            }
+
+            var e = Record.Exception(
+                () =>
+                    {
+                        using (DicomServer.Create<DicomCEchoProvider>(port))
+                        {
+                            Assert.NotNull(DicomServer.GetInstance(port));
+                        }
+                    });
+            Assert.Null(e);
+        }
+
+        [Fact]
         public void Create_GetInstanceDifferentPort_ReturnsNull()
         {
             var port = Ports.GetNext();

--- a/DICOM/DICOM.Core.csproj
+++ b/DICOM/DICOM.Core.csproj
@@ -275,6 +275,7 @@
     <Compile Include="Network\DicomResponse.cs" />
     <Compile Include="Network\IDicomCEchoProvider.cs" />
     <Compile Include="Network\IDicomCStoreProvider.cs" />
+    <Compile Include="Network\IDicomServer.cs" />
     <Compile Include="Network\IDicomServiceProvider.cs" />
     <Compile Include="Network\IDicomServiceUser.cs" />
     <Compile Include="Network\INetworkListener.cs" />

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -278,6 +278,8 @@ namespace Dicom.Network
 
         private static readonly HashSet<IDicomServer> Servers = new HashSet<IDicomServer>(DicomServerPortComparer.Default);
 
+        private static readonly object locker = new object();
+
         #endregion
 
         #region METHODS
@@ -305,7 +307,10 @@ namespace Dicom.Network
             }
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            return new DicomServer<T>(port, certificateName, options, fallbackEncoding, logger);
+            lock (locker)
+            {
+                return new DicomServer<T>(port, certificateName, options, fallbackEncoding, logger);
+            }
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
@@ -336,7 +341,10 @@ namespace Dicom.Network
         /// <returns>True if <paramref name="server"/> could be added, false otherwise.</returns>
         internal static bool Add(IDicomServer server)
         {
-            return Servers.Add(server);
+            lock (locker)
+            {
+                return Servers.Add(server);
+            }
         }
 
         /// <summary>
@@ -346,7 +354,10 @@ namespace Dicom.Network
         /// <returns>True if <paramref name="server"/> could be removed, false otherwise.</returns>
         internal static bool Remove(IDicomServer server)
         {
-            return Servers.Remove(server);
+            lock (locker)
+            {
+                return Servers.Remove(server);
+            }
         }
 
         #endregion

--- a/DICOM/Network/IDicomServer.cs
+++ b/DICOM/Network/IDicomServer.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System;
+
+    using Dicom.Log;
+
+    /// <summary>
+    /// Interface representing a DICOM server instance.
+    /// </summary>
+    public interface IDicomServer : IDisposable
+    {
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the port to which the server is listening.
+        /// </summary>
+        int Port { get; }
+
+        /// <summary>
+        /// Gets the logger used by <see cref="DicomServer{T}"/>
+        /// </summary>
+        Logger Logger { get; }
+
+        /// <summary>
+        /// Gets the options to control behavior of <see cref="DicomService"/> base class.
+        /// </summary>
+        DicomServiceOptions Options { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the server is actively listening for client connections.
+        /// </summary>
+        bool IsListening { get; }
+
+        /// <summary>
+        /// Gets the exception that was thrown if the server failed to listen.
+        /// </summary>
+        Exception Exception { get; }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Stop server from further listening.
+        /// </summary>
+        void Stop();
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #191 .

Changes proposed in this pull request:
- Implement a non-generic `IDicomServer` interface for the public properties and methods in `DicomServer<T>` and have `DicomServer<T>` implement this interface.
- Refactor the `port` field in `DicomServer<T>` to a public property and include it in the interface.
- Add a static class `DicomServer` to hold all instantiated `DicomServer<T>` objects.
- Implement a factory method `DicomServer.Create<T>` intended to substitute the public use of the `DicomServer<T>` constructor. Factory method returns `IDicomServer` and throws if another server has already been registered on the same port.
- Annotate the `DicomServer<T>` constructor `[Obsolete]` for now; in the future, consider declaring the constructor `protected internal` to ensure that initialization via `DicomServer.Create<T>` is enforced.
- Implement a method `DicomServer.GetInstance(int port)` to obtain the server registered for the specified port, or `null` if no server is registered for that port.
- Implement a method `DicomServer.IsListening(int port)` to return the server listening status on the specified port. Returns `true` if a server is registered on the specified port **and** the server is in listening mode. If the server on that port has been stopped, `DicomServer.IsListening` will return `false` even if the server is still registered. To check if a server on a specific port exists, listening or not, verify that `DicomServer.GetInstance` is not `null`.

Please review.