### PR TITLE
Ignore C-GET requests and do not throw when pending exceeds invoked async ops. Connected to #356

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (RC, TBD)
+* DicomClient multiple C-Store request cause exception when AsyncOps is not negotiated (#356 #400)
 * Unhandled exception after error in JPEG native decoding (#394 #399)
 * DicomDataset.Get&lt;T[]&gt; on empty tag should not throw (#392 #398)
 * Efilm 2.1.2 seems to send funny presentation contexts, break on PDU.read (#391 #397)

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -893,14 +893,11 @@ namespace Dicom.Network
                         return;
                     }
 
-                    if (!Options.IgnoreAsyncOps && Association.MaxAsyncOpsInvoked > 0
-                        && _pending.Count >= Association.MaxAsyncOpsInvoked)
+                    if (Association.MaxAsyncOpsInvoked > 0
+                        && _pending.Count(req => req.Type != DicomCommandField.CGetRequest)
+                        >= Association.MaxAsyncOpsInvoked)
                     {
-                        // Cannot easily recover from this unwanted state, so better to throw.
-                        throw new DicomNetworkException(
-                            "Cannot send messages since pending: {0} would exceed max async ops invoked: {1}",
-                            _pending.Count,
-                            Association.MaxAsyncOpsInvoked);
+                        return;
                     }
 
                     _sending = true;

--- a/DICOM/Network/DicomServiceOptions.cs
+++ b/DICOM/Network/DicomServiceOptions.cs
@@ -27,8 +27,6 @@ namespace Dicom.Network
 
             public static readonly bool IgnoreSslPolicyErrors = false;
 
-            public static readonly bool IgnoreAsyncOps = false;
-
             public static readonly bool TcpNoDelay = true;
         }
 
@@ -46,7 +44,6 @@ namespace Dicom.Network
             MaxDataBuffer = Default.MaxDataBuffer;
             ThreadPoolLinger = Default.ThreadPoolLinger;
             IgnoreSslPolicyErrors = Default.IgnoreSslPolicyErrors;
-            IgnoreAsyncOps = Default.IgnoreAsyncOps;
             TcpNoDelay = Default.TcpNoDelay;
         }
 
@@ -74,11 +71,6 @@ namespace Dicom.Network
 
         /// <summary>DICOM client should ignore SSL certificate errors.</summary>
         public bool IgnoreSslPolicyErrors { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether async operations invoked/performed limitations should be ignored while sending and retrieving messages.
-        /// </summary>
-        public bool IgnoreAsyncOps { get; set; }
 
         /// <summary>Enable or disable TCP Nagle algorithm.</summary>
         public bool TcpNoDelay { get; set; }

--- a/Tests/Network/DicomCGetRequestTest.cs
+++ b/Tests/Network/DicomCGetRequestTest.cs
@@ -13,7 +13,6 @@ namespace Dicom.Network
         public void DicomCGetRequest_OneImageInSeries_Received()
         {
             var client = new DicomClient();
-            client.Options = new DicomServiceOptions { IgnoreAsyncOps = true };
 
             var pcs = DicomPresentationContext.GetScpRolePresentationContextsFromStorageUids(
                 DicomStorageCategory.Image,
@@ -49,7 +48,6 @@ namespace Dicom.Network
         public void DicomCGetRequest_PickCTImagesInStudy_OnlyCTImagesRetrieved()
         {
             var client = new DicomClient();
-            client.Options = new DicomServiceOptions { IgnoreAsyncOps = true };
 
             var pc = DicomPresentationContext.GetScpRolePresentationContext(DicomUID.CTImageStorage);
             client.AdditionalPresentationContexts.Add(pc);

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -84,7 +84,7 @@ namespace Dicom.Network
 
         [Theory]
         [InlineData(20)]
-        //[InlineData(100)]
+        [InlineData(100)]
         public void Send_MultipleTimes_AllRecognized(int expected)
         {
             int port = Ports.GetNext();
@@ -152,7 +152,7 @@ namespace Dicom.Network
 
         [Theory]
         [InlineData(20)]
-        //[InlineData(100)]
+        [InlineData(100)]
         public async Task SendAsync_MultipleTimes_AllRecognized(int expected)
         {
             int port = Ports.GetNext();


### PR DESCRIPTION
Fixes #356 .

Changes proposed in this pull request:
- Remove `DicomServiceOptions.IgnoreAsyncOps`, which was introduced as a workaround for C-GET handling.
- When comparing negotiated async ops invoked with pending messages, ignore C-GET requests in the pending count.
- Do not throw if pending count is equal to or larger than negotiated async ops invoked, simply return.
