### PR TITLE
AAssociate Request/Reponse SOP Class Extended Negotiation. Connected to #241

### DIFF
--- a/DICOM.Tests/Network/PDUTest.cs
+++ b/DICOM.Tests/Network/PDUTest.cs
@@ -49,5 +49,47 @@ namespace Dicom.Network
 
             Assert.True(File.Exists(name));
         }
+
+        [Fact]
+        public void WriteReadAAssociateRQExtendedNegotiation()
+        {
+            DicomAssociation association = new DicomAssociation("testCalling", "testCalled");
+            association.ExtendedNegotiations.Add(
+                new DicomExtendedNegotiation(
+                    DicomUID.StudyRootQueryRetrieveInformationModelFIND,
+                    new RootQueryRetrieveInfoFind(1, 1, 1, 1, null)));
+
+            AAssociateRQ rq = new AAssociateRQ(association);
+
+            RawPDU writePdu = rq.Write();
+
+            RawPDU readPdu;
+            using (MemoryStream stream = new MemoryStream())
+            {
+                writePdu.WritePDU(stream);
+
+                int length = (int)stream.Length;
+                byte[] buffer = new byte[length];
+                stream.Seek(0, SeekOrigin.Begin);
+                stream.Read(buffer, 0, length);
+                readPdu = new RawPDU(buffer);
+            }
+
+            DicomAssociation testAssociation = new DicomAssociation();
+            AAssociateRQ rq2 = new AAssociateRQ(testAssociation);
+            rq2.Read(readPdu);
+
+            Assert.True(testAssociation.ExtendedNegotiations.Count == 1);
+            Assert.True(
+                testAssociation.ExtendedNegotiations[0].SopClassUid
+                == DicomUID.StudyRootQueryRetrieveInformationModelFIND);
+
+            RootQueryRetrieveInfoFind info =
+                testAssociation.ExtendedNegotiations[0].SubItem as RootQueryRetrieveInfoFind;
+            Assert.True(null != info);
+            Assert.True(
+                (1 == info.DateTimeMatching) && (1 == info.FuzzySemanticMatching) && (1 == info.RelationalQueries)
+                && (1 == info.TimezoneQueryAdjustment) && (false == info.EnhancedMultiFrameImageConversion.HasValue));
+        }
     }
 }

--- a/DICOM/DICOM.Core.csproj
+++ b/DICOM/DICOM.Core.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Imaging\Mathematics\Geometry3D.cs" />
     <Compile Include="Imaging\Mathematics\Matrix.cs" />
     <Compile Include="Imaging\Mathematics\Point2.cs" />
+    <Compile Include="Network\DicomExtendedNegotiation.cs" />
     <Compile Include="Network\DicomPriorityRequest.cs" />
     <Compile Include="Network\IDicomNServiceProvider.cs" />
     <Compile Include="Network\DicomNDeleteRequest.cs" />
@@ -281,6 +282,8 @@
     <Compile Include="Network\INetworkStream.cs" />
     <Compile Include="Network\NetworkManager.cs" />
     <Compile Include="Network\PDU.cs" />
+    <Compile Include="Network\RootQueryRetrieveInfoMove.cs" />
+    <Compile Include="Network\StudyRootQueryRetrieveInfo.cs" />
     <Compile Include="Printing\FilmBox.cs" />
     <Compile Include="Printing\FilmSession.cs" />
     <Compile Include="Printing\ImageBox.cs" />

--- a/DICOM/Network/DicomAssociation.cs
+++ b/DICOM/Network/DicomAssociation.cs
@@ -3,6 +3,7 @@
 
 namespace Dicom.Network
 {
+    using System.Collections.Generic;
     using System.Text;
 
     /// <summary>
@@ -18,6 +19,7 @@ namespace Dicom.Network
             PresentationContexts = new DicomPresentationContextCollection();
             MaxAsyncOpsInvoked = 1;
             MaxAsyncOpsPerformed = 1;
+            ExtendedNegotiations = new List<DicomExtendedNegotiation>();
         }
 
         /// <summary>
