### PR TITLE
Added compiler directive UNITY_5 to facilitate porting to Unity. Connected to #251

### DIFF
--- a/DICOM/DICOM.Core.csproj
+++ b/DICOM/DICOM.Core.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;UNITY_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/DICOM/DICOM.Core.csproj
+++ b/DICOM/DICOM.Core.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;UNITY_5</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/DICOM/DicomDatasetWalker.cs
+++ b/DICOM/DicomDatasetWalker.cs
@@ -6,11 +6,11 @@ namespace Dicom
     using System;
     using System.Collections.Generic;
 
-    using Dicom.IO.Buffer;
-
 #if !UNITY_5
     using System.Threading.Tasks;
 #endif
+
+    using Dicom.IO.Buffer;
 
     /// <summary>
     /// Interface for traversing a DICOM dataset.

--- a/DICOM/DicomDatasetWalker.cs
+++ b/DICOM/DicomDatasetWalker.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-
-using Dicom.IO.Buffer;
-
 namespace Dicom
 {
+    using System;
+    using System.Collections.Generic;
+
+    using Dicom.IO.Buffer;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Interface for traversing a DICOM dataset.
@@ -27,12 +29,14 @@ namespace Dicom
         /// <returns>true if traversing completed without issues, false otherwise.</returns>
         bool OnElement(DicomElement element);
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing a DICOM element.
         /// </summary>
         /// <param name="element">Element to traverse.</param>
         /// <returns>true if traversing completed without issues, false otherwise.</returns>
         Task<bool> OnElementAsync(DicomElement element);
+#endif
 
         /// <summary>
         /// Handler for traversing beginning of sequence.
@@ -74,12 +78,14 @@ namespace Dicom
         /// <returns>true if traversing completed without issues, false otherwise.</returns>
         bool OnFragmentItem(IByteBuffer item);
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing fragment item.
         /// </summary>
         /// <param name="item">Buffer containing the fragment item.</param>
         /// <returns>true if traversing completed without issues, false otherwise.</returns>
         Task<bool> OnFragmentItemAsync(IByteBuffer item);
+#endif
 
         /// <summary>
         /// Handler for traversing end of fragment.
@@ -221,6 +227,7 @@ namespace Dicom
                 DoWalk(walker, items);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Perform an asynchronous "walk" across the DICOM dataset provided in the <see cref="DicomDatasetWalker"/> constructor.
         /// </summary>
@@ -233,6 +240,7 @@ namespace Dicom
 
             return DoWalkAsync(walker, items);
         }
+#endif
 
         /// <summary>
         /// Populate the <paramref name="items"/> queue.
@@ -337,6 +345,7 @@ namespace Dicom
             }
         }
 
+#if !UNITY_5
         /// <summary>
         /// Perform an asynchronous dataset walk.
         /// </summary>
@@ -401,6 +410,7 @@ namespace Dicom
                 }
             }
         }
+#endif
 
         #endregion
     }

--- a/DICOM/DicomFile.cs
+++ b/DICOM/DicomFile.cs
@@ -6,7 +6,10 @@ namespace Dicom
     using System;
     using System.IO;
     using System.Text;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     using Dicom.IO;
     using Dicom.IO.Reader;
@@ -35,7 +38,7 @@ namespace Dicom
     /// <summary>
     /// Representation of one DICOM file.
     /// </summary>
-    public partial class DicomFile
+    public class DicomFile
     {
         #region CONSTRUCTORS
 
@@ -142,6 +145,7 @@ namespace Dicom
             writer.Write(target, FileMetaInfo, Dataset);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Save to file asynchronously.
         /// </summary>
@@ -196,6 +200,7 @@ namespace Dicom
             var writer = new DicomFileWriter(DicomWriteOptions.Default);
             await writer.WriteAsync(target, this.FileMetaInfo, this.Dataset).ConfigureAwait(false);
         }
+#endif
 
         /// <summary>
         /// Reads the specified filename and returns a DicomFile object.  Note that the values for large
@@ -320,6 +325,7 @@ namespace Dicom
             }
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously reads the specified filename and returns a DicomFile object.  Note that the values for large
         /// DICOM elements (e.g. PixelData) are read in "on demand" to conserve memory.  Large DICOM elements
@@ -444,6 +450,7 @@ namespace Dicom
                 throw new DicomFileException(df, e.Message, e);
             }
         }
+#endif
 
         /// <summary>
         /// Test if file has a valid preamble and DICOM 3.0 header.

--- a/DICOM/IO/Buffer/ByteBufferByteSource.cs
+++ b/DICOM/IO/Buffer/ByteBufferByteSource.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-
 namespace Dicom.IO.Buffer
 {
+    using System;
+    using System.Collections.Generic;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Byte source for reading in form of byte buffer.
@@ -331,6 +333,7 @@ namespace Dicom.IO.Buffer
             return new MemoryByteBuffer(GetBytes((int)count));
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously gets a byte buffer of specified length from the current position and moves to subsequent position.
         /// </summary>
@@ -340,6 +343,7 @@ namespace Dicom.IO.Buffer
         {
             return Task.FromResult(this.GetBuffer(count));
         }
+#endif
 
         /// <summary>
         /// Skip position <see cref="count"/> number of bytes.

--- a/DICOM/IO/Endian.cs
+++ b/DICOM/IO/Endian.cs
@@ -1,13 +1,15 @@
 // Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Dicom.IO
 {
+    using System;
+    using System.IO;
+    using System.Text;
+
+#if !UNITY_5
+    using System.Threading.Tasks;
+#endif
 
     #region Endian
 
@@ -174,22 +176,38 @@ namespace Dicom.IO
 
         public static void Swap(short[] values)
         {
+#if UNITY_5
+            for (var i = 0; i < values.Length; ++i) values[i] = Swap(values[i]);
+#else
             Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+#endif
         }
 
         public static void Swap(ushort[] values)
         {
+#if UNITY_5
+            for (var i = 0; i < values.Length; ++i) values[i] = Swap(values[i]);
+#else
             Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+#endif
         }
 
         public static void Swap(int[] values)
         {
+#if UNITY_5
+            for (var i = 0; i < values.Length; ++i) values[i] = Swap(values[i]);
+#else
             Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+#endif
         }
 
         public static void Swap(uint[] values)
         {
+#if UNITY_5
+            for (var i = 0; i < values.Length; ++i) values[i] = Swap(values[i]);
+#else
             Parallel.For(0, values.Length, (i) => { values[i] = Swap(values[i]); });
+#endif
         }
 
         public static void Swap<T>(T[] values)
@@ -202,21 +220,21 @@ namespace Dicom.IO
         }
     }
 
-    #endregion
+#endregion
 
-    #region EndianBinaryReader
+#region EndianBinaryReader
 
     public class EndianBinaryReader : BinaryReader
     {
-        #region Private Members
+#region Private Members
 
         private bool SwapBytes = false;
 
         private byte[] InternalBuffer = new byte[8];
 
-        #endregion
+#endregion
 
-        #region Public Constructors
+#region Public Constructors
 
         public EndianBinaryReader(Stream input)
             : base(input)
@@ -299,9 +317,9 @@ namespace Dicom.IO
             }
         }
 
