### PR TITLE
Corrected JPEG-LS encoding and JPEG decoding for YBR images. Connected to #358

### DIFF
--- a/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
@@ -462,7 +462,6 @@ void JPEGCODEC::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelDat
         if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
             if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
                 throw gcnew DicomCodecException("JPEG codec unable to perform colorspace conversion on signed pixel data");
-            //dinfo.jpeg_color_space = JCS_YCbCr;
             dinfo.out_color_space = JCS_RGB;
             newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
             newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;

--- a/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
@@ -66,11 +66,8 @@ namespace Dicom {
 				params.ilv =
 					oldPixelData->SamplesPerPixel == 3 && oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
 					? CharlsInterleaveModeType::Sample
-					: CharlsInterleaveModeType::None;
-				params.colorTransform =
-					oldPixelData->SamplesPerPixel == 3 && oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull
-					? CharlsColorTransformationType::HP1
-					: CharlsColorTransformationType::None;
+					: CharlsInterleaveModeType::Line;
+				params.colorTransform = CharlsColorTransformationType::None;
 
 				if (TransferSyntax == DicomTransferSyntax::JPEGLSNearLossless) {
 					params.allowedlossyerror = jparams->AllowedError;

--- a/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
@@ -63,14 +63,14 @@ namespace Dicom {
 				params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
 				params.components = oldPixelData->SamplesPerPixel;
 
-				params.ilv = CharlsInterleaveModeType::None;
-				params.colorTransform = CharlsColorTransformationType::None;
-
-				if (oldPixelData->SamplesPerPixel == 3) {
-					params.ilv = (CharlsInterleaveModeType)jparams->InterleaveMode;
-					if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb)
-						params.colorTransform = (CharlsColorTransformationType)jparams->ColorTransform;
-				}
+				params.ilv =
+					oldPixelData->SamplesPerPixel == 3 && oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
+					? CharlsInterleaveModeType::Sample
+					: CharlsInterleaveModeType::None;
+				params.colorTransform =
+					oldPixelData->SamplesPerPixel == 3 && oldPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull
+					? CharlsColorTransformationType::HP1
+					: CharlsColorTransformationType::None;
 
 				if (TransferSyntax == DicomTransferSyntax::JPEGLSNearLossless) {
 					params.allowedlossyerror = jparams->AllowedError;

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
@@ -470,7 +470,6 @@ void JPEGCODEC::Decode(NativePixelData^ oldPixelData, NativePixelData^ newPixelD
         if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
             if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
                 throw ref new FailureException("JPEG codec unable to perform colorspace conversion on signed pixel data");
-            //dinfo.jpeg_color_space = JCS_YCbCr;
             dinfo.out_color_space = JCS_RGB;
             newPixelData->PhotometricInterpretation = PhotometricInterpretation::Rgb;
             newPixelData->PlanarConfiguration = PlanarConfiguration::Interleaved;

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
@@ -52,18 +52,11 @@ void DicomJpegLsNativeCodec::Encode(NativePixelData^ oldPixelData, NativePixelDa
 	params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
 	params.components = oldPixelData->SamplesPerPixel;
 
-	params.ilv = CharlsInterleaveModeType::None;
+	params.ilv =
+		oldPixelData->SamplesPerPixel == 3 && oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
+		? CharlsInterleaveModeType::Sample
+		: CharlsInterleaveModeType::Line;
 	params.colorTransform = CharlsColorTransformationType::None;
-
-	if (oldPixelData->SamplesPerPixel == 3) {
-		params.ilv = (CharlsInterleaveModeType)jparams->InterleaveMode;
-		if (oldPixelData->PhotometricInterpretation == PhotometricInterpretation::Rgb)
-			params.colorTransform = (CharlsColorTransformationType)jparams->ColorTransform;
-	}
-
-	if (oldPixelData->TransferSyntaxIsLossy) {
-		params.allowedlossyerror = jparams->AllowedError;
-	}
 
 	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {
 		Array<unsigned char>^ frameData = oldPixelData->GetFrame(frame);

--- a/DICOM/Imaging/Codec/DicomTranscoder.cs
+++ b/DICOM/Imaging/Codec/DicomTranscoder.cs
@@ -30,7 +30,7 @@ namespace Dicom.Imaging.Codec
         {
             InputSyntax = inputSyntax;
             OutputSyntax = outputSyntax;
-            InputCodecParams = inputCodecParams;
+            InputCodecParams = inputCodecParams ?? DefaultInputCodecParams(inputSyntax);
             OutputCodecParams = outputCodecParams;
         }
 
@@ -204,6 +204,13 @@ namespace Dicom.Imaging.Codec
             var newPixelData = DicomPixelData.Create(newDataset);
 
             return PixelDataFactory.Create(newPixelData, 0);
+        }
+
+        private static DicomCodecParams DefaultInputCodecParams(DicomTransferSyntax inputSyntax)
+        {
+            return inputSyntax == DicomTransferSyntax.JPEGProcess1 || inputSyntax == DicomTransferSyntax.JPEGProcess2_4
+                       ? new DicomJpegParams { ConvertColorspaceToRGB = true }
+                       : null;
         }
 
         private static DicomDataset Decode(

--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -247,22 +247,12 @@ namespace Dicom.Imaging
                 return;
             }
 
-
             if (Dataset.InternalTransferSyntax.IsEncapsulated)
             {
                 // decompress single frame from source dataset
-                DicomCodecParams cparams = null;
-                if (Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1
-                    || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4)
-                {
-                    cparams = new DicomJpegParams { ConvertColorspaceToRGB = true };
-                }
-
                 var transcoder = new DicomTranscoder(
-                    this.Dataset.InternalTransferSyntax,
-                    DicomTransferSyntax.ExplicitVRLittleEndian,
-                    cparams,
-                    cparams);
+                                     this.Dataset.InternalTransferSyntax,
+                                     DicomTransferSyntax.ExplicitVRLittleEndian);
                 var buffer = transcoder.DecodeFrame(Dataset, frame);
 
                 // clone the dataset because modifying the pixel data modifies the dataset
@@ -270,40 +260,8 @@ namespace Dicom.Imaging
                 clone.InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
 
                 var pixelData = DicomPixelData.Create(clone, true);
+                TrimDecodedPixelDataProperties(pixelData, Dataset.InternalTransferSyntax);
                 pixelData.AddFrame(buffer);
-
-                // temporary fix for JPEG compressed YBR images, according to enforcement above
-                if ((Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess1
-                     || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess2_4)
-                    && pixelData.SamplesPerPixel == 3)
-                {
-                    // When converting to RGB in Dicom.Imaging.Codec.Jpeg.i, PlanarConfiguration is set to Interleaved
-                    pixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
-                    pixelData.PlanarConfiguration = PlanarConfiguration.Interleaved;
-                }
-
-                // temporary fix for JPEG 2000 Lossy images
-                if (pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrIct
-                    || pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrRct)
-                {
-                    // Converted to RGB in Dicom.Imaging.Codec.Jpeg2000.cpp
-                    pixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
-                }
-
-                // temporary fix for JPEG lossless and JPEG2000 compressed YBR images
-                if ((Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess14
-                     || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEGProcess14SV1
-                     || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEG2000Lossless
-                     || Dataset.InternalTransferSyntax == DicomTransferSyntax.JPEG2000Lossy)
-                    && (pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull
-                        || pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull422
-                        || pixelData.PhotometricInterpretation == PhotometricInterpretation.YbrPartial422))
-                {
-                    // For JPEG lossless YBR type images in Dicom.Imaging.Codec.Jpeg.i and JPEG2000 YBR type images in Dicom.Imaging.Codec.Jpeg2000.cpp, 
-                    // YBR_FULL is applied and PlanarConfiguration is set to Planar
-                    pixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull;
-                    pixelData.PlanarConfiguration = PlanarConfiguration.Planar;
-                }
 
                 _pixelData = PixelDataFactory.Create(pixelData, 0);
             }
@@ -325,6 +283,47 @@ namespace Dicom.Imaging
             if (_pipeline == null)
             {
                 CreatePipeline();
+            }
+        }
+
+        private static void TrimDecodedPixelDataProperties(
+            DicomPixelData decodedPixelData,
+            DicomTransferSyntax inputTransferSyntax)
+        {
+            if (!inputTransferSyntax.IsEncapsulated) return;
+
+            // temporary fix for JPEG compressed YBR images, according to enforcement above
+            if ((inputTransferSyntax == DicomTransferSyntax.JPEGProcess1
+                 || inputTransferSyntax == DicomTransferSyntax.JPEGProcess2_4) && decodedPixelData.SamplesPerPixel == 3)
+            {
+                // When converting to RGB in Dicom.Imaging.Codec.Jpeg.i, PlanarConfiguration is set to Interleaved
+                decodedPixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
+                decodedPixelData.PlanarConfiguration = PlanarConfiguration.Interleaved;
+            }
+
+            // temporary fix for JPEG 2000 Lossy images
+            if ((inputTransferSyntax == DicomTransferSyntax.JPEG2000Lossy
+                 && decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrIct)
+                || (inputTransferSyntax == DicomTransferSyntax.JPEG2000Lossless
+                    && decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrRct))
+            {
+                // Converted to RGB in Dicom.Imaging.Codec.Jpeg2000.cpp
+                decodedPixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
+            }
+
+            // temporary fix for JPEG lossless and JPEG2000 compressed YBR images
+            if ((inputTransferSyntax == DicomTransferSyntax.JPEGProcess14
+                 || inputTransferSyntax == DicomTransferSyntax.JPEGProcess14SV1
+                 || inputTransferSyntax == DicomTransferSyntax.JPEG2000Lossless
+                 || inputTransferSyntax == DicomTransferSyntax.JPEG2000Lossy)
+                && (decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull
+                    || decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull422
+                    || decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrPartial422))
+            {
+                // For JPEG lossless YBR type images in Dicom.Imaging.Codec.Jpeg.i and JPEG2000 YBR type images in Dicom.Imaging.Codec.Jpeg2000.cpp, 
+                // YBR_FULL is applied and PlanarConfiguration is set to Planar
+                decodedPixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull;
+                decodedPixelData.PlanarConfiguration = PlanarConfiguration.Planar;
             }
         }
 


### PR DESCRIPTION
Fixes #358 .

Changes proposed in this pull request:
- Use data from pixel data object to set interleave mode for JPEG-LS color images.
- Always use color transform None for JPEG-LS color images.
- In `DicomTranscoder`, if input parameters are `null` and input transfer syntax is JPEG baseline/sequential, then set input parameters to convert color images to RGB. 
- In `DicomImage`, apply all pixel data updates that are used in the different decoding processes (list of updates was previously incomplete)