### PR TITLE
Update to .NET Core 1.0 RTM

### DIFF
--- a/DICOM.Platform/Android/DICOM.Android.csproj
+++ b/DICOM.Platform/Android/DICOM.Android.csproj
@@ -41,12 +41,12 @@
     <AssemblyOriginatorKeyFile>..\..\DICOM\fo-dicom.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BitMiracle.LibJpeg.NetCore, Version=1.5.1.2, Culture=neutral, PublicKeyToken=d69f732e552243f5, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Portable.LibJpeg.NET.1.5.1-pre2\lib\netstandard1.0\BitMiracle.LibJpeg.NetCore.dll</HintPath>
+    <Reference Include="BitMiracle.LibJpeg.NetCore, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d69f732e552243f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Portable.LibJpeg.NET.1.5.1\lib\netstandard1.0\BitMiracle.LibJpeg.NetCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="CSJ2K, Version=1.9.0.0, Culture=neutral, PublicKeyToken=0ca7be2ec378a773, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CSJ2K.2.0.0-beta6\lib\MonoAndroid1\CSJ2K.dll</HintPath>
+    <Reference Include="CSJ2K, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0ca7be2ec378a773, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CSJ2K.2.0.0\lib\MonoAndroid1\CSJ2K.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Android" />
@@ -54,6 +54,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />

--- a/DICOM.Platform/Android/packages.config
+++ b/DICOM.Platform/Android/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSJ2K" version="2.0.0-beta6" targetFramework="monoandroid403" />
-  <package id="Portable.LibJpeg.NET" version="1.5.1-pre2" targetFramework="monoandroid403" />
+  <package id="CSJ2K" version="2.0.0" targetFramework="monoandroid403" />
+  <package id="Portable.LibJpeg.NET" version="1.5.1" targetFramework="monoandroid403" />
 </packages>

--- a/DICOM.Platform/iOS/DICOM.iOS.csproj
+++ b/DICOM.Platform/iOS/DICOM.iOS.csproj
@@ -103,16 +103,18 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="BitMiracle.LibJpeg.NetCore, Version=1.5.1.2, Culture=neutral, PublicKeyToken=d69f732e552243f5, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Portable.LibJpeg.NET.1.5.1-pre2\lib\netstandard1.0\BitMiracle.LibJpeg.NetCore.dll</HintPath>
+    <Reference Include="BitMiracle.LibJpeg.NetCore, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d69f732e552243f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Portable.LibJpeg.NET.1.5.1\lib\netstandard1.0\BitMiracle.LibJpeg.NetCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="CSJ2K, Version=1.9.0.0, Culture=neutral, PublicKeyToken=0ca7be2ec378a773, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CSJ2K.2.0.0-beta6\lib\Xamarin.iOS10\CSJ2K.dll</HintPath>
+    <Reference Include="CSJ2K, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0ca7be2ec378a773, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CSJ2K.2.0.0\lib\Xamarin.iOS10\CSJ2K.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />

--- a/DICOM.Platform/iOS/packages.config
+++ b/DICOM.Platform/iOS/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSJ2K" version="2.0.0-beta6" targetFramework="xamarinios10" />
-  <package id="Portable.LibJpeg.NET" version="1.5.1-pre2" targetFramework="xamarinios10" />
+  <package id="CSJ2K" version="2.0.0" targetFramework="xamarinios10" />
+  <package id="Portable.LibJpeg.NET" version="1.5.1" targetFramework="xamarinios10" />
 </packages>

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -75,11 +75,9 @@ namespace Dicom.Network
         /// is initialized with this server-side constructor.</remarks>
         internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate)
         {
-#if NETSTANDARD
-#else
             this.Host = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
             this.Port = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Port;
-#endif
+
             Stream stream = tcpClient.GetStream();
             if (certificate != null)
             {
@@ -96,7 +94,7 @@ namespace Dicom.Network
         }
 
         /// <summary>
-        /// Destrutor.
+        /// Destructor.
         /// </summary>
         ~DesktopNetworkStream()
         {

--- a/DICOM/project.json
+++ b/DICOM/project.json
@@ -59,8 +59,8 @@
     "System.Net.Security": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Threading.Tasks.Parallel": "4.0.1",
-    "CSJ2K": "2.0.0-beta6",
-    "Portable.LibJpeg.NET": "1.5.1-pre2"
+    "CSJ2K": "2.0.0",
+    "Portable.LibJpeg.NET": "1.5.1"
   },
 
   "frameworks": {

--- a/DICOM/project.json
+++ b/DICOM/project.json
@@ -52,13 +52,13 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-24027",
-    "System.Data.SqlClient": "4.1.0-rc2-24027",
-    "System.IO.FileSystem": "4.0.1-rc2-24027",
-    "System.Net.NetworkInformation": "4.1.0-rc2-24027",
-    "System.Net.Security": "4.0.0-rc2-24027",
-    "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
-    "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027",
+    "NETStandard.Library": "1.6.0",
+    "System.Data.SqlClient": "4.1.0",
+    "System.IO.FileSystem": "4.0.1",
+    "System.Net.NetworkInformation": "4.1.0",
+    "System.Net.Security": "4.0.0",
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "System.Threading.Tasks.Parallel": "4.0.1",
     "CSJ2K": "2.0.0-beta6",
     "Portable.LibJpeg.NET": "1.5.1-pre2"
   },

--- a/Setup/fo-dicom.NetCore.nuspec
+++ b/Setup/fo-dicom.NetCore.nuspec
@@ -9,16 +9,16 @@
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Core fo-dicom library for .NET Core Level 1.3 and higher.</description>
+        <description>Core fo-dicom library for .NET Core targeting Standard Library 1.3 and higher.</description>
         <language>en-US</language>
 		<dependencies>
-			<dependency id="NETStandard.Library" version="1.5.0-rc2-24027" />
-			<dependency id="System.Data.SqlClient" version="4.1.0-rc2-24027" />
-			<dependency id="System.IO.FileSystem" version="4.0.1-rc2-24027" />
-			<dependency id="System.Net.NetworkInformation" version="4.1.0-rc2-24027" />
-			<dependency id="System.Net.Security" version="4.0.0-rc2-24027" />
-			<dependency id="System.Runtime.Serialization.Primitives" version="4.1.1-rc2-24027" />
-			<dependency id="System.Threading.Tasks.Parallel" version="4.0.1-rc2-24027" />
+			<dependency id="NETStandard.Library" version="1.6.0" />
+			<dependency id="System.Data.SqlClient" version="4.1.0" />
+			<dependency id="System.IO.FileSystem" version="4.0.1" />
+			<dependency id="System.Net.NetworkInformation" version="4.1.0" />
+			<dependency id="System.Net.Security" version="4.0.0" />
+			<dependency id="System.Runtime.Serialization.Primitives" version="4.1.1" />
+			<dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
 			<dependency id="Portable.LibJpeg.NET" version="1.5.1-pre2" />
 			<dependency id="CSJ2K" version="2.0.0-beta6" />
 		</dependencies>

--- a/Tools/DICOM Dump/DICOM Dump.csproj
+++ b/Tools/DICOM Dump/DICOM Dump.csproj
@@ -41,14 +41,6 @@
     <StartupObject>Dicom.Dump.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BitMiracle.LibJpeg.NetCore, Version=1.5.1.2, Culture=neutral, PublicKeyToken=d69f732e552243f5, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Portable.LibJpeg.NET.1.5.1-pre2\lib\netstandard1.0\BitMiracle.LibJpeg.NetCore.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CSJ2K, Version=1.9.0.0, Culture=neutral, PublicKeyToken=0ca7be2ec378a773, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CSJ2K.2.0.0-beta6\lib\net40-client\CSJ2K.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Tools/DICOM Dump/packages.config
+++ b/Tools/DICOM Dump/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CSJ2K" version="2.0.0-beta6" targetFramework="net452" />
-  <package id="Portable.LibJpeg.NET" version="1.5.1-pre2" targetFramework="net452" />
+  <package id="CSJ2K" version="2.0.0" targetFramework="net452" />
+  <package id="Portable.LibJpeg.NET" version="1.5.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Fixes #325 .

Changes proposed in this pull request:
- Change references for *.NET Standard Library* to 1.6.0.
- Update *Portable.LibJpeg.NET* and *CSJ2K* references to 1.5.1 and 2.0, respectively.
- In `DesktopNetworkStream` constructor, host and port can be identified when compiled for .NET Core.

Please review.