### PR TITLE
Corrected format string arguments. Connected to #374

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (RC, TBD)
+* Incorrect message logged when async ops are not available, but requested (#374 #381)
 * Fix get object for all DicomValueElement inheritors (#367 #368)
 * Null characters not trimmed from string values (#359 #380)
 * Corrected JPEG-LS encoding and JPEG decoding for YBR images (#358 #379)

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -898,7 +898,7 @@ namespace Dicom.Network
                     {
                         // Cannot easily recover from this unwanted state, so better to throw.
                         throw new DicomNetworkException(
-                            "Cannot send messages since pending: {pending} would exceed max async ops invoked: {invoked}",
+                            "Cannot send messages since pending: {0} would exceed max async ops invoked: {1}",
                             _pending.Count,
                             Association.MaxAsyncOpsInvoked);
                     }


### PR DESCRIPTION
Fixes #374 .

Changes proposed in this pull request:
- Use numbers instead of incorrectly used labels to specify arguments in `DicomNetworkException` format string.