-        #endregion
+#endregion
 
-        #region Public Properties
+#region Public Properties
 
         public Endian Endian
         {
@@ -348,9 +366,9 @@ namespace Dicom.IO
             }
         }
 
-        #endregion
+#endregion
 
-        #region Private Methods
+#region Private Methods
 
         private byte[] ReadBytesInternal(int count)
         {
@@ -371,9 +389,9 @@ namespace Dicom.IO
             return Buffer;
         }
 
-        #endregion
+#endregion
 
-        #region BinaryReader Overrides
+#region BinaryReader Overrides
 
         public override short ReadInt16()
         {
@@ -449,22 +467,22 @@ namespace Dicom.IO
             return base.ReadUInt64();
         }
 
-        #endregion
+#endregion
     }
 
-    #endregion
+#endregion
 
-    #region EndianBinaryWriter
+#region EndianBinaryWriter
 
     public class EndianBinaryWriter : BinaryWriter
     {
-        #region Private Members
+#region Private Members
 
         private bool SwapBytes = false;
 
-        #endregion
+#endregion
 
-        #region Public Constructors
+#region Public Constructors
 
         public EndianBinaryWriter(Stream output)
             : base(output)
@@ -547,9 +565,9 @@ namespace Dicom.IO
             }
         }
 
-        #endregion
+#endregion
 
-        #region Public Properties
+#region Public Properties
 
         public Endian Endian
         {
@@ -577,9 +595,9 @@ namespace Dicom.IO
             }
         }
 
-        #endregion
+#endregion
 
-        #region Private Methods
+#region Private Methods
 
         private void WriteInternal(byte[] Buffer)
         {
@@ -590,9 +608,9 @@ namespace Dicom.IO
             base.Write(Buffer);
         }
 
-        #endregion
+#endregion
 
-        #region BinaryWriter Overrides
+#region BinaryWriter Overrides
 
         public override void Write(double value)
         {
@@ -698,8 +716,8 @@ namespace Dicom.IO
             }
         }
 
-        #endregion
+#endregion
     }
 
-    #endregion
+#endregion
 }

--- a/DICOM/IO/Endian.cs
+++ b/DICOM/IO/Endian.cs
@@ -220,21 +220,21 @@ namespace Dicom.IO
         }
     }
 
-#endregion
+    #endregion
 
-#region EndianBinaryReader
+    #region EndianBinaryReader
 
     public class EndianBinaryReader : BinaryReader
     {
-#region Private Members
+        #region Private Members
 
         private bool SwapBytes = false;
 
         private byte[] InternalBuffer = new byte[8];
 
-#endregion
+        #endregion
 
-#region Public Constructors
+        #region Public Constructors
 
         public EndianBinaryReader(Stream input)
             : base(input)
@@ -317,9 +317,9 @@ namespace Dicom.IO
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public Endian Endian
         {
@@ -366,9 +366,9 @@ namespace Dicom.IO
             }
         }
 
-#endregion
+        #endregion
 
-#region Private Methods
+        #region Private Methods
 
         private byte[] ReadBytesInternal(int count)
         {
@@ -389,9 +389,9 @@ namespace Dicom.IO
             return Buffer;
         }
 
-#endregion
+        #endregion
 
-#region BinaryReader Overrides
+        #region BinaryReader Overrides
 
         public override short ReadInt16()
         {
@@ -467,22 +467,22 @@ namespace Dicom.IO
             return base.ReadUInt64();
         }
 
-#endregion
+        #endregion
     }
 
-#endregion
+    #endregion
 
-#region EndianBinaryWriter
+    #region EndianBinaryWriter
 
     public class EndianBinaryWriter : BinaryWriter
     {
-#region Private Members
+        #region Private Members
 
         private bool SwapBytes = false;
 
-#endregion
+        #endregion
 
-#region Public Constructors
+        #region Public Constructors
 
         public EndianBinaryWriter(Stream output)
             : base(output)
@@ -565,9 +565,9 @@ namespace Dicom.IO
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public Endian Endian
         {
@@ -595,9 +595,9 @@ namespace Dicom.IO
             }
         }
 
-#endregion
+        #endregion
 
-#region Private Methods
+        #region Private Methods
 
         private void WriteInternal(byte[] Buffer)
         {
@@ -608,9 +608,9 @@ namespace Dicom.IO
             base.Write(Buffer);
         }
 
-#endregion
+        #endregion
 
-#region BinaryWriter Overrides
+        #region BinaryWriter Overrides
 
         public override void Write(double value)
         {
@@ -716,8 +716,8 @@ namespace Dicom.IO
             }
         }
 
-#endregion
+        #endregion
     }
 
-#endregion
+    #endregion
 }

--- a/DICOM/IO/FileByteSource.cs
+++ b/DICOM/IO/FileByteSource.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-
-using Dicom.IO.Buffer;
-
 namespace Dicom.IO
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
+
+    using Dicom.IO.Buffer;
 
     /// <summary>
     /// File byte source for reading.
@@ -256,6 +258,7 @@ namespace Dicom.IO
             return buffer;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously gets a byte buffer of specified length from the current position and moves to subsequent position.
         /// </summary>
@@ -265,6 +268,7 @@ namespace Dicom.IO
         {
             return Task.FromResult(this.GetBuffer(count));
         }
+#endif
 
         /// <summary>
         /// Skip position <see cref="count"/> number of bytes.

--- a/DICOM/IO/FileByteTarget.cs
+++ b/DICOM/IO/FileByteTarget.cs
@@ -5,7 +5,10 @@ namespace Dicom.IO
 {
     using System;
     using System.IO;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Representation of a file byte target.
@@ -160,6 +163,7 @@ namespace Dicom.IO
             _stream.Write(buffer, (int)offset, (int)count);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously write array of <see cref="byte"/>s to target.
         /// </summary>
@@ -171,6 +175,7 @@ namespace Dicom.IO
         {
             return _stream.WriteAsync(buffer, (int)offset, (int)count);
         }
+#endif
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/DICOM/IO/IByteSource.cs
+++ b/DICOM/IO/IByteSource.cs
@@ -3,7 +3,9 @@
 
 namespace Dicom.IO
 {
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     using Dicom.IO.Buffer;
 
@@ -117,12 +119,14 @@ namespace Dicom.IO
         /// <returns>Byte buffer containing the read bytes.</returns>
         IByteBuffer GetBuffer(uint count);
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously gets a byte buffer of specified length from the current position and moves to subsequent position.
         /// </summary>
         /// <param name="count">Number of bytes to read.</param>
         /// <returns>Awaitable byte buffer containing the read bytes.</returns>
         Task<IByteBuffer> GetBufferAsync(uint count);
+#endif
 
         /// <summary>
         /// Skip position <see cref="count"/> number of bytes.

--- a/DICOM/IO/IByteTarget.cs
+++ b/DICOM/IO/IByteTarget.cs
@@ -3,7 +3,9 @@
 
 namespace Dicom.IO
 {
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Callback delegate for asynchronous <see cref="IByteTarget"/> operations.
@@ -89,6 +91,7 @@ namespace Dicom.IO
         /// <param name="count">Number of bytes to write to byte target.</param>
         void Write(byte[] buffer, uint offset, uint count);
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously write array of <see cref="byte"/>s to target.
         /// </summary>
@@ -97,5 +100,6 @@ namespace Dicom.IO
         /// <param name="count">Number of bytes to write to byte target.</param>
         /// <returns>Avaitable <see cref="Task"/>.</returns>
         Task WriteAsync(byte[] buffer, uint offset, uint count);
+#endif
     }
 }

--- a/DICOM/IO/Reader/DicomFileReader.cs
+++ b/DICOM/IO/Reader/DicomFileReader.cs
@@ -421,6 +421,6 @@ namespace Dicom.IO.Reader
             }
         }
 
