### PR TITLE
Support creating DS Value elements from string and IByteBuffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ DICOM/T4/part16.xml
 *.VC.opendb
 *.db
 *.DotSettings
+/UpgradeLog.htm

--- a/DICOM.Tests/DICOM.Tests.csproj
+++ b/DICOM.Tests/DICOM.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="DicomDateRangeTest.cs" />
     <Compile Include="DicomDateTimeTest.cs" />
     <Compile Include="DicomDictionaryTest.cs" />
+    <Compile Include="DicomDatasetAddTest.cs" />
     <Compile Include="DicomFileMetaInformationTests.cs" />
     <Compile Include="DicomParseableTest.cs" />
     <Compile Include="Helpers\NLogHelper.cs" />

--- a/DICOM.Tests/DicomDatasetAddTest.cs
+++ b/DICOM.Tests/DicomDatasetAddTest.cs
@@ -3,10 +3,7 @@
 
 namespace Dicom
 {
-    using System;
-    using System.Globalization;
     using System.Linq;
-    using System.Threading;
 
     using Dicom.IO.Buffer;
 
@@ -18,77 +15,77 @@ namespace Dicom
         #region Unit tests
 
         [Fact]
-        public void DicomSignedShortTest ()
+        public void DicomSignedShortTest()
         {
-            short[] values = new short [] { 5 } ; //single Value element
-            DicomSignedShort element = new DicomSignedShort(DicomTag.TagAngleSecondAxis, values );
-            
-            TestAddElementToDatasetAsString<short> ( element, values ) ;
+            short[] values = new short[] { 5 }; //single Value element
+            DicomSignedShort element = new DicomSignedShort(DicomTag.TagAngleSecondAxis, values);
 
-            values = new short [] { 5, 8 } ; //multi-value element
-            element = new DicomSignedShort(DicomTag.CenterOfCircularExposureControlSensingRegion, values );
-            
-            TestAddElementToDatasetAsString<short> ( element, values ) ;
+            TestAddElementToDatasetAsString<short>(element, values);
+
+            values = new short[] { 5, 8 }; //multi-value element
+            element = new DicomSignedShort(DicomTag.CenterOfCircularExposureControlSensingRegion, values);
+
+            TestAddElementToDatasetAsString<short>(element, values);
         }
 
         [Fact]
         public void DicomAttributeTagTest()
         {
-            var expected = new DicomTag[] { DicomTag.ALinePixelSpacing}; //single value
+            var expected = new DicomTag[] { DicomTag.ALinePixelSpacing }; //single value
             DicomElement element = new DicomAttributeTag(DicomTag.DimensionIndexPointer, expected);
-            
-            
-            TestAddElementToDatasetAsString<string>(element, expected.Select ( n=> n.ToString ("J", null)).ToArray());
-            
-            expected = new DicomTag[] { DicomTag.ALinePixelSpacing, DicomTag.AccessionNumber}; //multi-value
+
+
+            TestAddElementToDatasetAsString<string>(element, expected.Select(n => n.ToString("J", null)).ToArray());
+
+            expected = new DicomTag[] { DicomTag.ALinePixelSpacing, DicomTag.AccessionNumber }; //multi-value
             element = new DicomAttributeTag(DicomTag.FrameIncrementPointer, expected);
-            
-            TestAddElementToDatasetAsString(element, expected.Select ( n=> n.ToString ("J", null)).ToArray());
+
+            TestAddElementToDatasetAsString(element, expected.Select(n => n.ToString("J", null)).ToArray());
         }
 
         [Fact]
-        public void DicomUnsignedShortTest ()
+        public void DicomUnsignedShortTest()
         {
-            ushort[] testValues = new ushort[] {1, 2, 3, 4, 5} ;
+            ushort[] testValues = new ushort[] { 1, 2, 3, 4, 5 };
 
             var element = new DicomUnsignedShort(DicomTag.ReferencedFrameNumbers, testValues);
 
-            TestAddElementToDatasetAsString<ushort> (element, testValues) ;
+            TestAddElementToDatasetAsString<ushort>(element, testValues);
         }
 
         [Fact]
-        public void DicomSignedLongTest ()
+        public void DicomSignedLongTest()
         {
-            var testValues = new int[] {0,1,2} ;
+            var testValues = new int[] { 0, 1, 2 };
             var element = new DicomSignedLong(DicomTag.ReferencePixelX0, testValues);
-            
-            TestAddElementToDatasetAsString (element, testValues ) ;
+
+            TestAddElementToDatasetAsString(element, testValues);
         }
 
         [Fact]
         public void DicomOtherDoubleTest()
         {
-            var testValues = new double[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 } ;
+            var testValues = new double[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 };
 
-            var element = new DicomOtherDouble(DicomTag.DoubleFloatPixelData, testValues );
-            
-            TestAddElementToDatasetAsByteBuffer<double> ( element, testValues ) ;
+            var element = new DicomOtherDouble(DicomTag.DoubleFloatPixelData, testValues);
+
+            TestAddElementToDatasetAsByteBuffer<double>(element, testValues);
         }
-        
-        [Fact]
-        public void DicomOtherByteTest ( ) 
-        {
-            var testValues = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 } ;
 
-            var element = new DicomOtherByte(DicomTag.PixelData, testValues );
-            
-            TestAddElementToDatasetAsByteBuffer ( element, testValues ) ;
+        [Fact]
+        public void DicomOtherByteTest()
+        {
+            var testValues = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 };
+
+            var element = new DicomOtherByte(DicomTag.PixelData, testValues);
+
+            TestAddElementToDatasetAsByteBuffer(element, testValues);
         }
         #endregion
 
         #region Support methods
 
