### PR TITLE
Copy N-ACTION and N-EVENTRESULT request data to response. Connected to #298

### DIFF
--- a/DICOM/Network/DicomMessage.cs
+++ b/DICOM/Network/DicomMessage.cs
@@ -1,26 +1,40 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
-using Dicom.Log;
-
 namespace Dicom.Network
 {
+    using System.Text;
+
+    using Dicom.Log;
+
+    /// <summary>
+    /// Base class for DIMSE-C and DIMSE-N message items.
+    /// </summary>
     public class DicomMessage
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomMessage"/> class.
+        /// </summary>
         public DicomMessage()
         {
             Command = new DicomDataset();
             Dataset = null;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomMessage"/> class.
+        /// </summary>
+        /// <param name="command">
+        /// The DICOM dataset representing the message command.
+        /// </param>
         public DicomMessage(DicomDataset command)
         {
             Command = command;
         }
 
+        /// <summary>
+        /// Gets or sets the command field type.
+        /// </summary>
         public DicomCommandField Type
         {
             get
@@ -33,7 +47,9 @@ namespace Dicom.Network
             }
         }
 
-        /// <summary>Affected or requested SOP Class UID</summary>
+        /// <summary>
+        /// Gets or sets the affected or requested SOP Class UID
+        /// </summary>
         public DicomUID SOPClassUID
         {
             get
@@ -66,18 +82,9 @@ namespace Dicom.Network
             }
         }
 
-        public ushort MessageID
-        {
-            get
-            {
-                return Command.Get<ushort>(DicomTag.MessageID);
-            }
-            set
-            {
-                Command.Add(DicomTag.MessageID, value);
-            }
-        }
-
+        /// <summary>
+        /// Gets a value indicating whether the message contains a dataset.
+        /// </summary>
         public bool HasDataset
         {
             get
@@ -88,14 +95,20 @@ namespace Dicom.Network
 
 
         /// <summary>
-        /// Presentation Context
+        /// Gets or sets the presentation Context.
         /// </summary>
         public DicomPresentationContext PresentationContext { get; set; }
 
+        /// <summary>
+        /// Gets or sets the associated DICOM command.
+        /// </summary>
         public DicomDataset Command { get; set; }
 
         private DicomDataset _dataset;
 
+        /// <summary>
+        /// Gets or sets the dataset potentially included in the message..
+        /// </summary>
         public DicomDataset Dataset
         {
             get
@@ -109,17 +122,30 @@ namespace Dicom.Network
             }
         }
 
-        /// <summary>State object that will be passed from request to response objects.</summary>
+        /// <summary>
+        /// Gets or sets the state object that will be passed from request to response objects.
+        /// </summary>
         public object UserState { get; set; }
 
+        /// <summary>
+        /// Formatted output of the DICOM message.
+        /// </summary>
+        /// <returns>Formatted output string of the DICOM message.</returns>
         public override string ToString()
         {
-            return String.Format(
+            return string.Format(
                 "{0} [{1}]",
                 ToString(Type),
-                IsRequest(Type) ? MessageID : Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo));
+                IsRequest(Type)
+                    ? Command.Get<ushort>(DicomTag.MessageID)
+                    : Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo));
         }
 
+        /// <summary>
+        /// Formatted output of the DICOM message.
+        /// </summary>
+        /// <param name="printDatasets">Indicates whether datasets should be printed.</param>
+        /// <returns>Formatted output string of the DICOM message.</returns>
         public string ToString(bool printDatasets)
         {
             var output = new StringBuilder(ToString());
@@ -145,6 +171,11 @@ namespace Dicom.Network
             return output.ToString();
         }
 
