### PR TITLE
Should be possible to C-STORE non-Part 10 DICOM files. Connected to #306

### DIFF
--- a/DICOM/Network/DicomCStoreRequest.cs
+++ b/DICOM/Network/DicomCStoreRequest.cs
@@ -60,7 +60,7 @@ namespace Dicom.Network
         /// <summary>
         /// Initializes DICOM C-Store request to be sent to SCP.
         /// </summary>
-        /// <param name="file">DICOM file to be sent</param>
+        /// <param name="fileName">DICOM file to be sent</param>
         /// <param name="priority">Priority of request</param>
         public DicomCStoreRequest(string fileName, DicomPriority priority = DicomPriority.Medium)
             : this(DicomFile.Open(fileName), priority)
@@ -85,12 +85,12 @@ namespace Dicom.Network
 
         /// <summary>Gets the transfer syntax of the DICOM file associated with this DICOM C-Store request.</summary>
         public DicomTransferSyntax TransferSyntax
-        {
-            get
-            {
-                return File.FileMetaInfo.TransferSyntax;
-            }
-        }
+            =>
+                this.File != null
+                    ? (this.File.FileMetaInfo.Contains(DicomTag.TransferSyntaxUID)
+                           ? this.File.FileMetaInfo.TransferSyntax
+                           : this.File.Dataset.InternalTransferSyntax)
+                    : null;
 
         /// <summary>
         /// Additional transfer syntaxes to propose in the association request.

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -337,6 +337,9 @@ namespace Dicom.Network
 
         private void InitializeSend(INetworkStream stream, DicomAssociation association)
         {
+            this.associateNotifier = new TaskCompletionSource<bool>();
+            this.completeNotifier = new TaskCompletionSource<bool>();
+
             foreach (var request in this.requests)
             {
                 association.PresentationContexts.AddFromRequest(request);
@@ -345,9 +348,6 @@ namespace Dicom.Network
             {
                 association.PresentationContexts.Add(context.AbstractSyntax, context.GetTransferSyntaxes().ToArray());
             }
-
-            this.associateNotifier = new TaskCompletionSource<bool>();
-            this.completeNotifier = new TaskCompletionSource<bool>();
 
             this.service = new DicomServiceUser(this, stream, association, this.Options, this.FallbackEncoding, this.Logger);
         }

--- a/Tests/Bugs/GH306.cs
+++ b/Tests/Bugs/GH306.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-using Dicom.Log;
-using Dicom.Network;
-
-using Xunit;
-
 namespace Dicom.Bugs
 {
+    using System;
+    using System.Text;
+    using Dicom.Log;
+    using Dicom.Network;
+
+    using Xunit;
+
     public class GH306
     {
         #region Unit tests

--- a/Tests/Bugs/GH306.cs
+++ b/Tests/Bugs/GH306.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
+using System.Text;
+using Dicom.Log;
+using Dicom.Network;
+
+using Xunit;
+
+namespace Dicom.Bugs
+{
+    public class GH306
+    {
+        #region Unit tests
+
+        [Fact]
+        public void DicomClientSend_StoreNonPart10File_ShouldSucceed()
+        {
+            var port = Ports.GetNext();
+
+            using (var server = DicomServer.Create<CStoreScp>(port))
+            {
+                var file = DicomFile.Open(@".\Test Data\CR-MONO1-10-chest");
+
+                var client = new DicomClient();
+                client.AddRequest(new DicomCStoreRequest(file));
+
+                var exception = Record.Exception(() => client.Send("127.0.0.1", port, false, "SCU", "SCP"));
+                Assert.Null(exception);
+            }
+        }
+
+        [Fact]
+        public void DicomClientSend_StorePart10File_ShouldSucceed()
+        {
+            var port = Ports.GetNext();
+
+            using (var server = DicomServer.Create<CStoreScp>(port))
+            {
+                var file = DicomFile.Open(@".\Test Data\CT-MONO2-16-ankle");
+
+                var client = new DicomClient();
+                client.AddRequest(new DicomCStoreRequest(file));
+
+                var exception = Record.Exception(() => client.Send("127.0.0.1", port, false, "SCU", "SCP"));
+                Assert.Null(exception);
+            }
+        }
+
+        #endregion
+
+        #region Support types
+
+        private class CStoreScp : DicomService, IDicomCStoreProvider, IDicomServiceProvider
+        {
+            private DicomTransferSyntax[] AcceptedImageTransferSyntaxes =
+                {
+                    DicomTransferSyntax.ExplicitVRLittleEndian,
+                    DicomTransferSyntax.ExplicitVRBigEndian,
+                    DicomTransferSyntax.ImplicitVRLittleEndian
+                };
+
+            public CStoreScp(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+                : base(stream, fallbackEncoding, log)
+            {
+            }
+
+            public DicomCStoreResponse OnCStoreRequest(DicomCStoreRequest request)
+            {
+                return new DicomCStoreResponse(request, DicomStatus.Success);
+            }
+
+            public void OnCStoreRequestException(string tempFileName, Exception e)
+            {
+            }
+
+            public void OnReceiveAssociationRequest(DicomAssociation association)
+            {
+                foreach (var pc in association.PresentationContexts)
+                {
+                    pc.AcceptTransferSyntaxes(AcceptedImageTransferSyntaxes);
+                }
+
+                SendAssociationAccept(association);
+            }
+
+            public void OnReceiveAssociationReleaseRequest()
+            {
+                SendAssociationReleaseResponse();
+            }
+
+            public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+            {
+            }
+
+            public void OnConnectionClosed(Exception exception)
+            {
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Bugs\GH220.cs" />
     <Compile Include="Bugs\GH258.cs" />
     <Compile Include="Bugs\GH265.cs" />
+    <Compile Include="Bugs\GH306.cs" />
     <Compile Include="DicomDatasetExtensionsTest.cs" />
     <Compile Include="DicomDatasetTest.cs" />
     <Compile Include="DicomDatasetWalkerTest.cs" />


### PR DESCRIPTION
Fixes #306 .

Changes proposed in this pull request:
- In `DicomClient.InitializeSend` define notifiers first to ensure that they are defined even in the case of an exception being thrown, thus avoiding a follow-up exception in `FinalizeSend`.
- When determining transfer syntax for the C-STORE request, verify that transfer syntax is set in meta file information before requesting it; if not, use `InternalTransferSyntax` from main `Dataset` as fallback.

Please review.