-        private void TestAddElementToDatasetAsString<T>(DicomElement element, T[] testValues )
+        private void TestAddElementToDatasetAsString<T>(DicomElement element, T[] testValues)
         {
             DicomDataset ds = new DicomDataset();
             string[] stringValues;
@@ -106,7 +103,7 @@ namespace Dicom
 
             ds.Add<string>(element.Tag, stringValues);
 
-            
+
             for (int index = 0; index < element.Count; index++)
             {
                 string val;
@@ -124,11 +121,11 @@ namespace Dicom
 
                 for (int index = 0; index < element.Count; index++)
                 {
-                    string val ;
+                    string val;
 
                     val = GetStringValue(element, ds, index);
-                    
-                    Assert.Equal(stringValues[index], val ) ;
+
+                    Assert.Equal(stringValues[index], val);
                 }
             }
         }
@@ -140,7 +137,7 @@ namespace Dicom
 
             if (element.ValueRepresentation == DicomVR.AT)
             {
-                //Should this be a fix in the toolkit?
+                //Should this be a updated in the AT DicomTag?
                 val = GetATElementValue(element, ds, index);
             }
             else
@@ -151,30 +148,30 @@ namespace Dicom
             return val;
         }
 
-        private static string GetATElementValue ( DicomElement element, DicomDataset ds, int index )
+        private static string GetATElementValue(DicomElement element, DicomDataset ds, int index)
         {
             var atElement = ds.Get<DicomElement>(element.Tag, null);
 
-            var testValue = atElement.Get<DicomTag> ( index ) ;
+            var testValue = atElement.Get<DicomTag>(index);
 
             return testValue.ToString("J", null);
         }
 
-        private void TestAddElementToDatasetAsByteBuffer<T>(DicomElement element, T[] testValues )
+        private void TestAddElementToDatasetAsByteBuffer<T>(DicomElement element, T[] testValues)
         {
-            DicomDataset ds = new DicomDataset ( ) ;
+            DicomDataset ds = new DicomDataset();
 
 
-            ds.Add<IByteBuffer> (element.Tag, element.Buffer) ;
+            ds.Add<IByteBuffer>(element.Tag, element.Buffer);
 
-            for ( int index = 0; index < testValues.Count ( ); index++ )
+            for (int index = 0; index < testValues.Count(); index++)
             {
-                Assert.Equal(testValues[index], ds.Get<T> ( element.Tag, index )) ;            
+                Assert.Equal(testValues[index], ds.Get<T>(element.Tag, index));
             }
         }
-                
+
         #endregion
 
-        
+
     }
 }