+        /// <summary>
+        /// Formatted output of the DICOM message.
+        /// </summary>
+        /// <param name="type">DICOM command field type.</param>
+        /// <returns>Formatted output string of the DICOM message.</returns>
         public static string ToString(DicomCommandField type)
         {
             switch (type)
@@ -200,6 +231,11 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Evaluates whether a DICOM message is a request or a response.
+        /// </summary>
+        /// <param name="type">DICOM command field type.</param>
+        /// <returns>True if message is a request, false otherwise.</returns>
         public static bool IsRequest(DicomCommandField type)
         {
             return ((int)type & 0x8000) == 0;

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Text;
-
 namespace Dicom.Network
 {
+    using System.Text;
+
     public class DicomNActionRequest : DicomRequest
     {
         public DicomNActionRequest(DicomDataset command)

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -46,6 +46,8 @@ namespace Dicom.Network
             }
         }
 
+        internal bool HasSOPInstanceUID => this.Command.Contains(DicomTag.RequestedSOPInstanceUID);
+
         public delegate void ResponseDelegate(DicomNActionRequest request, DicomNActionResponse response);
 
         public ResponseDelegate OnResponseReceived;

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -16,6 +16,12 @@ namespace Dicom.Network
         public DicomNActionResponse(DicomNActionRequest request, DicomStatus status)
             : base(request, status)
         {
+            if (request.HasSOPInstanceUID)
+            {
+                this.SOPInstanceUID = request.SOPInstanceUID;
+            }
+
+            this.ActionTypeID = request.ActionTypeID;
         }
 
         public DicomUID SOPInstanceUID

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -1,18 +1,38 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
 namespace Dicom.Network
 {
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// Representation of an N-ACTION response message.
+    /// </summary>
     public class DicomNActionResponse : DicomResponse
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNActionResponse"/> class.
+        /// </summary>
+        /// <param name="command">
+        /// A dataset representing the response command.
+        /// </param>
         public DicomNActionResponse(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNActionResponse"/> class.
+        /// </summary>
+        /// <param name="request">
+        /// The associated N-ACTION request.
+        /// </param>
+        /// <param name="status">
+        /// The response status.
+        /// </param>
         public DicomNActionResponse(DicomNActionRequest request, DicomStatus status)
             : base(request, status)
         {
@@ -24,6 +44,13 @@ namespace Dicom.Network
             this.ActionTypeID = request.ActionTypeID;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
@@ -36,6 +63,9 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Gets the action type ID.
+        /// </summary>
         public ushort ActionTypeID
         {
             get
@@ -48,6 +78,14 @@ namespace Dicom.Network
             }
         }
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Formatted output.
+        /// </summary>
+        /// <returns>Formetted output of the N-ACTION response.</returns>
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
@@ -59,5 +97,7 @@ namespace Dicom.Network
             }
             return sb.ToString();
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -11,22 +11,22 @@ namespace Dicom.Network
         }
 
         public DicomNCreateRequest(
-            DicomUID affectedClassUid,
-            DicomUID affectedInstanceUid)
-            : base(DicomCommandField.NCreateRequest, affectedClassUid)
+            DicomUID requestedClassUid,
+            DicomUID requestedInstanceUid)
+            : base(DicomCommandField.NCreateRequest, requestedClassUid)
         {
-            SOPInstanceUID = affectedInstanceUid;
+            SOPInstanceUID = requestedInstanceUid;
         }
 
         public DicomUID SOPInstanceUID
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -46,6 +46,8 @@ namespace Dicom.Network
             }
         }
 
