### PR TITLE
Improved reliability in DicomClient.Send. Connected to #389

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 * Unhandled exception after error in JPEG native decoding (#394 #399)
 * DicomDataset.Get&lt;T[]&gt; on empty tag should not throw (#392 #398)
 * Efilm 2.1.2 seems to send funny presentation contexts, break on PDU.read (#391 #397)
+* Improved reliability in DicomClient.Send (#389 #407)
 * Cannot catch exceptions while doing C-STORE if I close my network connection (#385 #390)
 * Handle UN encode group lengths and missing last item delimitation tag (#378 #388)
 * Invalid handling of overlay data type, description, subtype and label (#375 #382)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (RC, TBD)
+* Added method GenerateUuidDerived (#408)
 * Unhandled exception after error in JPEG native decoding (#394 #399)
 * DicomDataset.Get&lt;T[]&gt; on empty tag should not throw (#392 #398)
 * Efilm 2.1.2 seems to send funny presentation contexts, break on PDU.read (#391 #397)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -115,6 +115,23 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Gets whether a new send invocation is required. Send needs to be called if there are requests in queue and client is not connected.
+        /// </summary>
+        public bool IsSendRequired
+        {
+            get
+            {
+                bool required;
+                lock (this.locker)
+                {
+                    required = this.requests.Count > 0 && (this.service == null || !this.service.IsConnected);
+                }
+
+                return required;
+            }
+        }
+
         #endregion
 
         #region METHODS

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -50,7 +50,7 @@ namespace Dicom.Network
             this.AdditionalPresentationContexts = new List<DicomPresentationContext>();
             this.asyncInvoked = 1;
             this.asyncPerformed = 1;
-            this.Linger = 50;
+            this.Linger = 0;
         }
 
         #endregion

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -409,10 +409,16 @@ namespace Dicom.Network
                 }
             }
 
+            this.networkStream = null;
+            this.service = null;
+
+            var completedException = completeNotifier?.Task?.Exception;
             var lingerException = this.service?.LingerTask?.Exception;
 
-            this.service = null;
-            this.networkStream = null;
+            if (completedException != null)
+            {
+                throw completedException.Flatten().InnerException;
+            }
 
             if (lingerException != null)
             {

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2012-2016 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Threading;
-
 namespace Dicom.Network
 {
     using System;
@@ -10,6 +8,7 @@ namespace Dicom.Network
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
 
     using Dicom.Imaging.Codec;
@@ -249,7 +248,7 @@ namespace Dicom.Network
                     }
                 }
 
-                IsConnected = false;
+                lock (_lock) IsConnected = false;
                 _network.Dispose();
 
                 if (this is IDicomServiceProvider)
@@ -849,11 +848,7 @@ namespace Dicom.Network
             lock (_lock)
             {
                 _msgQueue.Enqueue(message);
-
-                if (_sending)
-                {
-                    return;
-                }
+                if (_sending) return;
             }
 
             SendNextMessage();
@@ -868,10 +863,7 @@ namespace Dicom.Network
                     _msgQueue.Enqueue(message);                    
                 }
 
-                if (_sending)
-                {
-                    return;
-                }
+                if (_sending) return;
             }
 
             SendNextMessage();

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -76,7 +76,7 @@ namespace Dicom.Network
             Logger = log ?? LogManager.GetLogger("Dicom.Network");
             Options = new DicomServiceOptions();
 
-            BackgroundWorker = ReadAndProcessPDUAsync();
+            PDUListener = ListenAndProcessPDUsAsync();
         }
 
         #endregion
@@ -135,7 +135,7 @@ namespace Dicom.Network
         /// <summary>
         /// Gets the <see cref="Task"/> maintaining the PDU reader/processor.
         /// </summary>
-        public Task BackgroundWorker { get; }
+        public Task PDUListener { get; }
 
         #endregion
 
@@ -303,7 +303,7 @@ namespace Dicom.Network
             return true;
         }
 
-        private async Task ReadAndProcessPDUAsync()
+        private async Task ListenAndProcessPDUsAsync()
         {
             try
             {

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -150,6 +150,15 @@ namespace Dicom.Network
         }
 
         /// <summary>
+        /// Send requests from service.
+        /// </summary>
+        /// <param name="requests">Requests to send.</param>
+        public virtual void SendRequests(IEnumerable<DicomRequest> requests)
+        {
+            SendMessages(requests);
+        }
+
+        /// <summary>
         /// Send response from service.
         /// </summary>
         /// <param name="response">Response to send.</param>
@@ -845,7 +854,24 @@ namespace Dicom.Network
                 {
                     return;
                 }
+            }
 
+            SendNextMessage();
+        }
+
+        private void SendMessages(IEnumerable<DicomMessage> messages)
+        {
+            lock (_lock)
+            {
+                foreach (var message in messages)
+                {
+                    _msgQueue.Enqueue(message);                    
+                }
+
+                if (_sending)
+                {
+                    return;
+                }
             }
 
             SendNextMessage();

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -369,7 +369,7 @@ namespace Dicom.Network
                                     "{callingAE} <- Association request:\n{association}",
                                     LogID,
                                     Association.ToString());
-                                if (this is IDicomServiceProvider) (this as IDicomServiceProvider).OnReceiveAssociationRequest(Association);
+                                (this as IDicomServiceProvider)?.OnReceiveAssociationRequest(Association);
                                 break;
                             }
                         case 0x02:
@@ -381,7 +381,7 @@ namespace Dicom.Network
                                     "{calledAE} <- Association accept:\n{assocation}",
                                     LogID,
                                     Association.ToString());
-                                if (this is IDicomServiceUser) (this as IDicomServiceUser).OnReceiveAssociationAccept(Association);
+                                (this as IDicomServiceUser)?.OnReceiveAssociationAccept(Association);
                                 break;
                             }
                         case 0x03:
@@ -394,11 +394,10 @@ namespace Dicom.Network
                                     pdu.Result,
                                     pdu.Source,
                                     pdu.Reason);
-                                if (this is IDicomServiceUser)
-                                    (this as IDicomServiceUser).OnReceiveAssociationReject(
-                                        pdu.Result,
-                                        pdu.Source,
-                                        pdu.Reason);
+                                (this as IDicomServiceUser)?.OnReceiveAssociationReject(
+                                    pdu.Result,
+                                    pdu.Source,
+                                    pdu.Reason);
                                 break;
                             }
                         case 0x04:
@@ -414,7 +413,7 @@ namespace Dicom.Network
                                 var pdu = new AReleaseRQ();
                                 pdu.Read(raw);
                                 Logger.Info("{logId} <- Association release request", LogID);
-                                if (this is IDicomServiceProvider) (this as IDicomServiceProvider).OnReceiveAssociationReleaseRequest();
+                                (this as IDicomServiceProvider)?.OnReceiveAssociationReleaseRequest();
                                 break;
                             }
                         case 0x06:
@@ -422,7 +421,7 @@ namespace Dicom.Network
                                 var pdu = new AReleaseRP();
                                 pdu.Read(raw);
                                 Logger.Info("{logId} <- Association release response", LogID);
-                                if (this is IDicomServiceUser) (this as IDicomServiceUser).OnReceiveAssociationReleaseResponse();
+                                (this as IDicomServiceUser)?.OnReceiveAssociationReleaseResponse();
                                 if (TryCloseConnection()) return;
                                 break;
                             }
@@ -435,8 +434,7 @@ namespace Dicom.Network
                                     LogID,
                                     pdu.Source,
                                     pdu.Reason);
-                                if (this is IDicomServiceProvider) (this as IDicomServiceProvider).OnReceiveAbort(pdu.Source, pdu.Reason);
-                                else if (this is IDicomServiceUser) (this as IDicomServiceUser).OnReceiveAbort(pdu.Source, pdu.Reason);
+                                (this as IDicomService)?.OnReceiveAbort(pdu.Source, pdu.Reason);
                                 if (TryCloseConnection()) return;
                                 break;
                             }
@@ -1046,15 +1044,7 @@ namespace Dicom.Network
                     }
                 }
 
