### PR TITLE
Handle zero-machine name in source AET. Connected to #411

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (RC, TBD)
+* DicomFile.Save throwing an exception in DotNetCore for macOS (#411 #413)
 * Added method GenerateUuidDerived (#408)
 * Incorrect handling of padded buffer end in EvenLengthBuffer.GetByteRange (#405 #412)
 * Unhandled exception after error in JPEG native decoding (#394 #399)

--- a/DICOM/DicomFileMetaInformation.cs
+++ b/DICOM/DicomFileMetaInformation.cs
@@ -35,7 +35,9 @@ namespace Dicom
 
             this.ImplementationClassUID = DicomImplementation.ClassUID;
             this.ImplementationVersionName = DicomImplementation.Version;
-            this.SourceApplicationEntityTitle = CreateSourceApplicationEntityTitle();
+
+            var aet = CreateSourceApplicationEntityTitle();
+            if (aet != null) this.SourceApplicationEntityTitle = aet;
         }
 
         /// <summary>
@@ -52,7 +54,9 @@ namespace Dicom
 
             this.ImplementationClassUID = DicomImplementation.ClassUID;
             this.ImplementationVersionName = DicomImplementation.Version;
-            this.SourceApplicationEntityTitle = CreateSourceApplicationEntityTitle();
+
+            var aet = CreateSourceApplicationEntityTitle();
+            if (aet != null) this.SourceApplicationEntityTitle = aet;
         }
 
         #endregion
@@ -181,7 +185,7 @@ namespace Dicom
         }
 
         /// <summary>
-        /// Create a source application title from the machine name..
+        /// Create a source application title from the machine name.
         /// </summary>
         /// <returns>
         /// The machine name truncated to a maximum of 16 characters.
@@ -189,7 +193,7 @@ namespace Dicom
         private static string CreateSourceApplicationEntityTitle()
         {
             var machine = NetworkManager.MachineName;
-            if (machine.Length > 16)
+            if (machine != null && machine.Length > 16)
             {
                 machine = machine.Substring(0, 16);
             }

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -104,7 +104,6 @@ namespace Dicom.Media
             FileMetaInfo.Version = new byte[] { 0x00, 0x01 };
             FileMetaInfo.MediaStorageSOPClassUID = DicomUID.MediaStorageDirectoryStorage;
             FileMetaInfo.MediaStorageSOPInstanceUID = DicomUID.Generate();
-            FileMetaInfo.SourceApplicationEntityTitle = string.Empty;
             FileMetaInfo.TransferSyntax = explicitVr
                                               ? DicomTransferSyntax.ExplicitVRLittleEndian
                                               : DicomTransferSyntax.ImplicitVRLittleEndian;


### PR DESCRIPTION
Fixes #411 .

Changes proposed in this pull request:
- Handle `NetworkManager.MachineName` equal to `null` in `DicomFileMetaInformation.CreateSourceApplicationEntityTitle`.
- In `DicomFileMetaInformation` constructors, only set `SourceApplicationEntityTitle` if created value is non-`null`.
- In `DicomDirectory`, do not set file meta information source AET to empty string.
