### PR TITLE
Functional changes in Dataset.Add, rename of ChangeTransferSyntax. Connected to #330

### DIFF
--- a/DICOM.Platform/Windows/project.json
+++ b/DICOM.Platform/Windows/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {
     "uap10.0": {}

--- a/DICOM/DatabaseQueryTransformRule.cs
+++ b/DICOM/DatabaseQueryTransformRule.cs
@@ -168,7 +168,7 @@ namespace Dicom
                                 {
                                     dataset.CopyTo(modifiedAttributesSequenceItem, _output[i]);
                                     string str = reader.GetString(i);
-                                    dataset.Add(_output[i], str);
+                                    dataset.AddOrUpdate(_output[i], str);
                                 }
                             }
                         }

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -193,37 +193,27 @@ namespace Dicom
         }
 
         /// <summary>
-        /// Add a collection of DICOM items to the dataset (replace existing).
-        /// </summary>
-        /// <param name="items">Collection of DICOM items to add.</param>
-        /// <returns>The dataset instance.</returns>
-        public DicomDataset Add(IEnumerable<DicomItem> items)
-        {
-            if (items != null)
-            {
-                foreach (var item in items)
-                {
-                    if (item != null)
-                    {
-                        _items[item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag] = item;
-                    }
-                }
-            }
-            return this;
-        }
-
-        /// <summary>
-        /// Add a collection of DICOM items to the dataset (replace existing).
+        /// Add a collection of DICOM items to the dataset.
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
         /// <returns>The dataset instance.</returns>
         public DicomDataset Add(params DicomItem[] items)
         {
-            return Add((IEnumerable<DicomItem>)items);
+            return DoAdd(items, false);
         }
 
         /// <summary>
-        /// Add single DICOM item given by <paramref name="tag"/> and <paramref name="values"/>. Replace existing item.
+        /// Add a collection of DICOM items to the dataset.
+        /// </summary>
+        /// <param name="items">Collection of DICOM items to add.</param>
+        /// <returns>The dataset instance.</returns>
+        public DicomDataset Add(IEnumerable<DicomItem> items)
+        {
+            return DoAdd(items, false);
+        }
+
+        /// <summary>
+        /// Add single DICOM item given by <paramref name="tag"/> and <paramref name="values"/>.
         /// </summary>
         /// <typeparam name="T">Type of added values.</typeparam>
         /// <param name="tag">DICOM tag of the added item.</param>
@@ -231,21 +221,11 @@ namespace Dicom
         /// <returns>The dataset instance.</returns>
         public DicomDataset Add<T>(DicomTag tag, params T[] values)
         {
-            var entry = DicomDictionary.Default[tag];
-            if (entry == null)
-                throw new DicomDataException(
-                    "Tag {0} not found in DICOM dictionary. Only dictionary tags may be added implicitly to the dataset.",
-                    tag);
-
-            DicomVR vr = null;
-            if (values != null) vr = entry.ValueRepresentations.FirstOrDefault(x => x.ValueType == typeof(T));
-            if (vr == null) vr = entry.ValueRepresentations.First();
-
-            return Add(vr, tag, values);
+            return DoAdd(tag, values, false);
         }
 
         /// <summary>
-        /// Add single DICOM item given by <paramref name="vr"/>, <paramref name="tag"/> and <paramref name="values"/>. Replace existing item.
+        /// Add single DICOM item given by <paramref name="vr"/>, <paramref name="tag"/> and <paramref name="values"/>.
         /// </summary>
         /// <typeparam name="T">Type of added values.</typeparam>
         /// <param name="vr">DICOM vr of the added item. Use when setting a private element.</param>
