### PR TITLE
Use FirstOrDefault to identify association contexts. Connected to #391

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 #### v.3.0.0 (RC, TBD)
-* Cannot catch exceptions while doing C-STORE if I close my network connection (#385 #389)
+* Efilm 2.1.2 seems to send funny presentation contexts, break on PDU.read (#391 #397)
+* Cannot catch exceptions while doing C-STORE if I close my network connection (#385 #390)
 * Handle UN encode group lengths and missing last item delimitation tag (#378 #388)
 * Invalid handling of overlay data type, description, subtype and label (#375 #382)
 * Incorrect message logged when async ops are not available, but requested (#374 #381)

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -630,7 +630,7 @@ namespace Dicom.Network
                             var userRole = raw.ReadByte("SCU role");
                             var providerRole = raw.ReadByte("SCP role");
                             var pc =
-                                _assoc.PresentationContexts.SingleOrDefault(
+                                _assoc.PresentationContexts.FirstOrDefault(
                                     context => context.AbstractSyntax.UID.Equals(syntax));
                             if (pc != null)
                             {
@@ -875,7 +875,7 @@ namespace Dicom.Network
                             var userRole = raw.ReadByte("SCU role");
                             var providerRole = raw.ReadByte("SCP role");
                             var pc =
-                                _assoc.PresentationContexts.SingleOrDefault(
+                                _assoc.PresentationContexts.FirstOrDefault(
                                     context => context.AbstractSyntax.UID.Equals(syntax));
                             if (pc != null)
                             {


### PR DESCRIPTION
Fixes #391 .

Changes proposed in this pull request:
- Use FirstOrDefault instead of SingleOrDefault to allow for duplicate association contexts in association requests.
