### PR TITLE
Corrections in fo-dicom.Universal.nuspec. Connected to #300

### DIFF
--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -238,9 +238,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)StructuredReport\DicomStructuredReportException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)DicomTagGenerated.tt" />
-    <Content Include="$(MSBuildThisFileDirectory)DicomUIDGenerated.tt" />
-    <Content Include="$(MSBuildThisFileDirectory)Dictionaries\DICOM Dictionary.tt" />
+    <None Include="$(MSBuildThisFileDirectory)DicomTagGenerated.tt" />
+    <None Include="$(MSBuildThisFileDirectory)DicomUIDGenerated.tt" />
+    <None Include="$(MSBuildThisFileDirectory)Dictionaries\DICOM Dictionary.tt" />
     <None Include="$(MSBuildThisFileDirectory)Dictionaries\DICOM Dictionary.xml">
       <DependentUpon>DICOM Dictionary.tt</DependentUpon>
     </None>

--- a/Setup/fo-dicom.Android.nuspec
+++ b/Setup/fo-dicom.Android.nuspec
@@ -3,17 +3,17 @@
     <metadata>
         <id>fo-dicom.Android</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM Android Libraries</title>
+        <title>Fellow Oak DICOM Android Library</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Xamarin Android specific support libraries for fo-dicom.</description>
+        <description>Core fo-dicom library for Xamarin Android.</description>
         <language>en-US</language>
         <dependencies>
-			<dependency id="Portable.LibJpeg.NET" version="1.5.0.1" />
-			<dependency id="CSJ2K" version="2.0.0-beta4" />
+			<dependency id="Portable.LibJpeg.NET" version="1.5.1-pre2" />
+			<dependency id="CSJ2K" version="2.0.0-beta6" />
         </dependencies>
     </metadata>
     <files>

--- a/Setup/fo-dicom.Core.nuspec
+++ b/Setup/fo-dicom.Core.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.Core</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM Core Library</title>
+        <title>Fellow Oak DICOM Portable Class Library</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>The core portable DICOM library for .NET, Universal Windows Platform, Xamarin iOS and Xamarin Android.</description>
+        <description>The core DICOM library for Portable Class Library development.</description>
         <language>en-US</language>
     </metadata>
     <files>

--- a/Setup/fo-dicom.Desktop.nuspec
+++ b/Setup/fo-dicom.Desktop.nuspec
@@ -3,13 +3,13 @@
     <metadata>
         <id>fo-dicom.Desktop</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM .NET Libraries</title>
+        <title>Fellow Oak DICOM .NET Framework Libraries</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>.NET specific support libraries for fo-dicom.</description>
+        <description>Core fo-dicom libraries for .NET Framework (Windows Desktop).</description>
         <language>en-US</language>
     </metadata>
     <files>

--- a/Setup/fo-dicom.NetCore.nuspec
+++ b/Setup/fo-dicom.NetCore.nuspec
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>fo-dicom.NetStandard</id>
+        <id>fo-dicom.NetCore</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM .NET Standard Library</title>
+        <title>Fellow Oak DICOM .NET Core Library</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>The core DICOM library for .NET Standard 1.3 and higher.</description>
+        <description>Core fo-dicom library for .NET Core Level 1.3 and higher.</description>
         <language>en-US</language>
 		<dependencies>
 			<dependency id="NETStandard.Library" version="1.5.0-rc2-24027" />
@@ -19,6 +19,8 @@
 			<dependency id="System.Net.Security" version="4.0.0-rc2-24027" />
 			<dependency id="System.Runtime.Serialization.Primitives" version="4.1.1-rc2-24027" />
 			<dependency id="System.Threading.Tasks.Parallel" version="4.0.1-rc2-24027" />
+			<dependency id="Portable.LibJpeg.NET" version="1.5.1-pre2" />
+			<dependency id="CSJ2K" version="2.0.0-beta6" />
 		</dependencies>
     </metadata>
     <files>

--- a/Setup/fo-dicom.Universal.nuspec
+++ b/Setup/fo-dicom.Universal.nuspec
@@ -9,11 +9,8 @@
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Universal Windows Platform specific support libraries for fo-dicom.</description>
+        <description>Core fo-dicom libraries for Universal Windows Platform (Windows 10).</description>
         <language>en-US</language>
-        <dependencies>
-			<dependency id="fo-dicom.Core" version="$version$" />
-        </dependencies>
     </metadata>
     <files>
 		<file src="Targets\fo-dicom.Universal.targets" target="build\uap" />

--- a/Setup/fo-dicom.iOS.nuspec
+++ b/Setup/fo-dicom.iOS.nuspec
@@ -3,17 +3,17 @@
     <metadata>
         <id>fo-dicom.iOS</id>
         <version>$version$</version>
-        <title>Fellow Oak DICOM iOS Libraries</title>
+        <title>Fellow Oak DICOM iOS Library</title>
         <authors>fo-dicom contributors</authors>
         <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Xamarin iOS specific support libraries for fo-dicom.</description>
+        <description>Core fo-dicom library for Xamarin iOS (Unified).</description>
         <language>en-US</language>
         <dependencies>
-			<dependency id="Portable.LibJpeg.NET" version="1.5.0.1" />
-			<dependency id="CSJ2K" version="2.0.0-beta4" />
+			<dependency id="Portable.LibJpeg.NET" version="1.5.1-pre2" />
+			<dependency id="CSJ2K" version="2.0.0-beta6" />
         </dependencies>
     </metadata>
     <files>

--- a/Setup/fo-dicom.nuspec
+++ b/Setup/fo-dicom.nuspec
@@ -9,7 +9,7 @@
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>A portable DICOM library for .NET, Universal Windows Platform, Xamarin iOS and Xamarin Android.</description>
+        <description>A portable DICOM library for .NET Framework, .NET Core, Universal Windows Platform, Xamarin iOS and Xamarin Android.</description>
         <language>en-US</language>
         <dependencies>
 			<group targetFramework="portable-net45+netcore45+wpa81">


### PR DESCRIPTION
Fixes #300 .

Changes proposed in this pull request:
- Remove depencency to *fo-dicom.Core* in *fo-dicom.Universal.nuspec*.
- Change type of *.tt* files in *DICOM.Shared* to **None**, to ensure that files are not incorrectly requested as part of the *fo-dicom* payload for UWP applications.
- Corrected *id* in *fo-dicom.NetCore.nuspec*. 
- Textual and dependency updates in the platform-specific core .nuspec files.

Please review.