+        internal bool HasSOPInstanceUID => this.Command.Contains(DicomTag.RequestedSOPInstanceUID);
+
         public delegate void ResponseDelegate(DicomNEventReportRequest request, DicomNEventReportResponse response);
 
         public ResponseDelegate OnResponseReceived;

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Text;
-
 namespace Dicom.Network
 {
+    using System.Text;
+
     public class DicomNEventReportRequest : DicomRequest
     {
         public DicomNEventReportRequest(DicomDataset command)
@@ -13,12 +13,12 @@ namespace Dicom.Network
         }
 
         public DicomNEventReportRequest(
-            DicomUID affectedClassUid,
-            DicomUID affectedInstanceUid,
+            DicomUID requestedClassUid,
+            DicomUID requestedInstanceUid,
             ushort eventTypeId)
-            : base(DicomCommandField.NEventReportRequest, affectedClassUid)
+            : base(DicomCommandField.NEventReportRequest, requestedClassUid)
         {
-            SOPInstanceUID = affectedInstanceUid;
+            SOPInstanceUID = requestedInstanceUid;
             EventTypeID = eventTypeId;
         }
 
@@ -26,11 +26,11 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 

--- a/DICOM/Network/DicomNEventReportResponse.cs
+++ b/DICOM/Network/DicomNEventReportResponse.cs
@@ -16,6 +16,12 @@ namespace Dicom.Network
         public DicomNEventReportResponse(DicomNEventReportRequest request, DicomStatus status)
             : base(request, status)
         {
+            if (request.HasSOPInstanceUID)
+            {
+                this.SOPInstanceUID = request.SOPInstanceUID;
+            }
+
+            this.EventTypeID = request.EventTypeID;
         }
 
         public DicomUID SOPInstanceUID

--- a/DICOM/Network/DicomNEventReportResponse.cs
+++ b/DICOM/Network/DicomNEventReportResponse.cs
@@ -1,18 +1,38 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
 namespace Dicom.Network
 {
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// Representation of an N-EVENTREPORT response message.
+    /// </summary>
     public class DicomNEventReportResponse : DicomResponse
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNEventReportResponse"/> class.
+        /// </summary>
+        /// <param name="command">
+        /// The dataset representing the N-EVENTREPORT response command.
+        /// </param>
         public DicomNEventReportResponse(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNEventReportResponse"/> class.
+        /// </summary>
+        /// <param name="request">
+        /// The request associated with the N-EVENTREPORT response.
+        /// </param>
+        /// <param name="status">
+        /// The response status.
+        /// </param>
         public DicomNEventReportResponse(DicomNEventReportRequest request, DicomStatus status)
             : base(request, status)
         {
@@ -24,6 +44,13 @@ namespace Dicom.Network
             this.EventTypeID = request.EventTypeID;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
@@ -36,6 +63,9 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Gets the event type ID.
+        /// </summary>
         public ushort EventTypeID
         {
             get
@@ -48,6 +78,14 @@ namespace Dicom.Network
             }
         }
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Formatted output of the N-EVENTREPORT response message.
+        /// </summary>
+        /// <returns>Formatted output of the N-EVENTREPORT response message.</returns>
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
@@ -59,5 +97,7 @@ namespace Dicom.Network
             }
             return sb.ToString();
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomPriorityRequest.cs
+++ b/DICOM/Network/DicomPriorityRequest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-
 namespace Dicom.Network
 {
     public abstract class DicomPriorityRequest : DicomRequest
@@ -12,8 +10,8 @@ namespace Dicom.Network
         {
         }
 
-        protected DicomPriorityRequest(DicomCommandField type, DicomUID affectedClassUid, DicomPriority priority)
-            : base(type, affectedClassUid)
+        protected DicomPriorityRequest(DicomCommandField type, DicomUID requestedClassUid, DicomPriority priority)
+            : base(type, requestedClassUid)
         {
             Priority = priority;
         }

--- a/DICOM/Network/DicomRequest.cs
+++ b/DICOM/Network/DicomRequest.cs
@@ -5,29 +5,78 @@ using System;
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Base class for DIMSE-C and DIMSE-N request items.
+    /// </summary>
     public abstract class DicomRequest : DicomMessage
     {
-        protected DicomRequest(DicomDataset command)
-            : base(command)
-        {
-        }
-
-        protected DicomRequest(DicomCommandField type, DicomUID affectedClassUid)
-            : base()
-        {
-            Type = type;
-            SOPClassUID = affectedClassUid;
-            MessageID = GetNextMessageID();
-            Dataset = null;
-        }
-
-        internal abstract void PostResponse(DicomService service, DicomResponse response);
+        #region FIELDS
 
         private static volatile ushort _messageId = 1;
 
         private static object _lock = new object();
 
-        internal ushort GetNextMessageID()
+        #endregion
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomRequest"/> class.
+        /// </summary>
+        /// <param name="command">
+        /// Dataset representing the request command.
+        /// </param>
+        protected DicomRequest(DicomDataset command)
+            : base(command)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomRequest"/> class.
+        /// </summary>
+        /// <param name="type">
+        /// The command field type.
+        /// </param>
+        /// <param name="requestedClassUid">
+        /// The requested Class Uid.
+        /// </param>
+        protected DicomRequest(DicomCommandField type, DicomUID requestedClassUid)
+        {
+            Type = type;
+            SOPClassUID = requestedClassUid;
+            MessageID = GetNextMessageID();
+            Dataset = null;
+        }
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets or sets the request message ID.
+        /// </summary>
+        public ushort MessageID
+        {
+            get
+            {
+                return Command.Get<ushort>(DicomTag.MessageID);
+            }
+            set
+            {
+                Command.Add(DicomTag.MessageID, value);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Operation to perform after response has been made.
+        /// </summary>
+        /// <param name="service">Active DICOM service.</param>
+        /// <param name="response">Response to be post-processed.</param>
+        internal abstract void PostResponse(DicomService service, DicomResponse response);
+
+        /// <summary>
+        /// Global message ID generator.
+        /// </summary>
+        /// <returns>A "unique" message ID.</returns>
+        private static ushort GetNextMessageID()
         {
             lock (_lock)
             {

--- a/DICOM/Network/DicomResponse.cs
+++ b/DICOM/Network/DicomResponse.cs
@@ -1,22 +1,38 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
 namespace Dicom.Network
 {
-    public class DicomResponse : DicomMessage
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// Base class for DIMSE-C and DIMSE-N response items.
+    /// </summary>
+    public abstract class DicomResponse : DicomMessage
     {
-        public DicomResponse(DicomDataset command)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomResponse"/> class.
+        /// </summary>
+        /// <param name="command">
+        /// The command dataset.
+        /// </param>
+        protected DicomResponse(DicomDataset command)
             : base(command)
         {
         }
 
-        public DicomResponse(DicomMessage request, DicomStatus status)
-            : base()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomResponse"/> class.
+        /// </summary>
+        /// <param name="request">
+        /// The request initiating the response.
+        /// </param>
+        /// <param name="status">
+        /// Response status.
+        /// </param>
+        protected DicomResponse(DicomRequest request, DicomStatus status)
         {
-
             PresentationContext = request.PresentationContext;
 
             Type = (DicomCommandField)(0x8000 | (int)request.Type);
@@ -25,6 +41,9 @@ namespace Dicom.Network
             Status = status;
         }
 
+        /// <summary>
+        /// Gets or sets the message ID of the request being responded to.
+        /// </summary>
         public ushort RequestMessageID
         {
             get
@@ -37,6 +56,9 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Gets or sets the response status.
+        /// </summary>
         public DicomStatus Status
         {
             get
@@ -53,6 +75,12 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Formatted output of the DICOM response.
+        /// </summary>
+        /// <returns>
+        /// The formatted output of the DICOM response.
+        /// </returns>
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -143,6 +143,8 @@
     <Compile Include="Media\DicomFileScannerTest.cs" />
     <Compile Include="Network\DicomCEchoProviderTest.cs" />
     <Compile Include="Network\DicomClientTest.cs" />
+    <Compile Include="Network\DicomNEventReportResponseTest.cs" />
+    <Compile Include="Network\DicomNActionResponseTest.cs" />
     <Compile Include="Network\DicomServerTest.cs" />
     <Compile Include="Network\DicomServiceTest.cs" />
     <Compile Include="Network\PDUTest.cs" />

--- a/Tests/Network/DicomNActionResponseTest.cs
+++ b/Tests/Network/DicomNActionResponseTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using Xunit;
+
+    public class DicomNActionResponseTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void ActionTypeIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
+        {
+            var request = new DicomNActionRequest(
+                DicomUID.BasicFilmSessionSOPClass,
+                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                1);
+            var response = new DicomNActionResponse(request, DicomStatus.Success);
+
+            var exception = Record.Exception(() => response.ActionTypeID);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void MessageIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
+        {
+            var request = new DicomNActionRequest(
+                DicomUID.BasicFilmSessionSOPClass,
+                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                1);
+            var response = new DicomNActionResponse(request, DicomStatus.Success);
+
+            var exception = Record.Exception(() => response.MessageID);
+            Assert.Null(exception);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Network/DicomNActionResponseTest.cs
+++ b/Tests/Network/DicomNActionResponseTest.cs
@@ -22,6 +22,19 @@ namespace Dicom.Network
             Assert.Null(exception);
         }
 
+        [Fact]
+        public void SOPInstanceUIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
+        {
+            var request = new DicomNActionRequest(
+                DicomUID.BasicFilmSessionSOPClass,
+                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                1);
+            var response = new DicomNActionResponse(request, DicomStatus.Success);
+
+            var exception = Record.Exception(() => response.SOPInstanceUID);
+            Assert.Null(exception);
+        }
+
         #endregion
     }
 }

--- a/Tests/Network/DicomNActionResponseTest.cs
+++ b/Tests/Network/DicomNActionResponseTest.cs
@@ -22,19 +22,6 @@ namespace Dicom.Network
             Assert.Null(exception);
         }
 
-        [Fact]
-        public void MessageIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
-        {
-            var request = new DicomNActionRequest(
-                DicomUID.BasicFilmSessionSOPClass,
-                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
-                1);
-            var response = new DicomNActionResponse(request, DicomStatus.Success);
-
-            var exception = Record.Exception(() => response.MessageID);
-            Assert.Null(exception);
-        }
-
         #endregion
     }
 }

--- a/Tests/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/Network/DicomNEventReportResponseTest.cs
@@ -22,19 +22,6 @@ namespace Dicom.Network
             Assert.Null(exception);
         }
 
-        [Fact]
-        public void MessageIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
-        {
-            var request = new DicomNEventReportRequest(
-                DicomUID.BasicFilmSessionSOPClass,
-                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
-                2);
-            var response = new DicomNEventReportResponse(request, DicomStatus.Success);
-
-            var exception = Record.Exception(() => response.MessageID);
-            Assert.Null(exception);
-        }
-
         #endregion
     }
 }

--- a/Tests/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/Network/DicomNEventReportResponseTest.cs
@@ -22,6 +22,19 @@ namespace Dicom.Network
             Assert.Null(exception);
         }
 
+        [Fact]
+        public void SOPInstanceUIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
+        {
+            var request = new DicomNEventReportRequest(
+                DicomUID.BasicFilmSessionSOPClass,
+                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                1);
+            var response = new DicomNEventReportResponse(request, DicomStatus.Success);
+
+            var exception = Record.Exception(() => response.SOPInstanceUID);
+            Assert.Null(exception);
+        }
+
         #endregion
     }
 }

--- a/Tests/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/Network/DicomNEventReportResponseTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using Xunit;
+
+    public class DicomNEventReportResponseTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void EventTypeIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
+        {
+            var request = new DicomNEventReportRequest(
+                DicomUID.BasicFilmSessionSOPClass,
+                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                1);
+            var response = new DicomNEventReportResponse(request, DicomStatus.Success);
+
+            var exception = Record.Exception(() => response.EventTypeID);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void MessageIDGetter_ResponseCreatedFromRequest_DoesNotThrow()
+        {
+            var request = new DicomNEventReportRequest(
+                DicomUID.BasicFilmSessionSOPClass,
+                new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                2);
+            var response = new DicomNEventReportResponse(request, DicomStatus.Success);
+
+            var exception = Record.Exception(() => response.MessageID);
+            Assert.Null(exception);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #298 .

Changes proposed in this pull request:
- `DicomResponse` made abstract.
- `MessageID` moved from `DicomMessage` to `DicomRequest`.
- Corrected misuse of `AffectedSOPInstanceUID` in some request classes.
- `DicomNActionResponse` and `DicomNEventResultResponse` constructors copy operation specific properties into object (`SopInstanceUID`, `ActionTypeID`, `EventTypeID`) within request-based constructor.

Please review.