### PR TITLE
Structured Report Children should not throws exception if there are no children. Connected to #332 

### DIFF
--- a/DICOM/StructuredReport/DicomContentItem.cs
+++ b/DICOM/StructuredReport/DicomContentItem.cs
@@ -352,7 +352,7 @@ namespace Dicom.StructuredReport
 
         public IEnumerable<DicomContentItem> Children()
         {
-            var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence);
+            var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence, 0, null);
 
             // silence exceptions for items without a content sequence
             if (sequence == null) sequence = new DicomSequence(DicomTag.ContentSequence);
@@ -362,7 +362,7 @@ namespace Dicom.StructuredReport
 
         public DicomContentItem Add(DicomContentItem item)
         {
-            var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence);
+            var sequence = Dataset.Get<DicomSequence>(DicomTag.ContentSequence, 0, null);
 
             if (sequence == null)
             {

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Printing\FilmBoxTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serialization\JsonDicomConverterTest.cs" />
+    <Compile Include="StructuredReport\DicomContentItemTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DICOM.Native\x64\DICOM.Native64.vcxproj">

--- a/Tests/StructuredReport/DicomContentItemTest.cs
+++ b/Tests/StructuredReport/DicomContentItemTest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Linq;
+
+namespace Dicom.StructuredReport
+{
+    using Xunit;
+
+    [Collection("General")]
+    public class DicomContentItemTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void Children_NodeWithoutChildren_Success()
+        {
+            var contentItem = new DicomContentItem(new DicomCodeItem("113820", "DCM", "CT Acquisition Type"),
+                DicomRelationship.Contains,
+                new DicomCodeItem("113805", "DCM", "Constant Angle Acquisition"));
+
+            Assert.Equal(0, contentItem.Children().Count());
+        }
+
+        [Fact]
+        public void Children_NodeWithChildren_Success()
+        {
+            var contentItem = new DicomContentItem(
+                new DicomCodeItem("113820", "DCM", "CT Acquisition Type"),
+                DicomRelationship.Contains,
+                new DicomCodeItem("113805", "DCM", "Constant Angle Acquisition"));
+            contentItem.Add(new DicomCodeItem("113961", "DCM", "Reconstruction Algorithm"),
+                DicomRelationship.Contains, new DicomCodeItem("113962", "DCM", "Filtered Back Projection"));
+
+            var children = contentItem.Children().ToList();
+            Assert.Equal(1, children.Count);
+            Assert.Equal(new DicomCodeItem("113961", "DCM", null), children[0].Code);
+            Assert.Equal(DicomRelationship.Contains, children[0].Relationship);
+            Assert.Equal(new DicomCodeItem("113962", "DCM", null), children[0].Get<DicomCodeItem>());
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #332 .

Changes proposed in this pull request:
`Dataset.Get<DicomSequence>(DicomTag.ContentSequence)` throws exception instead of return default value. But code below this call expects null as result instead of exception.

All requests to ContentSequence was changed to:
`Dataset.Get<DicomSequence>(DicomTag.ContentSequence, 0, null)`
to return null instead of throws exception.