-                if (this is IDicomServiceProvider)
-                {
-                    (this as IDicomServiceProvider).OnConnectionClosed(exception);
-                }
-                else if (this is IDicomServiceUser)
-                {
-                    (this as IDicomServiceUser).OnConnectionClosed(exception);
-                }
-
+                (this as IDicomService)?.OnConnectionClosed(exception);
                 lock (_lock) IsConnected = false;
             }
             catch (Exception e)

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -20,9 +20,11 @@ namespace Dicom.Network
     /// <summary>
     /// Base class for DICOM network services.
     /// </summary>
-    public abstract class DicomService
+    public abstract class DicomService : IDisposable
     {
         #region FIELDS
+
+        private bool _disposed = false;
 
         protected Stream _dimseStream;
 
@@ -138,6 +140,29 @@ namespace Dicom.Network
         #endregion
 
         #region METHODS
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                _dimseStream?.Dispose();
+                _network?.Dispose();
+                _pduQueueWatcher?.Dispose();
+            }
+
+            _disposed = true;
+        }
 
         /// <summary>
         /// Send request from service.

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -171,15 +171,6 @@ namespace Dicom.Network
         }
 
         /// <summary>
-        /// Send requests from service.
-        /// </summary>
-        /// <param name="requests">Requests to send.</param>
-        public virtual void SendRequests(IEnumerable<DicomRequest> requests)
-        {
-            SendMessages(requests);
-        }
-
-        /// <summary>
         /// Send response from service.
         /// </summary>
         /// <param name="response">Response to send.</param>
@@ -870,22 +861,6 @@ namespace Dicom.Network
             lock (_lock)
             {
                 _msgQueue.Enqueue(message);
-                if (_sending) return;
-            }
-
-            SendNextMessage();
-        }
-
-        private void SendMessages(IEnumerable<DicomMessage> messages)
-        {
-            lock (_lock)
-            {
-                foreach (var message in messages)
-                {
-                    _msgQueue.Enqueue(message);                    
-                }
-
-                if (_sending) return;
             }
 
             SendNextMessage();

--- a/DICOM/Network/DicomServiceOptions.cs
+++ b/DICOM/Network/DicomServiceOptions.cs
@@ -23,8 +23,6 @@ namespace Dicom.Network
 
             public static readonly uint MaxDataBuffer = 1 * 1024 * 1024; //1MB
 
-            public static readonly int ThreadPoolLinger = 200;
-
             public static readonly bool IgnoreSslPolicyErrors = false;
 
             public static readonly bool TcpNoDelay = true;
@@ -42,7 +40,6 @@ namespace Dicom.Network
             UseRemoteAEForLogName = Default.UseRemoteAEForLogName;
             MaxCommandBuffer = Default.MaxCommandBuffer;
             MaxDataBuffer = Default.MaxDataBuffer;
-            ThreadPoolLinger = Default.ThreadPoolLinger;
             IgnoreSslPolicyErrors = Default.IgnoreSslPolicyErrors;
             TcpNoDelay = Default.TcpNoDelay;
         }
@@ -65,9 +62,6 @@ namespace Dicom.Network
 
         /// <summary>Maximum buffer length for data PDVs when generating P-Data-TF PDUs.</summary>
         public uint MaxDataBuffer { get; set; }
-
-        /// <summary>Amount of time in milliseconds to retain Thread Pool thread to process additional requests.</summary>
-        public int ThreadPoolLinger { get; set; }
 
         /// <summary>DICOM client should ignore SSL certificate errors.</summary>
         public bool IgnoreSslPolicyErrors { get; set; }

