### PR TITLE
Allow a larger range of unicode characters in tag and UID descriptions. Connected to #266

### DIFF
--- a/DICOM/DicomTagGenerated.cs
+++ b/DICOM/DicomTagGenerated.cs
@@ -2093,7 +2093,7 @@ namespace Dicom
         ///<summary>(0018,1152) VR=IS VM=1 Exposure</summary>
         public readonly static DicomTag Exposure = new DicomTag(0x0018, 0x1152);
 
-        ///<summary>(0018,1153) VR=IS VM=1 Exposure in As</summary>
+        ///<summary>(0018,1153) VR=IS VM=1 Exposure in µAs</summary>
         public readonly static DicomTag ExposureInuAs = new DicomTag(0x0018, 0x1153);
 
         ///<summary>(0018,1154) VR=DS VM=1 Average Pulse Width</summary>
@@ -2765,10 +2765,10 @@ namespace Dicom
         ///<summary>(0018,7065) VR=DS VM=1 Phototimer Setting</summary>
         public readonly static DicomTag PhototimerSetting = new DicomTag(0x0018, 0x7065);
 
-        ///<summary>(0018,8150) VR=DS VM=1 Exposure Time in S</summary>
+        ///<summary>(0018,8150) VR=DS VM=1 Exposure Time in µS</summary>
         public readonly static DicomTag ExposureTimeInuS = new DicomTag(0x0018, 0x8150);
 
-        ///<summary>(0018,8151) VR=DS VM=1 X-Ray Tube Current in A</summary>
+        ///<summary>(0018,8151) VR=DS VM=1 X-Ray Tube Current in µA</summary>
         public readonly static DicomTag XRayTubeCurrentInuA = new DicomTag(0x0018, 0x8151);
 
         ///<summary>(0018,9004) VR=CS VM=1 Content Qualification</summary>

--- a/DICOM/Dictionaries/DICOM Dictionary.xml
+++ b/DICOM/Dictionaries/DICOM Dictionary.xml
@@ -700,7 +700,7 @@
     <tag group="0018" element="1150" keyword="ExposureTime" vr="IS" vm="1">Exposure Time</tag>
     <tag group="0018" element="1151" keyword="XRayTubeCurrent" vr="IS" vm="1">X-Ray Tube Current</tag>
     <tag group="0018" element="1152" keyword="Exposure" vr="IS" vm="1">Exposure</tag>
-    <tag group="0018" element="1153" keyword="ExposureInuAs" vr="IS" vm="1">Exposure in As</tag>
+    <tag group="0018" element="1153" keyword="ExposureInuAs" vr="IS" vm="1">Exposure in µAs</tag>
     <tag group="0018" element="1154" keyword="AveragePulseWidth" vr="DS" vm="1">Average Pulse Width</tag>
     <tag group="0018" element="1155" keyword="RadiationSetting" vr="CS" vm="1">Radiation Setting</tag>
     <tag group="0018" element="1156" keyword="RectificationType" vr="CS" vm="1">Rectification Type</tag>
@@ -924,8 +924,8 @@
     <tag group="0018" element="7062" keyword="ExposureControlModeDescription" vr="LT" vm="1">Exposure Control Mode Description</tag>
     <tag group="0018" element="7064" keyword="ExposureStatus" vr="CS" vm="1">Exposure Status</tag>
     <tag group="0018" element="7065" keyword="PhototimerSetting" vr="DS" vm="1">Phototimer Setting</tag>
-    <tag group="0018" element="8150" keyword="ExposureTimeInuS" vr="DS" vm="1">Exposure Time in S</tag>
-    <tag group="0018" element="8151" keyword="XRayTubeCurrentInuA" vr="DS" vm="1">X-Ray Tube Current in A</tag>
+    <tag group="0018" element="8150" keyword="ExposureTimeInuS" vr="DS" vm="1">Exposure Time in µS</tag>
+    <tag group="0018" element="8151" keyword="XRayTubeCurrentInuA" vr="DS" vm="1">X-Ray Tube Current in µA</tag>
     <tag group="0018" element="9004" keyword="ContentQualification" vr="CS" vm="1">Content Qualification</tag>
     <tag group="0018" element="9005" keyword="PulseSequenceName" vr="SH" vm="1">Pulse Sequence Name</tag>
     <tag group="0018" element="9006" keyword="MRImagingModifierSequence" vr="SQ" vm="1">MR Imaging Modifier Sequence</tag>

--- a/DICOM/T4/dictionarymethods.t4
+++ b/DICOM/T4/dictionarymethods.t4
@@ -181,7 +181,7 @@ private static Tuple<string, string, string, string, string, string, bool> GetTa
 	// If no description is provided (list[2] empty) ignore this entire <tr> node
 	var list = item.SelectNodes("./d:td/d:para", manager)
 					.OfType<XmlNode>()
-					.Select(x => Regex.Replace(x.InnerText, @"[^\u0020-\u007F]", string.Empty))
+					.Select(x => Regex.Replace(x.InnerText, @"[^\u0020-\u00FF]", string.Empty))
 					.ToList();
 	if (list.Count < 5 || string.IsNullOrWhiteSpace(list[2])) return null;
 
@@ -255,7 +255,7 @@ private static Tuple<string, string, string, bool> GetUidData(XmlNode item, XmlN
 	// If no UID type is provided (list[2] empty) ignore this entire <tr> node
 	var list = item.SelectNodes("./d:td/d:para", manager)
 					.OfType<XmlNode>()
-					.Select(x => Regex.Replace(x.InnerText, @"[^\u0020-\u007F]", string.Empty))
+					.Select(x => Regex.Replace(x.InnerText, @"[^\u0020-\u00FF]", string.Empty))
 					.ToList();
 	if (list.Count < 4 || string.IsNullOrWhiteSpace(list[2])) return null;
 
@@ -280,7 +280,7 @@ private static Tuple<string, string, string, bool> GetContextGroupNameData(XmlNo
 	// and isolating the corresponding attribute value in the string
 	// (Ideally, this parsing should have been done via the XML API, but for some reason the
 	// "targetptr" attribute value is incorrectly assigned on some (all?) VS 2013 installations.)
-	var olinkXml = Regex.Replace(list[1].InnerXml, @"[^\u0020-\u007F]", string.Empty);
+	var olinkXml = Regex.Replace(list[1].InnerXml, @"[^\u0020-\u00FF]", string.Empty);
 	var startIdx = olinkXml.IndexOf("targetptr=") + 11;
 	var length = olinkXml.IndexOf('"', startIdx) - startIdx;
 	var reference = olinkXml.Substring(startIdx, length);


### PR DESCRIPTION
Fixes #266. Replaces PR #267.

Changes proposed in this pull request:
- When "cleaning" tag and UID descriptions from undesired characters, keep Unicode characters in range hex 20-FF instead of hex 20-7F.

Please review.