### PR TITLE
Renamed Core to Portable and updated ID accordingly. Connected to #310

### DIFF
--- a/Setup/fo-dicom.Portable.nuspec
+++ b/Setup/fo-dicom.Portable.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
-        <id>fo-dicom.Core</id>
+        <id>fo-dicom.Portable</id>
         <version>$version$</version>
         <title>Fellow Oak DICOM Portable Class Library</title>
         <authors>fo-dicom contributors</authors>

--- a/Setup/fo-dicom.nuspec
+++ b/Setup/fo-dicom.nuspec
@@ -13,7 +13,7 @@
         <language>en-US</language>
         <dependencies>
 			<group targetFramework="portable-net45+netcore45+wpa81">
-				<dependency id="fo-dicom.Core" version="$version$" />
+				<dependency id="fo-dicom.Portable" version="$version$" />
 			</group>
 			<group targetFramework="netstandard1.3">
 				<dependency id="fo-dicom.NetCore" version="$version$" />


### PR DESCRIPTION
Fixes #310 .

Changes proposed in this pull request:
- Renamed *fo-dicom.Core* NuGet package to *fo-dicom.Portable*, changed ID accordingly.
- Updated reference in *fo-dicom* pacage.

Please review.