@@ -257,291 +237,7 @@ namespace Dicom
         /// <returns>The dataset instance.</returns>
         public DicomDataset Add<T>(DicomVR vr, DicomTag tag, params T[] values)
         {
-            if (vr == DicomVR.AE)
-            {
-                if (values == null) return Add(new DicomApplicationEntity(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomApplicationEntity(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.AS)
-            {
-                if (values == null) return Add(new DicomAgeString(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomAgeString(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.AT)
-            {
-                if (values == null) return Add(new DicomAttributeTag(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(DicomTag)) return Add(new DicomAttributeTag(tag, values.Cast<DicomTag>().ToArray()));
-
-                IEnumerable<DicomTag> parsedValues;
-                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, DicomTag.Parse, out parsedValues))
-                {
-                    return Add(new DicomAttributeTag(tag, parsedValues.ToArray()));
-                }
-            }
-
-            if (vr == DicomVR.CS)
-            {
-                if (values == null) return Add(new DicomCodeString(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomCodeString(tag, values.Cast<string>().ToArray()));
-                if (typeof(T).GetTypeInfo().IsEnum) return Add(new DicomCodeString(tag, values.Select(x => x.ToString()).ToArray()));
-            }
-
-            if (vr == DicomVR.DA)
-            {
-                if (values == null) return Add(new DicomDate(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(DateTime)) return Add(new DicomDate(tag, values.Cast<DateTime>().ToArray()));
-                if (typeof(T) == typeof(DicomDateRange))
-                    return
-                        Add(new DicomDate(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
-                if (typeof(T) == typeof(string)) return Add(new DicomDate(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.DS)
-            {
-                if (values == null) return Add(new DicomDecimalString(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(decimal)) return Add(new DicomDecimalString(tag, values.Cast<decimal>().ToArray()));
-                if (typeof(T) == typeof(string)) return Add(new DicomDecimalString(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.DT)
-            {
-                if (values == null) return Add(new DicomDateTime(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(DateTime)) return Add(new DicomDateTime(tag, values.Cast<DateTime>().ToArray()));
-                if (typeof(T) == typeof(DicomDateRange))
-                    return
-                        Add(
-                            new DicomDateTime(
-                                tag,
-                                values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
-                if (typeof(T) == typeof(string)) return Add(new DicomDateTime(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.FD)
-            {
-                if (values == null) return Add(new DicomFloatingPointDouble(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(double)) return Add(new DicomFloatingPointDouble(tag, values.Cast<double>().ToArray()));
-
-                IEnumerable<double> parsedValues;
-                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, double.Parse, out parsedValues))
-                {
-                    return Add(new DicomFloatingPointDouble(tag, parsedValues.ToArray()));
-                }              
-            }
-
-            if (vr == DicomVR.FL)
-            {
-                if (values == null) return Add(new DicomFloatingPointSingle(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(float)) return Add(new DicomFloatingPointSingle(tag, values.Cast<float>().ToArray()));
-
-                IEnumerable<float> parsedValues;
-                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, float.Parse, out parsedValues))
-                {
-                    return Add(new DicomFloatingPointSingle(tag, parsedValues.ToArray()));
-                }
-            }
-
-            if (vr == DicomVR.IS)
-            {
-                if (values == null) return Add(new DicomIntegerString(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(int)) return Add(new DicomIntegerString(tag, values.Cast<int>().ToArray()));
-                if (typeof(T) == typeof(string)) return Add(new DicomIntegerString(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.LO)
-            {
-                if (values == null) return Add(new DicomLongString(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomLongString(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.LT)
-            {
-                if (values == null) return Add(new DicomLongText(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomLongText(tag, values.Cast<string>().First()));
-            }
-
-            if (vr == DicomVR.OB)
-            {
-                if (values == null) return Add(new DicomOtherByte(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(byte)) return Add(new DicomOtherByte(tag, values.Cast<byte>().ToArray()));
-                
-                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
-                {
-                    return Add(new DicomOtherByte(tag, (IByteBuffer)values[0]));
-                }
-            }
-
-            if (vr == DicomVR.OD)
-            {
-                if (values == null) return Add(new DicomOtherDouble(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(double)) return Add(new DicomOtherDouble(tag, values.Cast<double>().ToArray()));
-            
-                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
-                {
-                    return Add(new DicomOtherDouble(tag, (IByteBuffer)values[0]));
-                }
-            }
-
-            if (vr == DicomVR.OF)
-            {
-                if (values == null) return Add(new DicomOtherFloat(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(float)) return Add(new DicomOtherFloat(tag, values.Cast<float>().ToArray()));
-
-                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
-                {
-                    return Add(new DicomOtherFloat(tag, (IByteBuffer)values[0]));
-                }
-            }
-
-            if (vr == DicomVR.OL)
-            {
-                if (values == null) return Add(new DicomOtherLong(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(uint)) return Add(new DicomOtherLong(tag, values.Cast<uint>().ToArray()));
-
-                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
-                {
-                    return Add(new DicomOtherLong(tag, (IByteBuffer)values[0]));
-                }
-            }
-
-            if (vr == DicomVR.OW)
-            {
-                if (values == null) return Add(new DicomOtherWord(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(ushort)) return Add(new DicomOtherWord(tag, values.Cast<ushort>().ToArray()));
-                
-                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
-                {
-                    return Add(new DicomOtherWord(tag, (IByteBuffer)values[0]));
-                }
-            }
-
-            if (vr == DicomVR.PN)
-            {
-                if (values == null) return Add(new DicomPersonName(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomPersonName(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.SH)
-            {
-                if (values == null) return Add(new DicomShortString(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomShortString(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.SL)
-            {
-                if (values == null) return Add(new DicomSignedLong(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(int)) return Add(new DicomSignedLong(tag, values.Cast<int>().ToArray()));
-
-                IEnumerable<int> parsedValues;
-                if ( ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, int.Parse, out parsedValues))
-                {
-                    return Add(new DicomSignedLong(tag, parsedValues.ToArray()));
-                }
-            }
-
-            if (vr == DicomVR.SQ)
-            {
-                if (values == null) return Add(new DicomSequence(tag));
-                if (typeof(T) == typeof(DicomContentItem)) return Add(new DicomSequence(tag, values.Cast<DicomContentItem>().Select(x => x.Dataset).ToArray()));
-                if (typeof(T) == typeof(DicomDataset) || typeof(T) == typeof(DicomCodeItem)
-                    || typeof(T) == typeof(DicomMeasuredValue) || typeof(T) == typeof(DicomReferencedSOP)) return Add(new DicomSequence(tag, values.Cast<DicomDataset>().ToArray()));
-            }
-
-            if (vr == DicomVR.SS)
-            {
-                if (values == null) return Add(new DicomSignedShort(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(short)) return Add(new DicomSignedShort(tag, values.Cast<short>().ToArray()));
-
-                IEnumerable<short> parsedValues;
-                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, short.Parse, out parsedValues))
-                {
-                    return Add(new DicomSignedShort(tag, parsedValues.ToArray()));
-                }
-            }
-
-            if (vr == DicomVR.ST)
-            {
-                if (values == null) return Add(new DicomShortText(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomShortText(tag, values.Cast<string>().First()));
-            }
-
-            if (vr == DicomVR.TM)
-            {
-                if (values == null) return Add(new DicomTime(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(DateTime)) return Add(new DicomTime(tag, values.Cast<DateTime>().ToArray()));
-                if (typeof(T) == typeof(DicomDateRange))
-                    return
-                        Add(new DicomTime(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()));
-                if (typeof(T) == typeof(string)) return Add(new DicomTime(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.UC)
-            {
-                if (values == null) return Add(new DicomUnlimitedCharacters(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomUnlimitedCharacters(tag, values.Cast<string>().ToArray()));
-            }
-
-            if (vr == DicomVR.UI)
-            {
-                if (values == null) return Add(new DicomUniqueIdentifier(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomUniqueIdentifier(tag, values.Cast<string>().ToArray()));
-                if (typeof(T) == typeof(DicomUID)) return Add(new DicomUniqueIdentifier(tag, values.Cast<DicomUID>().ToArray()));
-                if (typeof(T) == typeof(DicomTransferSyntax)) return Add(new DicomUniqueIdentifier(tag, values.Cast<DicomTransferSyntax>().ToArray()));
-            }
-
-            if (vr == DicomVR.UL)
-            {
-                if (values == null) return Add(new DicomUnsignedLong(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(uint)) return Add(new DicomUnsignedLong(tag, values.Cast<uint>().ToArray()));
-
-                IEnumerable<uint> parsedValues;
-                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, uint.Parse, out parsedValues))
-                {
-                    return Add(new DicomUnsignedLong(tag, parsedValues.ToArray()));
-                }
-            }
-
-            if (vr == DicomVR.UN)
-            {
-                if (values == null) return Add(new DicomUnknown(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(byte)) return Add(new DicomUnknown(tag, values.Cast<byte>().ToArray()));
-                
-                if (typeof(T) == typeof(IByteBuffer) && values.Length == 1)
-                {
-                    return Add(new DicomUnknown(tag, (IByteBuffer)values[0]));
-                }
-            }
-
-            if (vr == DicomVR.UR)
-            {
-                if (values == null) return Add(new DicomUniversalResource(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomUniversalResource(tag, values.Cast<string>().First()));
-            }
-
-            if (vr == DicomVR.US)
-            {
-                if (values == null) return Add(new DicomUnsignedShort(tag, EmptyBuffer.Value));
-                if (typeof(T) == typeof(ushort)) return Add(new DicomUnsignedShort(tag, values.Cast<ushort>().ToArray()));
-
-                IEnumerable<ushort> parsedValues;
-                if ( ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, ushort.Parse, out parsedValues))
-                {
-                    return Add(new DicomUnsignedShort(tag, parsedValues.ToArray()));
-                }
-            }
-
-            if (vr == DicomVR.UT)
-            {
-                if (values == null) return Add(new DicomUnlimitedText(tag, DicomEncoding.Default, EmptyBuffer.Value));
-                if (typeof(T) == typeof(string)) return Add(new DicomUnlimitedText(tag, values.Cast<string>().First()));
-            }
-
-            throw new InvalidOperationException(
-                string.Format(
-                    "Unable to create DICOM element of type {0} with values of type {1}",
-                    vr.Code,
-                    typeof(T)));
+            return DoAdd(vr, tag, values, false);
         }
 
         /// <summary>
@@ -708,6 +404,377 @@ namespace Dicom
                 "Unable to get a value type of {0} from DICOM item of type {1}",
                 typeof(T),
                 item.GetType());
+        }
+
+        /// <summary>
+        /// Add a collection of DICOM items to the dataset.
+        /// </summary>
+        /// <param name="items">Collection of DICOM items to add.</param>
+        /// <param name="allowUpdate">True if existing tag can be updated, false if method should throw when trying to add already existing tag.</param>
+        /// <returns>The dataset instance.</returns>
+        private DicomDataset DoAdd(IEnumerable<DicomItem> items, bool allowUpdate)
+        {
+            if (items != null)
+            {
+                if (allowUpdate)
+                {
+                    foreach (var item in items.Where(i => i != null))
+                    {
+                        _items[item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag] = item;
+                    }
+                }
+                else
+                {
+                    foreach (var item in items.Where(i => i != null))
+                    {
+                        _items.Add(item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag, item);
+                    }
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Add single DICOM item to the dataset.
+        /// </summary>
+        /// <param name="item">DICOM item to add.</param>
+        /// <param name="allowUpdate">True if existing tag can be updated, false if method should throw when trying to add already existing tag.</param>
+        /// <returns>The dataset instance.</returns>
+        private DicomDataset DoAdd(DicomItem item, bool allowUpdate)
+        {
+            if (item != null)
+            {
+                if (allowUpdate)
+                {
+                    _items[item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag] = item;
+                }
+                else
+                {
+                    _items.Add(item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag, item);
+                }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Add single DICOM item given by <paramref name="tag"/> and <paramref name="values"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of added values.</typeparam>
+        /// <param name="tag">DICOM tag of the added item.</param>
+        /// <param name="values">Values of the added item.</param>
+        /// <param name="allowUpdate">True if existing tag can be updated, false if method should throw when trying to add already existing tag.</param>
+        /// <returns>The dataset instance.</returns>
+        private DicomDataset DoAdd<T>(DicomTag tag, IList<T> values, bool allowUpdate)
+        {
+            var entry = DicomDictionary.Default[tag];
+            if (entry == null)
+                throw new DicomDataException(
+                    "Tag {0} not found in DICOM dictionary. Only dictionary tags may be added implicitly to the dataset.",
+                    tag);
+
+            DicomVR vr = null;
+            if (values != null) vr = entry.ValueRepresentations.FirstOrDefault(x => x.ValueType == typeof(T));
+            if (vr == null) vr = entry.ValueRepresentations.First();
+
+            return DoAdd(vr, tag, values, allowUpdate);
+        }
+
+        /// <summary>
+        /// Add single DICOM item given by <paramref name="vr"/>, <paramref name="tag"/> and <paramref name="values"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of added values.</typeparam>
+        /// <param name="vr">DICOM vr of the added item. Use when setting a private element.</param>
+        /// <param name="tag">DICOM tag of the added item.</param>
+        /// <param name="values">Values of the added item.</param>
+        /// <param name="allowUpdate">True if existing tag can be updated, false if method should throw when trying to add already existing tag.</param>
+        /// <remarks>No validation is performed on the <paramref name="vr"/> matching the element <paramref name="tag"/>
+        /// This method is useful when adding a private tag and need to explicitly set the VR of the created element.
+        /// </remarks>
+        /// <returns>The dataset instance.</returns>
+        private DicomDataset DoAdd<T>(DicomVR vr, DicomTag tag, IList<T> values, bool allowUpdate)
+        {
+            if (vr == DicomVR.AE)
+            {
+                if (values == null) return DoAdd(new DicomApplicationEntity(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomApplicationEntity(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.AS)
+            {
+                if (values == null) return DoAdd(new DicomAgeString(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomAgeString(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.AT)
+            {
+                if (values == null) return DoAdd(new DicomAttributeTag(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(DicomTag)) return DoAdd(new DicomAttributeTag(tag, values.Cast<DicomTag>().ToArray()), allowUpdate);
+
+                IEnumerable<DicomTag> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, DicomTag.Parse, out parsedValues))
+                {
+                    return DoAdd(new DicomAttributeTag(tag, parsedValues.ToArray()), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.CS)
+            {
+                if (values == null) return DoAdd(new DicomCodeString(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomCodeString(tag, values.Cast<string>().ToArray()), allowUpdate);
+                if (typeof(T).GetTypeInfo().IsEnum) return DoAdd(new DicomCodeString(tag, values.Select(x => x.ToString()).ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.DA)
+            {
+                if (values == null) return DoAdd(new DicomDate(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(DateTime)) return DoAdd(new DicomDate(tag, values.Cast<DateTime>().ToArray()), allowUpdate);
+                if (typeof(T) == typeof(DicomDateRange))
+                    return
+                        DoAdd(new DicomDate(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomDate(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.DS)
+            {
+                if (values == null) return DoAdd(new DicomDecimalString(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(decimal)) return DoAdd(new DicomDecimalString(tag, values.Cast<decimal>().ToArray()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomDecimalString(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.DT)
+            {
+                if (values == null) return DoAdd(new DicomDateTime(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(DateTime)) return DoAdd(new DicomDateTime(tag, values.Cast<DateTime>().ToArray()), allowUpdate);
+                if (typeof(T) == typeof(DicomDateRange))
+                    return
+                        DoAdd(
+                            new DicomDateTime(
+                                tag,
+                                values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomDateTime(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.FD)
+            {
+                if (values == null) return DoAdd(new DicomFloatingPointDouble(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(double)) return DoAdd(new DicomFloatingPointDouble(tag, values.Cast<double>().ToArray()), allowUpdate);
+
+                IEnumerable<double> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, double.Parse, out parsedValues))
+                {
+                    return DoAdd(new DicomFloatingPointDouble(tag, parsedValues.ToArray()), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.FL)
+            {
+                if (values == null) return DoAdd(new DicomFloatingPointSingle(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(float)) return DoAdd(new DicomFloatingPointSingle(tag, values.Cast<float>().ToArray()), allowUpdate);
+
+                IEnumerable<float> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, float.Parse, out parsedValues))
+                {
+                    return DoAdd(new DicomFloatingPointSingle(tag, parsedValues.ToArray()), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.IS)
+            {
+                if (values == null) return DoAdd(new DicomIntegerString(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(int)) return DoAdd(new DicomIntegerString(tag, values.Cast<int>().ToArray()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomIntegerString(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.LO)
+            {
+                if (values == null) return DoAdd(new DicomLongString(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomLongString(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.LT)
+            {
+                if (values == null) return DoAdd(new DicomLongText(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomLongText(tag, values.Cast<string>().First()), allowUpdate);
+            }
+
+            if (vr == DicomVR.OB)
+            {
+                if (values == null) return DoAdd(new DicomOtherByte(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(byte)) return DoAdd(new DicomOtherByte(tag, values.Cast<byte>().ToArray()), allowUpdate);
+
+                if (typeof(T) == typeof(IByteBuffer) && values.Count == 1)
+                {
+                    return DoAdd(new DicomOtherByte(tag, (IByteBuffer)values[0]), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.OD)
+            {
+                if (values == null) return DoAdd(new DicomOtherDouble(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(double)) return DoAdd(new DicomOtherDouble(tag, values.Cast<double>().ToArray()), allowUpdate);
+
+                if (typeof(T) == typeof(IByteBuffer) && values.Count == 1)
+                {
+                    return DoAdd(new DicomOtherDouble(tag, (IByteBuffer)values[0]), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.OF)
+            {
+                if (values == null) return DoAdd(new DicomOtherFloat(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(float)) return DoAdd(new DicomOtherFloat(tag, values.Cast<float>().ToArray()), allowUpdate);
+
+                if (typeof(T) == typeof(IByteBuffer) && values.Count == 1)
+                {
+                    return DoAdd(new DicomOtherFloat(tag, (IByteBuffer)values[0]), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.OL)
+            {
+                if (values == null) return DoAdd(new DicomOtherLong(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(uint)) return DoAdd(new DicomOtherLong(tag, values.Cast<uint>().ToArray()), allowUpdate);
+
+                if (typeof(T) == typeof(IByteBuffer) && values.Count == 1)
+                {
+                    return DoAdd(new DicomOtherLong(tag, (IByteBuffer)values[0]), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.OW)
+            {
+                if (values == null) return DoAdd(new DicomOtherWord(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(ushort)) return DoAdd(new DicomOtherWord(tag, values.Cast<ushort>().ToArray()), allowUpdate);
+
+                if (typeof(T) == typeof(IByteBuffer) && values.Count == 1)
+                {
+                    return DoAdd(new DicomOtherWord(tag, (IByteBuffer)values[0]), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.PN)
+            {
+                if (values == null) return DoAdd(new DicomPersonName(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomPersonName(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.SH)
+            {
+                if (values == null) return DoAdd(new DicomShortString(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomShortString(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.SL)
+            {
+                if (values == null) return DoAdd(new DicomSignedLong(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(int)) return DoAdd(new DicomSignedLong(tag, values.Cast<int>().ToArray()), allowUpdate);
+
+                IEnumerable<int> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, int.Parse, out parsedValues))
+                {
+                    return DoAdd(new DicomSignedLong(tag, parsedValues.ToArray()), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.SQ)
+            {
+                if (values == null) return DoAdd(new DicomSequence(tag), allowUpdate);
+                if (typeof(T) == typeof(DicomContentItem)) return DoAdd(new DicomSequence(tag, values.Cast<DicomContentItem>().Select(x => x.Dataset).ToArray()), allowUpdate);
+                if (typeof(T) == typeof(DicomDataset) || typeof(T) == typeof(DicomCodeItem)
+                    || typeof(T) == typeof(DicomMeasuredValue) || typeof(T) == typeof(DicomReferencedSOP)) return DoAdd(new DicomSequence(tag, values.Cast<DicomDataset>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.SS)
+            {
+                if (values == null) return DoAdd(new DicomSignedShort(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(short)) return DoAdd(new DicomSignedShort(tag, values.Cast<short>().ToArray()), allowUpdate);
+
+                IEnumerable<short> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, short.Parse, out parsedValues))
+                {
+                    return DoAdd(new DicomSignedShort(tag, parsedValues.ToArray()), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.ST)
+            {
+                if (values == null) return DoAdd(new DicomShortText(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomShortText(tag, values.Cast<string>().First()), allowUpdate);
+            }
+
+            if (vr == DicomVR.TM)
+            {
+                if (values == null) return DoAdd(new DicomTime(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(DateTime)) return DoAdd(new DicomTime(tag, values.Cast<DateTime>().ToArray()), allowUpdate);
+                if (typeof(T) == typeof(DicomDateRange))
+                    return
+                        DoAdd(new DicomTime(tag, values.Cast<DicomDateRange>().FirstOrDefault() ?? new DicomDateRange()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomTime(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.UC)
+            {
+                if (values == null) return DoAdd(new DicomUnlimitedCharacters(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomUnlimitedCharacters(tag, values.Cast<string>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.UI)
+            {
+                if (values == null) return DoAdd(new DicomUniqueIdentifier(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomUniqueIdentifier(tag, values.Cast<string>().ToArray()), allowUpdate);
+                if (typeof(T) == typeof(DicomUID)) return DoAdd(new DicomUniqueIdentifier(tag, values.Cast<DicomUID>().ToArray()), allowUpdate);
+                if (typeof(T) == typeof(DicomTransferSyntax)) return DoAdd(new DicomUniqueIdentifier(tag, values.Cast<DicomTransferSyntax>().ToArray()), allowUpdate);
+            }
+
+            if (vr == DicomVR.UL)
+            {
+                if (values == null) return DoAdd(new DicomUnsignedLong(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(uint)) return DoAdd(new DicomUnsignedLong(tag, values.Cast<uint>().ToArray()), allowUpdate);
+
+                IEnumerable<uint> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, uint.Parse, out parsedValues))
+                {
+                    return DoAdd(new DicomUnsignedLong(tag, parsedValues.ToArray()), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.UN)
+            {
+                if (values == null) return DoAdd(new DicomUnknown(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(byte)) return DoAdd(new DicomUnknown(tag, values.Cast<byte>().ToArray()), allowUpdate);
+
+                if (typeof(T) == typeof(IByteBuffer) && values.Count == 1)
+                {
+                    return DoAdd(new DicomUnknown(tag, (IByteBuffer)values[0]), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.UR)
+            {
+                if (values == null) return DoAdd(new DicomUniversalResource(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomUniversalResource(tag, values.Cast<string>().First()), allowUpdate);
+            }
+
+            if (vr == DicomVR.US)
+            {
+                if (values == null) return DoAdd(new DicomUnsignedShort(tag, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(ushort)) return DoAdd(new DicomUnsignedShort(tag, values.Cast<ushort>().ToArray()), allowUpdate);
+
+                IEnumerable<ushort> parsedValues;
+                if (ParseVrValueFromString(values, tag.DictionaryEntry.ValueMultiplicity, ushort.Parse, out parsedValues))
+                {
+                    return DoAdd(new DicomUnsignedShort(tag, parsedValues.ToArray()), allowUpdate);
+                }
+            }
+
+            if (vr == DicomVR.UT)
+            {
+                if (values == null) return DoAdd(new DicomUnlimitedText(tag, DicomEncoding.Default, EmptyBuffer.Value), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomUnlimitedText(tag, values.Cast<string>().First()), allowUpdate);
+            }
+
+            throw new InvalidOperationException(
+                $"Unable to create DICOM element of type {vr.Code} with values of type {typeof(T)}");
         }
 
         private static bool ParseVrValueFromString<T, TOut>(

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -197,9 +197,19 @@ namespace Dicom
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
         /// <returns>The dataset instance.</returns>
-        public DicomDataset Add(params DicomItem[] items)
+        public DicomDataset Add(IEnumerable<DicomItem> items)
         {
-            return Add((IEnumerable<DicomItem>)items);
+            if (items != null)
+            {
+                foreach (var item in items)
+                {
+                    if (item != null)
+                    {
+                        _items[item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag] = item;
+                    }
+                }
+            }
+            return this;
         }
 
         /// <summary>
@@ -207,20 +217,9 @@ namespace Dicom
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
         /// <returns>The dataset instance.</returns>
-        public DicomDataset Add(IEnumerable<DicomItem> items)
+        public DicomDataset Add(params DicomItem[] items)
         {
-            if (items != null)
-            {
-                foreach (DicomItem item in items)
-                {
-                    if (item != null)
-                    {
-                        if (item.Tag.IsPrivate) _items[GetPrivateTag(item.Tag)] = item;
-                        else _items[item.Tag] = item;
-                    }
-                }
-            }
-            return this;
+            return Add((IEnumerable<DicomItem>)items);
         }
 
         /// <summary>

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -199,18 +199,7 @@ namespace Dicom
         /// <returns>The dataset instance.</returns>
         public DicomDataset Add(params DicomItem[] items)
         {
-            if (items != null)
-            {
-                foreach (DicomItem item in items)
-                {
-                    if (item != null)
-                    {
-                        if (item.Tag.IsPrivate) _items[GetPrivateTag(item.Tag)] = item;
-                        else _items[item.Tag] = item;
-                    }
-                }
-            }
-            return this;
+            return Add((IEnumerable<DicomItem>)items);
         }
 
         /// <summary>

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -181,7 +181,7 @@ namespace Dicom
                 var creator = new DicomTag(tag.Group, group);
                 if (!Contains(creator))
                 {
-                    Add(new DicomLongString(creator, tag.PrivateCreator.Creator));
+                    AddOrUpdate(new DicomLongString(creator, tag.PrivateCreator.Creator));
                     break;
                 }
 
@@ -341,7 +341,7 @@ namespace Dicom
         /// <returns>Current Dataset</returns>
         public DicomDataset CopyTo(DicomDataset destination)
         {
-            if (destination != null) destination.Add(this);
+            if (destination != null) destination.AddOrUpdate(this);
             return this;
         }
 
@@ -355,7 +355,7 @@ namespace Dicom
         {
             if (destination != null)
             {
-                foreach (var tag in tags) destination.Add(Get<DicomItem>(tag));
+                foreach (var tag in tags) destination.AddOrUpdate(Get<DicomItem>(tag));
             }
             return this;
         }
@@ -368,7 +368,7 @@ namespace Dicom
         /// <returns>Current Dataset</returns>
         public DicomDataset CopyTo(DicomDataset destination, DicomMaskedTag mask)
         {
-            if (destination != null) destination.Add(_items.Values.Where(x => mask.IsMatch(x.Tag)));
+            destination?.AddOrUpdate(_items.Values.Where(x => mask.IsMatch(x.Tag)));
             return this;
         }
 
@@ -399,7 +399,7 @@ namespace Dicom
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            return String.Format("DICOM Dataset [{0} items]", _items.Count);
+            return $"DICOM Dataset [{_items.Count} items]";
         }
 
         /// <summary>

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -181,11 +181,11 @@ namespace Dicom
                 var creator = new DicomTag(tag.Group, group);
                 if (!Contains(creator))
                 {
-                    AddOrUpdate(new DicomLongString(creator, tag.PrivateCreator.Creator));
+                    Add(new DicomLongString(creator, tag.PrivateCreator.Creator));
                     break;
                 }
 
-                var value = Get<string>(creator, String.Empty);
+                var value = Get(creator, string.Empty);
                 if (tag.PrivateCreator.Creator == value) return new DicomTag(tag.Group, (ushort)((group << 8) + (tag.Element & 0xff)), tag.PrivateCreator);
             }
 

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -197,6 +197,7 @@ namespace Dicom
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
         /// <returns>The dataset instance.</returns>
+        /// <exception cref="ArgumentException">If tag of added item already exists in dataset.</exception>
         public DicomDataset Add(params DicomItem[] items)
         {
             return DoAdd(items, false);
@@ -207,6 +208,7 @@ namespace Dicom
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
         /// <returns>The dataset instance.</returns>
+        /// <exception cref="ArgumentException">If tag of added item already exists in dataset.</exception>
         public DicomDataset Add(IEnumerable<DicomItem> items)
         {
             return DoAdd(items, false);
@@ -219,6 +221,7 @@ namespace Dicom
         /// <param name="tag">DICOM tag of the added item.</param>
         /// <param name="values">Values of the added item.</param>
         /// <returns>The dataset instance.</returns>
+        /// <exception cref="ArgumentException">If tag already exists in dataset.</exception>
         public DicomDataset Add<T>(DicomTag tag, params T[] values)
         {
             return DoAdd(tag, values, false);
@@ -235,9 +238,58 @@ namespace Dicom
         /// This method is useful when adding a private tag and need to explicitly set the VR of the created element.
         /// </remarks>
         /// <returns>The dataset instance.</returns>
+        /// <exception cref="ArgumentException">If tag already exists in dataset.</exception>
         public DicomDataset Add<T>(DicomVR vr, DicomTag tag, params T[] values)
         {
             return DoAdd(vr, tag, values, false);
+        }
+
+        /// <summary>
+        /// Add a collection of DICOM items to the dataset. Update existing items.
+        /// </summary>
+        /// <param name="items">Collection of DICOM items to add.</param>
+        /// <returns>The dataset instance.</returns>
+        public DicomDataset AddOrUpdate(params DicomItem[] items)
+        {
+            return DoAdd(items, true);
+        }
+
+        /// <summary>
+        /// Add a collection of DICOM items to the dataset. Update existing items.
+        /// </summary>
+        /// <param name="items">Collection of DICOM items to add.</param>
+        /// <returns>The dataset instance.</returns>
+        public DicomDataset AddOrUpdate(IEnumerable<DicomItem> items)
+        {
+            return DoAdd(items, true);
+        }
+
+        /// <summary>
+        /// Add or update a single DICOM item given by <paramref name="tag"/> and <paramref name="values"/>. 
+        /// </summary>
+        /// <typeparam name="T">Type of added values.</typeparam>
+        /// <param name="tag">DICOM tag of the added item.</param>
+        /// <param name="values">Values of the added item.</param>
+        /// <returns>The dataset instance.</returns>
+        public DicomDataset AddOrUpdate<T>(DicomTag tag, params T[] values)
+        {
+            return DoAdd(tag, values, true);
+        }
+
+        /// <summary>
+        /// Add or update a single DICOM item given by <paramref name="vr"/>, <paramref name="tag"/> and <paramref name="values"/>. 
+        /// </summary>
+        /// <typeparam name="T">Type of added values.</typeparam>
+        /// <param name="vr">DICOM vr of the added item. Use when setting a private element.</param>
+        /// <param name="tag">DICOM tag of the added item.</param>
+        /// <param name="values">Values of the added item.</param>
+        /// <remarks>No validation is performed on the <paramref name="vr"/> matching the element <paramref name="tag"/>
+        /// This method is useful when adding a private tag and need to explicitly set the VR of the created element.
+        /// </remarks>
+        /// <returns>The dataset instance.</returns>
+        public DicomDataset AddOrUpdate<T>(DicomVR vr, DicomTag tag, params T[] values)
+        {
+            return DoAdd(vr, tag, values, true);
         }
 
         /// <summary>

--- a/DICOM/DicomFileMetaInformation.cs
+++ b/DICOM/DicomFileMetaInformation.cs
@@ -70,7 +70,7 @@ namespace Dicom
             }
             set
             {
-                Add(DicomTag.FileMetaInformationVersion, value);
+                AddOrUpdate(DicomTag.FileMetaInformationVersion, value);
             }
         }
 
@@ -85,7 +85,7 @@ namespace Dicom
             }
             set
             {
-                Add(DicomTag.MediaStorageSOPClassUID, value);
+                AddOrUpdate(DicomTag.MediaStorageSOPClassUID, value);
             }
         }
 
@@ -100,7 +100,7 @@ namespace Dicom
             }
             set
             {
-                Add(DicomTag.MediaStorageSOPInstanceUID, value);
+                AddOrUpdate(DicomTag.MediaStorageSOPInstanceUID, value);
             }
         }
 
@@ -115,7 +115,7 @@ namespace Dicom
             }
             set
             {
-                Add(DicomTag.TransferSyntaxUID, value.UID);
+                AddOrUpdate(DicomTag.TransferSyntaxUID, value.UID);
             }
         }
 
@@ -130,7 +130,7 @@ namespace Dicom
             }
             set
             {
-                Add(DicomTag.ImplementationClassUID, value);
+                AddOrUpdate(DicomTag.ImplementationClassUID, value);
             }
         }
 
@@ -145,7 +145,7 @@ namespace Dicom
             }
             set
             {
-                Add(DicomTag.ImplementationVersionName, value);
+                AddOrUpdate(DicomTag.ImplementationVersionName, value);
             }
         }
 
@@ -160,7 +160,7 @@ namespace Dicom
             }
             set
             {
-                Add(DicomTag.SourceApplicationEntityTitle, value);
+                AddOrUpdate(DicomTag.SourceApplicationEntityTitle, value);
             }
         }
 

--- a/DICOM/DicomTransformRules.cs
+++ b/DICOM/DicomTransformRules.cs
@@ -148,7 +148,7 @@ namespace Dicom
         public void Transform(DicomDataset dataset, DicomDataset modifiedAttributesSequenceItem = null)
         {
             dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-            dataset.Add(_tag, _value);
+            dataset.AddOrUpdate(_tag, _value);
         }
 
         public override string ToString()
@@ -193,7 +193,7 @@ namespace Dicom
             if (dataset.Contains(_tag) && dataset.Get<string>(_tag, -1, String.Empty) == _match)
             {
                 dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
-                dataset.Add(_tag, _value);
+                dataset.AddOrUpdate(_tag, _value);
             }
         }
 
@@ -236,7 +236,7 @@ namespace Dicom
             if (dataset.Contains(_src))
             {
                 dataset.CopyTo(modifiedAttributesSequenceItem, _dst);
-                dataset.Add(_dst, dataset.Get<IByteBuffer>(_src));
+                dataset.AddOrUpdate(_dst, dataset.Get<IByteBuffer>(_src));
             }
         }
 
@@ -285,7 +285,7 @@ namespace Dicom
                 dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
                 value = Regex.Replace(value, _pattern, _replacement);
-                dataset.Add(_tag, value);
+                dataset.AddOrUpdate(_tag, value);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Dicom
             {
                 dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
-                dataset.Add(_tag, _prefix + value);
+                dataset.AddOrUpdate(_tag, _prefix + value);
             }
         }
 
@@ -373,7 +373,7 @@ namespace Dicom
             {
                 dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
-                dataset.Add(_tag, value + _append);
+                dataset.AddOrUpdate(_tag, value + _append);
             }
         }
 
@@ -431,7 +431,7 @@ namespace Dicom
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
                 if (_position == DicomTrimPosition.Start || _position == DicomTrimPosition.Both) while (value.StartsWith(_trim)) value = value.Substring(_trim.Length);
                 if (_position == DicomTrimPosition.End || _position == DicomTrimPosition.Both) while (value.EndsWith(_trim)) value = value.Substring(0, value.Length - _trim.Length);
-                dataset.Add(_tag, value);
+                dataset.AddOrUpdate(_tag, value);
             }
         }
 
@@ -500,7 +500,7 @@ namespace Dicom
                     if (_trim != null) value = value.TrimEnd(_trim);
                     else value = value.TrimEnd();
                 }
-                dataset.Add(_tag, value);
+                dataset.AddOrUpdate(_tag, value);
             }
         }
 
@@ -555,7 +555,7 @@ namespace Dicom
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
                 if (_totalLength < 0) value = value.PadLeft(-_totalLength, _paddingChar);
                 else value = value.PadRight(_totalLength, _paddingChar);
-                dataset.Add(_tag, value);
+                dataset.AddOrUpdate(_tag, value);
             }
         }
 
@@ -605,7 +605,7 @@ namespace Dicom
                     if (parts[i].Length > _length) parts[i] = parts[i].Substring(0, _length);
                 }
                 value = String.Join("\\", parts);
-                dataset.Add(_tag, value);
+                dataset.AddOrUpdate(_tag, value);
             }
         }
 
@@ -654,7 +654,7 @@ namespace Dicom
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
                 string[] parts = value.Split(_seperators);
                 value = String.Format(_format, parts);
-                dataset.Add(_tag, value);
+                dataset.AddOrUpdate(_tag, value);
             }
         }
 
@@ -695,7 +695,7 @@ namespace Dicom
             {
                 dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
-                dataset.Add(_tag, value.ToUpper());
+                dataset.AddOrUpdate(_tag, value.ToUpper());
             }
         }
 
@@ -736,7 +736,7 @@ namespace Dicom
             {
                 dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
                 var value = dataset.Get<string>(_tag, -1, String.Empty);
-                dataset.Add(_tag, value.ToLower());
+                dataset.AddOrUpdate(_tag, value.ToLower());
             }
         }
 
@@ -778,7 +778,7 @@ namespace Dicom
         {
             dataset.CopyTo(modifiedAttributesSequenceItem, _tag);
             var uid = dataset.Get<DicomUID>(_tag);
-            dataset.Add(_tag, _generator.Generate(uid));
+            dataset.AddOrUpdate(_tag, _generator.Generate(uid));
         }
 
         public override string ToString()

--- a/DICOM/DicomUIDGenerator.cs
+++ b/DICOM/DicomUIDGenerator.cs
@@ -95,7 +95,7 @@ namespace Dicom
             foreach (var ui in dataset.Where(x => x.ValueRepresentation == DicomVR.UI).ToArray())
             {
                 var uid = dataset.Get<DicomUID>(ui.Tag);
-                if (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown) dataset.Add(ui.Tag, this.Generate(uid));
+                if (uid.Type == DicomUidType.SOPInstance || uid.Type == DicomUidType.Unknown) dataset.AddOrUpdate(ui.Tag, this.Generate(uid));
             }
 
             foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>().ToArray())

--- a/DICOM/IO/Reader/DicomDatasetReaderObserver.cs
+++ b/DICOM/IO/Reader/DicomDatasetReaderObserver.cs
@@ -147,7 +147,7 @@ namespace Dicom.IO.Reader
             }
 
             DicomDataset ds = _datasets.Peek();
-            ds.Add(element);
+            ds.AddOrUpdate(element);
         }
 
         public void OnBeginSequence(IByteSource source, DicomTag tag, uint length)
@@ -156,7 +156,7 @@ namespace Dicom.IO.Reader
             _sequences.Push(sq);
 
             DicomDataset ds = _datasets.Peek();
-            ds.Add(sq);
+            ds.AddOrUpdate(sq);
         }
 
         public void OnBeginSequenceItem(IByteSource source, uint length)
@@ -190,7 +190,7 @@ namespace Dicom.IO.Reader
             else throw new DicomDataException("Unexpected VR found for DICOM fragment sequence: {0}", vr.Code);
 
             DicomDataset ds = _datasets.Peek();
-            ds.Add(_fragment);
+            ds.AddOrUpdate(_fragment);
         }
 
         public void OnFragmentSequenceItem(IByteSource source, IByteBuffer data)

--- a/DICOM/IO/Writer/DicomDatasetExtensions.cs
+++ b/DICOM/IO/Writer/DicomDatasetExtensions.cs
@@ -29,7 +29,7 @@ namespace Dicom.IO.Writer
             var calculator = new DicomWriteLengthCalculator(dataset.InternalTransferSyntax, DicomWriteOptions.Default);
 
             uint length = calculator.Calculate(items);
-            dataset.Add(new DicomTag(group, 0x0000), length);
+            dataset.AddOrUpdate(new DicomTag(group, 0x0000), length);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Dicom.IO.Writer
                 }
 
                 uint length = calculator.Calculate(items);
-                dataset.Add(new DicomTag(group, 0x0000), length);
+                dataset.AddOrUpdate(new DicomTag(group, 0x0000), length);
             }
         }
 

--- a/DICOM/Imaging/Codec/DicomCodecExtensions.cs
+++ b/DICOM/Imaging/Codec/DicomCodecExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System;
+
 namespace Dicom.Imaging.Codec
 {
     /// <summary>
@@ -15,7 +17,7 @@ namespace Dicom.Imaging.Codec
         /// <param name="syntax">Requested transfer syntax for the created DICOM file.</param>
         /// <param name="parameters">Codec parameters.</param>
         /// <returns>DICOM file with modified transfer syntax.</returns>
-        public static DicomFile ChangeTransferSyntax(
+        public static DicomFile Clone(
             this DicomFile file,
             DicomTransferSyntax syntax,
             DicomCodecParams parameters = null)
@@ -31,13 +33,44 @@ namespace Dicom.Imaging.Codec
         /// <param name="syntax">Requested transfer syntax for the created DICOM dataset.</param>
         /// <param name="parameters">Codec parameters.</param>
         /// <returns>DICOM dataset with modified transfer syntax.</returns>
-        public static DicomDataset ChangeTransferSyntax(
+        public static DicomDataset Clone(
             this DicomDataset dataset,
             DicomTransferSyntax syntax,
             DicomCodecParams parameters = null)
         {
             var transcoder = new DicomTranscoder(dataset.InternalTransferSyntax, syntax, null, parameters);
             return transcoder.Transcode(dataset);
+        }
+        /// <summary>
+        /// Create a copy of the specified DICOM file with requested transfer syntax.
+        /// </summary>
+        /// <param name="file">DICOM file to copy.</param>
+        /// <param name="syntax">Requested transfer syntax for the created DICOM file.</param>
+        /// <param name="parameters">Codec parameters.</param>
+        /// <returns>DICOM file with modified transfer syntax.</returns>
+        [Obsolete("Deprecated, will be removed in later version. Use Clone instead.")]
+        public static DicomFile ChangeTransferSyntax(
+            this DicomFile file,
+            DicomTransferSyntax syntax,
+            DicomCodecParams parameters = null)
+        {
+            return Clone(file, syntax, parameters);
+        }
+
+        /// <summary>
+        /// Create a copy of the specified DICOM dataset with requested transfer syntax.
+        /// </summary>
+        /// <param name="dataset">DICOM dataset to copy.</param>
+        /// <param name="syntax">Requested transfer syntax for the created DICOM dataset.</param>
+        /// <param name="parameters">Codec parameters.</param>
+        /// <returns>DICOM dataset with modified transfer syntax.</returns>
+        [Obsolete("Deprecated, will be removed in later version. Use Clone instead.")]
+        public static DicomDataset ChangeTransferSyntax(
+            this DicomDataset dataset,
+            DicomTransferSyntax syntax,
+            DicomCodecParams parameters = null)
+        {
+            return Clone(dataset, syntax, parameters);
         }
     }
 }

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -243,17 +243,17 @@ namespace Dicom.Imaging.Codec
 
             if (codec.TransferSyntax.IsLossy && newPixelData.NumberOfFrames > 0)
             {
-                newDataset.Add(new DicomCodeString(DicomTag.LossyImageCompression, "01"));
+                newDataset.AddOrUpdate(new DicomCodeString(DicomTag.LossyImageCompression, "01"));
 
                 var methods = new List<string>();
                 if (newDataset.Contains(DicomTag.LossyImageCompressionMethod)) methods.AddRange(newDataset.Get<string[]>(DicomTag.LossyImageCompressionMethod));
                 methods.Add(codec.TransferSyntax.LossyCompressionMethod);
-                newDataset.Add(new DicomCodeString(DicomTag.LossyImageCompressionMethod, methods.ToArray()));
+                newDataset.AddOrUpdate(new DicomCodeString(DicomTag.LossyImageCompressionMethod, methods.ToArray()));
 
                 double oldSize = oldPixelData.GetFrame(0).Size;
                 double newSize = newPixelData.GetFrame(0).Size;
                 var ratio = String.Format("{0:0.000}", oldSize / newSize);
-                newDataset.Add(new DicomDecimalString(DicomTag.LossyImageCompressionRatio, ratio));
+                newDataset.AddOrUpdate(new DicomDecimalString(DicomTag.LossyImageCompressionRatio, ratio));
             }
 
             ProcessOverlays(oldDataset, newDataset);
@@ -276,11 +276,11 @@ namespace Dicom.Imaging.Codec
 
                 // If embedded overlay, Overlay Bits Allocated should equal Bits Allocated (#110).
                 var bitsAlloc = output.Get(DicomTag.BitsAllocated, (ushort)0);
-                output.Add(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), bitsAlloc);
+                output.AddOrUpdate(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), bitsAlloc);
 
                 var data = overlay.Data;
-                if (output.InternalTransferSyntax.IsExplicitVR) output.Add(new DicomOtherByte(dataTag, data));
-                else output.Add(new DicomOtherWord(dataTag, data));
+                if (output.InternalTransferSyntax.IsExplicitVR) output.AddOrUpdate(new DicomOtherByte(dataTag, data));
+                else output.AddOrUpdate(new DicomOtherWord(dataTag, data));
             }
         }
 

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -291,7 +291,7 @@ namespace Dicom.Imaging.Codec
             dataset = dataset.Clone();
 
             var input = dataset;
-            if (input.InternalTransferSyntax.IsEncapsulated) input = input.ChangeTransferSyntax(DicomTransferSyntax.ExplicitVRLittleEndian);
+            if (input.InternalTransferSyntax.IsEncapsulated) input = input.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
 
             ProcessOverlays(input, dataset);
 

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -63,7 +63,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.OverlayRows), (ushort)value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayRows), (ushort)value);
             }
         }
 
@@ -78,7 +78,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.OverlayColumns), (ushort)value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayColumns), (ushort)value);
             }
         }
 
@@ -95,7 +95,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.OverlayType), value.ToString().ToUpper());
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayType), value.ToString().ToUpper());
             }
         }
 
@@ -110,7 +110,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.OverlayBitsAllocated), (ushort)value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayBitsAllocated), (ushort)value);
             }
         }
 
@@ -125,7 +125,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.OverlayBitPosition), (ushort)value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayBitPosition), (ushort)value);
             }
         }
 
@@ -140,7 +140,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(DicomTag.OverlayDescription, value);
+                Dataset.AddOrUpdate(DicomTag.OverlayDescription, value);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(DicomTag.OverlaySubtype, value);
+                Dataset.AddOrUpdate(DicomTag.OverlaySubtype, value);
             }
         }
 
@@ -170,7 +170,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(DicomTag.OverlayLabel, value);
+                Dataset.AddOrUpdate(DicomTag.OverlayLabel, value);
             }
         }
 
@@ -185,7 +185,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.NumberOfFramesInOverlay), value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.NumberOfFramesInOverlay), value);
             }
         }
 
@@ -200,7 +200,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.ImageFrameOrigin), (ushort)value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.ImageFrameOrigin), (ushort)value);
             }
         }
 
@@ -215,7 +215,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginY);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginY);
             }
         }
 
@@ -230,7 +230,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(OverlayTag(DicomTag.OverlayOrigin), (short)OriginX, (short)value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)OriginX, (short)value);
             }
         }
 
@@ -245,7 +245,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomOtherWord(OverlayTag(DicomTag.OverlayData), value));
+                Dataset.AddOrUpdate(new DicomOtherWord(OverlayTag(DicomTag.OverlayData), value));
             }
         }
 

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -59,7 +59,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.Rows, value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.Rows, value));
             }
         }
 
@@ -75,7 +75,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomIntegerString(DicomTag.NumberOfFrames, value));
+                Dataset.AddOrUpdate(new DicomIntegerString(DicomTag.NumberOfFrames, value));
             }
         }
 
@@ -105,7 +105,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.BitsAllocated, value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.BitsAllocated, value));
             }
         }
 
@@ -120,7 +120,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.BitsStored, value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.BitsStored, value));
             }
         }
 
@@ -135,7 +135,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.HighBit, value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.HighBit, value));
             }
         }
 
@@ -150,7 +150,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.SamplesPerPixel, value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.SamplesPerPixel, value));
             }
         }
 
@@ -165,7 +165,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.PixelRepresentation, (ushort)value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.PixelRepresentation, (ushort)value));
             }
         }
 