@@ -85,6 +87,11 @@ namespace Dicom.Network
         public DicomPresentationContextCollection PresentationContexts { get; private set; }
 
         /// <summary>
+        /// Gets supported extended negotiations
+        /// </summary>
+        public List<DicomExtendedNegotiation> ExtendedNegotiations { get; private set; }
+
+        /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>
         /// <returns>
@@ -120,6 +127,16 @@ namespace Dicom.Network
                     sb.AppendFormat("       Transfer Syntax:  {0}\n", tx.UID.Name);
                 }
             }
+
+            if (ExtendedNegotiations.Count > 0)
+            {
+                sb.AppendFormat("Extended Negotiations: {0}\n", ExtendedNegotiations.Count);
+                foreach (DicomExtendedNegotiation exNeg in ExtendedNegotiations)
+                {
+                    sb.AppendFormat("  Extended Negotiation: {0}\n", exNeg.SopClassUid);
+                }
+            }
+
             sb.Length = sb.Length - 1;
             return sb.ToString();
         }

--- a/DICOM/Network/DicomExtendedNegotiation.cs
+++ b/DICOM/Network/DicomExtendedNegotiation.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Interface for extended negotiation sub-items.
+    /// </summary>
+    public interface IExtendedNegotiationSubItem
+    {
+        /// <summary>
+        /// Write PDU data.
+        /// </summary>
+        /// <param name="pdu">PDU data to write.</param>
+        void Write(RawPDU pdu);
+    }
+
+    /// <summary>
+    /// Delegate representing creation of an <see cref="IExtendedNegotiationSubItem"/>.
+    /// </summary>
+    /// <param name="raw">Raw PDU.</param>
+    /// <param name="itemSize">Item size.</param>
+    /// <param name="bytesRead">Bytes read.</param>
+    /// <returns>Created <see cref="IExtendedNegotiationSubItem"/>.</returns>
+    public delegate IExtendedNegotiationSubItem CreateIExtendedNegotiationSubItemDelegate(
+        RawPDU raw,
+        int itemSize,
+        out int bytesRead);
+
+    /// <summary>
+    /// Class for managing DICOM extended negotiation.
+    /// </summary>
+    public class DicomExtendedNegotiation
+    {
+        private static readonly Dictionary<DicomUID, CreateIExtendedNegotiationSubItemDelegate> subItemCreators =
+            new Dictionary<DicomUID, CreateIExtendedNegotiationSubItemDelegate>();
+
+        static DicomExtendedNegotiation()
+        {
+            AddSubItemCreator(DicomUID.StudyRootQueryRetrieveInformationModelFIND, RootQueryRetrieveInfoFind.Create);
+            AddSubItemCreator(DicomUID.PatientRootQueryRetrieveInformationModelFIND, RootQueryRetrieveInfoFind.Create);
+            AddSubItemCreator(DicomUID.StudyRootQueryRetrieveInformationModelMOVE, RootQueryRetrieveInfoMove.Create);
+            AddSubItemCreator(DicomUID.PatientRootQueryRetrieveInformationModelMOVE, RootQueryRetrieveInfoMove.Create);
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomExtendedNegotiation"/> class.
+        /// </summary>
+        /// <param name="sopClassUid">SOP class UID.</param>
+        /// <param name="subItem">Extended negotiation sub-item.</param>
+        public DicomExtendedNegotiation(DicomUID sopClassUid, IExtendedNegotiationSubItem subItem)
+        {
+            SopClassUid = sopClassUid;
+            SubItem = subItem;
+        }
+
+        /// <summary>
+        /// Gets SOP Class UID.
+        /// </summary>
+        public DicomUID SopClassUid { get; }
+
+        /// <summary>
+        /// Gets extended negotiation sub-item.
+        /// </summary>
+        public IExtendedNegotiationSubItem SubItem { get; }
+
+        /// <summary>
+        /// Add item for creating extended negotiation sub-items.
+        /// </summary>
+        /// <param name="uid">Associated UID.</param>
+        /// <param name="creator">Creator instance.</param>
+        public static void AddSubItemCreator(DicomUID uid, CreateIExtendedNegotiationSubItemDelegate creator)
+        {
+            if (false == subItemCreators.ContainsKey(uid))
+            {
+                subItemCreators.Add(uid, creator);
+            }
+        }
+
+        /// <summary>
+        /// Write PDU.
+        /// </summary>
+        /// <param name="pdu">PDU to write.</param>
+        public void Write(RawPDU pdu)
+        {
+            if (null != SubItem)
+            {
+                pdu.Write("Item-Type", (byte)0x56);
+                pdu.Write("Reserved", (byte)0x00);
+
+                pdu.MarkLength16("Item-Length");
+
+                pdu.Write("SOP Class UID Length", (ushort)(SopClassUid.UID.Length));
+                pdu.Write("SOP Class UID", SopClassUid.UID);
+
+                SubItem.Write(pdu);
+
+                pdu.WriteLength16();
+            }
+        }
+
+        /// <summary>
+        /// Factory method for creating <see cref="DicomExtendedNegotiation"/> instances.
+        /// </summary>
+        /// <param name="raw">Raw PDU.</param>
+        /// <param name="length">Length.</param>
+        /// <returns>A new <see cref="DicomExtendedNegotiation"/> instance.</returns>
+        public static DicomExtendedNegotiation Create(RawPDU raw, ushort length)
+        {
+            var uidLen = raw.ReadUInt16("SOP Class UID Length");
+            var uidStr = raw.ReadString("SOP Class UID", uidLen);
+
+            var uid = DicomUID.Parse(uidStr);
+            IExtendedNegotiationSubItem subItem = null;
+            var subItemSize = 0;
+
+            var remaining = length - uidLen - 2;
+            if (subItemCreators.ContainsKey(uid))
+            {
+                subItem = subItemCreators[uid](raw, remaining, out subItemSize);
+            }
+
+            remaining -= subItemSize;
+            if (remaining > 0)
+            {
+                raw.SkipBytes("Unread bytes", remaining);
+            }
+
+            return new DicomExtendedNegotiation(uid, subItem);
+        }
+    }
+}

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -508,6 +508,11 @@ namespace Dicom.Network
             pdu.Write("Implementation Version", DicomImplementation.Version);
             pdu.WriteLength16();
 