--- a/DICOM.Tests/DicomDatasetAddTest.cs
+++ b/DICOM.Tests/DicomDatasetAddTest.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
+{
+    using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Threading;
+
+    using Dicom.IO.Buffer;
+
+    using Xunit;
+
+    [Collection("General")]
+    public class DicomDatasetAddTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void DicomSignedShortTest ()
+        {
+            short[] values = new short [] { 5, 8 } ;
+            DicomSignedShort element = new DicomSignedShort(DicomTag.TagAngleSecondAxis, values );
+            
+            TestAddElementToDatasetAsString<short> ( element, values ) ;
+        }
+
+        [Fact]
+        public void DicomAttributeTagTest()
+        {
+            var expected = new DicomTag[] { DicomTag.ALinePixelSpacing};
+            DicomElement element = new DicomAttributeTag(DicomTag.DimensionIndexPointer, expected);
+
+            TestAddElementToDatasetAsString(element, expected);
+        }
+
+        [Fact]
+        public void DicomUnsignedShortTest ()
+        {
+            ushort[] testValues = new ushort[] {1, 2, 3, 4, 5} ;
+
+            var element = new DicomUnsignedShort(DicomTag.ReferencedFrameNumbers, testValues);
+
+            TestAddElementToDatasetAsString<ushort> (element, testValues) ;
+        }
+
+        [Fact]
+        public void DicomSignedLongTest ()
+        {
+            var testValues = new int[] {0,1,2} ;
+            var element = new DicomSignedLong(DicomTag.ReferencePixelX0, testValues);
+            
+            TestAddElementToDatasetAsString (element, testValues ) ;
+        }
+
+        [Fact]
+        public void DicomOtherDoubleTest()
+        {
+            var testValues = new double[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 } ;
+
+            var element = new DicomOtherDouble(DicomTag.DoubleFloatPixelData, testValues );
+            
+            TestAddElementToDatasetAsByteBuffer<double> ( element, testValues ) ;
+            TestAddElementToDatasetAsString<double>(element,testValues) ;
+        }
+        
+        [Fact]
+        public void DicomOtherByteTest ( ) 
+        {
+            var testValues = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 } ;
+
+            var element = new DicomOtherByte(DicomTag.PixelData, testValues );
+            
+            TestAddElementToDatasetAsByteBuffer<byte> ( element, testValues ) ;
+        }
+        #endregion
+
+        #region Support methods
+
+        private void TestAddElementToDatasetAsString<T>(DicomElement element, T[] testValues )
+        {
+            DicomDataset ds = new DicomDataset ( ) ;
+            var stringValues = testValues.Select ( x=>x.ToString());
+
+
+            ds.Add<string> (element.Tag, stringValues.ToArray ( ) ) ;
+
+            for (int index = 0; index < element.Count; index++ )
+            {
+                Assert.Equal(testValues[index], ds.Get<T> ( element.Tag, index )) ;
+            }
+        }
+
+        private void TestAddElementToDatasetAsByteBuffer<T>(DicomElement element, T[] testValues )
+        {
+            DicomDataset ds = new DicomDataset ( ) ;
+
+
+            ds.Add<IByteBuffer> (element.Tag, element.Buffer) ;
+
+            for ( int index = 0; index < testValues.Count ( ); index++ )
+            {
+                Assert.Equal(testValues[index], ds.Get<T> ( element.Tag, index )) ;            
+            }
+        }
+                
+        #endregion
+
+        
+    }
+}

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -244,6 +244,16 @@ namespace Dicom
             {
                 if (values == null) return Add(new DicomAttributeTag(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(DicomTag)) return Add(new DicomAttributeTag(tag, values.Cast<DicomTag>().ToArray()));
+
+                if (typeof(T) == typeof(string)) 
+                {
+                    var stringValues = values.Cast<string>().ToArray();
+
+                    var parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x => DicomTag.Parse(x));
+
+                    return Add(new DicomAttributeTag(tag, parsedValues.ToArray()));
+                }
+
             }
 
             if (vr == DicomVR.CS)
@@ -287,12 +297,30 @@ namespace Dicom
             {
                 if (values == null) return Add(new DicomFloatingPointDouble(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(double)) return Add(new DicomFloatingPointDouble(tag, values.Cast<double>().ToArray()));
+
+                if (typeof(T) == typeof(string)) 
+                {
+                    var stringValues = values.Cast<string>().ToArray();
+
+                    var parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x => double.Parse(x));
+
+                    return Add(new DicomFloatingPointDouble(tag, parsedValues.ToArray()));
+                }
             }
 
             if (vr == DicomVR.FL)
             {
                 if (values == null) return Add(new DicomFloatingPointSingle(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(float)) return Add(new DicomFloatingPointSingle(tag, values.Cast<float>().ToArray()));
+
+                if (typeof(T) == typeof(string)) 
+                {
+                    var stringValues = values.Cast<string>().ToArray();
+
+                    var parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x => float.Parse(x));
+
+                    return Add(new DicomFloatingPointSingle(tag, parsedValues.ToArray()));
+                }
             }
 
             if (vr == DicomVR.IS)