@@ -181,7 +181,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.PlanarConfiguration, (ushort)value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.PlanarConfiguration, (ushort)value));
             }
         }
 
@@ -196,7 +196,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomCodeString(DicomTag.PhotometricInterpretation, value.Value));
+                Dataset.AddOrUpdate(new DicomCodeString(DicomTag.PhotometricInterpretation, value.Value));
             }
         }
 
@@ -390,7 +390,7 @@ namespace Dicom.Imaging
                 {
                     NumberOfFrames = 0;
                     Element = new DicomOtherByte(DicomTag.PixelData, new CompositeByteBuffer());
-                    Dataset.Add(Element);
+                    Dataset.AddOrUpdate(Element);
                 }
                 else Element = dataset.Get<DicomOtherByte>(DicomTag.PixelData);
             }
@@ -436,7 +436,7 @@ namespace Dicom.Imaging
                 {
                     NumberOfFrames = 0;
                     Element = new DicomOtherWord(DicomTag.PixelData, new CompositeByteBuffer());
-                    Dataset.Add(Element);
+                    Dataset.AddOrUpdate(Element);
                 }
                 else Element = dataset.Get<DicomOtherWord>(DicomTag.PixelData);
             }
@@ -490,7 +490,7 @@ namespace Dicom.Imaging
                 {
                     NumberOfFrames = 0;
                     Element = new DicomOtherByteFragment(DicomTag.PixelData);
-                    Dataset.Add(Element);
+                    Dataset.AddOrUpdate(Element);
                 }
                 else Element = dataset.Get<DicomFragmentSequence>(DicomTag.PixelData);
             }

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -44,7 +44,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.Add(new DicomUnsignedShort(DicomTag.Columns, value));
+                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.Columns, value));
             }
         }
 

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -101,7 +101,7 @@ namespace Dicom.Media
         /// <param name="explicitVr">Indicates whether or not Value Representation of the DICOM directory should be explicit.</param>
         public DicomDirectory(bool explicitVr = true)
         {
-            FileMetaInfo.Add<byte>(DicomTag.FileMetaInformationVersion, 0x00, 0x01);
+            FileMetaInfo.Version = new byte[] { 0x00, 0x01 };
             FileMetaInfo.MediaStorageSOPClassUID = DicomUID.MediaStorageDirectoryStorage;
             FileMetaInfo.MediaStorageSOPInstanceUID = DicomUID.Generate();
             FileMetaInfo.SourceApplicationEntityTitle = string.Empty;

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -52,7 +52,7 @@ namespace Dicom.Media
             {
                 if (!string.IsNullOrEmpty(value?.Trim()))
                 {
-                    Dataset.Add(DicomTag.FileSetID, value);
+                    Dataset.AddOrUpdate(DicomTag.FileSetID, value);
                 }
                 else
                 {
@@ -370,7 +370,7 @@ namespace Dicom.Media
 
                 SetOffsets(RootDirectoryRecord);
 
-                Dataset.Add<uint>(
+                Dataset.AddOrUpdate<uint>(
                     DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity,
                     RootDirectoryRecord.Offset);
 
@@ -378,12 +378,12 @@ namespace Dicom.Media
 
                 while (lastRoot.NextDirectoryRecord != null) lastRoot = lastRoot.NextDirectoryRecord;
 
-                Dataset.Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, lastRoot.Offset);
+                Dataset.AddOrUpdate<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, lastRoot.Offset);
             }
             else
             {
-                Dataset.Add<uint>(DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity, 0);
-                Dataset.Add<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, 0);
+                Dataset.AddOrUpdate<uint>(DicomTag.OffsetOfTheFirstDirectoryRecordOfTheRootDirectoryEntity, 0);
+                Dataset.AddOrUpdate<uint>(DicomTag.OffsetOfTheLastDirectoryRecordOfTheRootDirectoryEntity, 0);
             }
         }
 