-#endregion
+        #endregion
     }
 }

--- a/DICOM/IO/Reader/DicomFileReader.cs
+++ b/DICOM/IO/Reader/DicomFileReader.cs
@@ -5,7 +5,10 @@ namespace Dicom.IO.Reader
 {
     using System;
     using System.Text;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Class for reading DICOM file objects.
@@ -92,6 +95,7 @@ namespace Dicom.IO.Reader
             return parse.Item1;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously read DICOM file object.
         /// </summary>
@@ -114,6 +118,7 @@ namespace Dicom.IO.Reader
             }
             return parse.Item1;
         }
+#endif
 
         private static Tuple<DicomReaderResult, DicomFileFormat, DicomTransferSyntax> Parse(
             IByteSource source,
@@ -142,6 +147,7 @@ namespace Dicom.IO.Reader
             return Tuple.Create(result, fileFormat, syntax);
         }
 
+#if !UNITY_5
         private static async Task<Tuple<DicomReaderResult, DicomFileFormat, DicomTransferSyntax>> ParseAsync(
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
@@ -162,6 +168,7 @@ namespace Dicom.IO.Reader
                 await
                 DoParseAsync(source, fileMetasetInfoObserver, datasetObserver, stop, syntax, fileFormat).ConfigureAwait(false);
         }
+#endif
 
         private static void Preprocess(
             IByteSource source,
@@ -315,6 +322,7 @@ namespace Dicom.IO.Reader
             return result;
         }
 
+#if !UNITY_5
         private static async Task<Tuple<DicomReaderResult, DicomFileFormat, DicomTransferSyntax>> DoParseAsync(
             IByteSource source,
             IDicomReaderObserver fileMetasetInfoObserver,
@@ -388,6 +396,7 @@ namespace Dicom.IO.Reader
 
             return Tuple.Create(result, fileFormat, syntax);
         }
+#endif
 
         private static void UpdateFileFormatAndSyntax(
             string code,
@@ -412,6 +421,6 @@ namespace Dicom.IO.Reader
             }
         }
 
-        #endregion
+#endregion
     }
 }

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -7,11 +7,13 @@ namespace Dicom.IO.Reader
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
-    using System.Threading.Tasks;
 
-    using Dicom.IO.Buffer;
+#if !UNITY_5
+    using System.Threading.Tasks;
+#endif
 
     using Dicom.Imaging.Mathematics;
+    using Dicom.IO.Buffer;
 
     /// <summary>
     /// DICOM reader implementation.
@@ -66,6 +68,7 @@ namespace Dicom.IO.Reader
             return worker.DoWork(source);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously perform DICOM reading of a byte source.
         /// </summary>
@@ -78,7 +81,7 @@ namespace Dicom.IO.Reader
             var worker = new DicomReaderWorker(observer, stop, this.Dictionary, this.IsExplicitVR, this._private);
             return worker.DoWorkAsync(source);
         }
-
+#endif
         #endregion
 
         #region INNER TYPES
@@ -179,6 +182,7 @@ namespace Dicom.IO.Reader
                 return this.result;
             }
 
+#if !UNITY_5
             /// <summary>
             /// Asynchronously read the byte source.
             /// </summary>
@@ -190,6 +194,7 @@ namespace Dicom.IO.Reader
                 await this.ParseDatasetAsync(source).ConfigureAwait(false);
                 return this.result;
             }
+#endif
 
             private void ParseDataset(IByteSource source)
             {
@@ -216,6 +221,7 @@ namespace Dicom.IO.Reader
                 this.result = DicomReaderResult.Success;
             }
 
+#if !UNITY_5
             private async Task ParseDatasetAsync(IByteSource source)
             {
                 this.result = DicomReaderResult.Processing;
@@ -240,6 +246,7 @@ namespace Dicom.IO.Reader
                 // end of processing
                 this.result = DicomReaderResult.Success;
             }
+#endif
 
             private bool ParseTag(IByteSource source)
             {
@@ -603,6 +610,7 @@ namespace Dicom.IO.Reader
                 return true;
             }
 
+#if !UNITY_5
             private async Task<bool> ParseValueAsync(IByteSource source)
             {
                 if (this.parseStage == ParseStage.Value)
@@ -735,6 +743,7 @@ namespace Dicom.IO.Reader
                 }
                 return true;
             }
+#endif
 
             private void ParseItemSequence(IByteSource source)
             {
@@ -749,6 +758,7 @@ namespace Dicom.IO.Reader
                 this.ParseItemSequencePostProcess(source);
             }
 
+#if !UNITY_5
             private async Task ParseItemSequenceAsync(IByteSource source)
             {
                 this.result = DicomReaderResult.Processing;
@@ -761,6 +771,7 @@ namespace Dicom.IO.Reader
 
                 this.ParseItemSequencePostProcess(source);
             }
+#endif
 
             private bool ParseItemSequenceTag(IByteSource source)
             {
@@ -851,6 +862,7 @@ namespace Dicom.IO.Reader
                 return true;
             }
 
+#if !UNITY_5
             private async Task<bool> ParseItemSequenceValueAsync(IByteSource source)
             {
                 if (this.parseStage == ParseStage.Value)
@@ -876,6 +888,7 @@ namespace Dicom.IO.Reader
                 }
                 return true;
             }
+#endif
 
             private void ParseItemSequencePostProcess(IByteSource source)
             {
@@ -904,6 +917,7 @@ namespace Dicom.IO.Reader
                 }
             }
 
+#if !UNITY_5
             private async Task ParseFragmentSequenceAsync(IByteSource source)
             {
                 this.result = DicomReaderResult.Processing;
@@ -914,6 +928,7 @@ namespace Dicom.IO.Reader
                     if (!await this.ParseFragmentSequenceValueAsync(source).ConfigureAwait(false)) return;
                 }
             }
+#endif
 
             private bool ParseFragmentSequenceTag(IByteSource source)
             {
@@ -973,6 +988,7 @@ namespace Dicom.IO.Reader
                 return true;
             }
 
+#if !UNITY_5
             private async Task<bool> ParseFragmentSequenceValueAsync(IByteSource source)
             {
                 if (this.parseStage == ParseStage.Value)
@@ -991,6 +1007,7 @@ namespace Dicom.IO.Reader
                 }
                 return true;
             }
