### PR TITLE
Improved reliability in network operations. Connected to #199 Connected to #312

### DIFF
--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -147,8 +147,9 @@ namespace Dicom.Network
         {
             if (!this.CanSend) return;
 
-            var noDelay = this.Options != null ? this.Options.TcpNoDelay : DicomServiceOptions.Default.TcpNoDelay;
-            var ignoreSslPolicyErrors = (this.Options ?? DicomServiceOptions.Default).IgnoreSslPolicyErrors;
+            var noDelay = Options?.TcpNoDelay ?? DicomServiceOptions.Default.TcpNoDelay;
+            var ignoreSslPolicyErrors = Options?.IgnoreSslPolicyErrors
+                                        ?? DicomServiceOptions.Default.IgnoreSslPolicyErrors;
 
             this.networkStream = NetworkManager.CreateNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
 
@@ -176,8 +177,9 @@ namespace Dicom.Network
         {
             if (!this.CanSend) Task.FromResult(false);   // TODO Replace with Task.CompletedTask when moving to .NET 4.6
 
-            var noDelay = this.Options != null ? this.Options.TcpNoDelay : DicomServiceOptions.Default.TcpNoDelay;
-            var ignoreSslPolicyErrors = (this.Options ?? DicomServiceOptions.Default).IgnoreSslPolicyErrors;
+            var noDelay = Options?.TcpNoDelay ?? DicomServiceOptions.Default.TcpNoDelay;
+            var ignoreSslPolicyErrors = Options?.IgnoreSslPolicyErrors
+                                        ?? DicomServiceOptions.Default.IgnoreSslPolicyErrors;
 
             this.networkStream = NetworkManager.CreateNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
 

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -396,7 +396,7 @@ namespace Dicom.Network
                 }
                 catch (Exception e)
                 {
-                    Logger.Warn("Failed to dispose network stream, reason: {error}", e);
+                    Logger.Warn("Failed to dispose network stream, reason: {@error}", e);
                 }
             }
 