@@ -414,24 +414,24 @@ namespace Dicom.Media
         {
             if (record.NextDirectoryRecord != null)
             {
-                record.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, record.NextDirectoryRecord.Offset);
+                record.AddOrUpdate<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, record.NextDirectoryRecord.Offset);
                 SetOffsets(record.NextDirectoryRecord);
             }
             else
             {
-                record.Add<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, 0);
+                record.AddOrUpdate<uint>(DicomTag.OffsetOfTheNextDirectoryRecord, 0);
             }
 
             if (record.LowerLevelDirectoryRecord != null)
             {
-                record.Add<uint>(
+                record.AddOrUpdate<uint>(
                     DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity,
                     record.LowerLevelDirectoryRecord.Offset);
                 SetOffsets(record.LowerLevelDirectoryRecord);
             }
             else
             {
-                record.Add<uint>(DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity, 0);
+                record.AddOrUpdate<uint>(DicomTag.OffsetOfReferencedLowerLevelDirectoryEntity, 0);
             }
         }
 
@@ -487,10 +487,10 @@ namespace Dicom.Media
                 }
             }
             var newImage = CreateRecordSequenceItem(DicomDirectoryRecordType.Image, dataset);
-            newImage.Add(DicomTag.ReferencedFileID, referencedFileId);
-            newImage.Add(DicomTag.ReferencedSOPClassUIDInFile, metaFileInfo.MediaStorageSOPClassUID.UID);
-            newImage.Add(DicomTag.ReferencedSOPInstanceUIDInFile, metaFileInfo.MediaStorageSOPInstanceUID.UID);
-            newImage.Add(DicomTag.ReferencedTransferSyntaxUIDInFile, metaFileInfo.TransferSyntax.UID);
+            newImage.AddOrUpdate(DicomTag.ReferencedFileID, referencedFileId);
+            newImage.AddOrUpdate(DicomTag.ReferencedSOPClassUIDInFile, metaFileInfo.MediaStorageSOPClassUID.UID);
+            newImage.AddOrUpdate(DicomTag.ReferencedSOPInstanceUIDInFile, metaFileInfo.MediaStorageSOPInstanceUID.UID);
+            newImage.AddOrUpdate(DicomTag.ReferencedTransferSyntaxUIDInFile, metaFileInfo.TransferSyntax.UID);
 
             if (currentImage != null)
             {

--- a/DICOM/Network/DicomCFindResponse.cs
+++ b/DICOM/Network/DicomCFindResponse.cs
@@ -26,7 +26,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
             }
         }
 