@@ -318,30 +346,93 @@ namespace Dicom
             {
                 if (values == null) return Add(new DicomOtherByte(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(byte)) return Add(new DicomOtherByte(tag, values.Cast<byte>().ToArray()));
+                
+                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                {
+                    return Add ( new DicomOtherByte(tag, (IByteBuffer) values.First () ));
+                }
+                
+                if ( typeof(T) == typeof(string) ) 
+                {
+                    //assume base 64?
+                    //Convert.FromBase64String (values.Cast(string))
+                }
             }
 
             if (vr == DicomVR.OD)
             {
+                IEnumerable<double> parsedValues ;
+
+
                 if (values == null) return Add(new DicomOtherDouble(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(double)) return Add(new DicomOtherDouble(tag, values.Cast<double>().ToArray()));
+            
+                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                {
+                    return Add ( new DicomOtherDouble (tag, (IByteBuffer) values.First () ));
+                }
+
+                if ( AddOtherVRFromString( values, double.Parse, out parsedValues) )
+                {
+                    return Add ( new DicomOtherDouble (tag, parsedValues.ToArray ( ) ) ) ;
+                }    
             }
 
             if (vr == DicomVR.OF)
             {
+                IEnumerable<float> parsedValues ;
+
+
                 if (values == null) return Add(new DicomOtherFloat(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(float)) return Add(new DicomOtherFloat(tag, values.Cast<float>().ToArray()));
+
+                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                {
+                    return Add ( new DicomOtherFloat(tag, (IByteBuffer) values.First () ));
+                }
+
+                if ( AddOtherVRFromString( values, float.Parse, out parsedValues) )
+                {
+                    return Add ( new DicomOtherFloat (tag, parsedValues.ToArray ( ) ) ) ;
+                }
             }
 
             if (vr == DicomVR.OL)
             {
+                IEnumerable<uint> parsedValues ;
+
+
                 if (values == null) return Add(new DicomOtherLong(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(uint)) return Add(new DicomOtherLong(tag, values.Cast<uint>().ToArray()));
+
+                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                {
+                    return Add ( new DicomOtherLong(tag, (IByteBuffer) values.First () ));
+                }
+
+                if (AddOtherVRFromString( values, uint.Parse, out parsedValues) )
+                {
+                    return Add ( new DicomOtherLong (tag, parsedValues.ToArray ( ) ) ) ;
+                }
             }
 
             if (vr == DicomVR.OW)
             {
+                IEnumerable<ushort> parsedValues ;
+
+
                 if (values == null) return Add(new DicomOtherWord(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(ushort)) return Add(new DicomOtherWord(tag, values.Cast<ushort>().ToArray()));
+                
+                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                {
+                    return Add ( new DicomOtherWord (tag, (IByteBuffer) values.First () ));
+                }
+
+                if ( AddOtherVRFromString ( values, ushort.Parse, out parsedValues) )
+                {
+                    return Add ( new DicomOtherWord (tag, parsedValues.ToArray ( ) ) ) ;
+                }
             }
 
             if (vr == DicomVR.PN)
@@ -360,6 +451,15 @@ namespace Dicom
             {
                 if (values == null) return Add(new DicomSignedLong(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(int)) return Add(new DicomSignedLong(tag, values.Cast<int>().ToArray()));
+
+                if (typeof(T) == typeof(string)) 
+                {
+                    var stringValues = values.Cast<string>().ToArray();
+
+                    var parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x => int.Parse(x));
+
+                    return Add(new DicomSignedLong(tag, parsedValues.ToArray()));
+                }
             }
 
             if (vr == DicomVR.SQ)
@@ -374,6 +474,15 @@ namespace Dicom
             {
                 if (values == null) return Add(new DicomSignedShort(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(short)) return Add(new DicomSignedShort(tag, values.Cast<short>().ToArray()));
+
+                if (typeof(T) == typeof(string)) 
+                {
+                    var stringValues = values.Cast<string>().ToArray();
+
+                    var parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x => short.Parse(x));
+
+                    return Add(new DicomSignedShort(tag, parsedValues.ToArray()));
+                }
             }
 
             if (vr == DicomVR.ST)
@@ -410,6 +519,15 @@ namespace Dicom
             {
                 if (values == null) return Add(new DicomUnsignedLong(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(uint)) return Add(new DicomUnsignedLong(tag, values.Cast<uint>().ToArray()));
+
+                if (typeof(T) == typeof(string)) 
+                {
+                    var stringValues = values.Cast<string>().ToArray();
+
+                    var parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x => uint.Parse(x));
+
+                    return Add(new DicomUnsignedLong(tag, parsedValues.ToArray()));
+                }
             }
 
             if (vr == DicomVR.UN)
@@ -428,6 +546,15 @@ namespace Dicom
             {
                 if (values == null) return Add(new DicomUnsignedShort(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(ushort)) return Add(new DicomUnsignedShort(tag, values.Cast<ushort>().ToArray()));
+
+                if (typeof(T) == typeof(string)) 
+                {
+                    var stringValues = values.Cast<string>().ToArray();
+
+                    var parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x => ushort.Parse(x));
+
+                    return Add(new DicomUnsignedShort(tag, parsedValues.ToArray()));
+                }
             }
 
             if (vr == DicomVR.UT)
@@ -607,6 +734,28 @@ namespace Dicom
                 "Unable to get a value type of {0} from DICOM item of type {1}",
                 typeof(T),
                 item.GetType());
+        }
+
+        private bool AddOtherVRFromString<R, T> ( T[] values, Func<string, R> parser, out IEnumerable<R> parsedValues ) 
+        {
+            parsedValues = null ;
+
+            if (typeof(T) == typeof(string)) 
+            {
+                var stringValues = values.Cast<string>().ToArray();
+
+
+                if ( stringValues.Length == 1 ) //should usually be the case
+                { 
+                    stringValues = stringValues[0].Split ( '\\' ) ;
+                }
+
+                parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x =>  parser (x) );
+
+                return true ;
+            }
+
+            return false ;
         }
     }
 }

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -228,7 +228,7 @@ namespace Dicom
             if (values != null) vr = entry.ValueRepresentations.FirstOrDefault(x => x.ValueType == typeof(T));
             if (vr == null) vr = entry.ValueRepresentations.First();
 