@@ -576,7 +576,7 @@ namespace Dicom.Network
                 }
                 catch (Exception e)
                 {
-                    Logger.Warn("Attempt to send association release request failed due to: {error}", e);
+                    Logger.Warn("Attempt to send association release request failed due to: {@error}", e);
                 }
                 finally
                 {

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -62,17 +62,7 @@ namespace Dicom.Network
             this.IsListening = false;
             this.Exception = null;
 
-            Task.Factory.StartNew(
-                this.OnTimerTickAsync,
-                this.cancellationSource.Token,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
-
-            Task.Factory.StartNew(
-                this.ListenAsync,
-                this.cancellationSource.Token,
-                TaskCreationOptions.LongRunning,
-                TaskScheduler.Default);
+            this.BackgroundWorker = Task.WhenAll(OnTimerTickAsync(), ListenAsync());
 
             this.disposed = false;
             this.Register();
@@ -106,6 +96,11 @@ namespace Dicom.Network
         /// Gets the exception that was thrown if the server failed to listen.
         /// </summary>
         public Exception Exception { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="Task"/> managing the background listening and unused client removal processes.
+        /// </summary>
+        public Task BackgroundWorker { get; }
 
         #endregion
 
@@ -193,7 +188,7 @@ namespace Dicom.Network
         /// <summary>
         /// Listen indefinitely for network connections on the specified port.
         /// </summary>
-        private async void ListenAsync()
+        private async Task ListenAsync()
         {
             try
             {
@@ -246,7 +241,7 @@ namespace Dicom.Network
         /// <summary>
         /// Remove no longer used client connections.
         /// </summary>
-        private async void OnTimerTickAsync()
+        private async Task OnTimerTickAsync()
         {
             while (!this.cancellationSource.IsCancellationRequested)
             {

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -122,7 +122,10 @@ namespace Dicom.Network
         {
             get
             {
-                lock (_lock) return _pending.Count == 0;
+                lock (_lock)
+                {
+                    return _msgQueue.Count == 0 && _pending.Count == 0;
+                }
             }
         }
 

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -70,7 +70,7 @@ namespace Dicom.Network
             _isConnected = true;
             _fallbackEncoding = fallbackEncoding ?? DicomEncoding.Default;
             Logger = log ?? LogManager.GetLogger("Dicom.Network");
-            Options = DicomServiceOptions.Default;
+            Options = new DicomServiceOptions();
 
             BackgroundWorker = ReadAndProcessPDUAsync();
         }

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -891,7 +891,11 @@ namespace Dicom.Network
                     if (!Options.IgnoreAsyncOps && Association.MaxAsyncOpsInvoked > 0
                         && _pending.Count >= Association.MaxAsyncOpsInvoked)
                     {
-                        return;
+                        // Cannot easily recover from this unwanted state, so better to throw.
+                        throw new DicomNetworkException(
+                            "Cannot send messages since pending: {pending} would exceed max async ops invoked: {invoked}",
+                            _pending.Count,
+                            Association.MaxAsyncOpsInvoked);
                     }
 
                     _sending = true;

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -855,7 +855,14 @@ namespace Dicom.Network
             lock (_lock)
             {
                 _msgQueue.Enqueue(message);
+
+                if (_sending)
+                {
+                    return;
+                }
+
             }
+
             SendNextMessage();
         }
 
@@ -867,14 +874,14 @@ namespace Dicom.Network
 
                 lock (_lock)
                 {
-                    if (_msgQueue.Count == 0)
+                    if (_sending)
                     {
-                        if (_pending.Count == 0) OnSendQueueEmpty();
                         return;
                     }
 
-                    if (_sending)
+                    if (_msgQueue.Count == 0)
                     {
+                        if (_pending.Count == 0) OnSendQueueEmpty();
                         return;
                     }
 

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -865,9 +865,16 @@ namespace Dicom.Network
                         return;
                     }
 
-                    if (_sending) return;
+                    if (_sending)
+                    {
+                        return;
+                    }
 
-                    if (Association.MaxAsyncOpsInvoked > 0 && _pending.Count >= Association.MaxAsyncOpsInvoked) return;
+                    if (!Options.IgnoreAsyncOps && Association.MaxAsyncOpsInvoked > 0
+                        && _pending.Count >= Association.MaxAsyncOpsInvoked)
+                    {
+                        return;
+                    }
 
                     _sending = true;
 

--- a/DICOM/Network/DicomServiceOptions.cs
+++ b/DICOM/Network/DicomServiceOptions.cs
@@ -45,6 +45,11 @@ namespace Dicom.Network
         /// <summary>DICOM client should ignore SSL certificate errors.</summary>
         public bool IgnoreSslPolicyErrors { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether async operations invoked/performed limitations should be ignored while sending and retrieving messages.
+        /// </summary>
+        public bool IgnoreAsyncOps { get; set; }
+
         /// <summary>Enable or disable TCP Nagle algorithm.</summary>
         public bool TcpNoDelay { get; set; }
     }

--- a/DICOM/Network/DicomServiceOptions.cs
+++ b/DICOM/Network/DicomServiceOptions.cs
@@ -8,21 +8,51 @@ namespace Dicom.Network
     /// </summary>
     public class DicomServiceOptions
     {
+        #region INNER TYPES
+
         /// <summary>Default options for use with the <see cref="DicomService"/> base class.</summary>
-        public static readonly DicomServiceOptions Default = new DicomServiceOptions();
+        public static class Default
+        {
+            public static readonly bool LogDataPDUs = false;
+
+            public static readonly bool LogDimseDatasets = false;
+
+            public static readonly bool UseRemoteAEForLogName = false;
+
+            public static readonly uint MaxCommandBuffer = 1 * 1024; //1KB
+
+            public static readonly uint MaxDataBuffer = 1 * 1024 * 1024; //1MB
+
+            public static readonly int ThreadPoolLinger = 200;
+
+            public static readonly bool IgnoreSslPolicyErrors = false;
+
+            public static readonly bool IgnoreAsyncOps = false;
+
+            public static readonly bool TcpNoDelay = true;
+        }
+
+        #endregion
+
+        #region CONSTRUCTORS
 
         /// <summary>Constructor</summary>
         public DicomServiceOptions()
         {
-            LogDataPDUs = false;
-            LogDimseDatasets = false;
-            UseRemoteAEForLogName = false;
-            MaxCommandBuffer = 1 * 1024; //1KB
-            MaxDataBuffer = 1 * 1024 * 1024; //1MB
-            ThreadPoolLinger = 200;
-            IgnoreSslPolicyErrors = false;
-            TcpNoDelay = true;
+            LogDataPDUs = Default.LogDataPDUs;
+            LogDimseDatasets = Default.LogDimseDatasets;
+            UseRemoteAEForLogName = Default.UseRemoteAEForLogName;
+            MaxCommandBuffer = Default.MaxCommandBuffer;
+            MaxDataBuffer = Default.MaxDataBuffer;
+            ThreadPoolLinger = Default.ThreadPoolLinger;
+            IgnoreSslPolicyErrors = Default.IgnoreSslPolicyErrors;
+            IgnoreAsyncOps = Default.IgnoreAsyncOps;
+            TcpNoDelay = Default.TcpNoDelay;
         }
+
+        #endregion
+
+        #region PROPERTIES
 
         /// <summary>Write message to log for each P-Data-TF PDU sent or received.</summary>
         public bool LogDataPDUs { get; set; }
@@ -52,5 +82,7 @@ namespace Dicom.Network
 
         /// <summary>Enable or disable TCP Nagle algorithm.</summary>
         public bool TcpNoDelay { get; set; }
+
+        #endregion
     }
 }

--- a/DICOM/Network/IDicomServer.cs
+++ b/DICOM/Network/IDicomServer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Threading.Tasks;
+
 namespace Dicom.Network
 {
     using System;
@@ -38,6 +40,11 @@ namespace Dicom.Network
         /// Gets the exception that was thrown if the server failed to listen.
         /// </summary>
         Exception Exception { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Task"/> managing the background listening and unused client removal processes.
+        /// </summary>
+        Task BackgroundWorker { get; }
 
         #endregion
 

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -792,9 +792,9 @@ namespace Dicom.Network
         /// <param name="raw">PDU buffer</param>
         public void Read(RawPDU raw)
         {
-            /*
-             * TODO Disabled async ops reset to ensure that C-GET works well with DCMTK dcmqrscp. Is there a better way?
-             */
+            // reset async ops in case remote end does not negotiate
+            _assoc.MaxAsyncOpsInvoked = 1;
+            _assoc.MaxAsyncOpsPerformed = 1;
 
             uint l = raw.Length - 6;
             ushort c = 0;

--- a/Tests/Network/DicomCGetRequestTest.cs
+++ b/Tests/Network/DicomCGetRequestTest.cs
@@ -13,7 +13,7 @@ namespace Dicom.Network
         public void DicomCGetRequest_OneImageInSeries_Received()
         {
             var client = new DicomClient();
-            client.NegotiateAsyncOps(2, 1);
+            client.Options = new DicomServiceOptions { IgnoreAsyncOps = true };
 
             var pcs = DicomPresentationContext.GetScpRolePresentationContextsFromStorageUids(
                 DicomStorageCategory.Image,
@@ -49,7 +49,7 @@ namespace Dicom.Network
         public void DicomCGetRequest_PickCTImagesInStudy_OnlyCTImagesRetrieved()
         {
             var client = new DicomClient();
-            client.NegotiateAsyncOps(2, 1);
+            client.Options = new DicomServiceOptions { IgnoreAsyncOps = true };
 
             var pc = DicomPresentationContext.GetScpRolePresentationContext(DicomUID.CTImageStorage);
             client.AdditionalPresentationContexts.Add(pc);

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -403,6 +403,7 @@ namespace Dicom.Network
                     DicomClientTest.remoteHost = association.RemoteHost;
                     DicomClientTest.remotePort = association.RemotePort;
                     this.SendAssociationAccept(association);
+                    Thread.Sleep(1000);
                 }
                 else
                 {

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -74,7 +74,7 @@ namespace Dicom.Network
             }
         }
 
-        [Theory(Skip = "Needs further attention")]
+        [Theory]
         [InlineData(20)]
         [InlineData(200)]
         public void Send_MultipleTimes_AllRecognized(int expected)
@@ -138,7 +138,7 @@ namespace Dicom.Network
             }
         }
 
-        [Theory(Skip = "Needs further attention")]
+        [Theory]
         [InlineData(20)]
         [InlineData(200)]
         public async Task SendAsync_MultipleTimes_AllRecognized(int expected)

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -310,8 +310,6 @@ namespace Dicom.Network
                 var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
                 client.WaitForAssociation();
-                Thread.Sleep(10);
-                Assert.False(task.IsCompleted);
 
                 client.Release();
                 Thread.Sleep(10);
@@ -330,8 +328,6 @@ namespace Dicom.Network
                 var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
                 client.WaitForAssociation();
-                Thread.Sleep(10);
-                Assert.False(task.IsCompleted);
 
                 await client.ReleaseAsync();
                 Thread.Sleep(10);
@@ -403,7 +399,6 @@ namespace Dicom.Network
                     DicomClientTest.remoteHost = association.RemoteHost;
                     DicomClientTest.remotePort = association.RemotePort;
                     this.SendAssociationAccept(association);
-                    Thread.Sleep(1000);
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #199 and #312 .

Changes proposed in this pull request:
- Replaced all `async void` method signatures with `async Task`.
- Added `Task` member properties to `DicomService` and `DicomServer` to monitor background tasks.
- Improved handling of requests added to `DicomClient` during sending and improved association release handling to ensure that requests are not accidentally ignored.
- Improved `DicomClient.WaitForAssociation(Async)` and `.Release(Async)` logic.
- `DicomClient.Abort` explicitly sends an abort request.
- In `DicomService.SendNextMessage`, throw when max async operations invoked are violated, since it is normally a non-recoverable state (#312).
- Enable previously skipped tests since `DicomClient.AddRequest` handling has been improved (#199).
- Various minor cleanups and improvements.

This PR will also replace PR #234, which can then be closed without further action. OK with you, @IanYates ?

Please review.