### PR TITLE
Basic support for C-GET. Connected to #180

### DIFF
--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -178,7 +178,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCFindRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCFindResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomClient.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCGetRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCMoveRequest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCGetResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCMoveResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCommandField.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomCStoreRequest.cs" />
@@ -212,6 +214,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomTimeout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCEchoProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCFindProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCGetProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCMoveProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCStoreProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomNServiceProvider.cs" />

--- a/DICOM/Network/DicomCEchoRequest.cs
+++ b/DICOM/Network/DicomCEchoRequest.cs
@@ -19,7 +19,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomCEchoRequest.cs
+++ b/DICOM/Network/DicomCEchoRequest.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomCEchoRequest : DicomRequest
+    public sealed class DicomCEchoRequest : DicomRequest
     {
         public DicomCEchoRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomCEchoResponse.cs
+++ b/DICOM/Network/DicomCEchoResponse.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomCEchoResponse : DicomResponse
+    public sealed class DicomCEchoResponse : DicomResponse
     {
         public DicomCEchoResponse(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-
 namespace Dicom.Network
 {
-    public class DicomCFindRequest : DicomPriorityRequest
+    using System;
+
+    public sealed class DicomCFindRequest : DicomPriorityRequest
     {
         public DicomCFindRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -36,7 +36,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomCFindResponse.cs
+++ b/DICOM/Network/DicomCFindResponse.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
 namespace Dicom.Network
 {
-    public class DicomCFindResponse : DicomResponse
+    using System;
+    using System.Text;
+
+    public sealed class DicomCFindResponse : DicomResponse
     {
         public DicomCFindResponse(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomCGetRequest.cs
+++ b/DICOM/Network/DicomCGetRequest.cs
@@ -6,7 +6,7 @@ namespace Dicom.Network
     /// <summary>
     /// Representation of a C-GET request.
     /// </summary>
-    public class DicomCGetRequest : DicomPriorityRequest
+    public sealed class DicomCGetRequest : DicomPriorityRequest
     {
         #region CONSTRUCTORS
 

--- a/DICOM/Network/DicomCGetRequest.cs
+++ b/DICOM/Network/DicomCGetRequest.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Representation of a C-GET request.
+    /// </summary>
+    public class DicomCGetRequest : DicomPriorityRequest
+    {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomCGetRequest"/> class.
+        /// </summary>
+        /// <param name="command">
+        /// The command associated with a C-GET request.
+        /// </param>
+        public DicomCGetRequest(DicomDataset command)
+            : base(command)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomCGetRequest"/> class.
+        /// </summary>
+        /// <param name="studyInstanceUid">
+        /// The Study Instance UID confining the C-GET operation.
+        /// </param>
+        /// <param name="priority">
+        /// The priority of the C-GET operation.
+        /// </param>
+        public DicomCGetRequest(
+            string studyInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
+        {
+            Dataset = new DicomDataset();
+            Level = DicomQueryRetrieveLevel.Study;
+            Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomCGetRequest"/> class.
+        /// </summary>
+        /// <param name="studyInstanceUid">
+        /// The Study Instance UID confining the C-GET operation.
+        /// </param>
+        /// <param name="seriesInstanceUid">
+        /// The Series Instance UID confining the C-GET operation.
+        /// </param>
+        /// <param name="priority">
+        /// The priority of the C-GET operation.
+        /// </param>
+        public DicomCGetRequest(
+            string studyInstanceUid,
+            string seriesInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
+        {
+            Dataset = new DicomDataset();
+            Level = DicomQueryRetrieveLevel.Series;
+            Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+            Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomCGetRequest"/> class.
+        /// </summary>
+        /// <param name="studyInstanceUid">
+        /// The Study Instance UID confining the C-GET operation.
+        /// </param>
+        /// <param name="seriesInstanceUid">
+        /// The Series Instance UID confining the C-GET operation.
+        /// </param>
+        /// <param name="sopInstanceUid">
+        /// The SOP Instance UID confining the C-GET operation.
+        /// </param>
+        /// <param name="priority">
+        /// The priority of the C-GET operation.
+        /// </param>
+        public DicomCGetRequest(
+            string studyInstanceUid,
+            string seriesInstanceUid,
+            string sopInstanceUid,
+            DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
+        {
+            Dataset = new DicomDataset();
+            Level = DicomQueryRetrieveLevel.Image;
+            Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+            Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
+            Dataset.Add(DicomTag.SOPInstanceUID, sopInstanceUid);
+        }
+
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets or sets the Query/Retrieve level of the C-GET operation.
+        /// </summary>
+        public DicomQueryRetrieveLevel Level
+        {
+            get
+            {
+                return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
+            }
+            set
+            {
+                Dataset.Remove(DicomTag.QueryRetrieveLevel);
+                if (value != DicomQueryRetrieveLevel.Worklist) Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+            }
+        }
+
+        #endregion
+
+        #region DELEGATES
+
+        /// <summary>
+        /// Represents a callback method to be executed when the response for the DIMSE C-GET request is received.
+        /// </summary>
+        /// <param name="request">Sent DIMSE C-GET request.</param>
+        /// <param name="response">Received DIMSE C-GET response.</param>
+        public delegate void ResponseDelegate(DicomCGetRequest request, DicomCGetResponse response);
+
+        #endregion
+
+        #region PUBLIC FIELDS
+
+        /// <summary>
+        /// Delegate to be executed when the response for the DIMSE C-GET request is received.
+        /// </summary>
+        public ResponseDelegate OnResponseReceived;
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Internal. Executes the DICOM C-GET response callback.
+        /// </summary>
+        /// <param name="service">DICOM SCP implementation</param>
+        /// <param name="response">Received DIMSE (C-GET) response</param>
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
+        {
+            try
+            {
+                if (OnResponseReceived != null) OnResponseReceived(this, (DicomCGetResponse)response);
+            }
+            catch
+            {
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Network/DicomCGetResponse.cs
+++ b/DICOM/Network/DicomCGetResponse.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// Representation of a C-GET response.
+    /// </summary>
+    public class DicomCGetResponse : DicomResponse
+    {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomCGetResponse"/> class.
+        /// </summary>
+        /// <param name="command">
+        /// The command associated with the C-GET operation.
+        /// </param>
+        public DicomCGetResponse(DicomDataset command)
+            : base(command)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomCGetResponse"/> class.
+        /// </summary>
+        /// <param name="request">
+        /// The C-GET request associated with the response.
+        /// </param>
+        /// <param name="status">
+        /// The status of the response.
+        /// </param>
+        public DicomCGetResponse(DicomCGetRequest request, DicomStatus status)
+            : base(request, status)
+        {
+        }
+
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets or sets the number of remaining sub-operations.
+        /// </summary>
+        public int Remaining
+        {
+            get
+            {
+                return Command.Get(DicomTag.NumberOfRemainingSuboperations, (ushort)0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of completed sub-operations.
+        /// </summary>
+        public int Completed
+        {
+            get
+            {
+                return Command.Get(DicomTag.NumberOfCompletedSuboperations, (ushort)0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of warning sub-operations.
+        /// </summary>
+        public int Warnings
+        {
+            get
+            {
+                return Command.Get(DicomTag.NumberOfWarningSuboperations, (ushort)0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of failed sub-operations.
+        /// </summary>
+        public int Failures
+        {
+            get
+            {
+                return Command.Get(DicomTag.NumberOfFailedSuboperations, (ushort)0);
+            }
+            set
+            {
+                Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value);
+            }
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Formatted output of the <see cref="DicomCGetResponse"/> item.
+        /// </summary>
+        /// <returns>Formatted output of the <see cref="DicomCGetResponse"/> item.</returns>
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
+            if (Completed != 0) sb.AppendFormat("\n\t\tCompleted:	{0}", Completed);
+            if (Remaining != 0) sb.AppendFormat("\n\t\tRemaining:	{0}", Remaining);
+            if (Warnings != 0) sb.AppendFormat("\n\t\tWarnings:	{0}", Warnings);
+            if (Failures != 0) sb.AppendFormat("\n\t\tFailures:	{0}", Failures);
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            {
+                if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+                if (Command.Contains(DicomTag.OffendingElement))
+                {
+                    string[] tags = Command.Get<string[]>(DicomTag.OffendingElement);
+                    if (tags.Length > 0)
+                    {
+                        sb.Append("\n\t\tTags:		");
+                        foreach (var tag in tags) sb.AppendFormat(" {0}", tag);
+                    }
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        #endregion
+    }
+}

--- a/DICOM/Network/DicomCGetResponse.cs
+++ b/DICOM/Network/DicomCGetResponse.cs
@@ -9,7 +9,7 @@ namespace Dicom.Network
     /// <summary>
     /// Representation of a C-GET response.
     /// </summary>
-    public class DicomCGetResponse : DicomResponse
+    public sealed class DicomCGetResponse : DicomResponse
     {
         #region CONSTRUCTORS
 

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -81,7 +81,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomCMoveRequest : DicomPriorityRequest
+    public sealed class DicomCMoveRequest : DicomPriorityRequest
     {
         public DicomCMoveRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomCMoveResponse.cs
+++ b/DICOM/Network/DicomCMoveResponse.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Text;
-
 namespace Dicom.Network
 {
-    public class DicomCMoveResponse : DicomResponse
+    using System;
+    using System.Text;
+
+    public sealed class DicomCMoveResponse : DicomResponse
     {
         public DicomCMoveResponse(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomCStoreRequest.cs
+++ b/DICOM/Network/DicomCStoreRequest.cs
@@ -114,7 +114,7 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="service">DICOM SCP implementation</param>
         /// <param name="response">Received DICOM response</param>
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomCStoreRequest.cs
+++ b/DICOM/Network/DicomCStoreRequest.cs
@@ -30,7 +30,7 @@ namespace Dicom.Network
     /// client.Send("127.0.0.1", 12345, false, "SCU", "ANY-SCP");
     /// </code>
     /// </example>
-    public class DicomCStoreRequest : DicomPriorityRequest
+    public sealed class DicomCStoreRequest : DicomPriorityRequest
     {
         /// <summary>
         /// Constructor for DICOM C-Store request received from SCU.

--- a/DICOM/Network/DicomCStoreResponse.cs
+++ b/DICOM/Network/DicomCStoreResponse.cs
@@ -6,7 +6,7 @@ namespace Dicom.Network
     /// <summary>
     /// Represents a DICOM C-Store response to be returned to a C-Store SCU or a C-Store response that has been received from a C-Store SCP.
     /// </summary>
-    public class DicomCStoreResponse : DicomResponse
+    public sealed class DicomCStoreResponse : DicomResponse
     {
         /// <summary>
         /// Constructor for DICOM C-Store response received from SCP.

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -346,7 +346,11 @@ namespace Dicom.Network
             }
             foreach (var context in this.AdditionalPresentationContexts)
             {
-                association.PresentationContexts.Add(context.AbstractSyntax, context.GetTransferSyntaxes().ToArray());
+                association.PresentationContexts.Add(
+                    context.AbstractSyntax,
+                    context.UserRole,
+                    context.ProviderRole,
+                    context.GetTransferSyntaxes().ToArray());
             }
 
             this.service = new DicomServiceUser(this, stream, association, this.Options, this.FallbackEncoding, this.Logger);

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -5,7 +5,7 @@ namespace Dicom.Network
 {
     using System.Text;
 
-    public class DicomNActionRequest : DicomRequest
+    public sealed class DicomNActionRequest : DicomRequest
     {
         public DicomNActionRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -52,7 +52,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -9,7 +9,7 @@ namespace Dicom.Network
     /// <summary>
     /// Representation of an N-ACTION response message.
     /// </summary>
-    public class DicomNActionResponse : DicomResponse
+    public sealed class DicomNActionResponse : DicomResponse
     {
         #region CONSTRUCTORS
 

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNCreateRequest : DicomRequest
+    public sealed class DicomNCreateRequest : DicomRequest
     {
         public DicomNCreateRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -34,7 +34,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomNCreateResponse.cs
+++ b/DICOM/Network/DicomNCreateResponse.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNCreateResponse : DicomResponse
+    public sealed class DicomNCreateResponse : DicomResponse
     {
         public DicomNCreateResponse(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNDeleteRequest.cs
+++ b/DICOM/Network/DicomNDeleteRequest.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNDeleteRequest : DicomRequest
+    public sealed class DicomNDeleteRequest : DicomRequest
     {
         public DicomNDeleteRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNDeleteRequest.cs
+++ b/DICOM/Network/DicomNDeleteRequest.cs
@@ -34,7 +34,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomNDeleteResponse.cs
+++ b/DICOM/Network/DicomNDeleteResponse.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNDeleteResponse : DicomResponse
+    public sealed class DicomNDeleteResponse : DicomResponse
     {
         public DicomNDeleteResponse(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -5,7 +5,7 @@ namespace Dicom.Network
 {
     using System.Text;
 
-    public class DicomNEventReportRequest : DicomRequest
+    public sealed class DicomNEventReportRequest : DicomRequest
     {
         public DicomNEventReportRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -52,7 +52,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomNEventReportResponse.cs
+++ b/DICOM/Network/DicomNEventReportResponse.cs
@@ -9,7 +9,7 @@ namespace Dicom.Network
     /// <summary>
     /// Representation of an N-EVENTREPORT response message.
     /// </summary>
-    public class DicomNEventReportResponse : DicomResponse
+    public sealed class DicomNEventReportResponse : DicomResponse
     {
         #region CONSTRUCTORS
 

--- a/DICOM/Network/DicomNGetRequest.cs
+++ b/DICOM/Network/DicomNGetRequest.cs
@@ -46,7 +46,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomNGetRequest.cs
+++ b/DICOM/Network/DicomNGetRequest.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNGetRequest : DicomRequest
+    public sealed class DicomNGetRequest : DicomRequest
     {
         public DicomNGetRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNGetResponse.cs
+++ b/DICOM/Network/DicomNGetResponse.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNGetResponse : DicomResponse
+    public sealed class DicomNGetResponse : DicomResponse
     {
         public DicomNGetResponse(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNSetRequest.cs
+++ b/DICOM/Network/DicomNSetRequest.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNSetRequest : DicomRequest
+    public sealed class DicomNSetRequest : DicomRequest
     {
         public DicomNSetRequest(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomNSetRequest.cs
+++ b/DICOM/Network/DicomNSetRequest.cs
@@ -34,7 +34,7 @@ namespace Dicom.Network
 
         public ResponseDelegate OnResponseReceived;
 
-        internal override void PostResponse(DicomService service, DicomResponse response)
+        protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
             {

--- a/DICOM/Network/DicomNSetResponse.cs
+++ b/DICOM/Network/DicomNSetResponse.cs
@@ -3,7 +3,7 @@
 
 namespace Dicom.Network
 {
-    public class DicomNSetResponse : DicomResponse
+    public sealed class DicomNSetResponse : DicomResponse
     {
         public DicomNSetResponse(DicomDataset command)
             : base(command)

--- a/DICOM/Network/DicomPresentationContext.cs
+++ b/DICOM/Network/DicomPresentationContext.cs
@@ -169,12 +169,12 @@ namespace Dicom.Network
         /// <summary>
         /// Gets an indicator whether presentation context supports an SCU role. If undefined, default value is assumed.
         /// </summary>
-        public bool? UserRole { get; set; }
+        public bool? UserRole { get; internal set; }
 
         /// <summary>
         /// Gets an indicator whether presentation context supports an SCU role. If undefined, default value is assumed.
         /// </summary>
-        public bool? ProviderRole { get; set; }
+        public bool? ProviderRole { get; internal set; }
 
         #endregion
 

--- a/DICOM/Network/DicomPresentationContext.cs
+++ b/DICOM/Network/DicomPresentationContext.cs
@@ -231,6 +231,22 @@ namespace Dicom.Network
         }
 
         /// <summary>
+        /// Get storage category collection of presentation contexts valid for C-GET requests.
+        /// </summary>
+        /// <param name="storageCategory">Storage category for which the sub-set of presentation context should be selected.</param>
+        /// <param name="transferSyntaxes">Supported transfer syntaxes.</param>
+        /// <returns>Collection of presentation contexts valid for C-GET requests.</returns>
+        public static IEnumerable<DicomPresentationContext> GetScpRolePresentationContextsFromStorageUids(
+            DicomStorageCategory storageCategory,
+            params DicomTransferSyntax[] transferSyntaxes)
+        {
+            return
+                DicomUID.Enumerate()
+                    .Where(uid => uid.StorageCategory == storageCategory && !uid.IsRetired)
+                    .Select(uid => GetScpRolePresentationContext(uid, transferSyntaxes));
+        }
+
+        /// <summary>
         /// Sets the <c>Result</c> of this presentation context.
         /// 
         /// The preferred method of accepting presentation contexts is to call one of the <c>AcceptTransferSyntaxes</c> methods.

--- a/DICOM/Network/DicomPresentationContextCollection.cs
+++ b/DICOM/Network/DicomPresentationContextCollection.cs
@@ -7,48 +7,98 @@ using System.Linq;
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Collection of presentation contexts, with unique ID:s.
+    /// </summary>
     public class DicomPresentationContextCollection : ICollection<DicomPresentationContext>
     {
-        private SortedDictionary<byte, DicomPresentationContext> _pc;
+        #region FIELDS
 
+        private readonly object locker = new object();
+
+        private readonly SortedDictionary<byte, DicomPresentationContext> _pc;
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DicomPresentationContextCollection"/>.
+        /// </summary>
         public DicomPresentationContextCollection()
         {
             _pc = new SortedDictionary<byte, DicomPresentationContext>();
         }
 
-        public DicomPresentationContext this[byte id]
-        {
-            get
-            {
-                return _pc[id];
-            }
-        }
+        #endregion
 
-        private byte GetNextPresentationContextID()
-        {
-            if (_pc.Count == 0) return 1;
+        #region INDEXERS
 
-            var id = _pc.Max(x => x.Key) + 2;
+        /// <summary>
+        /// Gets the presentation context associated with <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">Presentation context ID.</param>
+        /// <returns>Presentation context associated with <paramref name="id"/></returns>
+        public DicomPresentationContext this[byte id] =>_pc[id];
 
-            if (id >= 256) throw new DicomNetworkException("Too many presentation contexts configured for this association!");
+        #endregion
 
-            return (byte)id;
-        }
+        #region PROPERTIES
 
+        /// <summary>
+        /// Gets the number of presentation contexts in collection.
+        /// </summary>
+        public int Count => _pc.Count;
+
+        /// <summary>
+        /// Gets whether collection is read-only. Is always <code>false</code>.
+        /// </summary>
+        public bool IsReadOnly => false;
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Initialize and add new presentation context.
+        /// </summary>
+        /// <param name="abstractSyntax">Abstract syntax of the presentation context.</param>
+        /// <param name="transferSyntaxes">Supported transfer syntaxes.</param>
         public void Add(DicomUID abstractSyntax, params DicomTransferSyntax[] transferSyntaxes)
         {
-            var pc = new DicomPresentationContext(GetNextPresentationContextID(), abstractSyntax);
+            Add(abstractSyntax, null, null, transferSyntaxes);
+        }
+
+        /// <summary>
+        /// Initialize and add new presentation context.
+        /// </summary>
+        /// <param name="abstractSyntax">Abstract syntax of the presentation context.</param>
+        /// <param name="userRole">Supports SCU role?</param>
+        /// <param name="providerRole">Supports SCP role?</param>
+        /// <param name="transferSyntaxes">Supported transfer syntaxes.</param>
+        public void Add(DicomUID abstractSyntax, bool? userRole, bool? providerRole, params DicomTransferSyntax[] transferSyntaxes)
+        {
+            var pc = new DicomPresentationContext(GetNextPresentationContextID(), abstractSyntax, userRole, providerRole);
 
             foreach (var tx in transferSyntaxes) pc.AddTransferSyntax(tx);
 
             Add(pc);
         }
 
+        /// <summary>
+        /// Adds an item to the <see cref="T:System.Collections.Generic.ICollection`1"/>.
+        /// </summary>
+        /// <param name="item">The object to add to the <see cref="T:System.Collections.Generic.ICollection`1"/>.</param>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1"/> is read-only.</exception>
         public void Add(DicomPresentationContext item)
         {
             _pc.Add(item.ID, item);
         }
 
+        /// <summary>
+        /// Add presentation contexts obtained from DICOM request.
+        /// </summary>
+        /// <param name="request">Request from which presentation context(s) should be obtained.</param>
         public void AddFromRequest(DicomRequest request)
         {
             if (request is DicomCStoreRequest)
@@ -56,8 +106,14 @@ namespace Dicom.Network
                 var cstore = request as DicomCStoreRequest;
 
                 var pcs = _pc.Values.Where(x => x.AbstractSyntax == request.SOPClassUID);
-                if (cstore.TransferSyntax == DicomTransferSyntax.ImplicitVRLittleEndian) pcs = pcs.Where(x => x.GetTransferSyntaxes().Contains(DicomTransferSyntax.ImplicitVRLittleEndian));
-                else pcs = pcs.Where(x => x.AcceptedTransferSyntax == cstore.TransferSyntax);
+                if (cstore.TransferSyntax == DicomTransferSyntax.ImplicitVRLittleEndian)
+                {
+                    pcs = pcs.Where(x => x.GetTransferSyntaxes().Contains(DicomTransferSyntax.ImplicitVRLittleEndian));
+                }
+                else
+                {
+                    pcs = pcs.Where(x => x.AcceptedTransferSyntax == cstore.TransferSyntax);
+                }
 
                 var pc = pcs.FirstOrDefault();
                 if (pc == null)
@@ -86,7 +142,11 @@ namespace Dicom.Network
                         var transferSyntaxes = request.PresentationContext.GetTransferSyntaxes().ToArray();
                         if (!transferSyntaxes.Any())
                             transferSyntaxes = new[] { DicomTransferSyntax.ExplicitVRLittleEndian, DicomTransferSyntax.ImplicitVRLittleEndian };
-                        Add(request.PresentationContext.AbstractSyntax, transferSyntaxes);
+                        Add(
+                            request.PresentationContext.AbstractSyntax,
+                            request.PresentationContext.UserRole,
+                            request.PresentationContext.ProviderRole,
+                            transferSyntaxes);
                     }
                 }
                 else
@@ -101,50 +161,87 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Clear all presentation contexts in collection.
+        /// </summary>
         public void Clear()
         {
             _pc.Clear();
         }
 
+        /// <summary>
+        /// Indicates if specified presentation context is contained in collection.
+        /// </summary>
+        /// <param name="item">Presentation context to search for.</param>
+        /// <returns><code>true</code> if <paramref name="item"/> is contained in collection, <code>false</code> otherwise.</returns>
         public bool Contains(DicomPresentationContext item)
         {
             return _pc.ContainsKey(item.ID) && _pc[item.ID].AbstractSyntax == item.AbstractSyntax;
         }
 
-        public void CopyTo(DicomPresentationContext[] array, int arrayIndex)
+        /// <summary>
+        /// Copies the elements of the <see cref="T:System.Collections.Generic.ICollection`1"/> to an <see cref="T:System.Array"/>, starting at a particular <see cref="T:System.Array"/> index.
+        /// </summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array"/> that is the destination of the elements copied from <see cref="T:System.Collections.Generic.ICollection`1"/>. The <see cref="T:System.Array"/> must have zero-based indexing.</param><param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param><exception cref="T:System.ArgumentNullException"><paramref name="array"/> is null.</exception><exception cref="T:System.ArgumentOutOfRangeException"><paramref name="arrayIndex"/> is less than 0.</exception><exception cref="T:System.ArgumentException">The number of elements in the source <see cref="T:System.Collections.Generic.ICollection`1"/> is greater than the available space from <paramref name="arrayIndex"/> to the end of the destination <paramref name="array"/>.</exception>
+        void ICollection<DicomPresentationContext>.CopyTo(DicomPresentationContext[] array, int arrayIndex)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException("Not implemented");
         }
 
-        public int Count
-        {
-            get
-            {
-                return _pc.Count;
-            }
-        }
-
-        public bool IsReadOnly
-        {
-            get
-            {
-                return false;
-            }
-        }
-
+        /// <summary>
+        /// Removes the first occurrence of a specific object from the <see cref="T:System.Collections.Generic.ICollection`1"/>.
+        /// </summary>
+        /// <returns>
+        /// true if <paramref name="item"/> was successfully removed from the <see cref="T:System.Collections.Generic.ICollection`1"/>; otherwise, false. This method also returns false if <paramref name="item"/> is not found in the original <see cref="T:System.Collections.Generic.ICollection`1"/>.
+        /// </returns>
+        /// <param name="item">The object to remove from the <see cref="T:System.Collections.Generic.ICollection`1"/>.</param><exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1"/> is read-only.</exception>
         public bool Remove(DicomPresentationContext item)
         {
             return _pc.Remove(item.ID);
         }
 
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate through the collection.
+        /// </returns>
+        /// <filterpriority>1</filterpriority>
         public IEnumerator<DicomPresentationContext> GetEnumerator()
         {
             return _pc.Values.GetEnumerator();
         }
 
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
+
+        /// <summary>
+        /// Gets a unique presentation context ID.
+        /// </summary>
+        /// <returns>Unique presentation context ID.</returns>
+        private byte GetNextPresentationContextID()
+        {
+            lock (locker)
+            {
+                if (_pc.Count == 0) return 1;
+
+                var id = _pc.Max(x => x.Key) + 2;
+
+                if (id >= 256) throw new DicomNetworkException("Too many presentation contexts configured for this association!");
+
+                return (byte)id;
+            }
+        }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomRequest.cs
+++ b/DICOM/Network/DicomRequest.cs
@@ -70,7 +70,7 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="service">Active DICOM service.</param>
         /// <param name="response">Response to be post-processed.</param>
-        internal abstract void PostResponse(DicomService service, DicomResponse response);
+        protected internal abstract void PostResponse(DicomService service, DicomResponse response);
 
         /// <summary>
         /// Global message ID generator.

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -48,8 +48,6 @@ namespace Dicom.Network
         private bool _isConnected;
 
         private readonly Encoding _fallbackEncoding;
-
-        private readonly Dictionary<int, DicomDataset> localStore = new Dictionary<int, DicomDataset>();
          
         #endregion
 
@@ -682,23 +680,15 @@ namespace Dicom.Network
                         SendResponse(response);
                         return;
                     }
-                    else
+                    else if (this is IDicomServiceUser)
                     {
-                        var request = dimse as DicomCStoreRequest;
-                        DicomStatus status;
-                        if (request.HasDataset)
-                        {
-                            localStore.Add(request.MessageID, request.Dataset);
-                            status = DicomStatus.Success;
-                        }
-                        else
-                        {
-                            status = DicomStatus.MissingAttributeValue;
-                        }
-
-                        var response = new DicomCStoreResponse(request, status);
+                        var response = (this as IDicomServiceUser).OnCStoreRequest(dimse as DicomCStoreRequest);
                         SendResponse(response);
                         return;
+                    }
+                    else
+                    {
+                        throw new DicomNetworkException("C-Store SCP not implemented");
                     }
                 }
 

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -49,6 +49,8 @@ namespace Dicom.Network
 
         private readonly Encoding _fallbackEncoding;
 
+        private readonly Dictionary<int, DicomDataset> localStore = new Dictionary<int, DicomDataset>();
+         
         #endregion
 
         #region CONSTRUCTORS
@@ -680,7 +682,24 @@ namespace Dicom.Network
                         SendResponse(response);
                         return;
                     }
-                    else throw new DicomNetworkException("C-Store SCP not implemented");
+                    else
+                    {
+                        var request = dimse as DicomCStoreRequest;
+                        DicomStatus status;
+                        if (request.HasDataset)
+                        {
+                            localStore.Add(request.MessageID, request.Dataset);
+                            status = DicomStatus.Success;
+                        }
+                        else
+                        {
+                            status = DicomStatus.MissingAttributeValue;
+                        }
+
+                        var response = new DicomCStoreResponse(request, status);
+                        SendResponse(response);
+                        return;
+                    }
                 }
 
                 if (dimse.Type == DicomCommandField.CFindRequest)

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -511,6 +511,12 @@ namespace Dicom.Network
                                 case DicomCommandField.CFindResponse:
                                     _dimse = new DicomCFindResponse(command);
                                     break;
+                                case DicomCommandField.CGetRequest:
+                                    _dimse = new DicomCGetRequest(command);
+                                    break;
+                                case DicomCommandField.CGetResponse:
+                                    _dimse = new DicomCGetResponse(command);
+                                    break;
                                 case DicomCommandField.CMoveRequest:
                                     _dimse = new DicomCMoveRequest(command);
                                     break;
@@ -686,6 +692,17 @@ namespace Dicom.Network
                         return;
                     }
                     else throw new DicomNetworkException("C-Find SCP not implemented");
+                }
+
+                if (dimse.Type == DicomCommandField.CGetRequest)
+                {
+                    if (this is IDicomCGetProvider)
+                    {
+                        var responses = (this as IDicomCGetProvider).OnCGetRequest(dimse as DicomCGetRequest);
+                        foreach (var response in responses) SendResponse(response);
+                        return;
+                    }
+                    else throw new DicomNetworkException("C-GET SCP not implemented");
                 }
 
                 if (dimse.Type == DicomCommandField.CMoveRequest)
@@ -866,15 +883,61 @@ namespace Dicom.Network
                         else if (msg is DicomCFindRequest)
                             (msg as DicomCFindRequest).PostResponse(
                                 this,
-                                new DicomCFindResponse(msg as DicomCFindRequest, DicomStatus.SOPClassNotSupported));
+                                new DicomCFindResponse(
+                                    msg as DicomCFindRequest,
+                                    DicomStatus.SOPClassNotSupported));
+                        else if (msg is DicomCGetRequest)
+                            (msg as DicomCGetRequest).PostResponse(
+                                this,
+                                new DicomCGetResponse(
+                                    msg as DicomCGetRequest,
+                                    DicomStatus.SOPClassNotSupported));
                         else if (msg is DicomCMoveRequest)
                             (msg as DicomCMoveRequest).PostResponse(
                                 this,
                                 new DicomCMoveResponse(
                                     msg as DicomCMoveRequest,
                                     DicomStatus.SOPClassNotSupported));
-
-                        //TODO: add N services
+                        else if (msg is DicomNActionRequest)
+                            (msg as DicomNActionRequest).PostResponse(
+                                this,
+                                new DicomNActionResponse(
+                                    msg as DicomNActionRequest,
+                                    DicomStatus.SOPClassNotSupported));
+                        else if (msg is DicomNCreateRequest)
+                            (msg as DicomNCreateRequest).PostResponse(
+                                this,
+                                new DicomNCreateResponse(
+                                    msg as DicomNCreateRequest,
+                                    DicomStatus.SOPClassNotSupported));
+                        else if (msg is DicomNDeleteRequest)
+                            (msg as DicomNDeleteRequest).PostResponse(
+                                this,
+                                new DicomNDeleteResponse(
+                                    msg as DicomNDeleteRequest,
+                                    DicomStatus.SOPClassNotSupported));
+                        else if (msg is DicomNEventReportRequest)
+                            (msg as DicomNEventReportRequest).PostResponse(
+                                this,
+                                new DicomNEventReportResponse(
+                                    msg as DicomNEventReportRequest,
+                                    DicomStatus.SOPClassNotSupported));
+                        else if (msg is DicomNGetRequest)
+                            (msg as DicomNGetRequest).PostResponse(
+                                this,
+                                new DicomNGetResponse(
+                                    msg as DicomNGetRequest,
+                                    DicomStatus.SOPClassNotSupported));
+                        else if (msg is DicomNSetRequest)
+                            (msg as DicomNSetRequest).PostResponse(
+                                this,
+                                new DicomNSetResponse(
+                                    msg as DicomNSetRequest,
+                                    DicomStatus.SOPClassNotSupported));
+                        else
+                        {
+                            Logger.Warn("Unknown message type: {type}", msg.Type);
+                        }
                     }
                     catch
                     {

--- a/DICOM/Network/IDicomCGetProvider.cs
+++ b/DICOM/Network/IDicomCGetProvider.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Interface for methods related to a C-GET SCP.
+    /// </summary>
+    public interface IDicomCGetProvider
+    {
+        /// <summary>
+        /// Generate collection of <see cref="DicomCGetResponse">C-GET responses</see> from a <see cref="DicomCGetRequest">C-GET request</see>.
+        /// </summary>
+        /// <param name="request">C-GET request.</param>
+        /// <returns>Collection of C-GET responses resulting from the <paramref name="request"/>.</returns>
+        IEnumerable<DicomCGetResponse> OnCGetRequest(DicomCGetRequest request);
+    }
+}

--- a/DICOM/Network/IDicomServiceUser.cs
+++ b/DICOM/Network/IDicomServiceUser.cs
@@ -1,20 +1,56 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-
 namespace Dicom.Network
 {
+    using System;
+
+    /// <summary>
+    /// Interface for implementations of a DICOM service as a client.
+    /// </summary>
     public interface IDicomServiceUser
     {
+        /// <summary>
+        /// Callback for handling association accept scenarios.
+        /// </summary>
+        /// <param name="association">Accepted association.</param>
         void OnReceiveAssociationAccept(DicomAssociation association);
 
+        /// <summary>
+        /// Callback for handling association reject scenarios.
+        /// </summary>
+        /// <param name="result">Specification of rejection result.</param>
+        /// <param name="source">Source of rejection.</param>
+        /// <param name="reason">Detailed reason for rejection.</param>
         void OnReceiveAssociationReject(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason);
 
+        /// <summary>
+        /// Callback on response from an association release.
+        /// </summary>
         void OnReceiveAssociationReleaseResponse();
 
+        /// <summary>
+        /// Callback on recieving an abort message.
+        /// </summary>
+        /// <param name="source">Abort source.</param>
+        /// <param name="reason">Detailed reason for abort.</param>
         void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
 
+        /// <summary>
+        /// Callback when connection is closed.
+        /// </summary>
+        /// <param name="exception">Exception, if any, that forced connection to close.</param>
         void OnConnectionClosed(Exception exception);
+
+        /// <summary>
+        /// Callback for handling a client related C-STORE request, typically emanating from the client's C-GET request.
+        /// </summary>
+        /// <param name="request">
+        /// C-STORE request.
+        /// </param>
+        /// <returns>
+        /// The <see cref="DicomCStoreResponse"/> related to the C-STORE <paramref name="request"/>.
+        /// </returns>
+        DicomCStoreResponse OnCStoreRequest(DicomCStoreRequest request);
     }
 }

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -792,9 +792,10 @@ namespace Dicom.Network
         /// <param name="raw">PDU buffer</param>
         public void Read(RawPDU raw)
         {
+            // TODO Disabled reset to ensure that C-GET works well with DCMTK dcmqrscp. Is there a better way?
             // reset async ops in case remote end does not negotiate
-            _assoc.MaxAsyncOpsInvoked = 1;
-            _assoc.MaxAsyncOpsPerformed = 1;
+            //_assoc.MaxAsyncOpsInvoked = 1;
+            //_assoc.MaxAsyncOpsPerformed = 1;
 
             uint l = raw.Length - 6;
             ushort c = 0;

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -792,10 +792,9 @@ namespace Dicom.Network
         /// <param name="raw">PDU buffer</param>
         public void Read(RawPDU raw)
         {
-            // TODO Disabled reset to ensure that C-GET works well with DCMTK dcmqrscp. Is there a better way?
-            // reset async ops in case remote end does not negotiate
-            //_assoc.MaxAsyncOpsInvoked = 1;
-            //_assoc.MaxAsyncOpsPerformed = 1;
+            /*
+             * TODO Disabled async ops reset to ensure that C-GET works well with DCMTK dcmqrscp. Is there a better way?
+             */
 
             uint l = raw.Length - 6;
             ushort c = 0;

--- a/DICOM/Network/StudyRootQueryRetrieveInfo.cs
+++ b/DICOM/Network/StudyRootQueryRetrieveInfo.cs
@@ -35,25 +35,25 @@ namespace Dicom.Network
         /// </summary>
         public byte? RelationalQueries { get; set; }
 
-		/// <summary>
-		/// Gets or sets the date time matching.
-		/// </summary>
-		public byte? DateTimeMatching { get; set; }
+        /// <summary>
+        /// Gets or sets the date time matching.
+        /// </summary>
+        public byte? DateTimeMatching { get; set; }
 
-		/// <summary>
-		/// Gets or sets the fuzzy semantic matching.
-		/// </summary>
-		public byte? FuzzySemanticMatching { get; set; }
+        /// <summary>
+        /// Gets or sets the fuzzy semantic matching.
+        /// </summary>
+        public byte? FuzzySemanticMatching { get; set; }
 
-		/// <summary>
-		/// Gets or sets the time zone query adjustment.
-		/// </summary>
-		public byte? TimezoneQueryAdjustment { get; set; }
+        /// <summary>
+        /// Gets or sets the time zone query adjustment.
+        /// </summary>
+        public byte? TimezoneQueryAdjustment { get; set; }
 
-		/// <summary>
-		/// Gets or sets the enhanced multi frame image conversion.
-		/// </summary>
-		public byte? EnhancedMultiFrameImageConversion { get; set; }
+        /// <summary>
+        /// Gets or sets the enhanced multi frame image conversion.
+        /// </summary>
+        public byte? EnhancedMultiFrameImageConversion { get; set; }
 
         /// <summary>
         /// Factory method for creating a <see cref="RootQueryRetrieveInfoFind"/> instance.

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="IO\Reader\DicomDatasetReaderObserverTest.cs" />
     <Compile Include="Media\DicomFileScannerTest.cs" />
     <Compile Include="Network\DicomCEchoProviderTest.cs" />
+    <Compile Include="Network\DicomCGetRequestTest.cs" />
     <Compile Include="Network\DicomClientTest.cs" />
     <Compile Include="Network\DicomNEventReportResponseTest.cs" />
     <Compile Include="Network\DicomNActionResponseTest.cs" />

--- a/Tests/Network/DicomCGetRequestTest.cs
+++ b/Tests/Network/DicomCGetRequestTest.cs
@@ -3,30 +3,84 @@
 
 namespace Dicom.Network
 {
+    using System.Threading;
+
     using Xunit;
 
     public class DicomCGetRequestTest
     {
         [Fact(Skip = "Require running Q/R SCP containing CT-MONO2-16-ankle image")]
-        public void TestCGetWorkflow()
+        public void DicomCGetRequest_OneImageInSeries_Received()
         {
             var client = new DicomClient();
-            client.NegotiateAsyncOps(16, 16);
+            client.NegotiateAsyncOps(2, 1);
 
-            var pc = new DicomPresentationContext(3, DicomUID.SecondaryCaptureImageStorage, false, true);
-            pc.AddTransferSyntax(DicomTransferSyntax.ImplicitVRLittleEndian);
-            client.AdditionalPresentationContexts.Add(pc);
+            var pcs = DicomPresentationContext.GetScpRolePresentationContextsFromStorageUids(
+                DicomStorageCategory.Image,
+                DicomTransferSyntax.ExplicitVRLittleEndian,
+                DicomTransferSyntax.ImplicitVRLittleEndian,
+                DicomTransferSyntax.ImplicitVRBigEndian);
+            client.AdditionalPresentationContexts.AddRange(pcs);
+
+            DicomDataset dataset = null;
+            client.OnCStoreRequest = request =>
+                {
+                    dataset = request.Dataset;
+                    return new DicomCStoreResponse(request, DicomStatus.Success);
+                };
 
             var get = new DicomCGetRequest(
                 "1.2.840.113619.2.1.1.322987881.621.736170080.681",
                 "1.2.840.113619.2.1.2411.1031152382.365.736169244");
 
+            var handle = new ManualResetEventSlim();
             get.OnResponseReceived = (request, response) =>
             {
-                Assert.Equal(0, response.Failures);
+                handle.Set();
             };
             client.AddRequest(get);
             client.Send("localhost", 11112, false, "SCU", "COMMON");
+            handle.Wait();
+
+            Assert.Equal("RT ANKLE", dataset.Get<string>(DicomTag.StudyDescription));
+        }
+
+        [Fact(Skip = "Require running Q/R SCP containing specific study")]
+        public void DicomCGetRequest_PickCTImagesInStudy_OnlyCTImagesRetrieved()
+        {
+            var client = new DicomClient();
+            client.NegotiateAsyncOps(2, 1);
+
+            var pc = DicomPresentationContext.GetScpRolePresentationContext(DicomUID.CTImageStorage);
+            client.AdditionalPresentationContexts.Add(pc);
+
+            var counter = 0;
+            var locker = new object();
+            client.OnCStoreRequest = request =>
+            {
+                lock (locker)
+                {
+                    ++counter;
+                }
+
+                return new DicomCStoreResponse(request, DicomStatus.Success);
+            };
+
+            var get = new DicomCGetRequest("1.2.840.113619.2.55.3.2609388324.145.1222836278.84");
+
+            var handle = new ManualResetEventSlim();
+            get.OnResponseReceived = (request, response) =>
+            {
+                if (response.Remaining == 0)
+                {
+                    handle.Set();
+                }
+            };
+            client.AddRequest(get);
+            client.Send("localhost", 11112, false, "SCU", "COMMON");
+            handle.Wait();
+
+            Assert.Equal(140, counter);
         }
     }
 }

--- a/Tests/Network/DicomCGetRequestTest.cs
+++ b/Tests/Network/DicomCGetRequestTest.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    using Xunit;
+
+    public class DicomCGetRequestTest
+    {
+        [Fact(Skip = "Require running Q/R SCP containing CT-MONO2-16-ankle image")]
+        public void TestCGetWorkflow()
+        {
+            var client = new DicomClient();
+            client.NegotiateAsyncOps(16, 16);
+
+            var pc = new DicomPresentationContext(3, DicomUID.SecondaryCaptureImageStorage, false, true);
+            pc.AddTransferSyntax(DicomTransferSyntax.ImplicitVRLittleEndian);
+            client.AdditionalPresentationContexts.Add(pc);
+
+            var get = new DicomCGetRequest(
+                "1.2.840.113619.2.1.1.322987881.621.736170080.681",
+                "1.2.840.113619.2.1.2411.1031152382.365.736169244");
+
+            get.OnResponseReceived = (request, response) =>
+            {
+                Assert.Equal(0, response.Failures);
+            };
+            client.AddRequest(get);
+            client.Send("localhost", 11112, false, "SCU", "COMMON");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #180 .

Changes proposed in this pull request:
- Added `DicomCGetRequest`, `DicomCGetResponse` classes and `IDicomCGetProvider` interface.
- Added reading and writing of *SCU/SCP roles* in association messages, and added corresponding properties to `DicomPresentationContext`.
- Added convenience methods for defining presentation context(s) suitable for C-GET communication.
- Enabled C-STORE request handling in `DicomClient`via added delegate property `OnCStoreRequest`, to support direct C-STORE requests during C-GET sessions.
- Disabled reset of async ops invoked and performed in AA-ASSOCIATE-AC parsing (reset prevented multiple async ops which are necessary during C-GET session).
- Added support for C-GET requests and responses in `DicomService`.
- Complete handling of DIMSE-N responses in `DicomService`.
- Declared all requests and responses `sealed`.
- Added XML documentation in new and modified types.
- Added unit tests to illustrate basic C-GET usage.

Functionality successfully tested against DCMTK's Q/R server application *dcmqrscp*.

Please review.