--- a/DICOM/Network/IDicomServiceProvider.cs
+++ b/DICOM/Network/IDicomServiceProvider.cs
@@ -5,14 +5,39 @@ using System;
 
 namespace Dicom.Network
 {
-    public interface IDicomServiceProvider
+    /// <summary>
+    /// Common interface for DICOM service users and providers.
+    /// </summary>
+    public interface IDicomService
     {
-        void OnReceiveAssociationRequest(DicomAssociation association);
-
-        void OnReceiveAssociationReleaseRequest();
-
+        /// <summary>
+        /// Callback on recieving an abort message.
+        /// </summary>
+        /// <param name="source">Abort source.</param>
+        /// <param name="reason">Detailed reason for abort.</param>
         void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
 
+        /// <summary>
+        /// Callback when connection is closed.
+        /// </summary>
+        /// <param name="exception">Exception, if any, that forced connection to close.</param>
         void OnConnectionClosed(Exception exception);
+    }
+
+    /// <summary>
+    /// Interface for DICOM service providers.
+    /// </summary>
+    public interface IDicomServiceProvider : IDicomService
+    {
+        /// <summary>
+        /// Callback to invoke when receiving an association request.
+        /// </summary>
+        /// <param name="association">DICOM association corresponding to the request.</param>
+        void OnReceiveAssociationRequest(DicomAssociation association);
+
+        /// <summary>
+        /// Callback to invoke when receiving an association release request.
+        /// </summary>
+        void OnReceiveAssociationReleaseRequest();
     }
 }

--- a/DICOM/Network/IDicomServiceUser.cs
+++ b/DICOM/Network/IDicomServiceUser.cs
@@ -3,12 +3,10 @@
 
 namespace Dicom.Network
 {
-    using System;
-
     /// <summary>
     /// Interface for implementations of a DICOM service as a client.
     /// </summary>
-    public interface IDicomServiceUser
+    public interface IDicomServiceUser : IDicomService
     {
         /// <summary>
         /// Callback for handling association accept scenarios.
@@ -28,19 +26,6 @@ namespace Dicom.Network
         /// Callback on response from an association release.
         /// </summary>
         void OnReceiveAssociationReleaseResponse();
-
-        /// <summary>
-        /// Callback on recieving an abort message.
-        /// </summary>
-        /// <param name="source">Abort source.</param>
-        /// <param name="reason">Detailed reason for abort.</param>
-        void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason);
-
-        /// <summary>
-        /// Callback when connection is closed.
-        /// </summary>
-        /// <param name="exception">Exception, if any, that forced connection to close.</param>
-        void OnConnectionClosed(Exception exception);
 
         /// <summary>
         /// Callback for handling a client related C-STORE request, typically emanating from the client's C-GET request.

--- a/Tests/DicomDateRangeTest.cs
+++ b/Tests/DicomDateRangeTest.cs
@@ -86,7 +86,7 @@ namespace Dicom
                 DicomTag.AcquisitionDateTime,
                 new DicomDateRange(new DateTime(2016, 4, 20, 10, 20, 30), new DateTime(2016, 4, 21, 8, 50, 5)));
 
-            var zone = DateTime.Now.ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
+            var zone = new DateTime(2016, 4, 20).ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
             var expected = $"20160420102030{zone}-20160421085005{zone}";
             var actual = dataset.Get<string>(DicomTag.AcquisitionDateTime);
 

--- a/Tests/DicomDateTimeTest.cs
+++ b/Tests/DicomDateTimeTest.cs
@@ -18,7 +18,7 @@ namespace Dicom
                     new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3"),
                     new DicomDateTime(DicomTag.AcquisitionDateTime, new DateTime(2016, 4, 20, 10, 20, 30)));
 
-            var zone = DateTime.Now.ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
+            var zone = new DateTime(2016, 4, 20).ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
             var expected = $"20160420102030{zone}";
             var actual = dataset.Get<string>(DicomTag.AcquisitionDateTime);
 
@@ -33,7 +33,7 @@ namespace Dicom
                     new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage),
                     new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3"));
 
-            var zone = DateTime.Now.ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
+            var zone = new DateTime(2016, 4, 20).ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
 
             var exception = Record.Exception(() => dataset.Add(DicomTag.AcquisitionDateTime, $"20160420102030{zone}"));
             Assert.Null(exception);

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -74,7 +74,7 @@ namespace Dicom.Network
                 var client = new DicomClient();
                 client.NegotiateAsyncOps(expected, 1);
 
