### PR TITLE
Quick fix: check that action/event type ID exists before output. Connected to #323

### DIFF
--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -67,7 +67,7 @@ namespace Dicom.Network
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("{0} [{1}]", ToString(Type), MessageID);
-            sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
+            if (Command.Contains(DicomTag.ActionTypeID)) sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
             return sb.ToString();
         }
     }

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -63,6 +63,10 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Formatted output.
+        /// </summary>
+        /// <returns>Formatted output of the N-ACTION request.</returns>
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -90,7 +90,7 @@ namespace Dicom.Network
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-            sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
+            if (Command.Contains(DicomTag.ActionTypeID)) sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID));
             if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
             {
                 if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -85,12 +85,12 @@ namespace Dicom.Network
         /// <summary>
         /// Formatted output.
         /// </summary>
-        /// <returns>Formetted output of the N-ACTION response.</returns>
+        /// <returns>Formatted output of the N-ACTION response.</returns>
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-            if (Command.Contains(DicomTag.ActionTypeID)) sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID));
+            if (Command.Contains(DicomTag.ActionTypeID)) sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
             if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
             {
                 if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -67,7 +67,7 @@ namespace Dicom.Network
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("{0} [{1}]", ToString(Type), MessageID);
-            sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
+            if (Command.Contains(DicomTag.EventTypeID)) sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
             return sb.ToString();
         }
     }

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -63,6 +63,10 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Formatted output.
+        /// </summary>
+        /// <returns>Formatted output of the N-EVENTREPORT response message.</returns>
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();

--- a/DICOM/Network/DicomNEventReportResponse.cs
+++ b/DICOM/Network/DicomNEventReportResponse.cs
@@ -90,7 +90,7 @@ namespace Dicom.Network
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
-            sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
+            if (Command.Contains(DicomTag.EventTypeID)) sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
             if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
             {
                 if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);

--- a/Tests/Network/DicomNActionResponseTest.cs
+++ b/Tests/Network/DicomNActionResponseTest.cs
@@ -35,6 +35,19 @@ namespace Dicom.Network
             Assert.Null(exception);
         }
 
+        [Fact]
+        public void ToString_ResponseWithoutActionTypeID_DoesNotThrow()
+        {
+            var command = new DicomDataset(new DicomUnsignedShort(DicomTag.CommandField, (ushort)DicomCommandField.NActionResponse),
+                new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.BasicFilmSessionSOPClass),
+                new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, new DicomUID("1.2.3", null, DicomUidType.SOPInstance)),
+                new DicomUnsignedShort(DicomTag.MessageIDBeingRespondedTo, 1));
+            var response = new DicomNActionResponse(command) { Status = DicomStatus.Success };
+
+            var exception = Record.Exception(() => response.ToString());
+            Assert.Null(exception);
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #323 .

Changes proposed in this pull request:
- In `ToString` of the N-ACTION and N-EVENTREPORT RQ and RSP classes, check that *Event/Action Type ID* exists before writing it.

Please review.