### PR TITLE
PDV must always be even length. Connected to #284

### DIFF
--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -1298,6 +1298,11 @@ namespace Dicom.Network
         /// <param name="last">Is last fragment of command or data</param>
         public PDV(byte pcid, byte[] value, bool command, bool last)
         {
+            if (value.Length % 2 == 1)
+            {
+                Array.Resize(ref value, value.Length + 1);
+            }
+
             _pcid = pcid;
             _value = value;
             _command = command;

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Network\DicomServiceTest.cs" />
     <Compile Include="Network\PDUTest.cs" />
     <Compile Include="Logging\MessageNameFormatToOrdinalFormatTests.cs" />
+    <Compile Include="Network\PDVTest.cs" />
     <Compile Include="Network\Ports.cs" />
     <Compile Include="Printing\FilmBoxTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/Network/PDVTest.cs
+++ b/Tests/Network/PDVTest.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
+
+namespace Dicom.Network
+{
+    using Xunit;
+
+    public class PDVTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void Constructor_EvenLengthValue_Unmodified()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+            var expected = new byte[6];
+            Array.Copy(bytes, expected, bytes.Length);
+
+            var pdv = new PDV(1, bytes, true, true);
+            var actual = pdv.Value;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Constructor_OddLengthValue_PaddedToEvenLength()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5 };
+            var expected = new byte[6];
+            Array.Copy(bytes, expected, bytes.Length);
+
+            var pdv = new PDV(1, bytes, true, true);
+            var actual = pdv.Value;
+
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #284 .

According to DICOM Standard, Part 8, [Annex E](http://dicom.nema.org/medical/dicom/current/output/chtml/part08/chapter_E.html) all Presentation Data Values must be of even length.

Changes proposed in this pull request:
- Upon `PDV` initialization, if odd length, the `value` array is expanded to even length 

Thanks to @Jarekw69 for identifying this error.

Please review.