@@ -38,7 +38,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
             }
         }
 
@@ -50,7 +50,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfWarningSuboperations, (ushort)value);
             }
         }
 
@@ -62,7 +62,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfFailedSuboperations, (ushort)value);
             }
         }
 

--- a/DICOM/Network/DicomCGetResponse.cs
+++ b/DICOM/Network/DicomCGetResponse.cs
@@ -53,7 +53,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
             }
         }
 
@@ -68,7 +68,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfWarningSuboperations, (ushort)value);
             }
         }
 
@@ -98,7 +98,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfFailedSuboperations, (ushort)value);
             }
         }
 

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -73,7 +73,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.MoveDestination, value);
+                Command.AddOrUpdate(DicomTag.MoveDestination, value);
             }
         }
 

--- a/DICOM/Network/DicomCMoveResponse.cs
+++ b/DICOM/Network/DicomCMoveResponse.cs
@@ -26,7 +26,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfRemainingSuboperations, (ushort)value);
             }
         }
 
@@ -38,7 +38,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfCompletedSuboperations, (ushort)value);
             }
         }
 
@@ -50,7 +50,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfWarningSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfWarningSuboperations, (ushort)value);
             }
         }
 
@@ -62,7 +62,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.NumberOfFailedSuboperations, (ushort)value);
+                Command.AddOrUpdate(DicomTag.NumberOfFailedSuboperations, (ushort)value);
             }
         }
 

