### PR TITLE
Create new datasets for sequence items in copy constructor. Connected to #153

### DIFF
--- a/DICOM.Platform/Desktop/Properties/AssemblyInfo.cs
+++ b/DICOM.Platform/Desktop/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -9,3 +10,10 @@ using System.Reflection;
 [assembly: AssemblyTitle("Dicom.Platform")]
 [assembly: AssemblyDescription(".NET specific assembly for fo-dicom")]
 [assembly: AssemblyConfiguration("")]
+
+[assembly: InternalsVisibleTo("DICOM [Unit Tests], PublicKey=" +
+    "00240000048000009400000006020000002400005253413100040000010001007d5f00794554cd" +
+    "cb3905e27fc311b1bdb7f0aca2ce20b83e1d647c2ff7674cbb5b9557d3add3d3a69c9445f8d0df" +
+    "f7cdf5b251cc4e0b2df984a778fc82dd68987f574c1867f414c23ee8b65d3d6b688368624b772e" +
+    "3b8d272eb0e3e8eff6bd7bd5a57abcdd47fb323682cc68b2d2693cc22895daff7afb4fede61ae6" +
+    "3216b8bf")]

--- a/Serialization/DICOM.Json/DICOM.Json.csproj
+++ b/Serialization/DICOM.Json/DICOM.Json.csproj
@@ -33,6 +33,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\DICOM\fo-dicom.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -40,6 +40,12 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\DICOM\fo-dicom.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Tests/DicomDatasetTest.cs
+++ b/Tests/DicomDatasetTest.cs
@@ -294,6 +294,27 @@ namespace Dicom
                     DicomTag.ScheduledProtocolCodeSequence).Items[0].Get<string>(DicomTag.ContextIdentifier));
         }
 
+        [Fact]
+        public void InternalTransferSyntax_Setter_AppliesToAllSequenceDepths()
+        {
+            var ds = new DicomDataset { { DicomTag.PatientID, "1" } };
+            var sps = new DicomDataset { { DicomTag.ScheduledStationName, "1" } };
+            var spcs = new DicomDataset { { DicomTag.ContextIdentifier, "1" } };
+            sps.Add(new DicomSequence(DicomTag.ScheduledProtocolCodeSequence, spcs));
+            ds.Add(new DicomSequence(DicomTag.ScheduledProcedureStepSequence, sps));
+
+            var newSyntax = DicomTransferSyntax.DeflatedExplicitVRLittleEndian;
+            ds.InternalTransferSyntax = newSyntax;
+            Assert.Equal(newSyntax, ds.InternalTransferSyntax);
+            Assert.Equal(
+                newSyntax,
+                ds.Get<DicomSequence>(DicomTag.ScheduledProcedureStepSequence).Items[0].InternalTransferSyntax);
+            Assert.Equal(
+                newSyntax,
+                ds.Get<DicomSequence>(DicomTag.ScheduledProcedureStepSequence).Items[0].Get<DicomSequence>(
+                    DicomTag.ScheduledProtocolCodeSequence).Items[0].InternalTransferSyntax);
+        }
+
         #endregion
 
         #region Support methods


### PR DESCRIPTION
Fixes #153 .

Changes proposed in this pull request:
- In the "copy" `DicomDataset` constructor (which is also used by the `Clone` extension method), loop over items to identify sequences. For all sequences, initialize new `DicomDataset` instances using the copy constructor, to break deep back-references to copied dataset.
- Signed *Dicom.Json* and unit test project to sufficiently be able to unit test methods and properties declared as `internal`.

This is not a true "deep copy" implementation, since individual, non-composite, items will still share references across original and copy. But simply using `Add` and `Remove` methods to alter the copied dataset will not affect the original dataset, which appears to be the major concern in issue #153. A true "deep copy" implementation would require substantially more development and verification work.

Please review.