-                for (var i = 0; i < expected; ++i) client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => ++actual });
+                for (var i = 0; i < expected; ++i) client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref actual) });
 
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
@@ -473,8 +473,6 @@ namespace Dicom.Network
             var port = Ports.GetNext();
             using (DicomServer.Create<DicomCEchoProvider>(port))
             {
-                var counter = 0;
-
                 var client = new DicomClient();
                 client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Thread.Sleep(100) });
                 Assert.True(client.IsSendRequired);
@@ -493,8 +491,6 @@ namespace Dicom.Network
             var port = Ports.GetNext();
             using (DicomServer.Create<DicomCEchoProvider>(port))
             {
-                var counter = 0;
-
                 var client = new DicomClient();
                 client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Thread.Sleep(100) });
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
@@ -512,10 +508,10 @@ namespace Dicom.Network
                 var counter = 0;
 
                 var client = new DicomClient { Linger = 10000 };
-                client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => ++counter });
+                client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref counter) });
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
-                client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => ++counter });
+                client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref counter) });
                 Thread.Sleep(100);
 
                 Assert.Equal(2, counter);

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -87,6 +87,8 @@ namespace Dicom.Network
         [InlineData(100)]
         public void Send_MultipleTimes_AllRecognized(int expected)
         {
+            //LogManager.SetImplementation(NLogManager.Instance);
+
             var port = Ports.GetNext();
             var locker = new object();
             var flag = new ManualResetEventSlim();
@@ -97,7 +99,7 @@ namespace Dicom.Network
 
                 var actual = 0;
 
-                var client = new DicomClient { Linger = 0 };
+                var client = new DicomClient { Linger = 100 };
                 for (var i = 0; i < expected; ++i)
                 {
                     client.AddRequest(
@@ -105,9 +107,9 @@ namespace Dicom.Network
                             {
                                 OnResponseReceived = (req, res) =>
                                     {
+                                        _testOutputHelper.WriteLine($"{i}");
                                         lock (locker)
                                         {
-                                            _testOutputHelper.WriteLine($"{i}");
                                             if (++actual == expected) flag.Set();
                                         }
                                     }

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -48,7 +48,7 @@ namespace Dicom.Network
             using (DicomServer.Create<DicomCEchoProvider>(port))
             {
                 var counter = 0;
-                var request = new DicomCEchoRequest { OnResponseReceived = (req, res) => ++counter };
+                var request = new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref counter) };
 
                 var client = new DicomClient();
                 client.AddRequest(request);
@@ -106,10 +106,8 @@ namespace Dicom.Network
                                 OnResponseReceived = (req, res) =>
                                     {
                                         _testOutputHelper.WriteLine($"{i}");
-                                        lock (locker)
-                                        {
-                                            if (++actual == expected) flag.Set();
-                                        }
+                                        Interlocked.Increment(ref actual);
+                                        if (actual == expected) flag.Set();
                                     }
                             });
                     client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
@@ -127,7 +125,7 @@ namespace Dicom.Network
             using (DicomServer.Create<DicomCEchoProvider>(port))
             {
                 var counter = 0;
-                var request = new DicomCEchoRequest { OnResponseReceived = (req, res) => ++counter };
+                var request = new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref counter) };
 
                 var client = new DicomClient();
                 client.AddRequest(request);
@@ -154,7 +152,7 @@ namespace Dicom.Network
                 var client = new DicomClient();
                 client.NegotiateAsyncOps(expected, 1);
 
-                for (var i = 0; i < expected; ++i) client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => ++actual });
+                for (var i = 0; i < expected; ++i) client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref actual) });
 
                 var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
                 await Task.WhenAny(task, Task.Delay(10000));
@@ -186,10 +184,8 @@ namespace Dicom.Network
                             {
                                 OnResponseReceived = (req, res) =>
                                     {
-                                        lock (locker)
-                                        {
-                                            if (++actual == expected) flag.Set();
-                                        }
+                                        Interlocked.Increment(ref actual);
+                                        if (actual == expected) flag.Set();
                                     }
                             });
                     await client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
@@ -246,7 +242,7 @@ namespace Dicom.Network
             using (DicomServer.Create<DicomCEchoProvider>(port))
             {
                 var counter = 0;
-                var request = new DicomCEchoRequest { OnResponseReceived = (req, res) => ++counter };
+                var request = new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref counter) };
 
                 var client = new DicomClient();
                 client.AddRequest(request);
