### PR TITLE
Correctly handle comparison of private tags. Connected to #319

### DIFF
--- a/DICOM/DicomTag.cs
+++ b/DICOM/DicomTag.cs
@@ -107,8 +107,6 @@ namespace Dicom
         {
             if (Group != other.Group) return Group.CompareTo(other.Group);
 
-            if (Element != other.Element) return Element.CompareTo(other.Element);
-
             // sort by private creator only if element values are equal
             if (PrivateCreator != null || other.PrivateCreator != null)
             {
@@ -116,9 +114,11 @@ namespace Dicom
                 if (other.PrivateCreator == null) return 1;
 
                 if (PrivateCreator != other.PrivateCreator) return PrivateCreator.CompareTo(other.PrivateCreator);
+
+                return (Element & 0xff).CompareTo(other.Element & 0xff);
             }
 
-            return 0;
+            return Element.CompareTo(other.Element);
         }
 
         public int CompareTo(object obj)

--- a/Tests/Bugs/GH319.cs
+++ b/Tests/Bugs/GH319.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Xunit;
+
+namespace Dicom.Bugs
+{
+    public class GH319
+    {
+        [Fact]
+        public void Contains_PrivateTag_SufficientlyFound()
+        {
+            var dataset = new DicomDataset();
+            dataset.Add(new DicomTag(0x0021, 0x0010, "TEST"), "TEST");
+            var found = dataset.Contains(new DicomTag(0x0021, 0x0010, "TEST"));
+            Assert.True(found);
+        }
+    }
+}

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Bugs\GH319.cs" />
     <Compile Include="Bugs\GH340.cs" />
     <Compile Include="Bugs\GH342.cs" />
     <Compile Include="Bugs\GH227.cs" />

--- a/Tests/DicomTagTest.cs
+++ b/Tests/DicomTagTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Collections.Generic;
+
 namespace Dicom
 {
     using System;
@@ -14,6 +16,8 @@ namespace Dicom
     [Collection("General")]
     public class DicomTagTest
     {
+        #region Unit tests
+
         /// <summary>
         ///     A test for ToString
         /// </summary>
@@ -30,5 +34,47 @@ namespace Dicom
             actual = target.ToString(format, formatProvider);
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [MemberData(nameof(DoesContain))]
+        public void Contains_Existing_ReturnsTrue(DicomTag tag)
+        {
+            var dataset = new DicomDataset { new DicomUnknown(tag) };
+            Assert.True(dataset.Contains(tag));
+        }
+
+        [Theory]
+        [MemberData(nameof(DoesNotContain))]
+        public void Contains_NonExisting_ReturnsFalse(DicomTag datasetTag, DicomTag containsTag)
+        {
+            var dataset = new DicomDataset { new DicomUnknown(datasetTag) };
+            Assert.False(dataset.Contains(containsTag));
+        }
+
+        [Fact]
+        public void Contains_SamePrivateTagsDifferentPrivateCreator_ReturnsTrue()
+        {
+            var dataset = new DicomDataset { new DicomUnknown(new DicomTag(0x3005, 0x3025, "PRIVATE")) };
+            Assert.True(dataset.Contains(new DicomTag(0x3005, 0x1525, "PRIVATE")));
+        }
+
+        #endregion
+
+        #region Test data
+
+        public static readonly IEnumerable<object[]> DoesContain = new[]
+                                                                 {
+                                                                     new[] { DicomTag.BitsAllocated },
+                                                                     new[] { DicomTag.AcquisitionContextSequence },
+                                                                     new[] { new DicomTag(0x3005, 0x25, "PRIVATE") }
+                                                                 };
+
+        public static readonly IEnumerable<object[]> DoesNotContain = new[]
+                                                                 {
+                                                                     new[] { DicomTag.BitsAllocated, DicomTag.BitsStored },
+                                                                     new[] { new DicomTag(0x3005, 0x25, "PRIVATE"), new DicomTag(0x3005, 0x26, "PRIVATE") }
+                                                                 };
+
+        #endregion
     }
 }

--- a/Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Serialization/JsonDicomConverterTest.cs
@@ -329,7 +329,7 @@ namespace Dicom.Serialization
                            new DicomOtherWord(new DicomTag(3, 0x1011, privateCreator), new ushort[] { 0xffff, 0x0000, 0x1234 }),
                            new DicomPersonName(new DicomTag(3, 0x1012, privateCreator), "Morrison-Jones^Susan^^^Ph.D."),
                            new DicomShortString(new DicomTag(3, 0x1013, privateCreator), "顔文字"),
-                           new DicomSignedLong(new DicomTag(3, 0x1104, privateCreator), -65538),
+                           new DicomSignedLong(new DicomTag(3, 0x1001, privateCreator), -65538),
                            new DicomSequence(new DicomTag(3, 0x1015, privateCreator), new [] {
                              new DicomDataset { new DicomShortText(new DicomTag(3, 0x1016, privateCreator), "ಠ_ಠ") }
                            }),
@@ -369,7 +369,7 @@ namespace Dicom.Serialization
                            new DicomOtherWord(new DicomTag(3, 0x1011, privateCreator), new ushort[0]),
                            new DicomPersonName(new DicomTag(3, 0x1012, privateCreator)),
                            new DicomShortString(new DicomTag(3, 0x1013, privateCreator)),
-                           new DicomSignedLong(new DicomTag(3, 0x1104, privateCreator)),
+                           new DicomSignedLong(new DicomTag(3, 0x1001, privateCreator)),
                            new DicomSequence(new DicomTag(3, 0x1015, privateCreator)),
                            new DicomSignedShort(new DicomTag(3, 0x1017, privateCreator)),
                            new DicomShortText(new DicomTag(3, 0x1018, privateCreator), null),


### PR DESCRIPTION
Fixes #319 .

Changes proposed in this pull request:
- `DicomTag.CompareTo` has been synchronized with `DicomTag.Equals` such that only the lower byte in the tag element is compared when tag is private.