+#endif
 
             private void ResetState()
             {

--- a/DICOM/IO/Reader/IDicomReader.cs
+++ b/DICOM/IO/Reader/IDicomReader.cs
@@ -4,7 +4,10 @@
 namespace Dicom.IO.Reader
 {
     using System;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Possible DICOM reader results.
@@ -61,6 +64,7 @@ namespace Dicom.IO.Reader
         /// <returns>Reader resulting status.</returns>
         DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null);
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously perform DICOM reading of a byte source.
         /// </summary>
@@ -69,5 +73,6 @@ namespace Dicom.IO.Reader
         /// <param name="stop">Criterion at which to stop.</param>
         /// <returns>Awaitable reader resulting status.</returns>
         Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null);
+#endif
     }
 }

--- a/DICOM/IO/StreamByteSource.cs
+++ b/DICOM/IO/StreamByteSource.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Collections.Generic;
-using System.IO;
-
-using Dicom.IO.Buffer;
-
 namespace Dicom.IO
 {
+    using System.Collections.Generic;
+    using System.IO;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
+
+    using Dicom.IO.Buffer;
 
     /// <summary>
     /// Stream byte source for reading.
@@ -249,6 +251,7 @@ namespace Dicom.IO
             return buffer;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously gets a byte buffer of specified length from the current position and moves to subsequent position.
         /// </summary>
@@ -258,6 +261,7 @@ namespace Dicom.IO
         {
             return Task.FromResult(this.GetBuffer(count));
         }
+#endif
 
         /// <summary>
         /// Skip position <see cref="count"/> number of bytes.

--- a/DICOM/IO/StreamByteTarget.cs
+++ b/DICOM/IO/StreamByteTarget.cs
@@ -4,7 +4,10 @@
 namespace Dicom.IO
 {
     using System.IO;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Representation of a stream byte target.
@@ -156,6 +159,7 @@ namespace Dicom.IO
             _stream.Write(buffer, (int)offset, (int)count);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously write array of <see cref="byte"/>s to target.
         /// </summary>
@@ -167,5 +171,6 @@ namespace Dicom.IO
         {
             return _stream.WriteAsync(buffer, (int)offset, (int)count);
         }
+#endif
     }
 }

--- a/DICOM/IO/TemporaryFileRemover.cs
+++ b/DICOM/IO/TemporaryFileRemover.cs
@@ -5,7 +5,12 @@ namespace Dicom.IO
 {
     using System;
     using System.Collections.Generic;
+
+#if UNITY_5
+    using System.Threading;
+#else
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Support class for removing temporary files, with repeated attempts if required.
@@ -109,7 +114,11 @@ namespace Dicom.IO
                         if (!this.running)
                         {
                             this.running = true;
+#if UNITY_5
+                            ThreadPool.QueueUserWorkItem(this.DeleteAll);
+#else
                             Task.Run((Action)this.DeleteAll);
+#endif
                         }
                     }
                 }
@@ -119,7 +128,11 @@ namespace Dicom.IO
         /// <summary>
         /// Event handler for repeated file removal attempts.
         /// </summary>
+#if UNITY_5
+        private void DeleteAll(object dummy)
+#else
         private async void DeleteAll()
+#endif
         {
             while (true)
             {
@@ -145,7 +158,11 @@ namespace Dicom.IO
                     }
                 }
 
+#if UNITY_5
+                Thread.Sleep(1000);
+#else
                 await Task.Delay(1000).ConfigureAwait(false);
+#endif
             }
         }
 

--- a/DICOM/IO/Writer/DicomFileWriter.cs
+++ b/DICOM/IO/Writer/DicomFileWriter.cs
@@ -204,6 +204,6 @@ namespace Dicom.IO.Writer
             }
         }
 
-#endregion
+        #endregion
     }
 }

--- a/DICOM/IO/Writer/DicomFileWriter.cs
+++ b/DICOM/IO/Writer/DicomFileWriter.cs
@@ -3,7 +3,9 @@
 
 namespace Dicom.IO.Writer
 {
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
 
     /// <summary>
     /// Writer for DICOM Part 10 objects.
@@ -44,6 +46,7 @@ namespace Dicom.IO.Writer
             WriteDataset(target, fileMetaInfo.TransferSyntax, dataset, this.options);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Write DICOM Part 10 object to <paramref name="target"/> asynchronously.
         /// </summary>
@@ -57,6 +60,7 @@ namespace Dicom.IO.Writer
             await WriteFileMetaInfoAsync(target, fileMetaInfo, this.options).ConfigureAwait(false);
             await WriteDatasetAsync(target, fileMetaInfo.TransferSyntax, dataset, this.options).ConfigureAwait(false);
         }
+#endif
 
         /// <summary>
         /// Write DICOM file preamble.
@@ -73,6 +77,7 @@ namespace Dicom.IO.Writer
             target.Write(preamble, 0, 132);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Write DICOM file preamble.
         /// </summary>
@@ -87,6 +92,7 @@ namespace Dicom.IO.Writer
 
             return target.WriteAsync(preamble, 0, 132);
         }
+#endif
 
         /// <summary>
         /// Write DICOM file meta information.
@@ -107,6 +113,7 @@ namespace Dicom.IO.Writer
             walker.Walk(writer);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Write DICOM file meta information.
         /// </summary>
@@ -125,6 +132,7 @@ namespace Dicom.IO.Writer
             var walker = new DicomDatasetWalker(fileMetaInfo);
             return walker.WalkAsync(writer);
         }
+#endif
 
         /// <summary>
         /// Write DICOM dataset.
@@ -146,6 +154,7 @@ namespace Dicom.IO.Writer
             walker.Walk(writer);
         }
 
+#if !UNITY_5
         /// <summary>
         /// Write DICOM dataset.
         /// </summary>
@@ -165,6 +174,7 @@ namespace Dicom.IO.Writer
             var walker = new DicomDatasetWalker(dataset);
             return walker.WalkAsync(writer);
         }
+#endif
 
         /// <summary>
         /// If necessary, update dataset syntax and group lengths.
@@ -194,6 +204,6 @@ namespace Dicom.IO.Writer
             }
         }
 
-        #endregion
+#endregion
     }
 }

--- a/DICOM/IO/Writer/DicomWriter.cs
+++ b/DICOM/IO/Writer/DicomWriter.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Collections.Generic;
-
-using Dicom.IO.Buffer;
-
 namespace Dicom.IO.Writer
 {
+    using System.Collections.Generic;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
+
+    using Dicom.IO.Buffer;
 
     /// <summary>
     /// DICOM object writer.
@@ -87,6 +89,7 @@ namespace Dicom.IO.Writer
             return true;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing a DICOM element.
         /// </summary>
@@ -118,6 +121,7 @@ namespace Dicom.IO.Writer
 
             return true;
         }
+#endif
 
         /// <summary>
         /// Handler for traversing beginning of sequence.
@@ -231,6 +235,7 @@ namespace Dicom.IO.Writer
             return true;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing fragment item.
         /// </summary>
@@ -258,6 +263,7 @@ namespace Dicom.IO.Writer
 
             return true;
         }
