### PR TITLE
Invalid handling of overlay data type, description, subtype and label. Connected to #375

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (RC, TBD)
+* Invalid handling of overlay data type, description, subtype and label (#375 #382)
 * Incorrect message logged when async ops are not available, but requested (#374 #381)
 * Fix get object for all DicomValueElement inheritors (#367 #368)
 * Null characters not trimmed from string values (#359 #380)

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -140,7 +140,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.AddOrUpdate(DicomTag.OverlayDescription, value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayDescription), value);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.AddOrUpdate(DicomTag.OverlaySubtype, value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlaySubtype), value);
             }
         }
 
@@ -170,7 +170,7 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.AddOrUpdate(DicomTag.OverlayLabel, value);
+                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayLabel), value);
             }
         }
 

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -91,7 +91,8 @@ namespace Dicom.Imaging
             {
                 var type = Dataset.Get<string>(OverlayTag(DicomTag.OverlayType));
                 if (type.StartsWith("R")) return DicomOverlayType.ROI;
-                else return DicomOverlayType.Graphics;
+                if (type.StartsWith("G")) return DicomOverlayType.Graphics;
+                throw new DicomImagingException("Unsupported overlay type: {0}", type);
             }
             set
             {

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -95,7 +95,9 @@ namespace Dicom.Imaging
             }
             set
             {
-                Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayType), value.ToString().ToUpper());
+                Dataset.AddOrUpdate(
+                    OverlayTag(DicomTag.OverlayType),
+                    value.ToString().Substring(0, 1).ToUpperInvariant());
             }
         }
 

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -89,7 +89,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                var type = Dataset.Get<string>(OverlayTag(DicomTag.OverlayType), "Unknown");
+                var type = Dataset.Get<string>(OverlayTag(DicomTag.OverlayType));
                 if (type.StartsWith("R")) return DicomOverlayType.ROI;
                 else return DicomOverlayType.Graphics;
             }

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Imaging\Codec\DicomCodecExtensionsTest.cs" />
     <Compile Include="Imaging\ColorTableTest.cs" />
     <Compile Include="Imaging\DicomImageTest.cs" />
+    <Compile Include="Imaging\DicomOverlayDataTest.cs" />
     <Compile Include="Imaging\GrayscaleRenderOptionsTest.cs" />
     <Compile Include="Imaging\ImageManagerTest.cs" />
     <Compile Include="Imaging\LUT\OutputLUTTest.cs" />

--- a/Tests/Imaging/DicomOverlayDataTest.cs
+++ b/Tests/Imaging/DicomOverlayDataTest.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) 2012-2016 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Xunit;
+
+namespace Dicom.Imaging
+{
+    public class DicomOverlayDataTest
+    {
+        [Fact]
+        public void Constructor_GroupSpecified_GroupTransferredToDescription()
+        {
+            const string expected = "Description 6002";
+            const ushort group = 0x6002;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group) { Description = expected };
+
+            var actual = dataset.Get<string>(new DicomTag(group, 0x0022));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Constructor_GroupSpecified_GroupTransferredToSubtype()
+        {
+            const string expected = "Subtype 6005";
+            const ushort group = 0x6005;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group) { Subtype = expected };
+
+            var actual = dataset.Get<string>(new DicomTag(group, 0x0045));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Constructor_GroupSpecified_GroupTransferredToLabel()
+        {
+            const string expected = "Label 6003";
+            const ushort group = 0x6003;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group) { Label = expected };
+
+            var actual = dataset.Get<string>(new DicomTag(group, 0x1500));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OverlayTypeSetter_SetToGraphics_ReturnsG()
+        {
+            const string expected = "G";
+            const ushort group = 0x6011;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group) { Type = DicomOverlayType.Graphics };
+
+            var actual = dataset.Get<string>(new DicomTag(group, 0x0040));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OverlayTypeSetter_SetToROI_ReturnsR()
+        {
+            const string expected = "R";
+            const ushort group = 0x6011;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group) { Type = DicomOverlayType.ROI };
+
+            var actual = dataset.Get<string>(new DicomTag(group, 0x0040));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OverlayTypeGetter_TypeNotSet_ShouldThrow()
+        {
+            const ushort group = 0x6008;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group);
+
+            var exception = Record.Exception(() => od.Type);
+            Assert.NotNull(exception);
+        }
+
+        [Fact]
+        public void OverlayTypeGetter_TypeSetToG_ReturnsGraphics()
+        {
+            const DicomOverlayType expected = DicomOverlayType.Graphics;
+            const ushort group = 0x6012;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group);
+            dataset.AddOrUpdate(new DicomTag(group, 0x0040), "G");
+
+            var actual = od.Type;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OverlayTypeGetter_TypeSetToR_ReturnsROI()
+        {
+            const DicomOverlayType expected = DicomOverlayType.ROI;
+            const ushort group = 0x6012;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group);
+            dataset.AddOrUpdate(new DicomTag(group, 0x0040), "R");
+
+            var actual = od.Type;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OverlayTypeGetter_TypeSetToOtherThanRAndG_ShouldThrow()
+        {
+            const ushort group = 0x6001;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group);
+            dataset.AddOrUpdate(new DicomTag(group, 0x0040), "O");
+
+            var exception = Record.Exception(() => od.Type);
+            Assert.NotNull(exception);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #375 .

Changes proposed in this pull request:
- Overlay `Type` setter should only write `R` or `G` letter to dataset.
- Overlay `Type` is mandatory; throw if not included in overlay data.
- Overlay `Type` only supports *R(OI)* and *(G)RAPHICS* enumerated values; throw if other first character.
- Always apply specified overlay group number when adding element to dataset, including for `Description`, `Subtype` and `Label`.