### PR TITLE
Load XML files as resource assets in Unity assembly. Connected to #292

### DIFF
--- a/DICOM.Platform/Unity/DICOM.Unity.csproj
+++ b/DICOM.Platform/Unity/DICOM.Unity.csproj
@@ -36,9 +36,8 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Unity-4.5.0\Editor\Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine">
+      <HintPath>C:\Program Files (x86)\Unity_4.5.0f6\Editor\Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -610,23 +609,19 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>DICOM Dictionary.xml</LastGenOutput>
     </Content>
-    <EmbeddedResource Include="..\..\DICOM\Dictionaries\DICOM Dictionary.xml">
+    <Content Include="..\..\DICOM\Dictionaries\DICOM Dictionary.xml">
       <Link>Dictionaries\DICOM Dictionary.xml</Link>
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>DICOM Dictionary.tt</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\..\DICOM\Dictionaries\Private Dictionary.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\DICOM\Dictionaries\Private Dictionary.xml">
       <Link>Dictionaries\Private Dictionary.xml</Link>
-    </EmbeddedResource>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\DICOM\Dictionaries\DICOM Dictionary.xml.gz">
-      <Link>Dictionaries\DICOM Dictionary.xml.gz</Link>
-    </None>
-    <None Include="..\..\DICOM\Dictionaries\Private Dictionary.xml.gz">
-      <Link>Dictionaries\Private Dictionary.xml.gz</Link>
-    </None>
     <None Include="..\..\DICOM\T4\dictionarymethods.t4">
       <Link>T4\dictionarymethods.t4</Link>
     </None>

--- a/DICOM/DicomDictionary.cs
+++ b/DICOM/DicomDictionary.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+
 namespace Dicom
 {
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.IO;
     using System.IO.Compression;
     using System.Linq;
     using System.Reflection;
@@ -148,16 +150,22 @@ namespace Dicom
                             DicomVR.UL));
                     try
                     {
-                        var assembly = typeof(DicomDictionary).GetTypeInfo().Assembly;
 #if NET35
-                        var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.DICOM Dictionary.xml");
-                        var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, stream);
+                        using (
+                            var stream =
+                                new MemoryStream(
+                                    UnityEngine.Resources.Load<UnityEngine.TextAsset>("DICOM Dictionary").bytes))
+                        {
+                            var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, stream);
+                            reader.Process();
+                        }
 #else
+                        var assembly = typeof(DicomDictionary).GetTypeInfo().Assembly;
                         var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.DICOM Dictionary.xml.gz");
                         var gzip = new GZipStream(stream, CompressionMode.Decompress);
                         var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, gzip);
-#endif
                         reader.Process();
+#endif
                     }
                     catch (Exception e)
                     {
@@ -169,17 +177,23 @@ namespace Dicom
                     {
                         try
                         {
-                            var assembly = typeof(DicomDictionary).GetTypeInfo().Assembly;
 #if NET35
-                            var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml");
-                            var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, stream);
+                            using (
+                                var stream =
+                                    new MemoryStream(
+                                        UnityEngine.Resources.Load<UnityEngine.TextAsset>("Private Dictionary").bytes))
+                            {
+                                var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, stream);
+                                reader.Process();
+                            }
 #else
+                            var assembly = typeof(DicomDictionary).GetTypeInfo().Assembly;
                             var stream =
                                 assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml.gz");
                             var gzip = new GZipStream(stream, CompressionMode.Decompress);
                             var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, gzip);
-#endif
                             reader.Process();
+#endif
                         }
                         catch (Exception e)
                         {

--- a/DICOM/DicomDictionary.cs
+++ b/DICOM/DicomDictionary.cs
@@ -161,10 +161,14 @@ namespace Dicom
                         }
 #else
                         var assembly = typeof(DicomDictionary).GetTypeInfo().Assembly;
-                        var stream = assembly.GetManifestResourceStream("Dicom.Dictionaries.DICOM Dictionary.xml.gz");
-                        var gzip = new GZipStream(stream, CompressionMode.Decompress);
-                        var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, gzip);
-                        reader.Process();
+                        using (
+                            var stream = assembly.GetManifestResourceStream(
+                                "Dicom.Dictionaries.DICOM Dictionary.xml.gz"))
+                        {
+                            var gzip = new GZipStream(stream, CompressionMode.Decompress);
+                            var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, gzip);
+                            reader.Process();
+                        }
 #endif
                     }
                     catch (Exception e)
@@ -188,11 +192,14 @@ namespace Dicom
                             }
 #else
                             var assembly = typeof(DicomDictionary).GetTypeInfo().Assembly;
-                            var stream =
-                                assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml.gz");
-                            var gzip = new GZipStream(stream, CompressionMode.Decompress);
-                            var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, gzip);
-                            reader.Process();
+                            using (
+                                var stream =
+                                    assembly.GetManifestResourceStream("Dicom.Dictionaries.Private Dictionary.xml.gz"))
+                            {
+                                var gzip = new GZipStream(stream, CompressionMode.Decompress);
+                                var reader = new DicomDictionaryReader(dict, DicomDictionaryFormat.XML, gzip);
+                                reader.Process();
+                            }
 #endif
                         }
                         catch (Exception e)


### PR DESCRIPTION
Fixes #292 .

Changes proposed in this pull request:
- Change *Build Action* to **Content**, and **Copy Always** for XML dictionary files in Unity platform project.
- Use `UnityEngine` resource loading to load dictionary files.
- When loading dictionaries, apply `using` statement to ensure that `Stream` is sufficiently cleaned up after usage.

Please review.