+#endif
 
         /// <summary>
         /// Handler for traversing end of fragment.

--- a/DICOM/Imaging/Algorithms/BilinearInterpolation.cs
+++ b/DICOM/Imaging/Algorithms/BilinearInterpolation.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Threading.Tasks;
-
 namespace Dicom.Imaging.Algorithms
 {
+#if !UNITY_5
+    using System.Threading.Tasks;
+#endif
+
     public static class BilinearInterpolation
     {
         public static byte[] RescaleGrayscale(
@@ -24,40 +26,44 @@ namespace Dicom.Imaging.Algorithms
 
             unchecked
             {
-                Parallel.For(
-                    0,
-                    outputHeight,
-                    y =>
-                        {
-                            double oy0 = y * yF;
-                            int oy1 = (int)oy0; // rounds down
-                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+#if UNITY_5
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    double oy0 = y * yF;
+                    int oy1 = (int)oy0; // rounds down
+                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                            double dy1 = oy0 - oy1;
-                            double dy2 = 1.0 - dy1;
+                    double dy1 = oy0 - oy1;
+                    double dy2 = 1.0 - dy1;
 
-                            int yo0 = outputWidth * y;
-                            int yo1 = inputWidth * oy1;
-                            int yo2 = inputWidth * oy2;
+                    int yo0 = outputWidth * y;
+                    int yo1 = inputWidth * oy1;
+                    int yo2 = inputWidth * oy2;
 
-                            double ox0, dx1, dx2;
-                            int ox1, ox2;
+                    double ox0, dx1, dx2;
+                    int ox1, ox2;
 
-                            for (int x = 0; x < outputWidth; x++)
-                            {
-                                ox0 = x * xF;
-                                ox1 = (int)ox0;
-                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                    for (int x = 0; x < outputWidth; x++)
+                    {
+                        ox0 = x * xF;
+                        ox1 = (int)ox0;
+                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                                dx1 = ox0 - ox1;
-                                dx2 = 1.0 - dx1;
+                        dx1 = ox0 - ox1;
+                        dx2 = 1.0 - dx1;
 
-                                output[yo0 + x] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                            }
-                        });
+                        output[yo0 + x] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                    }
+                }
+#if !UNITY_5
+                );
+#endif
             }
 
             return output;
@@ -80,40 +86,44 @@ namespace Dicom.Imaging.Algorithms
 
             unchecked
             {
-                Parallel.For(
-                    0,
-                    outputHeight,
-                    y =>
-                        {
-                            double oy0 = y * yF;
-                            int oy1 = (int)oy0; // rounds down
-                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+#if UNITY_5
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    double oy0 = y * yF;
+                    int oy1 = (int)oy0; // rounds down
+                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                            double dy1 = oy0 - oy1;
-                            double dy2 = 1.0 - dy1;
+                    double dy1 = oy0 - oy1;
+                    double dy2 = 1.0 - dy1;
 
-                            int yo0 = outputWidth * y;
-                            int yo1 = inputWidth * oy1;
-                            int yo2 = inputWidth * oy2;
+                    int yo0 = outputWidth * y;
+                    int yo1 = inputWidth * oy1;
+                    int yo2 = inputWidth * oy2;
 
-                            double ox0, dx1, dx2;
-                            int ox1, ox2;
+                    double ox0, dx1, dx2;
+                    int ox1, ox2;
 
-                            for (int x = 0; x < outputWidth; x++)
-                            {
-                                ox0 = x * xF;
-                                ox1 = (int)ox0;
-                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                    for (int x = 0; x < outputWidth; x++)
+                    {
+                        ox0 = x * xF;
+                        ox1 = (int)ox0;
+                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                                dx1 = ox0 - ox1;
-                                dx2 = 1.0 - dx1;
+                        dx1 = ox0 - ox1;
+                        dx2 = 1.0 - dx1;
 
-                                output[yo0 + x] =
-                                    (short)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                            }
-                        });
+                        output[yo0 + x] =
+                            (short)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                    }
+                }
+#if !UNITY_5
+                );
+#endif
             }
 
             return output;
@@ -136,40 +146,44 @@ namespace Dicom.Imaging.Algorithms
 
             unchecked
             {
-                Parallel.For(
-                    0,
-                    outputHeight,
-                    y =>
-                        {
-                            double oy0 = y * yF;
-                            int oy1 = (int)oy0; // rounds down
-                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+#if UNITY_5
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    double oy0 = y * yF;
+                    int oy1 = (int)oy0; // rounds down
+                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                            double dy1 = oy0 - oy1;
-                            double dy2 = 1.0 - dy1;
+                    double dy1 = oy0 - oy1;
+                    double dy2 = 1.0 - dy1;
 
-                            int yo0 = outputWidth * y;
-                            int yo1 = inputWidth * oy1;
-                            int yo2 = inputWidth * oy2;
+                    int yo0 = outputWidth * y;
+                    int yo1 = inputWidth * oy1;
+                    int yo2 = inputWidth * oy2;
 
-                            double ox0, dx1, dx2;
-                            int ox1, ox2;
+                    double ox0, dx1, dx2;
+                    int ox1, ox2;
 
-                            for (int x = 0; x < outputWidth; x++)
-                            {
-                                ox0 = x * xF;
-                                ox1 = (int)ox0;
-                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                    for (int x = 0; x < outputWidth; x++)
+                    {
+                        ox0 = x * xF;
+                        ox1 = (int)ox0;
+                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                                dx1 = ox0 - ox1;
-                                dx2 = 1.0 - dx1;
+                        dx1 = ox0 - ox1;
+                        dx2 = 1.0 - dx1;
 
-                                output[yo0 + x] =
-                                    (ushort)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                            }
-                        });
+                        output[yo0 + x] =
+                            (ushort)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                    }
+                }
+#if !UNITY_5
+                );
+#endif
             }
 
             return output;
@@ -192,40 +206,44 @@ namespace Dicom.Imaging.Algorithms
 
             unchecked
             {
-                Parallel.For(
-                    0,
-                    outputHeight,
-                    y =>
-                        {
-                            double oy0 = y * yF;
-                            int oy1 = (int)oy0; // rounds down
-                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+#if UNITY_5
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    double oy0 = y * yF;
+                    int oy1 = (int)oy0; // rounds down
+                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                            double dy1 = oy0 - oy1;
-                            double dy2 = 1.0 - dy1;
+                    double dy1 = oy0 - oy1;
+                    double dy2 = 1.0 - dy1;
 
-                            int yo0 = outputWidth * y;
-                            int yo1 = inputWidth * oy1;
-                            int yo2 = inputWidth * oy2;
+                    int yo0 = outputWidth * y;
+                    int yo1 = inputWidth * oy1;
+                    int yo2 = inputWidth * oy2;
 
-                            double ox0, dx1, dx2;
-                            int ox1, ox2;
+                    double ox0, dx1, dx2;
+                    int ox1, ox2;
 
-                            for (int x = 0; x < outputWidth; x++)
-                            {
-                                ox0 = x * xF;
-                                ox1 = (int)ox0;
-                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                    for (int x = 0; x < outputWidth; x++)
+                    {
+                        ox0 = x * xF;
+                        ox1 = (int)ox0;
+                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                                dx1 = ox0 - ox1;
-                                dx2 = 1.0 - dx1;
+                        dx1 = ox0 - ox1;
+                        dx2 = 1.0 - dx1;
 
-                                output[yo0 + x] =
-                                    (int)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                            }
-                        });
+                        output[yo0 + x] =
+                            (int)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                    }
+                }
+#if !UNITY_5
+                );
+#endif
             }
 
             return output;
