### PR TITLE
Make dimse stream and file fields accessible in derived classes. Connected to #357

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 * System Out Of Memory Exception when saving large DICOM files (#363 #384)
 * Null characters not trimmed from string values (#359 #380)
 * Corrected JPEG-LS encoding and JPEG decoding for YBR images (#358 #379)
+* Cannot override CreateCStoreReceiveStream due to private fields (#357 #386)
 * DICOM Parse error - Stack empty (#342)
 * Sufficient image creation when Bits Allocated does not match destination type size (#340 #350)
 * Some Dicom Printer refuse print requests from fo-dicom (#336)

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -23,6 +23,10 @@ namespace Dicom.Network
     {
         #region FIELDS
 
+        protected Stream _dimseStream;
+
+        protected IFileReference _dimseStreamFile;
+
         private readonly INetworkStream _network;
 
         private readonly object _lock;
@@ -38,10 +42,6 @@ namespace Dicom.Network
         private readonly List<DicomRequest> _pending;
 
         private DicomMessage _dimse;
-
-        private Stream _dimseStream;
-
-        private IFileReference _dimseStreamFile;
 
         private int _readLength;
 
@@ -178,7 +178,6 @@ namespace Dicom.Network
             _dimseStream = _dimseStreamFile.Open();
             file.Save(_dimseStream);
             _dimseStream.Seek(0, SeekOrigin.End);
-
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #357 .

Changes proposed in this pull request:
- `_dimseStream` and `_dimseStreamFile` fields in `DicomService` declared `protected`, to facilitate overriding the `CreateCStoreReceiveStream` method in derived classes.

