### PR TITLE
Check date and time existence before obtaining in GetDateTime method. Connected to #299

### DIFF
--- a/DICOM/DicomDatasetExtensions.cs
+++ b/DICOM/DicomDatasetExtensions.cs
@@ -1,14 +1,22 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace Dicom
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// <see cref="DicomDataset"/> extension methods.
+    /// </summary>
     public static class DicomDatasetExtensions
     {
+        /// <summary>
+        /// Clone a dataset.
+        /// </summary>
+        /// <param name="dataset">Dataset to be cloned.</param>
+        /// <returns>Clone of dataset.</returns>
         public static DicomDataset Clone(this DicomDataset dataset)
         {
             var ds = new DicomDataset(dataset);
@@ -16,16 +24,20 @@ namespace Dicom
             return ds;
         }
 
+        /// <summary>
+        /// Get a composite <see cref="DateTime"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
+        /// </summary>
+        /// <param name="dataset">Dataset from which data should be retrieved.</param>
+        /// <param name="date">Tag associated with date value.</param>
+        /// <param name="time">Tag associated with time value.</param>
+        /// <returns>Composite <see cref="DateTime"/>.</returns>
         public static DateTime GetDateTime(this DicomDataset dataset, DicomTag date, DicomTag time)
         {
-            DicomDate dd = dataset.Get<DicomDate>(date);
-            DicomTime dt = dataset.Get<DicomTime>(time);
+            var dd = dataset.Contains(date) ? dataset.Get<DicomDate>(date) : null;
+            var dt = dataset.Contains(time) ? dataset.Get<DicomTime>(time) : null;
 
-            DateTime da = DateTime.Today;
-            if (dd != null && dd.Count > 0) da = dd.Get<DateTime>(0);
-
-            DateTime tm = DateTime.Today;
-            if (dt != null && dt.Count > 0) tm = dt.Get<DateTime>(0);
+            var da = dd != null && dd.Count > 0 ? dd.Get<DateTime>(0) : DateTime.MinValue;
+            var tm = dt != null && dt.Count > 0 ? dt.Get<DateTime>(0) : DateTime.MinValue;
 
             return new DateTime(da.Year, da.Month, da.Day, tm.Hour, tm.Minute, tm.Second);
         }
@@ -33,8 +45,9 @@ namespace Dicom
         /// <summary>
         /// Enumerates DICOM items matching mask.
         /// </summary>
-        /// <param name="mask">Mask</param>
-        /// <returns>Enumeration of DICOM items</returns>
+        /// <param name="dataset">Dataset from which masked items should be retrieved.</param>
+        /// <param name="mask">Requested mask.</param>
+        /// <returns>Enumeration of masked DICOM items.</returns>
         public static IEnumerable<DicomItem> EnumerateMasked(this DicomDataset dataset, DicomMaskedTag mask)
         {
             return dataset.Where(x => mask.IsMatch(x.Tag));
@@ -43,8 +56,9 @@ namespace Dicom
         /// <summary>
         /// Enumerates DICOM items for specified group.
         /// </summary>
-        /// <param name="group">Group</param>
-        /// <returns>Enumeration of DICOM items</returns>
+        /// <param name="dataset">Dataset from which group items should be retrieved.</param>
+        /// <param name="group">Requested group.</param>
+        /// <returns>Enumeration of DICOM items for specified <paramref name="group"/>.</returns>
         public static IEnumerable<DicomItem> EnumerateGroup(this DicomDataset dataset, ushort group)
         {
             return dataset.Where(x => x.Tag.Group == group && x.Tag.Element != 0x0000);

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Bugs\GH220.cs" />
     <Compile Include="Bugs\GH258.cs" />
     <Compile Include="Bugs\GH265.cs" />
+    <Compile Include="DicomDatasetExtensionsTest.cs" />
     <Compile Include="DicomDatasetTest.cs" />
     <Compile Include="DicomDatasetWalkerTest.cs" />
     <Compile Include="DicomDateRangeTest.cs" />

--- a/Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/DicomDatasetExtensionsTest.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
+{
+    using System;
+
+    using Xunit;
+
+    public class DicomDatasetExtensionsTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void GetDateTime_DateAndTimeAvailable_ReturnsSpecifiedDateTime()
+        {
+            var expected = new DateTime(2016, 5, 25, 15, 54, 31);
+
+            var dataset = new DicomDataset(
+                new DicomDate(DicomTag.CreationDate, "20160525"),
+                new DicomTime(DicomTag.CreationTime, "155431"));
+            var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetDateTime_DateAndTimeMissing_ReturnsMinimumDateTime()
+        {
+            var expected = DateTime.MinValue;
+
+            var dataset = new DicomDataset();
+            var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetDateTime_DateMissingTimeAvailable_ReturnsMinimumDateSpecifiedTime()
+        {
+            var expected = new DateTime(DateTime.MinValue.Year, DateTime.MinValue.Month, DateTime.MinValue.Day, 16, 2, 15);
+
+            var dataset = new DicomDataset(
+                new DicomTime(DicomTag.CreationTime, "160215"));
+            var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetDateTime_DateAvaliableTimeMissing_ReturnsSpecifiedDateMinimumTime()
+        {
+            var expected = new DateTime(2016, 5, 25, DateTime.MinValue.Hour, DateTime.MinValue.Minute, DateTime.MinValue.Second);
+
+            var dataset = new DicomDataset(
+                new DicomDate(DicomTag.CreationDate, "20160525"));
+            var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
+
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #299 .

Changes proposed in this pull request:
- Check that date and time tags exist in dataset, otherwise use default value `null`.
- Apply `DateTime.MinValue` when date and/or time is missing.

Please review.