@@ -248,40 +266,44 @@ namespace Dicom.Imaging.Algorithms
 
             unchecked
             {
-                Parallel.For(
-                    0,
-                    outputHeight,
-                    y =>
-                        {
-                            double oy0 = y * yF;
-                            int oy1 = (int)oy0; // rounds down
-                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+#if UNITY_5
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    double oy0 = y * yF;
+                    int oy1 = (int)oy0; // rounds down
+                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                            double dy1 = oy0 - oy1;
-                            double dy2 = 1.0 - dy1;
+                    double dy1 = oy0 - oy1;
+                    double dy2 = 1.0 - dy1;
 
-                            int yo0 = outputWidth * y;
-                            int yo1 = inputWidth * oy1;
-                            int yo2 = inputWidth * oy2;
+                    int yo0 = outputWidth * y;
+                    int yo1 = inputWidth * oy1;
+                    int yo2 = inputWidth * oy2;
 
-                            double ox0, dx1, dx2;
-                            int ox1, ox2;
+                    double ox0, dx1, dx2;
+                    int ox1, ox2;
 
-                            for (int x = 0; x < outputWidth; x++)
-                            {
-                                ox0 = x * xF;
-                                ox1 = (int)ox0;
-                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                    for (int x = 0; x < outputWidth; x++)
+                    {
+                        ox0 = x * xF;
+                        ox1 = (int)ox0;
+                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                                dx1 = ox0 - ox1;
-                                dx2 = 1.0 - dx1;
+                        dx1 = ox0 - ox1;
+                        dx2 = 1.0 - dx1;
 
-                                output[yo0 + x] =
-                                    (uint)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                            }
-                        });
+                        output[yo0 + x] =
+                            (uint)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                    }
+                }
+#if !UNITY_5
+                );
+#endif
             }
 
             return output;
@@ -304,62 +326,66 @@ namespace Dicom.Imaging.Algorithms
 
             unchecked
             {
-                Parallel.For(
-                    0,
-                    outputHeight,
-                    y =>
-                        {
-                            double oy0 = y * yF;
-                            int oy1 = (int)oy0; // rounds down
-                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+#if UNITY_5
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    double oy0 = y * yF;
+                    int oy1 = (int)oy0; // rounds down
+                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                            double dy1 = oy0 - oy1;
-                            double dy2 = 1.0 - dy1;
+                    double dy1 = oy0 - oy1;
+                    double dy2 = 1.0 - dy1;
 
-                            int yo0 = outputWidth * y * 3;
-                            int yo1 = inputWidth * oy1 * 3;
-                            int yo2 = inputWidth * oy2 * 3;
+                    int yo0 = outputWidth * y * 3;
+                    int yo1 = inputWidth * oy1 * 3;
+                    int yo2 = inputWidth * oy2 * 3;
 
-                            double ox0, dx1, dx2;
-                            int ox1, ox2;
+                    double ox0, dx1, dx2;
+                    int ox1, ox2;
 
-                            for (int x = 0, px = 0; x < outputWidth; x++)
-                            {
-                                ox0 = x * xF;
-                                ox1 = (int)ox0;
-                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                    for (int x = 0, px = 0; x < outputWidth; x++)
+                    {
+                        ox0 = x * xF;
+                        ox1 = (int)ox0;
+                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                                dx1 = ox0 - ox1;
-                                dx2 = 1.0 - dx1;
+                        dx1 = ox0 - ox1;
+                        dx2 = 1.0 - dx1;
 
-                                int x1 = ox1 * 3; //first byte of first pixel
-                                int x2 = ox2 * 3; //first byte of second pixel
+                        int x1 = ox1 * 3; //first byte of first pixel
+                        int x2 = ox2 * 3; //first byte of second pixel
 
-                                output[yo0 + px] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
-                                     + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
-                                px++;
-                                x1++;
-                                x2++;
+                        output[yo0 + px] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
+                                + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
+                        px++;
+                        x1++;
+                        x2++;
 
-                                output[yo0 + px] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
-                                     + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
-                                px++;
-                                x1++;
-                                x2++;
+                        output[yo0 + px] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
+                                + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
+                        px++;
+                        x1++;
+                        x2++;
 
-                                output[yo0 + px] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
-                                     + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
-                                px++;
-                                x1++;
-                                x2++;
-                            }
-                        });
+                        output[yo0 + px] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
+                                + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
+                        px++;
+                        x1++;
+                        x2++;
+                    }
+                }
+#if !UNITY_5
+                );
+#endif
             }
 
             return output;
@@ -382,67 +408,71 @@ namespace Dicom.Imaging.Algorithms
 
             unchecked
             {
-                Parallel.For(
-                    0,
-                    outputHeight,
-                    y =>
-                        {
-                            double oy0 = y * yF;
-                            int oy1 = (int)oy0; // rounds down
-                            int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
+#if UNITY_5
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    double oy0 = y * yF;
+                    int oy1 = (int)oy0; // rounds down
+                    int oy2 = (oy1 == yMax) ? oy1 : oy1 + 1;
 
-                            double dy1 = oy0 - oy1;
-                            double dy2 = 1.0 - dy1;
+                    double dy1 = oy0 - oy1;
+                    double dy2 = 1.0 - dy1;
 
-                            int yo0 = outputWidth * y * 4;
-                            int yo1 = inputWidth * oy1 * 4;
-                            int yo2 = inputWidth * oy2 * 4;
+                    int yo0 = outputWidth * y * 4;
+                    int yo1 = inputWidth * oy1 * 4;
+                    int yo2 = inputWidth * oy2 * 4;
 
-                            double ox0, dx1, dx2;
-                            int ox1, ox2;
+                    double ox0, dx1, dx2;
+                    int ox1, ox2;
 
-                            for (int x = 0, px = 0; x < outputWidth; x++)
-                            {
-                                ox0 = x * xF;
-                                ox1 = (int)ox0;
-                                ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
+                    for (int x = 0, px = 0; x < outputWidth; x++)
+                    {
+                        ox0 = x * xF;
+                        ox1 = (int)ox0;
+                        ox2 = (ox1 == xMax) ? ox1 : ox1 + 1;
 
-                                dx1 = ox0 - ox1;
-                                dx2 = 1.0 - dx1;
+                        dx1 = ox0 - ox1;
+                        dx2 = 1.0 - dx1;
 
-                                output[yo0 + px] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                                px++;
-                                ox1++;
-                                ox2++;
+                        output[yo0 + px] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                        px++;
+                        ox1++;
+                        ox2++;
 
-                                output[yo0 + px] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                                px++;
-                                ox1++;
-                                ox2++;
+                        output[yo0 + px] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                        px++;
+                        ox1++;
+                        ox2++;
 
-                                output[yo0 + px] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                                px++;
-                                ox1++;
-                                ox2++;
+                        output[yo0 + px] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                        px++;
+                        ox1++;
+                        ox2++;
 
-                                output[yo0 + px] =
-                                    (byte)
-                                    ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
-                                     + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
-                                px++;
-                                ox1++;
-                                ox2++;
-                            }
-                        });
+                        output[yo0 + px] =
+                            (byte)
+                            ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
+                                + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
+                        px++;
+                        ox1++;
+                        ox2++;
+                    }
+                }
+#if !UNITY_5
+                );
+#endif
             }
 
             return output;

