### PR TITLE
Unhandled exception after error in JPEG native decoding. Connected to #394

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (RC, TBD)
+* Unhandled exception after error in JPEG native decoding (#394 #399)
 * DicomDataset.Get&lt;T[]&gt; on empty tag should not throw (#392 #398)
 * Efilm 2.1.2 seems to send funny presentation contexts, break on PDU.read (#391 #397)
 * Cannot catch exceptions while doing C-STORE if I close my network connection (#385 #390)

--- a/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
@@ -10,18 +10,21 @@ namespace IJGVERS {
       struct jpeg_error_mgr pub;
     };
 
-    // error handler, executes longjmp
-    void ErrorExit(j_common_ptr cinfo) {
+    // error handler
+	void ErrorExit(j_common_ptr cinfo) {
         ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
-    }
+		char buffer[JMSG_LENGTH_MAX];
+        (*cinfo->err->format_message)((jpeg_common_struct *)cinfo, buffer); /* Create the message */
+		throw gcnew DicomCodecException(gcnew String(buffer));
+	}
 
     // message handler for warning messages and the like
-    void OutputMessage(j_common_ptr cinfo) {
+	void OutputMessage(j_common_ptr cinfo) {
         ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
         char buffer[JMSG_LENGTH_MAX];
         (*cinfo->err->format_message)((jpeg_common_struct *)cinfo, buffer); /* Create the message */
-        //DicomLog::Debug::Log->Info("IJG: {0}", gcnew String(buffer));
-    }
+        LogManager::GetLogger("Dicom.Imaging.Codec")->Debug("IJG: {0}", gcnew String(buffer));
+	}
 }
 
 

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
@@ -13,17 +13,28 @@ namespace IJGVERS {
       struct jpeg_error_mgr pub;
     };
 
-    // error handler, executes longjmp
-    void ErrorExit(j_common_ptr cinfo) {
+	// char * to wchar_t * converter
+	wchar_t * Convert(const char * src) {
+		size_t size = strlen(src) + 1, convertedChars = 0;
+		wchar_t * dest = new wchar_t[size];
+		mbstowcs_s(&convertedChars, dest, size, src, _TRUNCATE);
+		return dest;
+	}
+    
+	// error handler
+	void ErrorExit(j_common_ptr cinfo) {
         ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
-    }
+		char buffer[JMSG_LENGTH_MAX];
+        (*cinfo->err->format_message)((jpeg_common_struct *)cinfo, buffer); /* Create the message */
+		throw ref new FailureException(ref new String(Convert(buffer)));
+	}
 
     // message handler for warning messages and the like
-    void OutputMessage(j_common_ptr cinfo) {
+	void OutputMessage(j_common_ptr cinfo) {
         ErrorStruct *myerr = (ErrorStruct *)cinfo->err;
         char buffer[JMSG_LENGTH_MAX];
         (*cinfo->err->format_message)((jpeg_common_struct *)cinfo, buffer); /* Create the message */
-        //DicomLog::Debug::Log->Info("IJG: {0}", gcnew String(buffer));
+        //LogManager::GetLogger("Dicom.Imaging.Codec")->Debug("IJG: {0}", ref new String(Convert(buffer)));
     }
 }
 


### PR DESCRIPTION
Fixes #394 .

Changes proposed in this pull request:
- In `ErrorExit` function, identify error message and throw exception.

