### PR TITLE
Account for offset when determining buffer copy length in EvenLengthBuffer. Connected to #405

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 #### v.3.0.0 (RC, TBD)
 * Added method GenerateUuidDerived (#408)
+* Incorrect handling of padded buffer end in EvenLengthBuffer.GetByteRange (#405 #412)
 * Unhandled exception after error in JPEG native decoding (#394 #399)
 * DicomDataset.Get&lt;T[]&gt; on empty tag should not throw (#392 #398)
 * Efilm 2.1.2 seems to send funny presentation contexts, break on PDU.read (#391 #397)

--- a/DICOM/IO/Buffer/EvenLengthBuffer.cs
+++ b/DICOM/IO/Buffer/EvenLengthBuffer.cs
@@ -5,48 +5,72 @@ using System;
 
 namespace Dicom.IO.Buffer
 {
+    /// <summary>
+    /// Wrapper class for uneven length buffers that needs to be represented as even length buffers.
+    /// </summary>
     public class EvenLengthBuffer : IByteBuffer
     {
+        /// <summary>
+        /// Initializes an instance of the <see cref="EvenLengthBuffer"/> class.
+        /// </summary>
+        /// <param name="buffer">Uneven length buffer.</param>
+        /// <remarks>Constructor is private to ensure that instance is not created for an even length buffer. Static method <see cref="Create"/>
+        /// should be used to initialize buffers.</remarks>
         private EvenLengthBuffer(IByteBuffer buffer)
         {
             Buffer = buffer;
         }
 
-        public IByteBuffer Buffer { get; private set; }
+        /// <summary>
+        /// Underlying uneven length buffer.
+        /// </summary>
+        public IByteBuffer Buffer { get; }
 
-        public bool IsMemory
-        {
-            get
-            {
-                return true;
-            }
-        }
+        /// <summary>
+        /// Gets whether the buffer is held in memory.
+        /// </summary>
+        public bool IsMemory => Buffer.IsMemory;
 
-        public uint Size
-        {
-            get
-            {
-                return Buffer.Size + 1;
-            }
-        }
+        /// <summary>
+        /// Gets the size of the even length buffer, which is always equal to the underlying (uneven length) buffer plus 1.
+        /// </summary>
+        public uint Size => Buffer.Size + 1;
 
+        /// <summary>
+        /// Gets the buffer data, which is equal to the underlying buffer data plus a padding byte at the end.
+        /// </summary>
         public byte[] Data
         {
             get
             {
-                byte[] data = new byte[Size];
+                var data = new byte[Size];
                 System.Buffer.BlockCopy(Buffer.Data, 0, data, 0, (int)Buffer.Size);
                 return data;
             }
         }
 
+        /// <summary>
+        /// Gets a subset of the data.
+        /// </summary>
+        /// <param name="offset">Offset from beginning of data array.</param>
+        /// <param name="count">Number of bytes to return.</param>
+        /// <returns>Requested sub-range of the <see name="Data"/> array.</returns>
+        /// <remarks>Allows for reach to the padded byte at the end of the even length buffer.</remarks>
         public byte[] GetByteRange(int offset, int count)
         {
-            byte[] data = new byte[count];
-            System.Buffer.BlockCopy(Buffer.Data, offset, data, 0, Math.Min((int)Buffer.Size, count));
+            var data = new byte[count];
+            System.Buffer.BlockCopy(Buffer.Data, offset, data, 0, Math.Min((int)Buffer.Size - offset, count));
             return data;
         }
 
+        /// <summary>
+        /// If necessary, creates an even length buffer for the specified <paramref name="buffer"/>.
+        /// </summary>
+        /// <param name="buffer">Buffer that is required to be of even length.</param>
+        /// <returns>
+        /// If <paramref name="buffer"/> is of uneven length, returns an even length buffer wrapping the <paramref name="buffer"/>,
+        /// otherwise returns the buffer itself.
+        /// </returns>
         public static IByteBuffer Create(IByteBuffer buffer)
         {
             if ((buffer.Size & 1) == 1) return new EvenLengthBuffer(buffer);

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Imaging\SpatialTransformTest.cs" />
     <Compile Include="Imaging\WinFormsImageTest.cs" />
     <Compile Include="Imaging\WPFImageTest.cs" />
+    <Compile Include="IO\Buffer\EvenLengthBufferTest.cs" />
     <Compile Include="IO\Buffer\TempFileBufferTest.cs" />
     <Compile Include="IO\DesktopFileReferenceTest.cs" />
     <Compile Include="IO\DesktopPathTest.cs" />

--- a/Tests/IO/Buffer/EvenLengthBufferTest.cs
+++ b/Tests/IO/Buffer/EvenLengthBufferTest.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Xunit;
+
+namespace Dicom.IO.Buffer
+{
+    public class EvenLengthBufferTest
+    {
+        [Theory]
+        [InlineData(0, 8)]
+        [InlineData(4, 4)]
+        [InlineData(5, 3)]
+        public void GetByteRange_WithOffset_ToEnd_ShouldReturnValidArray(int offset, int count)
+        {
+            var buffer = EvenLengthBuffer.Create(new MemoryByteBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7 }));
+            var range = buffer.GetByteRange(offset, count);
+            Assert.Equal(count, range.Length);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #405 .

Changes proposed in this pull request:
- When determining how many bytes to copy in `EvenLengthBuffer`, correctly account for remaining bytes of underlying buffer even when offset is non-zero.