-            return Add<T> (vr, tag, values ) ;
+            return Add<T> (vr, tag, values);
         }
 
         /// <summary>
@@ -244,12 +244,6 @@ namespace Dicom
         /// <returns>The dataset instance.</returns>
         public DicomDataset Add<T>(DicomVR vr, DicomTag tag, params T[] values)
         {
-            var entry = DicomDictionary.Default[tag];
-            if (entry == null)
-                throw new DicomDataException(
-                    "Tag {0} not found in DICOM dictionary. Only dictionary tags may be added implicitly to the dataset.",
-                    tag);
-
             if (vr == DicomVR.AE)
             {
                 if (values == null) return Add(new DicomApplicationEntity(tag, EmptyBuffer.Value));
@@ -264,17 +258,14 @@ namespace Dicom
 
             if (vr == DicomVR.AT)
             {
-                IEnumerable<DicomTag> parsedValues ;
-
-
                 if (values == null) return Add(new DicomAttributeTag(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(DicomTag)) return Add(new DicomAttributeTag(tag, values.Cast<DicomTag>().ToArray()));
 
-                if ( ParseVrValueFromString ( values, tag.DictionaryEntry.ValueMultiplicity, DicomTag.Parse, out parsedValues) )
+                IEnumerable<DicomTag> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, DicomTag.Parse, out parsedValues))
                 {
-                    return Add ( new DicomAttributeTag (tag, parsedValues.ToArray () ) ) ;
-                } 
-
+                    return Add(new DicomAttributeTag (tag, parsedValues.ToArray()));
+                }
             }
 
             if (vr == DicomVR.CS)
