### PR TITLE
Set interleave mode to None for grayscale JPEG-LS encoding. Connected to #416

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@
 * Handle parsing sequence items not associated with any sequence (#364 #383)
 * System Out Of Memory Exception when saving large DICOM files (#363 #384)
 * Null characters not trimmed from string values (#359 #380)
-* Corrected JPEG-LS encoding and JPEG decoding for YBR images (#358 #379)
+* Corrected JPEG-LS encoding and JPEG decoding for YBR images (#358 #379 #416 #418)
 * Cannot override CreateCStoreReceiveStream due to private fields (#357 #386)
 * DicomClient multiple C-Store request cause exception when AsyncOps is not negotiated (#356 #400)
 * Enable registration of private UIDs (#355 #387)

--- a/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Dicom.Imaging.Codec.JpegLS.cpp
@@ -63,10 +63,11 @@ namespace Dicom {
 				params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
 				params.components = oldPixelData->SamplesPerPixel;
 
-				params.ilv =
-					oldPixelData->SamplesPerPixel == 3 && oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
-					? CharlsInterleaveModeType::Sample
-					: CharlsInterleaveModeType::Line;
+				params.ilv = oldPixelData->SamplesPerPixel == 1 
+					? CharlsInterleaveModeType::None : 
+					oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
+						? CharlsInterleaveModeType::Sample
+						: CharlsInterleaveModeType::Line;
 				params.colorTransform = CharlsColorTransformationType::None;
 
 				if (TransferSyntax == DicomTransferSyntax::JPEGLSNearLossless) {

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
@@ -52,10 +52,10 @@ void DicomJpegLsNativeCodec::Encode(NativePixelData^ oldPixelData, NativePixelDa
 	params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
 	params.components = oldPixelData->SamplesPerPixel;
 
-	params.ilv =
-		oldPixelData->SamplesPerPixel == 3 && oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
-		? CharlsInterleaveModeType::Sample
-		: CharlsInterleaveModeType::Line;
+		? CharlsInterleaveModeType::None :
+		oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
+			? CharlsInterleaveModeType::Sample
+			: CharlsInterleaveModeType::Line;
 	params.colorTransform = CharlsColorTransformationType::None;
 
 	for (int frame = 0; frame < oldPixelData->NumberOfFrames; frame++) {

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.JpegLS.cpp
@@ -52,6 +52,7 @@ void DicomJpegLsNativeCodec::Encode(NativePixelData^ oldPixelData, NativePixelDa
 	params.bytesperline = oldPixelData->BytesAllocated * oldPixelData->Width * oldPixelData->SamplesPerPixel;
 	params.components = oldPixelData->SamplesPerPixel;
 
+	params.ilv = oldPixelData->SamplesPerPixel == 1
 		? CharlsInterleaveModeType::None :
 		oldPixelData->PlanarConfiguration == PlanarConfiguration::Interleaved
 			? CharlsInterleaveModeType::Sample


### PR DESCRIPTION
Fixes #416 .

Changes proposed in this pull request:
- In JPEG-LS encoding, when samples per pixel is set to 1, use interleave mode None. Apply to Desktop and UWP implementations.

Note! For grayscale images, this is a revert to the state before PR #379.