--- a/DICOM/Imaging/Render/OverlayGraphic.cs
+++ b/DICOM/Imaging/Render/OverlayGraphic.cs
@@ -94,6 +94,6 @@ namespace Dicom.Imaging.Render
 #endif
         }
 
-#endregion
+        #endregion
     }
 }

--- a/DICOM/Imaging/Render/OverlayGraphic.cs
+++ b/DICOM/Imaging/Render/OverlayGraphic.cs
@@ -1,11 +1,14 @@
 // Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Threading.Tasks;
-
 namespace Dicom.Imaging.Render
 {
+    using System;
+
+#if !UNITY_5
+    using System.Threading.Tasks;
+#endif
+
     /// <summary>
     /// The Overlay Graphic which render overlay over pixel data
     /// </summary>
@@ -69,24 +72,28 @@ namespace Dicom.Imaging.Render
             int ox = (int)(_offsetX * _scale);
             int oy = (int)(_offsetY * _scale);
 
-            Parallel.For(
-                0,
-                _scaledData.Height,
-                y =>
+#if UNITY_5
+            for (var y = 0; y < _scaledData.Height; ++y)
+#else
+                Parallel.For(0, _scaledData.Height, y =>
+#endif
+            {
+                if ((oy + y) >= height) return;
+                for (int i = _scaledData.Width * y, e = i + _scaledData.Width, x = 0; i < e; i++, x++)
+                {
+                    if (data[i] > 0)
                     {
-                        if ((oy + y) >= height) return;
-                        for (int i = _scaledData.Width * y, e = i + _scaledData.Width, x = 0; i < e; i++, x++)
-                        {
-                            if (data[i] > 0)
-                            {
-                                if ((ox + x) >= width) break;
-                                int p = (oy * width) + ox + i;
-                                pixels[p] = _color;
-                            }
-                        }
-                    });
+                        if ((ox + x) >= width) break;
+                        int p = (oy * width) + ox + i;
+                        pixels[p] = _color;
+                    }
+                }
+            }
+#if !UNITY_5
+            );
+#endif
         }
 
-        #endregion
+#endregion
     }
 }

