### PR TITLE
Added RemoteHost and RemotePort to the networkstream interface

### DIFF
--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -14,7 +14,7 @@ namespace Dicom.Network
     /// <summary>
     /// .NET implementation of <see cref="INetworkStream"/>.
     /// </summary>
-    public sealed class DesktopNetworkStream : INetworkStream
+    public class DesktopNetworkStream : INetworkStream
     {
         #region FIELDS
 
@@ -74,9 +74,11 @@ namespace Dicom.Network
         /// disposal. Therefore, a handle to <paramref name="tcpClient"/> is <em>not</em> stored when <see cref="DesktopNetworkStream"/>
         /// is initialized with this server-side constructor.</remarks>
         internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate)
-        {
-            this.Host = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
-            this.Port = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Port;
+        {            
+			this.Host = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Address.ToString(); ;
+            this.Port = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Port;
+            this.RemoteHost = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
+            this.RemotePort = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Port;			
 
             Stream stream = tcpClient.GetStream();
             if (certificate != null)
@@ -109,12 +111,12 @@ namespace Dicom.Network
         /// Gets the host of the network stream.
         /// </summary>
         public string Host { get; }
-
+		public string RemoteHost { get; }
         /// <summary>
         /// Gets the port of the network stream.
         /// </summary>
         public int Port { get; }
-
+		public int RemotePort { get; }
         #endregion
 
         #region METHODS

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -38,8 +38,8 @@ namespace Dicom.Network
         /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
         internal DesktopNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
-            this.Host = host;
-            this.Port = port;
+            this.RemoteHost = host;
+            this.RemotePort = port;
 #if NETSTANDARD
             this.tcpClient = new TcpClient { NoDelay = noDelay };
             this.tcpClient.ConnectAsync(host, port).Wait();
@@ -75,8 +75,8 @@ namespace Dicom.Network
         /// is initialized with this server-side constructor.</remarks>
         internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate)
         {            
-			this.Host = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Address.ToString(); ;
-            this.Port = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Port;
+			this.LocalHost = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Address.ToString(); ;
+            this.LocalPort = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Port;
             this.RemoteHost = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
             this.RemotePort = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Port;			
 
@@ -110,12 +110,12 @@ namespace Dicom.Network
         /// <summary>
         /// Gets the host of the network stream.
         /// </summary>
-        public string Host { get; }
+        public string LocalHost { get; }
 		public string RemoteHost { get; }
         /// <summary>
         /// Gets the port of the network stream.
         /// </summary>
-        public int Port { get; }
+        public int LocalPort { get; }
 		public int RemotePort { get; }
         #endregion
 

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -108,15 +108,25 @@ namespace Dicom.Network
         #region PROPERTIES
 
         /// <summary>
-        /// Gets the host of the network stream.
+        /// Gets the remote host of the network stream.
+        /// </summary>
+		public string RemoteHost { get; }
+
+        /// <summary>
+        /// Gets the local host of the network stream.
         /// </summary>
         public string LocalHost { get; }
-		public string RemoteHost { get; }
+
         /// <summary>
-        /// Gets the port of the network stream.
+        /// Gets the remote port of the network stream.
+        /// </summary>
+        public int RemotePort { get; }
+
+        /// <summary>
+        /// Gets the local port of the network stream.
         /// </summary>
         public int LocalPort { get; }
-		public int RemotePort { get; }
+		
         #endregion
 
         #region METHODS

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -222,8 +222,8 @@ namespace Dicom.Network
             {
                 MaxAsyncOpsInvoked = this.asyncInvoked,
                 MaxAsyncOpsPerformed = this.asyncPerformed,
-                RemoteHost = stream.Host,
-                RemotePort = stream.Port
+                RemoteHost = stream.LocalHost,
+                RemotePort = stream.LocalPort
             };
 
             try
@@ -251,8 +251,8 @@ namespace Dicom.Network
             {
                 MaxAsyncOpsInvoked = this.asyncInvoked,
                 MaxAsyncOpsPerformed = this.asyncPerformed,
-                RemoteHost = stream.Host,
-                RemotePort = stream.Port
+                RemoteHost = stream.LocalHost,
+                RemotePort = stream.LocalPort
             };
 
             return DoSendAsync(stream, assoc);

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -347,8 +347,8 @@ namespace Dicom.Network
                             {
                                 Association = new DicomAssociation
                                                   {
-                                                      RemoteHost = _network.Host,
-                                                      RemotePort = _network.Port
+                                                      RemoteHost = _network.RemoteHost,
+                                                      RemotePort = _network.RemotePort
                                                   };
                                 var pdu = new AAssociateRQ(Association);
                                 pdu.Read(raw);

--- a/DICOM/Network/INetworkStream.cs
+++ b/DICOM/Network/INetworkStream.cs
@@ -17,12 +17,12 @@ namespace Dicom.Network
         /// Gets the host of the network stream.
         /// </summary>
         string Host { get; }
-
+		string RemoteHost { get; }
         /// <summary>
         /// Gets the port of the network stream.
         /// </summary>
         int Port { get; }
-
+		int RemotePort { get; }
         #endregion
 
         #region METHODS

--- a/DICOM/Network/INetworkStream.cs
+++ b/DICOM/Network/INetworkStream.cs
@@ -14,15 +14,25 @@ namespace Dicom.Network
         #region PROPERTIES
 
         /// <summary>
-        /// Gets the host of the network stream.
+        /// Gets the remote host of the network stream.
+        /// </summary>
+        string RemoteHost { get; }
+
+        /// <summary>
+        /// Gets the local host of the network stream.
         /// </summary>
         string LocalHost { get; }
-		string RemoteHost { get; }
+
         /// <summary>
-        /// Gets the port of the network stream.
+        /// Gets the remote port of the network stream.
+        /// </summary>
+        int RemotePort { get; }
+
+        /// <summary>
+        /// Gets the local port of the network stream.
         /// </summary>
         int LocalPort { get; }
-		int RemotePort { get; }
+        
         #endregion
 
         #region METHODS

--- a/DICOM/Network/INetworkStream.cs
+++ b/DICOM/Network/INetworkStream.cs
@@ -16,12 +16,12 @@ namespace Dicom.Network
         /// <summary>
         /// Gets the host of the network stream.
         /// </summary>
-        string Host { get; }
+        string LocalHost { get; }
 		string RemoteHost { get; }
         /// <summary>
         /// Gets the port of the network stream.
         /// </summary>
-        int Port { get; }
+        int LocalPort { get; }
 		int RemotePort { get; }
         #endregion
 

--- a/DICOM/Network/WindowsNetworkStream.cs
+++ b/DICOM/Network/WindowsNetworkStream.cs
@@ -93,15 +93,23 @@ namespace Dicom.Network
         #region PROPERTIES
 
         /// <summary>
-        /// Gets the host of the network stream.
+        /// Gets the remote host of the network stream.
         /// </summary>
         public string RemoteHost { get; }
+
+        /// <summary>
+        /// Gets the local host of the network stream
+        /// </summary>
         public string LocalHost { get; }
 
         /// <summary>
-        /// Gets the port of the network stream.
+        /// Gets the remote port of the network stream.
         /// </summary>
         public int RemotePort { get; }
+
+        /// <summary>
+        /// Gets the local port of the network stream.
+        /// </summary>
         public int LocalPort { get; }
 
         #endregion

--- a/DICOM/Network/WindowsNetworkStream.cs
+++ b/DICOM/Network/WindowsNetworkStream.cs
@@ -46,8 +46,8 @@ namespace Dicom.Network
         /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
         internal WindowsNetworkStream(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
-            this.Host = host;
-            this.Port = port;
+            this.RemoteHost = host;
+            this.RemotePort = port;
             this.socket = new StreamSocket();
             this.canDisposeSocket = true;
 
@@ -73,8 +73,8 @@ namespace Dicom.Network
         /// is initialized with this server-side constructor.</remarks>
         internal WindowsNetworkStream(StreamSocket socket)
         {
-            this.Host = socket.Information.RemoteAddress.DisplayName;
-            this.Port = int.Parse(socket.Information.RemotePort, CultureInfo.InvariantCulture);
+            this.RemoteHost = socket.Information.RemoteAddress.DisplayName;
+            this.RemotePort = int.Parse(socket.Information.RemotePort, CultureInfo.InvariantCulture);
             this.socket = socket;
             this.canDisposeSocket = false;
             this.isConnected = true;
@@ -95,12 +95,14 @@ namespace Dicom.Network
         /// <summary>
         /// Gets the host of the network stream.
         /// </summary>
-        public string Host { get; }
+        public string RemoteHost { get; }
+        public string LocalHost { get; }
 
         /// <summary>
         /// Gets the port of the network stream.
         /// </summary>
-        public int Port { get; }
+        public int RemotePort { get; }
+        public int LocalPort { get; }
 
         #endregion
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-Change so that you can get the connection port and the negotiated port.
-Needed when the SCP is listening on multiple ports and has different actions for each listener.
-