--- a/DICOM/Network/DicomCStoreRequest.cs
+++ b/DICOM/Network/DicomCStoreRequest.cs
@@ -79,7 +79,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
 

--- a/DICOM/Network/DicomMessage.cs
+++ b/DICOM/Network/DicomMessage.cs
@@ -43,7 +43,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.CommandField, (ushort)value);
+                Command.AddOrUpdate(DicomTag.CommandField, (ushort)value);
             }
         }
 
@@ -73,10 +73,10 @@ namespace Dicom.Network
                     case DicomCommandField.NSetRequest:
                     case DicomCommandField.NActionRequest:
                     case DicomCommandField.NDeleteRequest:
-                        Command.Add(DicomTag.RequestedSOPClassUID, value);
+                        Command.AddOrUpdate(DicomTag.RequestedSOPClassUID, value);
                         break;
                     default:
-                        Command.Add(DicomTag.AffectedSOPClassUID, value);
+                        Command.AddOrUpdate(DicomTag.AffectedSOPClassUID, value);
                         break;
                 }
             }
@@ -118,7 +118,7 @@ namespace Dicom.Network
             set
             {
                 _dataset = value;
-                Command.Add(DicomTag.CommandDataSetType, (_dataset != null) ? (ushort)0x0202 : (ushort)0x0101);
+                Command.AddOrUpdate(DicomTag.CommandDataSetType, (_dataset != null) ? (ushort)0x0202 : (ushort)0x0101);
             }
         }
 

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -30,7 +30,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.ActionTypeID, value);
+                Command.AddOrUpdate(DicomTag.ActionTypeID, value);
             }
         }
 

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -59,7 +59,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
 
@@ -74,7 +74,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.ActionTypeID, value);
+                Command.AddOrUpdate(DicomTag.ActionTypeID, value);
             }
         }
 

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -26,7 +26,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 

--- a/DICOM/Network/DicomNCreateResponse.cs
+++ b/DICOM/Network/DicomNCreateResponse.cs
@@ -23,7 +23,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
     }

--- a/DICOM/Network/DicomNDeleteRequest.cs
+++ b/DICOM/Network/DicomNDeleteRequest.cs
@@ -26,7 +26,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 

--- a/DICOM/Network/DicomNDeleteResponse.cs
+++ b/DICOM/Network/DicomNDeleteResponse.cs
@@ -23,7 +23,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
     }

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -30,7 +30,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.EventTypeID, value);
+                Command.AddOrUpdate(DicomTag.EventTypeID, value);
             }
         }
 

--- a/DICOM/Network/DicomNEventReportResponse.cs
+++ b/DICOM/Network/DicomNEventReportResponse.cs
@@ -59,7 +59,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
 
@@ -74,7 +74,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.EventTypeID, value);
+                Command.AddOrUpdate(DicomTag.EventTypeID, value);
             }
         }
 

--- a/DICOM/Network/DicomNGetRequest.cs
+++ b/DICOM/Network/DicomNGetRequest.cs
@@ -26,7 +26,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 
@@ -38,7 +38,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AttributeIdentifierList, value);
+                Command.AddOrUpdate(DicomTag.AttributeIdentifierList, value);
             }
         }
 

--- a/DICOM/Network/DicomNGetResponse.cs
+++ b/DICOM/Network/DicomNGetResponse.cs
@@ -24,7 +24,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
     }

--- a/DICOM/Network/DicomNSetRequest.cs
+++ b/DICOM/Network/DicomNSetRequest.cs
@@ -26,7 +26,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.RequestedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
             }
         }
 