+            foreach (DicomExtendedNegotiation exNeg in _assoc.ExtendedNegotiations)
+            {
+                exNeg.Write(pdu);
+            }
+
             pdu.WriteLength16();
 
             return pdu;
@@ -613,6 +618,10 @@ namespace Dicom.Network
                                     raw.ReadByte();		// SCU role
                                     raw.ReadByte();		// SCP role
                                     */
+                        }
+                        else if (ut == 0x56)
+                        {
+                            _assoc.ExtendedNegotiations.Add(DicomExtendedNegotiation.Create(raw, ul));
                         }
                         else
                         {
@@ -729,6 +738,11 @@ namespace Dicom.Network
             pdu.Write("Implementation Version", DicomImplementation.Version);
             pdu.WriteLength16();
 
+            foreach (DicomExtendedNegotiation exNeg in _assoc.ExtendedNegotiations)
+            {
+                exNeg.Write(pdu);
+            }
+
             pdu.WriteLength16();
 
             return pdu;
@@ -823,6 +837,10 @@ namespace Dicom.Network
                         else if (ut == 0x55)
                         {
                             _assoc.RemoteImplementationVersion = raw.ReadString("Implementation Version", ul);
+                        }
+                        else if (ut == 0x56)
+                        {
+                            _assoc.ExtendedNegotiations.Add(DicomExtendedNegotiation.Create(raw, ul));
                         }
                         else
                         {

--- a/DICOM/Network/RootQueryRetrieveInfoMove.cs
+++ b/DICOM/Network/RootQueryRetrieveInfoMove.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Implementation of a Root Query Retrieve Info Move sub-item.
+    /// </summary>
+    public class RootQueryRetrieveInfoMove : IExtendedNegotiationSubItem
+    {
+        /// <summary>
+        /// Initializes an instance of the <see cref="RootQueryRetrieveInfoMove"/> class.
+        /// </summary>
+        /// <param name="relationalRetrieval">Relational retrieval flag.</param>
+        public RootQueryRetrieveInfoMove(byte? relationalRetrieval)
+        {
+            RelationalRetrieval = relationalRetrieval;
+        }
+
+        /// <summary>
+        /// Gets the relational retrieval flag.
+        /// </summary>
+        public byte? RelationalRetrieval { get; }
+
+        /// <summary>
+        /// Factory method for creating a <see cref="RootQueryRetrieveInfoMove"/> instance.
+        /// </summary>
+        /// <param name="pdu">Raw PDU.</param>
+        /// <param name="itemSize">Item size.</param>
+        /// <param name="bytesRead">Bytes read.</param>
+        /// <returns>The created <see cref="RootQueryRetrieveInfoMove"/> instance.</returns>
+        public static RootQueryRetrieveInfoMove Create(RawPDU pdu, int itemSize, out int bytesRead)
+        {
+            bytesRead = 0;
+            byte? relationalRetrieval = null;
+            if (itemSize > 0)
+            {
+                relationalRetrieval = pdu.ReadByte("Relational Retrieval");
+
+                bytesRead = 1;
+            }
+
+            return new RootQueryRetrieveInfoMove(relationalRetrieval);
+        }
+
+        /// <summary>
+        /// Write PDU data.
+        /// </summary>
+        /// <param name="pdu">PDU data to write.</param>
+        public void Write(RawPDU pdu)
+        {
+            if (RelationalRetrieval.HasValue)
+            {
+                pdu.Write("Relational RelationalRetrieval", RelationalRetrieval.Value);
+            }
+        }
+    }
+}

--- a/DICOM/Network/StudyRootQueryRetrieveInfo.cs
+++ b/DICOM/Network/StudyRootQueryRetrieveInfo.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Implementation of the root query retrieve info find sub-item.
+    /// </summary>
+    public class RootQueryRetrieveInfoFind : IExtendedNegotiationSubItem
+    {
+        /// <summary>
+        /// Initializes an instance of the <see cref="RootQueryRetrieveInfoFind"/> class.
+        /// </summary>
+        /// <param name="relationalQueries">Relational queries flag.</param>
+        /// <param name="dateTimeMatching">Date time matching flag.</param>
+        /// <param name="fuzzySemanticMatching">Fuzzy semantic matching flag.</param>
+        /// <param name="timezoneQueryAdjustment">Time zone query adjustment flag.</param>
+        /// <param name="enhancedMultiFrameImageConversion">Enhanced multi-frame image conversion flag.</param>
+        public RootQueryRetrieveInfoFind(
+            byte? relationalQueries,
+            byte? dateTimeMatching,
+            byte? fuzzySemanticMatching,
+            byte? timezoneQueryAdjustment,
+            byte? enhancedMultiFrameImageConversion)
+        {
+            RelationalQueries = relationalQueries;
+            DateTimeMatching = dateTimeMatching;
+            FuzzySemanticMatching = fuzzySemanticMatching;
+            TimezoneQueryAdjustment = timezoneQueryAdjustment;
+            EnhancedMultiFrameImageConversion = enhancedMultiFrameImageConversion;
+        }
+
+        /// <summary>
+        /// Gets the relational queries.
+        /// </summary>
+        public byte? RelationalQueries { get; }
+
+        /// <summary>
+        /// Gets the date time matching.
+        /// </summary>
+        public byte? DateTimeMatching { get; }
+
+        /// <summary>
+        /// Gets the fuzzy semantic matching.
+        /// </summary>
+        public byte? FuzzySemanticMatching { get; }
+
+        /// <summary>
+        /// Gets the time zone query adjustment.
+        /// </summary>
+        public byte? TimezoneQueryAdjustment { get; }
+
+        /// <summary>
+        /// Gets the enhanced multi frame image conversion.
+        /// </summary>
+        public byte? EnhancedMultiFrameImageConversion { get; }
+
+        /// <summary>
+        /// Factory method for creating a <see cref="RootQueryRetrieveInfoFind"/> instance.
+        /// </summary>
+        /// <param name="raw">Raw PDU.</param>
+        /// <param name="itemSize">Item size.</param>
+        /// <param name="bytesRead">Bytes read.</param>
+        /// <returns>The created <see cref="RootQueryRetrieveInfoFind"/> instance.</returns>
+        public static RootQueryRetrieveInfoFind Create(RawPDU raw, int itemSize, out int bytesRead)
+        {
+            byte? relationalQueries = null;
+            byte? dateTimeMatching = null;
+            byte? fuzzySemanticMatching = null;
+            byte? timezoneQueryAdjustment = null;
+            byte? enhancedMultiFrameImageConversion = null;
+
+            bytesRead = 0;
+            if (itemSize > 0)
+            {
+                relationalQueries = raw.ReadByte("Relational-queries");
+                bytesRead++;
+
+                if (itemSize > 1)
+                {
+                    dateTimeMatching = raw.ReadByte("Date-Time matching");
+                    bytesRead++;
+
+                    if (itemSize > 2)
+                    {
+                        fuzzySemanticMatching = raw.ReadByte("Fuzzy semantic matching");
+                        bytesRead++;
+
+                        if (itemSize > 3)
+                        {
+                            timezoneQueryAdjustment = raw.ReadByte("Timezone query adjustment");
+                            bytesRead++;
+
+                            if (itemSize > 4)
+                            {
+                                enhancedMultiFrameImageConversion = raw.ReadByte(
+                                    "Enhanced Multi-Frame Image Conversion");
+                                bytesRead++;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return new RootQueryRetrieveInfoFind(
+                relationalQueries,
+                dateTimeMatching,
+                fuzzySemanticMatching,
+                timezoneQueryAdjustment,
+                enhancedMultiFrameImageConversion);
+        }
+
+        /// <summary>
+        /// Write PDU data.
+        /// </summary>
+        /// <param name="pdu">PDU data to write.</param>
+        public void Write(RawPDU pdu)
+        {
+            if (RelationalQueries.HasValue)
+            {
+                pdu.Write("Relational-queries", RelationalQueries.Value);
+
+                if (DateTimeMatching.HasValue)
+                {
+                    pdu.Write("Date-Time matching", DateTimeMatching.Value);
+                    if (FuzzySemanticMatching.HasValue)
+                    {
+                        pdu.Write("Fuzzy semantic matching", FuzzySemanticMatching.Value);
+                        if (TimezoneQueryAdjustment.HasValue)
+                        {
+                            pdu.Write("Timezone query adjustment", TimezoneQueryAdjustment.Value);
+
+                            if (EnhancedMultiFrameImageConversion.HasValue)
+                            {
+                                pdu.Write(
+                                    "Enhanced Multi-Frame Image Conversion",
+                                    EnhancedMultiFrameImageConversion.Value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #241. Replaces #243.

Changes proposed in this pull request:
- Add a collection of Extended Negotiaion objects to DicomAssociation
- Write/read Extended Negotiation to/from RawPDU (current support for StudyRootQueryRetrieveInformationModelFIND, PatientRootQueryRetrieveInformationModelFIND, StudyRootQueryRetrieveInformationModelMOVE, PatientRootQueryRetrieveInformationModelMOVE, with a pattern for implementing more.
- Allow users to implement new extended negotiation sub items at their service level through DicomExtendedNegotiation.AddSubItemCreator()

Code from #243 has been cleaned-up and rudimentary API documentation added.

Please review.