@@ -272,7 +268,7 @@ namespace Dicom.Network
                 var client = new DicomClient();
                 client.NegotiateAsyncOps(expected, 1);
 
-                for (var i = 0; i < expected; ++i) client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => ++actual });
+                for (var i = 0; i < expected; ++i) client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref actual) });
 
                 client.EndSend(client.BeginSend("127.0.0.1", port, false, "SCU", "ANY-SCP", null, null));
 

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -88,7 +88,6 @@ namespace Dicom.Network
         public void Send_MultipleTimes_AllRecognized(int expected)
         {
             var port = Ports.GetNext();
-            var locker = new object();
             var flag = new ManualResetEventSlim();
 
             using (var server = DicomServer.Create<DicomCEchoProvider>(port))
@@ -97,7 +96,7 @@ namespace Dicom.Network
 
                 var actual = 0;
 
-                var client = new DicomClient { Linger = 0 };
+                var client = new DicomClient();
                 for (var i = 0; i < expected; ++i)
                 {
                     client.AddRequest(
@@ -167,7 +166,6 @@ namespace Dicom.Network
         public async Task SendAsync_MultipleTimes_AllRecognized(int expected)
         {
             var port = Ports.GetNext();
-            var locker = new object();
             var flag = new ManualResetEventSlim();
 
             using (var server = DicomServer.Create<DicomCEchoProvider>(port))
@@ -176,7 +174,7 @@ namespace Dicom.Network
 
                 var actual = 0;
 
-                var client = new DicomClient { Linger = 0 };
+                var client = new DicomClient();
                 for (var i = 0; i < expected; i++)
                 {
                     client.AddRequest(
@@ -529,11 +527,10 @@ namespace Dicom.Network
                 var counter = 0;
                 var flag = new ManualResetEventSlim();
 
-                var client = new DicomClient { Linger = 1000 };
+                var client = new DicomClient { Linger = 100 };
                 client.AddRequest(
                     new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref counter) });
                 client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
-                Thread.Sleep(100);
 
                 client.AddRequest(
                     new DicomCEchoRequest

--- a/Tests/Network/DicomClientTest.cs
+++ b/Tests/Network/DicomClientTest.cs
@@ -87,8 +87,6 @@ namespace Dicom.Network
         [InlineData(100)]
         public void Send_MultipleTimes_AllRecognized(int expected)
         {
-            //LogManager.SetImplementation(NLogManager.Instance);
-
             var port = Ports.GetNext();
             var locker = new object();
             var flag = new ManualResetEventSlim();
@@ -99,7 +97,7 @@ namespace Dicom.Network
 
                 var actual = 0;
 
-                var client = new DicomClient { Linger = 100 };
+                var client = new DicomClient { Linger = 0 };
                 for (var i = 0; i < expected; ++i)
                 {
                     client.AddRequest(
@@ -180,7 +178,7 @@ namespace Dicom.Network
 
                 var actual = 0;
 
-                var client = new DicomClient();
+                var client = new DicomClient { Linger = 0 };
                 for (var i = 0; i < expected; i++)
                 {
                     client.AddRequest(

--- a/Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Serialization/JsonDicomConverterTest.cs
@@ -59,7 +59,7 @@ namespace Dicom.Serialization
         /// <summary>
         /// Tests that DS values are not mangled
         /// </summary>
-        [Fact(Skip = "Json.NET does not support accessing the string value of a json floating point number")]
+        [Fact]
         public void DecimalStringValuesShouldPass()
         {
             var ds = new DicomDataset { { DicomTag.ImagePositionPatient, new[] { "1.0000", "0.00", "0", "1e-3096", "1", "0.0000000" } } };


### PR DESCRIPTION
Fixes #389 .

Changes proposed in this pull request:
- Added new property `DicomClient.IsSendRequired`, to indicate whether `Send` needs to called again after adding new requests.
- General improvement of connection reliability in `DicomClient` and `DicomService`.
- Removed obsolete `DicomServiceOptions.ThreadPoolLinger` property.