@@ -316,30 +307,27 @@ namespace Dicom
 
             if (vr == DicomVR.FD)
             {
-                IEnumerable<double> parsedValues ;
-
-
                 if (values == null) return Add(new DicomFloatingPointDouble(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(double)) return Add(new DicomFloatingPointDouble(tag, values.Cast<double>().ToArray()));
 
-                if ( ParseVrValueFromString ( values, tag.DictionaryEntry.ValueMultiplicity, double.Parse, out parsedValues) )
+                IEnumerable<double> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, double.Parse, out parsedValues))
                 {
-                    return Add ( new DicomFloatingPointDouble (tag, parsedValues.ToArray () ) ) ;
+                    return Add(new DicomFloatingPointDouble(tag, parsedValues.ToArray()));
                 }              
             }
 
             if (vr == DicomVR.FL)
             {
-                IEnumerable<float> parsedValues ;
-
-
                 if (values == null) return Add(new DicomFloatingPointSingle(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(float)) return Add(new DicomFloatingPointSingle(tag, values.Cast<float>().ToArray()));
 
-                if ( ParseVrValueFromString<float, T> ( values, tag.DictionaryEntry.ValueMultiplicity, float.Parse, out parsedValues) )
+                IEnumerable<float> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, float.Parse, out parsedValues))
                 {
-                    return Add ( new DicomFloatingPointSingle (tag, parsedValues.ToArray () ) ) ;
-                }              }
+                    return Add(new DicomFloatingPointSingle(tag, parsedValues.ToArray()));
+                }
+            }
 
             if (vr == DicomVR.IS)
             {
@@ -365,9 +353,9 @@ namespace Dicom
                 if (values == null) return Add(new DicomOtherByte(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(byte)) return Add(new DicomOtherByte(tag, values.Cast<byte>().ToArray()));
                 
-                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
                 {
-                    return Add ( new DicomOtherByte(tag, (IByteBuffer) values.First () ));
+                    return Add(new DicomOtherByte(tag, (IByteBuffer) values.First()));
                 }
             }
 
@@ -376,9 +364,9 @@ namespace Dicom
                 if (values == null) return Add(new DicomOtherDouble(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(double)) return Add(new DicomOtherDouble(tag, values.Cast<double>().ToArray()));
             
-                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
                 {
-                    return Add ( new DicomOtherDouble (tag, (IByteBuffer) values.First () ));
+                    return Add(new DicomOtherDouble (tag, (IByteBuffer) values.First()));
                 }
             }
 
@@ -387,9 +375,9 @@ namespace Dicom
                 if (values == null) return Add(new DicomOtherFloat(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(float)) return Add(new DicomOtherFloat(tag, values.Cast<float>().ToArray()));
 
-                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
                 {
-                    return Add ( new DicomOtherFloat(tag, (IByteBuffer) values.First () ));
+                    return Add(new DicomOtherFloat(tag, (IByteBuffer) values.First()));
                 }
             }
 
@@ -398,9 +386,9 @@ namespace Dicom
                 if (values == null) return Add(new DicomOtherLong(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(uint)) return Add(new DicomOtherLong(tag, values.Cast<uint>().ToArray()));
 
-                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
                 {
-                    return Add ( new DicomOtherLong(tag, (IByteBuffer) values.First () ));
+                    return Add(new DicomOtherLong(tag, (IByteBuffer) values.First()));
                 }
             }
 
@@ -409,9 +397,9 @@ namespace Dicom
                 if (values == null) return Add(new DicomOtherWord(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(ushort)) return Add(new DicomOtherWord(tag, values.Cast<ushort>().ToArray()));
                 
-                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
                 {
-                    return Add ( new DicomOtherWord (tag, (IByteBuffer) values.First () ));
+                    return Add(new DicomOtherWord (tag, (IByteBuffer) values.First()));
                 }
             }
 
@@ -429,15 +417,13 @@ namespace Dicom
 
             if (vr == DicomVR.SL)
             {
-                IEnumerable<int> parsedValues ;
-                
                 if (values == null) return Add(new DicomSignedLong(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(int)) return Add(new DicomSignedLong(tag, values.Cast<int>().ToArray()));
 
-
-                if ( ParseVrValueFromString ( values, tag.DictionaryEntry.ValueMultiplicity, int.Parse, out parsedValues) )
+                IEnumerable<int> parsedValues;
+                if ( ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, int.Parse, out parsedValues))
                 {
-                    return Add ( new DicomSignedLong (tag, parsedValues.ToArray ( ) ) ) ;
+                    return Add(new DicomSignedLong (tag, parsedValues.ToArray ()));
                 }
             }
 
@@ -451,16 +437,13 @@ namespace Dicom
 
             if (vr == DicomVR.SS)
             {
-                IEnumerable<short> parsedValues ;
-                
-                
                 if (values == null) return Add(new DicomSignedShort(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(short)) return Add(new DicomSignedShort(tag, values.Cast<short>().ToArray()));
 
-                
-                if ( ParseVrValueFromString ( values, tag.DictionaryEntry.ValueMultiplicity, short.Parse, out parsedValues) )
+                IEnumerable<short> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, short.Parse, out parsedValues))
                 {
-                    return Add ( new DicomSignedShort (tag, parsedValues.ToArray ( ) ) ) ;
+                    return Add(new DicomSignedShort (tag, parsedValues.ToArray()));
                 }
             }
 
