### PR TITLE
Apply ChangeTransferSyntax parameters to output only. Connected to #277

### DIFF
--- a/DICOM.Tests/DICOM.Tests.csproj
+++ b/DICOM.Tests/DICOM.Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="DicomFileMetaInformationTests.cs" />
     <Compile Include="DicomParseableTest.cs" />
     <Compile Include="Helpers\NLogHelper.cs" />
+    <Compile Include="Imaging\Codec\DicomCodecExtensionsTest.cs" />
     <Compile Include="Imaging\ColorTableTest.cs" />
     <Compile Include="Imaging\DicomImageTest.cs" />
     <Compile Include="Imaging\GrayscaleRenderOptionsTest.cs" />

--- a/DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -16,7 +16,7 @@ namespace Dicom.Imaging.Codec
             var exception =
                 Record.Exception(
                     () =>
-                    file.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { Quality = 50 }));
+                    file.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess14, new DicomJpegParams { Quality = 50 }));
             Assert.Null(exception);
         }
 
@@ -27,7 +27,7 @@ namespace Dicom.Imaging.Codec
             var exception =
                 Record.Exception(
                     () =>
-                    file.Dataset.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { Quality = 50 }));
+                    file.Dataset.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess14, new DicomJpegParams { Quality = 50 }));
             Assert.Null(exception);
         }
 

--- a/DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -7,8 +7,10 @@ namespace Dicom.Imaging.Codec
 {
     public class DicomCodecExtensionsTest
     {
+        #region Unit tests
+
         [Fact]
-        public void ChangeTransferSyntax_FromJ2KToJPEGWithParameters_DoesNotThrow()
+        public void ChangeTransferSyntax_FileFromJ2KToJPEGWithParameters_DoesNotThrow()
         {
             var file = DicomFile.Open(@".\Test Data\CT1_J2KI");
             var exception =
@@ -17,5 +19,18 @@ namespace Dicom.Imaging.Codec
                     file.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { Quality = 50 }));
             Assert.Null(exception);
         }
+
+        [Fact]
+        public void ChangeTransferSyntax_DatasetFromJ2KToJPEGWithParameters_DoesNotThrow()
+        {
+            var file = DicomFile.Open(@".\Test Data\CT1_J2KI");
+            var exception =
+                Record.Exception(
+                    () =>
+                    file.Dataset.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { Quality = 50 }));
+            Assert.Null(exception);
+        }
+
+        #endregion
     }
 }

--- a/DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Xunit;
+
+namespace Dicom.Imaging.Codec
+{
+    public class DicomCodecExtensionsTest
+    {
+        [Fact]
+        public void ChangeTransferSyntax_FromJ2KToJPEGWithParameters_DoesNotThrow()
+        {
+            var file = DicomFile.Open(@".\Test Data\CT1_J2KI");
+            var exception =
+                Record.Exception(
+                    () =>
+                    file.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { Quality = 50 }));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/DICOM/Imaging/Codec/DicomCodecExtensions.cs
+++ b/DICOM/Imaging/Codec/DicomCodecExtensions.cs
@@ -20,7 +20,7 @@ namespace Dicom.Imaging.Codec
             DicomTransferSyntax syntax,
             DicomCodecParams parameters = null)
         {
-            var transcoder = new DicomTranscoder(file.FileMetaInfo.TransferSyntax, syntax, parameters, parameters);
+            var transcoder = new DicomTranscoder(file.FileMetaInfo.TransferSyntax, syntax, null, parameters);
             return transcoder.Transcode(file);
         }
 
@@ -36,7 +36,7 @@ namespace Dicom.Imaging.Codec
             DicomTransferSyntax syntax,
             DicomCodecParams parameters = null)
         {
-            var transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, syntax, parameters, parameters);
+            var transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, syntax, null, parameters);
             return transcoder.Transcode(dataset);
         }
     }


### PR DESCRIPTION
Fixes #277 .

Changes proposed in this pull request:
- In `DicomCodecExtensions.ChangeTransferSyntax` overloads, only apply `parameters` to the output transfer syntax. For input transfer syntax, apply `null`.

Please review.