--- a/DICOM/Network/DicomNSetResponse.cs
+++ b/DICOM/Network/DicomNSetResponse.cs
@@ -24,7 +24,7 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.Add(DicomTag.AffectedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
     }

--- a/DICOM/Network/DicomPriorityRequest.cs
+++ b/DICOM/Network/DicomPriorityRequest.cs
@@ -24,7 +24,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.Priority, (ushort)value);
+                Command.AddOrUpdate(DicomTag.Priority, (ushort)value);
             }
         }
     }

--- a/DICOM/Network/DicomRequest.cs
+++ b/DICOM/Network/DicomRequest.cs
@@ -59,7 +59,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.MessageID, value);
+                Command.AddOrUpdate(DicomTag.MessageID, value);
             }
         }
 

--- a/DICOM/Network/DicomResponse.cs
+++ b/DICOM/Network/DicomResponse.cs
@@ -52,7 +52,7 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.MessageIDBeingRespondedTo, value);
+                Command.AddOrUpdate(DicomTag.MessageIDBeingRespondedTo, value);
             }
         }
 
@@ -70,8 +70,8 @@ namespace Dicom.Network
             }
             set
             {
-                Command.Add(DicomTag.Status, value.Code);
-                Command.Add(DicomTag.ErrorComment, value.ErrorComment);
+                Command.AddOrUpdate(DicomTag.Status, value.Code);
+                Command.AddOrUpdate(DicomTag.ErrorComment, value.ErrorComment);
             }
         }
 

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -1059,7 +1059,7 @@ namespace Dicom.Network
 
                         if (msg.Dataset.InternalTransferSyntax != dimse.PresentationContext.AcceptedTransferSyntax)
                             msg.Dataset =
-                                msg.Dataset.ChangeTransferSyntax(dimse.PresentationContext.AcceptedTransferSyntax);
+                                msg.Dataset.Clone(dimse.PresentationContext.AcceptedTransferSyntax);
                     }
 
                     Logger.Info("{logId} -> {dicomMessage}", LogID, msg.ToString(Options.LogDimseDatasets));

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -107,7 +107,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.ImageDisplayFormat, value);
+                this.AddOrUpdate(DicomTag.ImageDisplayFormat, value);
             }
         }
 
@@ -135,7 +135,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.FilmOrientation, value);
+                this.AddOrUpdate(DicomTag.FilmOrientation, value);
             }
         }
 
@@ -172,7 +172,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.FilmSizeID, value);
+                this.AddOrUpdate(DicomTag.FilmSizeID, value);
             }
         }
 
@@ -197,7 +197,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MagnificationType, value);
+                this.AddOrUpdate(DicomTag.MagnificationType, value);
             }
         }
 
@@ -213,7 +213,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MaxDensity, value);
+                this.AddOrUpdate(DicomTag.MaxDensity, value);
             }
         }
 
@@ -230,7 +230,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MinDensity, value);
+                this.AddOrUpdate(DicomTag.MinDensity, value);
             }
         }
 
@@ -261,7 +261,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.ConfigurationInformation, value);
+                this.AddOrUpdate(DicomTag.ConfigurationInformation, value);
             }
         }
 
@@ -278,7 +278,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.AnnotationDisplayFormatID, value);
+                this.AddOrUpdate(DicomTag.AnnotationDisplayFormatID, value);
             }
         }
 
@@ -294,7 +294,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.SmoothingType, value);
+                this.AddOrUpdate(DicomTag.SmoothingType, value);
             }
         }
 
@@ -321,7 +321,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.BorderDensity, value);
+                this.AddOrUpdate(DicomTag.BorderDensity, value);
             }
         }
 
@@ -348,7 +348,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.EmptyImageDensity, value);
+                this.AddOrUpdate(DicomTag.EmptyImageDensity, value);
             }
         }
 
@@ -370,7 +370,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.Trim, value);
+                this.AddOrUpdate(DicomTag.Trim, value);
             }
         }
 
@@ -387,7 +387,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.Illumination, value);
+                this.AddOrUpdate(DicomTag.Illumination, value);
             }
         }
 
@@ -403,7 +403,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.ReflectedAmbientLight, value);
+                this.AddOrUpdate(DicomTag.ReflectedAmbientLight, value);
             }
         }
 
@@ -431,7 +431,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.RequestedResolutionID, value);
+                this.AddOrUpdate(DicomTag.RequestedResolutionID, value);
             }
         }
 
@@ -443,7 +443,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(value);
+                this.AddOrUpdate(value);
             }
         }
 

--- a/DICOM/Printing/FilmSession.cs
+++ b/DICOM/Printing/FilmSession.cs
@@ -56,7 +56,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.FilmDestination, value);
+                this.AddOrUpdate(DicomTag.FilmDestination, value);
             }
         }
 
@@ -68,7 +68,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.FilmSessionLabel, value);
+                this.AddOrUpdate(DicomTag.FilmSessionLabel, value);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MemoryAllocation, value);
+                this.AddOrUpdate(DicomTag.MemoryAllocation, value);
             }
         }
 
@@ -108,7 +108,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MediumType, value);
+                this.AddOrUpdate(DicomTag.MediumType, value);
             }
         }
 
@@ -131,7 +131,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.PrintPriority, value);
+                this.AddOrUpdate(DicomTag.PrintPriority, value);
             }
         }
 
@@ -146,7 +146,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.NumberOfCopies, value);
+                this.AddOrUpdate(DicomTag.NumberOfCopies, value);
             }
         }
 

--- a/DICOM/Printing/ImageBox.cs
+++ b/DICOM/Printing/ImageBox.cs
@@ -68,12 +68,11 @@ namespace Dicom.Printing
             {
                 if (SOPClassUID == ColorSOPClassUID)
                 {
-                    this.Add(DicomTag.BasicColorImageSequence, value);
+                    this.AddOrUpdate(DicomTag.BasicColorImageSequence, value);
                 }
                 else
                 {
-                    this.Add(DicomTag.BasicGrayscaleImageSequence, value);
-
+                    this.AddOrUpdate(DicomTag.BasicGrayscaleImageSequence, value);
                 }
             }
         }
@@ -89,7 +88,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.ImageBoxPosition, value);
+                this.AddOrUpdate(DicomTag.ImageBoxPosition, value);
             }
         }
 
@@ -119,7 +118,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.Polarity, value);
+                this.AddOrUpdate(DicomTag.Polarity, value);
             }
         }
 
@@ -144,7 +143,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MagnificationType, value);
+                this.AddOrUpdate(DicomTag.MagnificationType, value);
             }
         }
 
@@ -160,7 +159,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.SmoothingType, value);
+                this.AddOrUpdate(DicomTag.SmoothingType, value);
             }
         }
 
@@ -176,7 +175,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MaxDensity, value);
+                this.AddOrUpdate(DicomTag.MaxDensity, value);
             }
         }
 
@@ -192,7 +191,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.MinDensity, value);
+                this.AddOrUpdate(DicomTag.MinDensity, value);
             }
         }
 
@@ -221,7 +220,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.ConfigurationInformation, value);
+                this.AddOrUpdate(DicomTag.ConfigurationInformation, value);
             }
         }
 
@@ -237,7 +236,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.RequestedImageSize, value);
+                this.AddOrUpdate(DicomTag.RequestedImageSize, value);
             }
         }
 
@@ -277,7 +276,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.RequestedDecimateCropBehavior, value);
+                this.AddOrUpdate(DicomTag.RequestedDecimateCropBehavior, value);
             }
         }
 

--- a/DICOM/Printing/PresentationLut.cs
+++ b/DICOM/Printing/PresentationLut.cs
@@ -45,7 +45,7 @@ namespace Dicom.Printing
             {
                 if (LutSequence != null)
                 {
-                    LutSequence.Add(DicomTag.LUTDescriptor, value);
+                    LutSequence.AddOrUpdate(DicomTag.LUTDescriptor, value);
                 }
                 else
                 {
@@ -71,7 +71,7 @@ namespace Dicom.Printing
             {
                 if (LutSequence != null)
                 {
-                    LutSequence.Add(DicomTag.LUTDescriptor, value);
+                    LutSequence.AddOrUpdate(DicomTag.LUTDescriptor, value);
                 }
                 else
                 {
@@ -97,7 +97,7 @@ namespace Dicom.Printing
             {
                 if (LutSequence != null)
                 {
-                    LutSequence.Add(DicomTag.LUTData, value);
+                    LutSequence.AddOrUpdate(DicomTag.LUTData, value);
                 }
                 else
                 {
@@ -114,7 +114,7 @@ namespace Dicom.Printing
             }
             set
             {
-                this.Add(DicomTag.PresentationLUTShape, value);
+                this.AddOrUpdate(DicomTag.PresentationLUTShape, value);
             }
         }
 

--- a/DICOM/StructuredReport/DicomContentItem.cs
+++ b/DICOM/StructuredReport/DicomContentItem.cs
@@ -367,7 +367,7 @@ namespace Dicom.StructuredReport
             if (sequence == null)
             {
                 sequence = new DicomSequence(DicomTag.ContentSequence);
-                Dataset.AddOrUpdate(sequence);
+                Dataset.Add(sequence);
             }
 
             sequence.Items.Add(item.Dataset);

--- a/DICOM/StructuredReport/DicomContentItem.cs
+++ b/DICOM/StructuredReport/DicomContentItem.cs
@@ -187,7 +187,7 @@ namespace Dicom.StructuredReport
             }
             private set
             {
-                Dataset.Add(DicomTag.ConceptNameCodeSequence, value);
+                Dataset.AddOrUpdate(DicomTag.ConceptNameCodeSequence, value);
             }
         }
 
@@ -235,46 +235,46 @@ namespace Dicom.StructuredReport
                 switch (value)
                 {
                     case DicomValueType.Container:
-                        Dataset.Add(DicomTag.ValueType, "CONTAINER");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "CONTAINER");
                         return;
                     case DicomValueType.Text:
-                        Dataset.Add(DicomTag.ValueType, "TEXT");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "TEXT");
                         return;
                     case DicomValueType.Code:
-                        Dataset.Add(DicomTag.ValueType, "CODE");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "CODE");
                         return;
                     case DicomValueType.Numeric:
-                        Dataset.Add(DicomTag.ValueType, "NUM");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "NUM");
                         return;
                     case DicomValueType.PersonName:
-                        Dataset.Add(DicomTag.ValueType, "PNAME");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "PNAME");
                         return;
                     case DicomValueType.Date:
-                        Dataset.Add(DicomTag.ValueType, "DATE");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "DATE");
                         return;
                     case DicomValueType.Time:
-                        Dataset.Add(DicomTag.ValueType, "TIME");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "TIME");
                         return;
                     case DicomValueType.DateTime:
-                        Dataset.Add(DicomTag.ValueType, "DATETIME");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "DATETIME");
                         return;
                     case DicomValueType.UIDReference:
-                        Dataset.Add(DicomTag.ValueType, "UIDREF");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "UIDREF");
                         return;
                     case DicomValueType.Composite:
-                        Dataset.Add(DicomTag.ValueType, "COMPOSITE");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "COMPOSITE");
                         return;
                     case DicomValueType.Image:
-                        Dataset.Add(DicomTag.ValueType, "IMAGE");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "IMAGE");
                         return;
                     case DicomValueType.Waveform:
-                        Dataset.Add(DicomTag.ValueType, "WAVEFORM");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "WAVEFORM");
                         return;
                     case DicomValueType.SpatialCoordinate:
-                        Dataset.Add(DicomTag.ValueType, "SCOORD");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "SCOORD");
                         return;
                     case DicomValueType.TemporalCoordinate:
-                        Dataset.Add(DicomTag.ValueType, "TCOORD");
+                        Dataset.AddOrUpdate(DicomTag.ValueType, "TCOORD");
                         return;
                     default:
                         break;
@@ -312,25 +312,25 @@ namespace Dicom.StructuredReport
                 switch (value)
                 {
                     case DicomRelationship.Contains:
-                        Dataset.Add(DicomTag.RelationshipType, "CONTAINS");
+                        Dataset.AddOrUpdate(DicomTag.RelationshipType, "CONTAINS");
                         return;
                     case DicomRelationship.HasProperties:
-                        Dataset.Add(DicomTag.RelationshipType, "HAS PROPERTIES");
+                        Dataset.AddOrUpdate(DicomTag.RelationshipType, "HAS PROPERTIES");
                         return;
                     case DicomRelationship.InferredFrom:
-                        Dataset.Add(DicomTag.RelationshipType, "INFERRED FROM");
+                        Dataset.AddOrUpdate(DicomTag.RelationshipType, "INFERRED FROM");
                         return;
                     case DicomRelationship.SelectedFrom:
-                        Dataset.Add(DicomTag.RelationshipType, "SELECTED FROM");
+                        Dataset.AddOrUpdate(DicomTag.RelationshipType, "SELECTED FROM");
                         return;
                     case DicomRelationship.HasObservationContext:
-                        Dataset.Add(DicomTag.RelationshipType, "HAS OBS CONTEXT");
+                        Dataset.AddOrUpdate(DicomTag.RelationshipType, "HAS OBS CONTEXT");
                         return;
                     case DicomRelationship.HasAcquisitionContext:
-                        Dataset.Add(DicomTag.RelationshipType, "HAS ACQ CONTEXT");
+                        Dataset.AddOrUpdate(DicomTag.RelationshipType, "HAS ACQ CONTEXT");
                         return;
                     case DicomRelationship.HasConceptModifier:
-                        Dataset.Add(DicomTag.RelationshipType, "HAS CONCEPT MOD");
+                        Dataset.AddOrUpdate(DicomTag.RelationshipType, "HAS CONCEPT MOD");
                         return;
                     default:
                         break;
@@ -346,7 +346,7 @@ namespace Dicom.StructuredReport
             }
             private set
             {
-                Dataset.Add(DicomTag.ContinuityOfContent, value.ToString().ToUpper());
+                Dataset.AddOrUpdate(DicomTag.ContinuityOfContent, value.ToString().ToUpper());
             }
         }
 
@@ -367,7 +367,7 @@ namespace Dicom.StructuredReport
             if (sequence == null)
             {
                 sequence = new DicomSequence(DicomTag.ContentSequence);
-                Dataset.Add(sequence);
+                Dataset.AddOrUpdate(sequence);
             }
 
             sequence.Items.Add(item.Dataset);

--- a/Tests/Bugs/GH227.cs
+++ b/Tests/Bugs/GH227.cs
@@ -38,7 +38,7 @@ namespace Dicom.Bugs
         {
             var deflated =
                 DicomFile.Open(@"Test Data\CT-MONO2-16-ankle")
-                    .ChangeTransferSyntax(DicomTransferSyntax.DeflatedExplicitVRLittleEndian);
+                    .Clone(DicomTransferSyntax.DeflatedExplicitVRLittleEndian);
 
             using (var stream = new MemoryStream())
             {
@@ -57,7 +57,7 @@ namespace Dicom.Bugs
         {
             var deflated =
                 DicomFile.Open(@"Test Data\CT-MONO2-16-ankle")
-                    .ChangeTransferSyntax(DicomTransferSyntax.DeflatedExplicitVRLittleEndian);
+                    .Clone(DicomTransferSyntax.DeflatedExplicitVRLittleEndian);
 
             using (var stream = new MemoryStream())
             {

--- a/Tests/DicomDatasetTest.cs
+++ b/Tests/DicomDatasetTest.cs
@@ -278,10 +278,10 @@ namespace Dicom
             ds.Add(new DicomSequence(DicomTag.ScheduledProcedureStepSequence, sps));
 
             var ds2 = new DicomDataset(ds);
-            ds2.Add(DicomTag.PatientID, "2");
-            ds2.Get<DicomSequence>(DicomTag.ScheduledProcedureStepSequence).Items[0].Add(DicomTag.ScheduledStationName, "2");
+            ds2.AddOrUpdate(DicomTag.PatientID, "2");
+            ds2.Get<DicomSequence>(DicomTag.ScheduledProcedureStepSequence).Items[0].AddOrUpdate(DicomTag.ScheduledStationName, "2");
             ds2.Get<DicomSequence>(DicomTag.ScheduledProcedureStepSequence).Items[0].Get<DicomSequence>(
-                DicomTag.ScheduledProtocolCodeSequence).Items[0].Add(DicomTag.ContextIdentifier, "2");
+                DicomTag.ScheduledProtocolCodeSequence).Items[0].AddOrUpdate(DicomTag.ContextIdentifier, "2");
 
             Assert.Equal("1", ds.Get<string>(DicomTag.PatientID));
             Assert.Equal(
@@ -335,7 +335,7 @@ namespace Dicom
             }
 
 
-            ds.Add(element.Tag, stringValues);
+            ds.AddOrUpdate(element.Tag, stringValues);
 
 
             for (int index = 0; index < element.Count; index++)
@@ -351,7 +351,7 @@ namespace Dicom
             {
                 var stringValue = string.Join("\\", testValues);
 
-                ds.Add(element.Tag, stringValue);
+                ds.AddOrUpdate(element.Tag, stringValue);
 
                 for (int index = 0; index < element.Count; index++)
                 {

--- a/Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -16,7 +16,7 @@ namespace Dicom.Imaging.Codec
             var exception =
                 Record.Exception(
                     () =>
-                    file.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess14, new DicomJpegParams { Quality = 50 }));
+                    file.Clone(DicomTransferSyntax.JPEGProcess14, new DicomJpegParams { Quality = 50 }));
             Assert.Null(exception);
         }
 
@@ -27,7 +27,7 @@ namespace Dicom.Imaging.Codec
             var exception =
                 Record.Exception(
                     () =>
-                    file.Dataset.ChangeTransferSyntax(DicomTransferSyntax.JPEGProcess14, new DicomJpegParams { Quality = 50 }));
+                    file.Dataset.Clone(DicomTransferSyntax.JPEGProcess14, new DicomJpegParams { Quality = 50 }));
             Assert.Null(exception);
         }
 

--- a/Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Serialization/JsonDicomConverterTest.cs
@@ -310,7 +310,6 @@ namespace Dicom.Serialization
         {
             var privateCreator = DicomDictionary.Default.GetPrivateCreator("TEST");
             return new DicomDataset {
-                           new DicomLongString(new DicomTag(3, 0x0010, privateCreator), privateCreator.Creator),
                            new DicomApplicationEntity(new DicomTag(3, 0x1002, privateCreator), "AETITLE"),
                            new DicomAgeString(new DicomTag(3, 0x1003, privateCreator), "34y"),
                            new DicomAttributeTag(new DicomTag(3, 0x1004, privateCreator), new[] { DicomTag.SOPInstanceUID }),
@@ -351,7 +350,6 @@ namespace Dicom.Serialization
         {
             var privateCreator = DicomDictionary.Default.GetPrivateCreator("TEST");
             return new DicomDataset {
-                           new DicomLongString(new DicomTag(3, 0x0010, privateCreator), privateCreator.Creator),
                            new DicomApplicationEntity(new DicomTag(3, 0x1002, privateCreator)),
                            new DicomAgeString(new DicomTag(3, 0x1003, privateCreator)),
                            new DicomAttributeTag(new DicomTag(3, 0x1004, privateCreator)),

--- a/Tools/DICOM Dump/MainForm.cs
+++ b/Tools/DICOM Dump/MainForm.cs
@@ -340,7 +340,7 @@ namespace Dicom.Dump
 
         private void ChangeSyntax(DicomTransferSyntax syntax, DicomCodecParams param = null)
         {
-            var file = _file.ChangeTransferSyntax(syntax, param);
+            var file = _file.Clone(syntax, param);
             OpenFile(file);
         }
 


### PR DESCRIPTION
Fixes #330 .

Changes proposed in this pull request:

- Changed functionality of `DicomDataset.Add` overloads to only allow pure adding; when trying to add an already existing tag with `DicomDataset.Add`, the method(s) will now throw.
- Added matching `DicomDataset.AddOrUpdate` methods to provide the same function as `Add` did before this change, i.e. the tag is added if not existing in the dataset, and its data is updated if the tag is already existing in the dataset.
- The extension methods `ChangeTransferSyntax(this DicomDataset/DicomFile, DicomTransferSyntax, DicomCodecParameters)` have been replaced with `Clone`, using the same signatures. For backwards compatibility, `ChangeTransferSyntax` overloads are maintained but marked obsolete.
- Code using `DicomDataset.Add` has been updated where appropriate to instead use `DicomDataset.AddOrUpdate`. Where functionality is evidently purely to add a new tag to the dataset, `DicomDataset.Add` is used for clarity.

These changes have been implemented primarily to clarify intent. Many questions on the community forums concern these two method overloads, like "how do I update an existing tag", or "the transfer syntax of my DicomFile is not changed after calling ChangeTransferSyntax". With these name changes we hope to reduce these basic questions to a minimum.

Please note that the functional change of `DicomDataset.Add` might have substantial impact on third-party code. Therefore it is important that the PR is review both from a correctness and from an applicability point of view.