@@ -496,15 +479,13 @@ namespace Dicom
 
             if (vr == DicomVR.UL)
             {
-                IEnumerable<uint> parsedValues ;
-
-
                 if (values == null) return Add(new DicomUnsignedLong(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(uint)) return Add(new DicomUnsignedLong(tag, values.Cast<uint>().ToArray()));
 
-                if ( ParseVrValueFromString ( values, tag.DictionaryEntry.ValueMultiplicity, uint.Parse, out parsedValues) )
+                IEnumerable<uint> parsedValues;
+                if ( ParseVrValueFromString( values, tag.DictionaryEntry.ValueMultiplicity, uint.Parse, out parsedValues))
                 {
-                    return Add ( new DicomUnsignedLong (tag, parsedValues.ToArray ( ) ) ) ;
+                    return Add(new DicomUnsignedLong(tag, parsedValues.ToArray()));
                 }
             }
 
@@ -513,9 +494,9 @@ namespace Dicom
                 if (values == null) return Add(new DicomUnknown(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(byte)) return Add(new DicomUnknown(tag, values.Cast<byte>().ToArray()));
                 
-                if ( typeof(T)==typeof(IByteBuffer) && values.Length == 1 )
+                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
                 {
-                    return Add ( new DicomUnknown (tag, (IByteBuffer) values.First () ));
+                    return Add(new DicomUnknown(tag, (IByteBuffer) values.First()));
                 }
             }
 
@@ -527,15 +508,13 @@ namespace Dicom
 
             if (vr == DicomVR.US)
             {
-                IEnumerable<ushort> parsedValues ;
-                
-                
                 if (values == null) return Add(new DicomUnsignedShort(tag, EmptyBuffer.Value));
                 if (typeof(T) == typeof(ushort)) return Add(new DicomUnsignedShort(tag, values.Cast<ushort>().ToArray()));
 
-                if ( ParseVrValueFromString ( values, tag.DictionaryEntry.ValueMultiplicity, ushort.Parse, out parsedValues) )
+                IEnumerable<ushort> parsedValues;
+                if ( ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, ushort.Parse, out parsedValues))
                 {
-                    return Add ( new DicomUnsignedShort (tag, parsedValues.ToArray ( ) ) ) ;
+                    return Add(new DicomUnsignedShort (tag, parsedValues.ToArray()));
                 }
             }
 
@@ -726,24 +705,24 @@ namespace Dicom
             out IEnumerable<R> parsedValues 
         ) 
         {
-            parsedValues = null ;
+            parsedValues = null;
 
             if (typeof(T) == typeof(string)) 
             {
                 var stringValues = values.Cast<string>().ToArray();
 
-                if ( valueMultiplicity.Maximum > 1 && 
+                if ( valueMultiplicity.Maximum > 1 &&
                      stringValues.Length == 1 )
                 { 
-                    stringValues = stringValues[0].Split ( '\\' ) ;
+                    stringValues = stringValues[0].Split ('\\');
                 }
 
-                parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x =>  parser (x) );
+                parsedValues = stringValues.Where(n => !string.IsNullOrWhiteSpace(n)).Select(x =>  parser (x));
 
-                return true ;
+                return true;
             }
 
-            return false ;
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixes # .
N/A
Changes proposed in this pull request:
1. Add new overload to DicomDataset.Add to include VR (useful/needed when adding private elements)
2. Binaries VRs support settings from IByteBuffer UN, OW, OL, OF, OB, OD
3. Other Dicom Value elements support adding from String FD, FL, SL, SS, UL, US
4. Updates to unit Tests
