### PR TITLE
Minor adjustments to managed codecs. Connected to #128

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-#### v.3.0.0 (Beta 1, TBD)
+#### v.3.0.0 (Beta 1, 5/20/2016)
 * .NET Core Library Build Request (#256 #294)
 * Red and Blue bytes swapped in color images on iOS (#290 #291)
 * Support creating DS Value elements from string and IByteBuffer (#288)
@@ -31,7 +31,7 @@
 * Implement JSON serialization and deserialization of DICOM objects (#182 #186)
 * Open and save DicomDirectory to Stream (#181 #235)
 * Exposing network infos (ip and port) in association (#173 #225)
-* Image compression/decompression for Mono and Xamarin (#128 #279)
+* Image compression/decompression for Mono and Xamarin (#128 #279 #295)
 
 #### v2.0.2 (2/15/2016)
 * "Index was outside the bounds of the array" in PrecalculatedLUT indexer (#219 #221)

--- a/DICOM/Imaging/Codec/DicomJpeg2000CodecImpl.cs
+++ b/DICOM/Imaging/Codec/DicomJpeg2000CodecImpl.cs
@@ -91,6 +91,7 @@ namespace Dicom.Imaging.Codec
                             }
                         }
                     }
+#if SUPPORT16BIT
                     else if (oldPixelData.BytesAllocated == 2)
                     {
                         if (sgnd)
@@ -133,9 +134,11 @@ namespace Dicom.Imaging.Codec
                             }
                         }
                     }
+#endif
                     else
                     {
-                        throw new InvalidOperationException("JPEG 2000 codec only supports Bits Allocated == 8 or 16");
+                        throw new InvalidOperationException(
+                            $"JPEG 2000 codec does not support Bits Allocated == {oldPixelData.BitsAllocated}");
                     }
 
                     comps[c] = comp;
@@ -226,6 +229,7 @@ namespace Dicom.Imaging.Codec
                             pos += offset;
                         }
                     }
+#if SUPPORT16BIT
                     else if (newPixelData.BytesAllocated == 2)
                     {
                         for (var p = 0; p < pixelCount; p++)
@@ -234,10 +238,11 @@ namespace Dicom.Imaging.Codec
                             pos += offset;
                         }
                     }
+#endif
                     else
                     {
                         throw new InvalidOperationException(
-                            "JPEG 2000 module only supports Bytes Allocated == 8 or 16!");
+                            $"JPEG 2000 codec does not support Bits Allocated == {newPixelData.BitsAllocated}!");
                     }
                 }
 

--- a/DICOM/Imaging/Codec/DicomJpeg2000CodecImpl.cs
+++ b/DICOM/Imaging/Codec/DicomJpeg2000CodecImpl.cs
@@ -2,7 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 
-namespace Dicom
+namespace Dicom.Imaging.Codec
 {
     using System;
     using System.Linq;
@@ -12,7 +12,6 @@ namespace Dicom
     using CSJ2K.Util;
 
     using Dicom.Imaging;
-    using Dicom.Imaging.Codec;
     using Dicom.IO.Buffer;
 
     using JpegColorSpace = CSJ2K.Color.ColorSpace.CSEnum;

--- a/DICOM/Imaging/Codec/DicomJpegCodecImpl.cs
+++ b/DICOM/Imaging/Codec/DicomJpegCodecImpl.cs
@@ -1,24 +1,16 @@
 // Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Linq;
-
-using BitMiracle.LibJpeg;
-
-namespace Dicom
+namespace Dicom.Imaging.Codec
 {
     using System;
     using System.IO;
+    using System.Linq;
+
+    using BitMiracle.LibJpeg;
 
     using Dicom.Imaging;
-    using Dicom.Imaging.Codec;
     using Dicom.IO.Buffer;
-
-//    using FluxJpeg.Core;
-//    using FluxJpeg.Core.Decoder;
-//    using FluxJpeg.Core.Encoder;
-
-//    using JpegColorSpace = FluxJpeg.Core.ColorSpace;
 
     internal static class DicomJpegCodecImpl
     {
@@ -168,8 +160,10 @@ namespace Dicom
                                     (byte)oldPixelData.BitsStored,
                                     (byte)nc)).ToArray();
                         var colorSpace = GetColorSpace(oldPixelData.PhotometricInterpretation);
-                        var encoder = new JpegImage(sampleRows, colorSpace);
-                        encoder.WriteJpeg(stream);
+                        using (var encoder = new JpegImage(sampleRows, colorSpace))
+                        {
+                            encoder.WriteJpeg(stream);
+                        }
                         newPixelData.AddFrame(new MemoryByteBuffer(stream.ToArray()));
                     }
                 }
@@ -260,8 +254,7 @@ namespace Dicom
                         }
                         else
                         {
-                            throw new InvalidOperationException(
-                                "JPEG module only supports Bytes Allocated == 8!");
+                            throw new InvalidOperationException("JPEG module only supports Bytes Allocated == 8!");
                         }
                     }
 

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -17,6 +17,6 @@ using System.Resources;
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
 
-[assembly: AssemblyVersion("2.9.0")]
-[assembly: AssemblyFileVersion("2.9.0.1")]
-[assembly: AssemblyInformationalVersion("2.9.0")]
+[assembly: AssemblyVersion("2.9.9")]
+[assembly: AssemblyFileVersion("2.9.9.1")]
+[assembly: AssemblyInformationalVersion("2.9.9")]

--- a/Tools/DICOM Dump/MainForm.cs
+++ b/Tools/DICOM Dump/MainForm.cs
@@ -63,15 +63,9 @@ namespace Dicom.Dump
             lvi.SubItems.Add(value);
         }
 
-        private bool IsStructuredReport
-        {
-            get
-            {
-                return _file != null && _file.Format == DicomFileFormat.DICOM3
-                       && _file.FileMetaInfo.MediaStorageSOPClassUID.StorageCategory
-                       == DicomStorageCategory.StructuredReport;
-            }
-        }
+        private bool IsStructuredReport => this._file != null
+                                           && this._file.Dataset.Get<DicomUID>(DicomTag.SOPClassUID, null)?.StorageCategory
+                                           == DicomStorageCategory.StructuredReport;
 
         public void OpenFile(string fileName)
         {


### PR DESCRIPTION
Fixes #128 .

I have made a few small adjustments to finalize the managed codec implementations applicable on the Xamarin and Mono platforms.

Changes proposed in this pull request:
- Disabled non-functional 2 byte allocation support, i.e. only 8-bit grayscale and 8 bits per component color images can be transcoded.
- Corrected bug in JPEG encoding that made all rows equivalent
- Use JPEG compression parameters when available.

With this PR there is now functional 8-bit greyscale and color support for JPEG Baseline 1 and JPEG 2000 codecs, as well as full RLE, on Xamarin Android, Xamarin iOS and Mono. For extended support (>8-bit, JPEG Lossless, JPEG-LS) either the managed codecs will require substantial new development or we will need to consider re-using the C/C++ libraries via P/Invoke.

Please review.