--- a/DICOM/Imaging/Render/PixelData.cs
+++ b/DICOM/Imaging/Render/PixelData.cs
@@ -192,7 +192,7 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class GrayscalePixelDataU8 : IPixelData
     {
-#region Private Members
+        #region Private Members
 
         private int _width;
 
@@ -200,9 +200,9 @@ namespace Dicom.Imaging.Render
 
         private readonly byte[] _data;
  
-#endregion
+        #endregion
 
-#region Public Constructor
+        #region Public Constructor
 
         public GrayscalePixelDataU8(int width, int height, IByteBuffer data)
         {
@@ -219,9 +219,9 @@ namespace Dicom.Imaging.Render
         }
 
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public int Width
         {
@@ -255,9 +255,9 @@ namespace Dicom.Imaging.Render
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public DicomRange<double> GetMinMax(int padding)
         {
@@ -341,7 +341,7 @@ namespace Dicom.Imaging.Render
             return histogram;
         }
 
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -349,16 +349,16 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class SingleBitPixelData : GrayscalePixelDataU8
     {
-#region Public Constructor
+        #region Public Constructor
 
         public SingleBitPixelData(int width, int height, IByteBuffer data)
             : base(width, height, ExpandBits(width, height, data.Data))
         {
         }
 
-#endregion
+        #endregion
 
-#region Static Methods
+        #region Static Methods
 
         private const byte One = 1;
 
@@ -375,9 +375,9 @@ namespace Dicom.Imaging.Render
             return output;
         }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public override Histogram GetHistogram(int channel)
         {
@@ -391,7 +391,7 @@ namespace Dicom.Imaging.Render
             return histogram;
         }
 
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -399,7 +399,7 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class GrayscalePixelDataS16 : IPixelData
     {
-#region Private Members
+        #region Private Members
 
         private BitDepth _bits;
 
@@ -409,9 +409,9 @@ namespace Dicom.Imaging.Render
 
         private readonly short[] _data;
  
-#endregion
+        #endregion
 
-#region Public Constructor
+        #region Public Constructor
 
         public GrayscalePixelDataS16(int width, int height, BitDepth bitDepth, IByteBuffer data)
         {
@@ -458,9 +458,9 @@ namespace Dicom.Imaging.Render
             _data = data;
         }
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public int Width
         {
@@ -494,9 +494,9 @@ namespace Dicom.Imaging.Render
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public DicomRange<double> GetMinMax(int padding)
         {
@@ -582,7 +582,7 @@ namespace Dicom.Imaging.Render
             return histogram;
         }
 
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -590,7 +590,7 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class GrayscalePixelDataU16 : IPixelData
     {
-#region Private Members
+        #region Private Members
 
         private BitDepth _bits;
 
@@ -600,9 +600,9 @@ namespace Dicom.Imaging.Render
 
         private readonly ushort[] _data;
 
-#endregion
+        #endregion
 
-#region Public Constructor
+        #region Public Constructor
 
         public GrayscalePixelDataU16(int width, int height, BitDepth bitDepth, IByteBuffer data)
         {
@@ -649,9 +649,9 @@ namespace Dicom.Imaging.Render
             _data = data;
         }
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public int Width
         {
@@ -685,9 +685,9 @@ namespace Dicom.Imaging.Render
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public DicomRange<double> GetMinMax(int padding)
         {
@@ -773,7 +773,7 @@ namespace Dicom.Imaging.Render
             return histogram;
         }
 
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -781,7 +781,7 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class GrayscalePixelDataS32 : IPixelData
     {
-#region Private Members
+        #region Private Members
 
         private int _width;
 
@@ -789,9 +789,9 @@ namespace Dicom.Imaging.Render
 
         private int[] _data; 
 
-#endregion
+        #endregion
 
-#region Public Constructor
+        #region Public Constructor
 
         public GrayscalePixelDataS32(int width, int height, BitDepth bitDepth, IByteBuffer data)
         {
@@ -834,9 +834,9 @@ namespace Dicom.Imaging.Render
             _data = data;
         }
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public int Width
         {
@@ -870,9 +870,9 @@ namespace Dicom.Imaging.Render
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public DicomRange<double> GetMinMax(int padding)
         {
@@ -948,7 +948,7 @@ namespace Dicom.Imaging.Render
             throw new NotSupportedException("Histograms are not supported for signed 32-bit images.");
         }
 
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -956,7 +956,7 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class GrayscalePixelDataU32 : IPixelData
     {
-#region Private Members
+        #region Private Members
 
         private int _width;
 
@@ -964,9 +964,9 @@ namespace Dicom.Imaging.Render
 
         private uint[] _data;
  
-#endregion
+        #endregion
 
-#region Public Constructor
+        #region Public Constructor
 
         public GrayscalePixelDataU32(int width, int height, BitDepth bitDepth, IByteBuffer data)
         {
@@ -1012,9 +1012,9 @@ namespace Dicom.Imaging.Render
             _data = data;
         }
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public int Width
         {
@@ -1048,9 +1048,9 @@ namespace Dicom.Imaging.Render
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public DicomRange<double> GetMinMax(int padding)
         {
@@ -1125,7 +1125,7 @@ namespace Dicom.Imaging.Render
             throw new NotSupportedException("Histograms are not supported for unsigned 32-bit images.");
         }
 
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -1133,7 +1133,7 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class ColorPixelData24 : IPixelData
     {
-#region Private Members
+        #region Private Members
 
         private int _width;
 
@@ -1141,9 +1141,9 @@ namespace Dicom.Imaging.Render
 
         private readonly byte[] _data;
 
-#endregion
+        #endregion
 
-#region Public Constructor
+        #region Public Constructor
 
         public ColorPixelData24(int width, int height, IByteBuffer data)
         {
@@ -1159,9 +1159,9 @@ namespace Dicom.Imaging.Render
             _data = data;
         }
 
-#endregion
+        #endregion
 
-#region Public Properties
+        #region Public Properties
 
         public int Width
         {
@@ -1195,9 +1195,9 @@ namespace Dicom.Imaging.Render
             }
         }
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public DicomRange<double> GetMinMax(int padding)
         {
@@ -1276,6 +1276,6 @@ namespace Dicom.Imaging.Render
             return histogram;
         }
 
-#endregion
+        #endregion
     }
 }

--- a/DICOM/Log/DicomDatasetDumper.cs
+++ b/DICOM/Log/DicomDatasetDumper.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
-using Dicom.IO.Buffer;
-
 namespace Dicom.Log
 {
+    using System;
+    using System.Text;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
+
+    using Dicom.IO.Buffer;
 
     public class DicomDatasetDumper : IDicomDatasetWalker
     {
@@ -95,6 +97,7 @@ namespace Dicom.Log
             return true;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing a DICOM element.
         /// </summary>
@@ -104,6 +107,7 @@ namespace Dicom.Log
         {
             return Task.FromResult(this.OnElement(element));
         }
+#endif
 
         /// <summary>
         /// Handler for traversing beginning of sequence.
@@ -181,6 +185,7 @@ namespace Dicom.Log
             return true;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing fragment item.
         /// </summary>
@@ -190,6 +195,7 @@ namespace Dicom.Log
         {
             return Task.FromResult(this.OnFragmentItem(item));
         }
+#endif
 
         /// <summary>
         /// Handler for traversing end of fragment.

--- a/DICOM/Log/DicomDatasetLogger.cs
+++ b/DICOM/Log/DicomDatasetLogger.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
-using Dicom.IO.Buffer;
-
 namespace Dicom.Log
 {
+    using System;
+    using System.Text;
+
+#if !UNITY_5
     using System.Threading.Tasks;
+#endif
+
+    using Dicom.IO.Buffer;
 
     /// <summary>
     /// DICOM dataset walker for logging.
@@ -108,6 +110,7 @@ namespace Dicom.Log
             return true;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing a DICOM element.
         /// </summary>
@@ -117,6 +120,7 @@ namespace Dicom.Log
         {
             return Task.FromResult(this.OnElement(element));
         }
+#endif
 
         /// <summary>
         /// Handler for traversing beginning of sequence.
@@ -196,6 +200,7 @@ namespace Dicom.Log
             return true;
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronous handler for traversing fragment item.
         /// </summary>
@@ -205,6 +210,7 @@ namespace Dicom.Log
         {
             return Task.FromResult(this.OnFragmentItem(item));
         }
+#endif
 
         /// <summary>
         /// Handler for traversing end of fragment.

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -5,7 +5,10 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+
+#if !UNITY_5
 using System.Threading.Tasks;
+#endif
 
 using Dicom.IO;
 using Dicom.IO.Reader;
@@ -229,6 +232,7 @@ namespace Dicom.Media
             }
         }
 
+#if !UNITY_5
         /// <summary>
         /// Asynchronously read DICOM Directory.
         /// </summary>
@@ -331,6 +335,7 @@ namespace Dicom.Media
                 throw new DicomFileException(df, e.Message, e);
             }
         }
+#endif
 
         /// <summary>
         /// Method to call before performing the actual saving.

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -1,21 +1,20 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Text;
-
-#if !UNITY_5
-using System.Threading.Tasks;
-#endif
-
-using Dicom.IO;
-using Dicom.IO.Reader;
-using Dicom.IO.Writer;
-
 namespace Dicom.Media
 {
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+
+    #if !UNITY_5
+    using System.Threading.Tasks;
+    #endif
+
+    using Dicom.IO;
+    using Dicom.IO.Reader;
+    using Dicom.IO.Writer;
 
     /// <summary>
     /// Class for managing DICOM directory objects.

--- a/DICOM/Media/DicomFileScanner.cs
+++ b/DICOM/Media/DicomFileScanner.cs
@@ -3,7 +3,11 @@
 
 namespace Dicom.Media
 {
+#if UNITY_5
+    using System.Threading;
+#else
     using System.Threading.Tasks;
+#endif
 
     using Dicom.IO;
 
@@ -97,7 +101,11 @@ namespace Dicom.Media
         {
             _stop = false;
             _count = 0;
+#if UNITY_5
+            ThreadPool.QueueUserWorkItem(this.ScanProc, directory);
+#else
             Task.Run(() => this.ScanProc(directory));
+#endif
         }
 
         public void Stop()
@@ -109,12 +117,19 @@ namespace Dicom.Media
 
         #region Private Methods
 
+#if UNITY_5
+        private void ScanProc(object directory)
+        {
+            ScanDirectory((string)directory);
+            if (Complete != null) Complete(this);
+        }
+#else
         private void ScanProc(string directory)
         {
             ScanDirectory(directory);
-
             if (Complete != null) Complete(this);
         }
+#endif
 
         private void ScanDirectory(string path)
         {


### PR DESCRIPTION
Fixes #251 .

Changes proposed in this pull request:  
_When compiling with UNITY_5 directive,_
- Exclude all Task Asynchronous Pattern methods
- Use single-threaded `for` loop instead of `Parallel.For`
- Use `ThreadPool.QueueUserWorkItem` instead of `Task.Run`
- Use `Thread.Sleep` instead of `Task.Delay`

Changes apply to all types in *DICOM.Core* project except those in the `Dicom.Network` namespace.

Please note that this is only a preparation to facilitate porting of *fo-dicom* to [Unity](https://unity3d.com/). When compiling *without* the UNITY_5 directive, the modifications in this pull request do not apply at all. 

Please review.