### PR TITLE
Corrections related to DIMSE-N services. Connected to #353

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-#### v.3.0.0 (TBD)
+#### v.3.0.0 (RC2, 2/2/2017)
 * Print SCP exception due to insufficient DicomDataset.AddOrUpdate refactoring (#353 #420)
 * Invalid decoding of JPEG baseline RGB images with managed JPEG codec (#417 #419)
 * DicomFile.Save throwing an exception in DotNetCore for macOS (#411 #413)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (TBD)
+* Print SCP exception due to insufficient DicomDataset.AddOrUpdate refactoring (#353 #420)
 * Invalid decoding of JPEG baseline RGB images with managed JPEG codec (#417 #419)
 * DicomFile.Save throwing an exception in DotNetCore for macOS (#411 #413)
 * Added method GenerateUuidDerived (#408)

--- a/DICOM/DicomUIDGenerator.cs
+++ b/DICOM/DicomUIDGenerator.cs
@@ -116,6 +116,7 @@ namespace Dicom
         {            
             var guid = Guid.NewGuid().ToByteArray();
             var bigint = new System.Numerics.BigInteger(guid);
+            if (bigint < 0) bigint = -bigint;
             var uid = "2.25." + bigint;
 
             return new DicomUID(uid, "Local UID", DicomUidType.Unknown);

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -5,37 +5,79 @@ namespace Dicom.Network
 {
     using System;
 
+    /// <summary>
+    /// Representation of a C-FIND request.
+    /// </summary>
     public sealed class DicomCFindRequest : DicomPriorityRequest
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomCFindRequest"/> class.
+        /// </summary>
+        /// <param name="command">C-FIND RQ command.</param>
         public DicomCFindRequest(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomCFindRequest"/> class.
+        /// </summary>
+        /// <param name="level">Query&#47;Retrieve level.</param>
+        /// <param name="priority">Command priority.</param>
         public DicomCFindRequest(DicomQueryRetrieveLevel level, DicomPriority priority = DicomPriority.Medium)
-            : base(DicomCommandField.CFindRequest, DicomUID.StudyRootQueryRetrieveInformationModelFIND, priority)
+            : base(DicomCommandField.CFindRequest, GetAffectedSOPClassUID(level), priority)
         {
             Dataset = new DicomDataset();
             Level = level;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets or sets the query&#47;Retrieve level.
+        /// </summary>
         public DicomQueryRetrieveLevel Level
         {
             get
             {
                 return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
             }
-            set
+            private set
             {
                 Dataset.Remove(DicomTag.QueryRetrieveLevel);
                 if (value != DicomQueryRetrieveLevel.Worklist) Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
             }
         }
 
+        #endregion
+
+        #region DELEGATES AND EVENTS
+
+        /// <summary>
+        /// Delegate for response received event handling.
+        /// </summary>
+        /// <param name="request">C-FIND request.</param>
+        /// <param name="response">C-FIND response.</param>
         public delegate void ResponseDelegate(DicomCFindRequest request, DicomCFindResponse response);
 
+        /// <summary>
+        /// Gets or sets the response received event handler.
+        /// </summary>
         public ResponseDelegate OnResponseReceived;
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Event handler to perform when response has been received.
+        /// </summary>
+        /// <param name="service">Associated DICOM service.</param>
+        /// <param name="response">C-FIND response.</param>
         protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
@@ -47,19 +89,35 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Convenience method for creating a C-FIND patient query.
+        /// </summary>
+        /// <param name="patientId">Patient ID</param>
+        /// <param name="patientName">Patient name.</param>
+        /// <returns>C-FIND patient query object.</returns>
         public static DicomCFindRequest CreatePatientQuery(string patientId = null, string patientName = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Patient);
-            dimse.SOPClassUID = DicomUID.PatientRootQueryRetrieveInformationModelFIND;
             dimse.Dataset.Add(DicomTag.PatientID, patientId);
             dimse.Dataset.Add(DicomTag.PatientName, patientName);
-            dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
-            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
+            dimse.Dataset.Add(DicomTag.OtherPatientIDs, string.Empty);
+            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientSex, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientBirthDate, string.Empty);
             return dimse;
         }
 
+        /// <summary>
+        /// Convenience method for creating a C-FIND study query.
+        /// </summary>
+        /// <param name="patientId">Patient ID.</param>
+        /// <param name="patientName">Patient name.</param>
+        /// <param name="studyDateTime">Time range of studies.</param>
+        /// <param name="accession">Accession number.</param>
+        /// <param name="studyId">Study ID.</param>
+        /// <param name="modalitiesInStudy">Modalities in study.</param>
+        /// <param name="studyInstanceUid">Study instance UID.</param>
+        /// <returns>C-FIND study query object.</returns>
         public static DicomCFindRequest CreateStudyQuery(
             string patientId = null,
             string patientName = null,
@@ -70,40 +128,75 @@ namespace Dicom.Network
             string studyInstanceUid = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Study);
-            dimse.SOPClassUID = DicomUID.StudyRootQueryRetrieveInformationModelFIND;
             dimse.Dataset.Add(DicomTag.PatientID, patientId);
             dimse.Dataset.Add(DicomTag.PatientName, patientName);
-            dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
-            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
+            dimse.Dataset.Add(DicomTag.OtherPatientIDs, string.Empty);
+            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientSex, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientBirthDate, string.Empty);
             dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             dimse.Dataset.Add(DicomTag.ModalitiesInStudy, modalitiesInStudy);
             dimse.Dataset.Add(DicomTag.StudyID, studyId);
             dimse.Dataset.Add(DicomTag.AccessionNumber, accession);
             dimse.Dataset.Add(DicomTag.StudyDate, studyDateTime);
             dimse.Dataset.Add(DicomTag.StudyTime, studyDateTime);
-            dimse.Dataset.Add(DicomTag.StudyDescription, String.Empty);
-            dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedSeries, String.Empty);
-            dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedInstances, String.Empty);
+            dimse.Dataset.Add(DicomTag.StudyDescription, string.Empty);
+            dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedSeries, string.Empty);
+            dimse.Dataset.Add(DicomTag.NumberOfStudyRelatedInstances, string.Empty);
             return dimse;
         }
 
+        /// <summary>
+        /// Convenience method for creating a C-FIND series query.
+        /// </summary>
+        /// <param name="studyInstanceUid">Study instance UID.</param>
+        /// <param name="modality">Modality.</param>
+        /// <returns>C-FIND series query object.</returns>
         public static DicomCFindRequest CreateSeriesQuery(string studyInstanceUid, string modality = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
-            dimse.SOPClassUID = DicomUID.StudyRootQueryRetrieveInformationModelFIND;
             dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
-            dimse.Dataset.Add(DicomTag.SeriesInstanceUID, String.Empty);
-            dimse.Dataset.Add(DicomTag.SeriesNumber, String.Empty);
-            dimse.Dataset.Add(DicomTag.SeriesDescription, String.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesInstanceUID, string.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesNumber, string.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesDescription, string.Empty);
             dimse.Dataset.Add(DicomTag.Modality, modality);
-            dimse.Dataset.Add(DicomTag.SeriesDate, String.Empty);
-            dimse.Dataset.Add(DicomTag.SeriesTime, String.Empty);
-            dimse.Dataset.Add(DicomTag.NumberOfSeriesRelatedInstances, String.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesDate, string.Empty);
+            dimse.Dataset.Add(DicomTag.SeriesTime, string.Empty);
+            dimse.Dataset.Add(DicomTag.NumberOfSeriesRelatedInstances, string.Empty);
             return dimse;
         }
 
+        /// <summary>
+        /// Convenience method for creating a C-FIND image query.
+        /// </summary>
+        /// <param name="studyInstanceUid">Study instance UID.</param>
+        /// <param name="seriesInstanceUid">Series instance UID.</param>
+        /// <param name="modality">Modality.</param>
+        /// <returns>C-FIND image query object.</returns>
+        public static DicomCFindRequest CreateImageQuery(
+            string studyInstanceUid,
+            string seriesInstanceUid,
+            string modality = null)
+        {
+            var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Image);
+            dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
+            dimse.Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
+            dimse.Dataset.Add(DicomTag.SOPInstanceUID, string.Empty);
+            dimse.Dataset.Add(DicomTag.InstanceNumber, string.Empty);
+            dimse.Dataset.Add(DicomTag.Modality, modality);
+            return dimse;
+        }
+
+        /// <summary>
+        /// Convenience method for creating a C-FIND modality worklist query.
+        /// </summary>
+        /// <param name="patientId">Patient ID.</param>
+        /// <param name="patientName">Patient name.</param>
+        /// <param name="stationAE">Scheduled station Application Entity Title.</param>
+        /// <param name="stationName">Scheduled station name.</param>
+        /// <param name="modality">Modality.</param>
+        /// <param name="scheduledDateTime">Scheduled procedure step start time.</param>
+        /// <returns>C-FIND modality worklist query object.</returns>
         public static DicomCFindRequest CreateWorklistQuery(
             string patientId = null,
             string patientName = null,
@@ -113,37 +206,36 @@ namespace Dicom.Network
             DicomDateRange scheduledDateTime = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Worklist);
-            dimse.SOPClassUID = DicomUID.ModalityWorklistInformationModelFIND;
             dimse.Dataset.Add(DicomTag.PatientID, patientId);
             dimse.Dataset.Add(DicomTag.PatientName, patientName);
-            dimse.Dataset.Add(DicomTag.OtherPatientIDs, String.Empty);
-            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientSex, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientWeight, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientBirthDate, String.Empty);
-            dimse.Dataset.Add(DicomTag.MedicalAlerts, String.Empty);
+            dimse.Dataset.Add(DicomTag.OtherPatientIDs, string.Empty);
+            dimse.Dataset.Add(DicomTag.IssuerOfPatientID, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientSex, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientWeight, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientBirthDate, string.Empty);
+            dimse.Dataset.Add(DicomTag.MedicalAlerts, string.Empty);
             dimse.Dataset.Add(DicomTag.PregnancyStatus, new ushort[0]);
-            dimse.Dataset.Add(DicomTag.Allergies, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientComments, String.Empty);
-            dimse.Dataset.Add(DicomTag.SpecialNeeds, String.Empty);
-            dimse.Dataset.Add(DicomTag.PatientState, String.Empty);
-            dimse.Dataset.Add(DicomTag.CurrentPatientLocation, String.Empty);
-            dimse.Dataset.Add(DicomTag.InstitutionName, String.Empty);
-            dimse.Dataset.Add(DicomTag.AdmissionID, String.Empty);
-            dimse.Dataset.Add(DicomTag.AccessionNumber, String.Empty);
-            dimse.Dataset.Add(DicomTag.ReferringPhysicianName, String.Empty);
-            dimse.Dataset.Add(DicomTag.AdmittingDiagnosesDescription, String.Empty);
-            dimse.Dataset.Add(DicomTag.RequestingPhysician, String.Empty);
-            dimse.Dataset.Add(DicomTag.StudyInstanceUID, String.Empty);
-            dimse.Dataset.Add(DicomTag.StudyDescription, String.Empty);
-            dimse.Dataset.Add(DicomTag.StudyID, String.Empty);
-            dimse.Dataset.Add(DicomTag.ReasonForTheRequestedProcedure, String.Empty);
-            dimse.Dataset.Add(DicomTag.StudyDate, String.Empty);
-            dimse.Dataset.Add(DicomTag.StudyTime, String.Empty);
+            dimse.Dataset.Add(DicomTag.Allergies, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientComments, string.Empty);
+            dimse.Dataset.Add(DicomTag.SpecialNeeds, string.Empty);
+            dimse.Dataset.Add(DicomTag.PatientState, string.Empty);
+            dimse.Dataset.Add(DicomTag.CurrentPatientLocation, string.Empty);
+            dimse.Dataset.Add(DicomTag.InstitutionName, string.Empty);
+            dimse.Dataset.Add(DicomTag.AdmissionID, string.Empty);
+            dimse.Dataset.Add(DicomTag.AccessionNumber, string.Empty);
+            dimse.Dataset.Add(DicomTag.ReferringPhysicianName, string.Empty);
+            dimse.Dataset.Add(DicomTag.AdmittingDiagnosesDescription, string.Empty);
+            dimse.Dataset.Add(DicomTag.RequestingPhysician, string.Empty);
+            dimse.Dataset.Add(DicomTag.StudyInstanceUID, string.Empty);
+            dimse.Dataset.Add(DicomTag.StudyDescription, string.Empty);
+            dimse.Dataset.Add(DicomTag.StudyID, string.Empty);
+            dimse.Dataset.Add(DicomTag.ReasonForTheRequestedProcedure, string.Empty);
+            dimse.Dataset.Add(DicomTag.StudyDate, string.Empty);
+            dimse.Dataset.Add(DicomTag.StudyTime, string.Empty);
 
-            dimse.Dataset.Add(DicomTag.RequestedProcedureID, String.Empty);
-            dimse.Dataset.Add(DicomTag.RequestedProcedureDescription, String.Empty);
-            dimse.Dataset.Add(DicomTag.RequestedProcedurePriority, String.Empty);
+            dimse.Dataset.Add(DicomTag.RequestedProcedureID, string.Empty);
+            dimse.Dataset.Add(DicomTag.RequestedProcedureDescription, string.Empty);
+            dimse.Dataset.Add(DicomTag.RequestedProcedurePriority, string.Empty);
             dimse.Dataset.Add(new DicomSequence(DicomTag.RequestedProcedureCodeSequence));
             dimse.Dataset.Add(new DicomSequence(DicomTag.ReferencedStudySequence));
 
@@ -155,17 +247,41 @@ namespace Dicom.Network
             sps.Add(DicomTag.ScheduledProcedureStepStartDate, scheduledDateTime);
             sps.Add(DicomTag.ScheduledProcedureStepStartTime, scheduledDateTime);
             sps.Add(DicomTag.Modality, modality);
-            sps.Add(DicomTag.ScheduledPerformingPhysicianName, String.Empty);
-            sps.Add(DicomTag.ScheduledProcedureStepDescription, String.Empty);
+            sps.Add(DicomTag.ScheduledPerformingPhysicianName, string.Empty);
+            sps.Add(DicomTag.ScheduledProcedureStepDescription, string.Empty);
             sps.Add(new DicomSequence(DicomTag.ScheduledProtocolCodeSequence));
-            sps.Add(DicomTag.ScheduledProcedureStepLocation, String.Empty);
-            sps.Add(DicomTag.ScheduledProcedureStepID, String.Empty);
-            sps.Add(DicomTag.RequestedContrastAgent, String.Empty);
-            sps.Add(DicomTag.PreMedication, String.Empty);
-            sps.Add(DicomTag.AnatomicalOrientationType, String.Empty);
+            sps.Add(DicomTag.ScheduledProcedureStepLocation, string.Empty);
+            sps.Add(DicomTag.ScheduledProcedureStepID, string.Empty);
+            sps.Add(DicomTag.RequestedContrastAgent, string.Empty);
+            sps.Add(DicomTag.PreMedication, string.Empty);
+            sps.Add(DicomTag.AnatomicalOrientationType, string.Empty);
             dimse.Dataset.Add(new DicomSequence(DicomTag.ScheduledProcedureStepSequence, sps));
 
             return dimse;
         }
+
+        /// <summary>
+        /// Gets affected SOP class UID corresponding to specified Query&#47;Retrieve <paramref name="level"/>.
+        /// </summary>
+        /// <param name="level">Query&#47;Retrieve level.</param>
+        /// <returns>Affected SOP class UID corresponding to specified Query&#47;Retrieve <paramref name="level"/>.</returns>
+        private static DicomUID GetAffectedSOPClassUID(DicomQueryRetrieveLevel level)
+        {
+            switch (level)
+            {
+                case DicomQueryRetrieveLevel.Patient:
+                    return DicomUID.PatientRootQueryRetrieveInformationModelFIND;
+                case DicomQueryRetrieveLevel.Study:
+                case DicomQueryRetrieveLevel.Series:
+                case DicomQueryRetrieveLevel.Image:
+                    return DicomUID.StudyRootQueryRetrieveInformationModelFIND;
+                case DicomQueryRetrieveLevel.Worklist:
+                    return DicomUID.ModalityWorklistInformationModelFIND;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
+            }
+        }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -3,13 +3,28 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Representation of a C-MOVE request.
+    /// </summary>
     public sealed class DicomCMoveRequest : DicomPriorityRequest
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Inititalizes an instance of the <see cref="DicomCMoveRequest"/> class.
+        /// </summary>
+        /// <param name="command">Request command.</param>
         public DicomCMoveRequest(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomCMoveRequest"/> class for a specific study.
+        /// </summary>
+        /// <param name="destinationAe">Move destination Application Entity Title.</param>
+        /// <param name="studyInstanceUid">Study instance UID.</param>
+        /// <param name="priority">Request priority.</param>
         public DicomCMoveRequest(
             string destinationAe,
             string studyInstanceUid,
@@ -22,6 +37,13 @@ namespace Dicom.Network
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomCMoveRequest"/> class for a specific series.
+        /// </summary>
+        /// <param name="destinationAe">Move destination Application Entity Title.</param>
+        /// <param name="studyInstanceUid">Study instance UID.</param>
+        /// <param name="seriesInstanceUid">Series instance UID.</param>
+        /// <param name="priority">Request priority.</param>
         public DicomCMoveRequest(
             string destinationAe,
             string studyInstanceUid,
@@ -36,6 +58,14 @@ namespace Dicom.Network
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomCMoveRequest"/> class for a specific image.
+        /// </summary>
+        /// <param name="destinationAe">Move destination Application Entity Title.</param>
+        /// <param name="studyInstanceUid">Study instance UID.</param>
+        /// <param name="seriesInstanceUid">Series instance UID.</param>
+        /// <param name="sopInstanceUid">SOP instance UID.</param>
+        /// <param name="priority">Request priority.</param>
         public DicomCMoveRequest(
             string destinationAe,
             string studyInstanceUid,
@@ -52,35 +82,66 @@ namespace Dicom.Network
             Dataset.Add(DicomTag.SOPInstanceUID, sopInstanceUid);
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the Query&#47;Retrieve level.
+        /// </summary>
         public DicomQueryRetrieveLevel Level
         {
             get
             {
                 return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
             }
-            set
+            private set
             {
                 Dataset.Remove(DicomTag.QueryRetrieveLevel);
                 if (value != DicomQueryRetrieveLevel.Worklist) Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
             }
         }
 
+        /// <summary>
+        /// Gets the move destination Application Entity Title.
+        /// </summary>
         public string DestinationAE
         {
             get
             {
                 return Command.Get<string>(DicomTag.MoveDestination);
             }
-            set
+            private set
             {
                 Command.AddOrUpdate(DicomTag.MoveDestination, value);
             }
         }
 
+        #endregion
+
+        #region DELEGATES AND EVENTS
+
+        /// <summary>
+        /// Delegate representing a C-MOVE RSP received event handler.
+        /// </summary>
+        /// <param name="request">C-MOVE RQ.</param>
+        /// <param name="response">C-MOVE RSP.</param>
         public delegate void ResponseDelegate(DicomCMoveRequest request, DicomCMoveResponse response);
 
+        /// <summary>
+        /// Gets or sets the handler for the C-MOVE response received event.
+        /// </summary>
         public ResponseDelegate OnResponseReceived;
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Invoke the event handler upon receiving a C-MOVE response.
+        /// </summary>
+        /// <param name="service">Associated DICOM service.</param>
+        /// <param name="response">C-MOVE response.</param>
         protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
@@ -91,5 +152,7 @@ namespace Dicom.Network
             {
             }
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomMessage.cs
+++ b/DICOM/Network/DicomMessage.cs
@@ -12,6 +12,12 @@ namespace Dicom.Network
     /// </summary>
     public class DicomMessage
     {
+        #region FIELDS
+
+        private DicomDataset _dataset;
+
+        #endregion
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DicomMessage"/> class.
         /// </summary>
@@ -41,7 +47,7 @@ namespace Dicom.Network
             {
                 return Command.Get<DicomCommandField>(DicomTag.CommandField);
             }
-            set
+            protected set
             {
                 Command.AddOrUpdate(DicomTag.CommandField, (ushort)value);
             }
@@ -61,11 +67,19 @@ namespace Dicom.Network
                     case DicomCommandField.NActionRequest:
                     case DicomCommandField.NDeleteRequest:
                         return Command.Get<DicomUID>(DicomTag.RequestedSOPClassUID);
-                    default:
+                    case DicomCommandField.CStoreRequest:
+                    case DicomCommandField.CFindRequest:
+                    case DicomCommandField.CGetRequest:
+                    case DicomCommandField.CMoveRequest:
+                    case DicomCommandField.CEchoRequest:
+                    case DicomCommandField.NEventReportRequest:
+                    case DicomCommandField.NCreateRequest:
                         return Command.Get<DicomUID>(DicomTag.AffectedSOPClassUID);
+                    default:
+                        return Command.Get<DicomUID>(DicomTag.AffectedSOPClassUID, null);
                 }
             }
-            set
+            protected set
             {
                 switch (Type)
                 {
@@ -85,14 +99,7 @@ namespace Dicom.Network
         /// <summary>
         /// Gets a value indicating whether the message contains a dataset.
         /// </summary>
-        public bool HasDataset
-        {
-            get
-            {
-                return Command.Get<ushort>(DicomTag.CommandDataSetType, 0, 0x0101) != 0x0101;
-            }
-        }
-
+        public bool HasDataset => Command.Get<ushort>(DicomTag.CommandDataSetType, 0, 0x0101) != 0x0101;
 
         /// <summary>
         /// Gets or sets the presentation Context.
@@ -102,9 +109,7 @@ namespace Dicom.Network
         /// <summary>
         /// Gets or sets the associated DICOM command.
         /// </summary>
-        public DicomDataset Command { get; set; }
-
-        private DicomDataset _dataset;
+        public DicomDataset Command { get; protected set; }
 
         /// <summary>
         /// Gets or sets the dataset potentially included in the message..
@@ -118,7 +123,7 @@ namespace Dicom.Network
             set
             {
                 _dataset = value;
-                Command.AddOrUpdate(DicomTag.CommandDataSetType, (_dataset != null) ? (ushort)0x0202 : (ushort)0x0101);
+                Command.AddOrUpdate(DicomTag.CommandDataSetType, _dataset != null ? (ushort)0x0202 : (ushort)0x0101);
             }
         }
 
@@ -133,12 +138,8 @@ namespace Dicom.Network
         /// <returns>Formatted output string of the DICOM message.</returns>
         public override string ToString()
         {
-            return string.Format(
-                "{0} [{1}]",
-                ToString(Type),
-                IsRequest(Type)
-                    ? Command.Get<ushort>(DicomTag.MessageID)
-                    : Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo));
+            return
+                $"{ToString(Type)} [{(IsRequest(Type) ? Command.Get<ushort>(DicomTag.MessageID) : Command.Get<ushort>(DicomTag.MessageIDBeingRespondedTo))}]";
         }
 
         /// <summary>

--- a/DICOM/Network/DicomNActionRequest.cs
+++ b/DICOM/Network/DicomNActionRequest.cs
@@ -5,13 +5,28 @@ namespace Dicom.Network
 {
     using System.Text;
 
+    /// <summary>
+    /// Representation of an N-ACTION request.
+    /// </summary>
     public sealed class DicomNActionRequest : DicomRequest
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNActionRequest"/> class.
+        /// </summary>
+        /// <param name="command">N-ACTION request command.</param>
         public DicomNActionRequest(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNActionRequest"/> class.
+        /// </summary>
+        /// <param name="requestedClassUid">Requested SOP class UID.</param>
+        /// <param name="requestedInstanceUid">Requested SOP instance UID.</param>
+        /// <param name="actionTypeId">Action type ID.</param>
         public DicomNActionRequest(
             DicomUID requestedClassUid,
             DicomUID requestedInstanceUid,
@@ -22,6 +37,13 @@ namespace Dicom.Network
             ActionTypeID = actionTypeId;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the requested SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
@@ -34,6 +56,9 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Gets the action type ID.
+        /// </summary>
         public ushort ActionTypeID
         {
             get
@@ -46,12 +71,31 @@ namespace Dicom.Network
             }
         }
 
-        internal bool HasSOPInstanceUID => this.Command.Contains(DicomTag.RequestedSOPInstanceUID);
+        #endregion
 
+        #region DELEGATES AND EVENTS
+
+        /// <summary>
+        /// Delegate representing a N-ACTION RSP received event handler.
+        /// </summary>
+        /// <param name="request">N-ACTION RQ.</param>
+        /// <param name="response">N-ACTION RSP.</param>
         public delegate void ResponseDelegate(DicomNActionRequest request, DicomNActionResponse response);
 
+        /// <summary>
+        /// Gets or sets the handler for the N-ACTION response received event.
+        /// </summary>
         public ResponseDelegate OnResponseReceived;
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Invoke the event handler upon receiving a N-ACTION response.
+        /// </summary>
+        /// <param name="service">Associated DICOM service.</param>
+        /// <param name="response">N-ACTION response.</param>
         protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
@@ -74,5 +118,7 @@ namespace Dicom.Network
             if (Command.Contains(DicomTag.ActionTypeID)) sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
             return sb.ToString();
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNActionResponse.cs
+++ b/DICOM/Network/DicomNActionResponse.cs
@@ -3,7 +3,6 @@
 
 namespace Dicom.Network
 {
-    using System;
     using System.Text;
 
     /// <summary>
@@ -36,12 +35,8 @@ namespace Dicom.Network
         public DicomNActionResponse(DicomNActionRequest request, DicomStatus status)
             : base(request, status)
         {
-            if (request.HasSOPInstanceUID)
-            {
-                this.SOPInstanceUID = request.SOPInstanceUID;
-            }
-
-            this.ActionTypeID = request.ActionTypeID;
+            SOPInstanceUID = request.SOPInstanceUID;
+            ActionTypeID = request.ActionTypeID;
         }
 
         #endregion
@@ -88,12 +83,12 @@ namespace Dicom.Network
         /// <returns>Formatted output of the N-ACTION response.</returns>
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             sb.AppendFormat("{0} [{1}]: {2}", ToString(Type), RequestMessageID, Status.Description);
             if (Command.Contains(DicomTag.ActionTypeID)) sb.AppendFormat("\n\t\tAction Type:	{0:x4}", ActionTypeID);
             if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
             {
-                if (!String.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+                if (!string.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
             }
             return sb.ToString();
         }

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -3,21 +3,42 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Representation of the N-CREATE request.
+    /// </summary>
     public sealed class DicomNCreateRequest : DicomRequest
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNCreateRequest"/> class.
+        /// </summary>
+        /// <param name="command">N-CREATE request command.</param>
         public DicomNCreateRequest(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNCreateRequest"/> class.
+        /// </summary>
+        /// <param name="affectedClassUid">Affected SOP class UID.</param>
+        /// <param name="affectedInstanceUid">Affected SOP instance UID.</param>
         public DicomNCreateRequest(
-            DicomUID requestedClassUid,
-            DicomUID requestedInstanceUid)
-            : base(DicomCommandField.NCreateRequest, requestedClassUid)
+            DicomUID affectedClassUid,
+            DicomUID affectedInstanceUid)
+            : base(DicomCommandField.NCreateRequest, affectedClassUid)
         {
-            SOPInstanceUID = requestedInstanceUid;
+            SOPInstanceUID = affectedInstanceUid;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
@@ -30,10 +51,31 @@ namespace Dicom.Network
             }
         }
 
+        #endregion
+
+        #region DELEGATES AND EVENTS
+
+        /// <summary>
+        /// Delegate representing a N-CREATE RSP received event handler.
+        /// </summary>
+        /// <param name="request">N-CREATE RQ.</param>
+        /// <param name="response">N-CREATE RSP.</param>
         public delegate void ResponseDelegate(DicomNCreateRequest request, DicomNCreateResponse response);
 
+        /// <summary>
+        /// Gets or sets the handler for the N-CREATE response received event.
+        /// </summary>
         public ResponseDelegate OnResponseReceived;
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Invoke the event handler upon receiving a N-CREATE response.
+        /// </summary>
+        /// <param name="service">Associated DICOM service.</param>
+        /// <param name="response">N-CREATE response.</param>
         protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
@@ -44,5 +86,7 @@ namespace Dicom.Network
             {
             }
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -5,12 +5,6 @@ namespace Dicom.Network
 {
     public sealed class DicomNCreateRequest : DicomRequest
     {
-        #region Fields
-
-        private DicomUID _sopInstanceUID;
-
-        #endregion
-
         public DicomNCreateRequest(DicomDataset command)
             : base(command)
         {
@@ -28,18 +22,11 @@ namespace Dicom.Network
         {
             get
             {
-                if (_sopInstanceUID == null
-                    && (_sopInstanceUID = Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID, null)) == null)
-                {
-                    SOPInstanceUID = DicomUIDGenerator.GenerateDerivedFromUUID();
-                }
-
-                return _sopInstanceUID;
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID, null);
             }
             private set
             {
-                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
-                _sopInstanceUID = value;
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
 

--- a/DICOM/Network/DicomNCreateRequest.cs
+++ b/DICOM/Network/DicomNCreateRequest.cs
@@ -5,6 +5,12 @@ namespace Dicom.Network
 {
     public sealed class DicomNCreateRequest : DicomRequest
     {
+        #region Fields
+
+        private DicomUID _sopInstanceUID;
+
+        #endregion
+
         public DicomNCreateRequest(DicomDataset command)
             : base(command)
         {
@@ -22,11 +28,18 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
+                if (_sopInstanceUID == null
+                    && (_sopInstanceUID = Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID, null)) == null)
+                {
+                    SOPInstanceUID = DicomUIDGenerator.GenerateDerivedFromUUID();
+                }
+
+                return _sopInstanceUID;
             }
             private set
             {
                 Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
+                _sopInstanceUID = value;
             }
         }
 

--- a/DICOM/Network/DicomNCreateResponse.cs
+++ b/DICOM/Network/DicomNCreateResponse.cs
@@ -3,29 +3,52 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Representation of the N-CREATE response.
+    /// </summary>
     public sealed class DicomNCreateResponse : DicomResponse
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNCreateResponse"/> class.
+        /// </summary>
+        /// <param name="command">N-CREATE response command.</param>
         public DicomNCreateResponse(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initizalizes a new instance of the <see cref="DicomNCreateResponse"/> class.
+        /// </summary>
+        /// <param name="request">Associated N-CREATE request.</param>
+        /// <param name="status">Response status.</param>
         public DicomNCreateResponse(DicomNCreateRequest request, DicomStatus status)
             : base(request, status)
         {
             SOPInstanceUID = request.SOPInstanceUID;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID, null);
             }
             private set
             {
                 Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNCreateResponse.cs
+++ b/DICOM/Network/DicomNCreateResponse.cs
@@ -13,6 +13,7 @@ namespace Dicom.Network
         public DicomNCreateResponse(DicomNCreateRequest request, DicomStatus status)
             : base(request, status)
         {
+            SOPInstanceUID = request.SOPInstanceUID;
         }
 
         public DicomUID SOPInstanceUID

--- a/DICOM/Network/DicomNDeleteResponse.cs
+++ b/DICOM/Network/DicomNDeleteResponse.cs
@@ -13,6 +13,7 @@ namespace Dicom.Network
         public DicomNDeleteResponse(DicomNDeleteRequest request, DicomStatus status)
             : base(request, status)
         {
+            SOPInstanceUID = request.SOPInstanceUID;
         }
 
         public DicomUID SOPInstanceUID

--- a/DICOM/Network/DicomNDeleteResponse.cs
+++ b/DICOM/Network/DicomNDeleteResponse.cs
@@ -3,29 +3,52 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Representation of an N-DELETE response.
+    /// </summary>
     public sealed class DicomNDeleteResponse : DicomResponse
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNDeleteResponse"/> class.
+        /// </summary>
+        /// <param name="command">N-DELETE response command.</param>
         public DicomNDeleteResponse(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomNDeleteResponse"/> class.
+        /// </summary>
+        /// <param name="request">Associated N-DELETE request.</param>
+        /// <param name="status">Response status.</param>
         public DicomNDeleteResponse(DicomNDeleteRequest request, DicomStatus status)
             : base(request, status)
         {
             SOPInstanceUID = request.SOPInstanceUID;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID, null);
             }
             private set
             {
                 Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -5,23 +5,45 @@ namespace Dicom.Network
 {
     using System.Text;
 
+    /// <summary>
+    /// Representation of an N-EVENTREPORT request.
+    /// </summary>
     public sealed class DicomNEventReportRequest : DicomRequest
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNEventReportRequest"/> class.
+        /// </summary>
+        /// <param name="command">N-EVENTREPORT request command.</param>
         public DicomNEventReportRequest(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNEventReportRequest"/> class.
+        /// </summary>
+        /// <param name="affectedClassUid">Affected SOP class UID.</param>
+        /// <param name="affectedInstanceUid">Affected SOP instance UID.</param>
+        /// <param name="eventTypeId">Event type ID.</param>
         public DicomNEventReportRequest(
-            DicomUID requestedClassUid,
-            DicomUID requestedInstanceUid,
+            DicomUID affectedClassUid,
+            DicomUID affectedInstanceUid,
             ushort eventTypeId)
-            : base(DicomCommandField.NEventReportRequest, requestedClassUid)
+            : base(DicomCommandField.NEventReportRequest, affectedClassUid)
         {
-            SOPInstanceUID = requestedInstanceUid;
+            SOPInstanceUID = affectedInstanceUid;
             EventTypeID = eventTypeId;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
@@ -34,6 +56,9 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Gets the event type ID.
+        /// </summary>
         public ushort EventTypeID
         {
             get
@@ -46,12 +71,31 @@ namespace Dicom.Network
             }
         }
 
-        internal bool HasSOPInstanceUID => this.Command.Contains(DicomTag.AffectedSOPInstanceUID);
+        #endregion
 
+        #region DELEGATES AND EVENTS
+
+        /// <summary>
+        /// Delegate representing a N-EVENTREPORT RSP received event handler.
+        /// </summary>
+        /// <param name="request">N-EVENTREPORT RQ.</param>
+        /// <param name="response">N-EVENTREPORT RSP.</param>
         public delegate void ResponseDelegate(DicomNEventReportRequest request, DicomNEventReportResponse response);
 
+        /// <summary>
+        /// Gets or sets the handler for the N-EVENTREPORT response received event.
+        /// </summary>
         public ResponseDelegate OnResponseReceived;
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Invoke the event handler upon receiving a N-EVENTREPORT response.
+        /// </summary>
+        /// <param name="service">Associated DICOM service.</param>
+        /// <param name="response">N-EVENTREPORT response.</param>
         protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
@@ -74,5 +118,7 @@ namespace Dicom.Network
             if (Command.Contains(DicomTag.EventTypeID)) sb.AppendFormat("\n\t\tEvent Type:	{0:x4}", EventTypeID);
             return sb.ToString();
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNEventReportRequest.cs
+++ b/DICOM/Network/DicomNEventReportRequest.cs
@@ -26,11 +26,11 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.RequestedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
             }
             private set
             {
-                Command.AddOrUpdate(DicomTag.RequestedSOPInstanceUID, value);
+                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
 
@@ -46,7 +46,7 @@ namespace Dicom.Network
             }
         }
 
-        internal bool HasSOPInstanceUID => this.Command.Contains(DicomTag.RequestedSOPInstanceUID);
+        internal bool HasSOPInstanceUID => this.Command.Contains(DicomTag.AffectedSOPInstanceUID);
 
         public delegate void ResponseDelegate(DicomNEventReportRequest request, DicomNEventReportResponse response);
 

--- a/DICOM/Network/DicomNEventReportResponse.cs
+++ b/DICOM/Network/DicomNEventReportResponse.cs
@@ -36,12 +36,8 @@ namespace Dicom.Network
         public DicomNEventReportResponse(DicomNEventReportRequest request, DicomStatus status)
             : base(request, status)
         {
-            if (request.HasSOPInstanceUID)
-            {
-                this.SOPInstanceUID = request.SOPInstanceUID;
-            }
-
-            this.EventTypeID = request.EventTypeID;
+            SOPInstanceUID = request.SOPInstanceUID;
+            EventTypeID = request.EventTypeID;
         }
 
         #endregion
@@ -55,7 +51,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID, null);
             }
             private set
             {
@@ -70,7 +66,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Command.Get<ushort>(DicomTag.EventTypeID);
+                return Command.Get(DicomTag.EventTypeID, (ushort)0);
             }
             private set
             {

--- a/DICOM/Network/DicomNGetRequest.cs
+++ b/DICOM/Network/DicomNGetRequest.cs
@@ -3,13 +3,27 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Representation of an N-GET request.
+    /// </summary>
     public sealed class DicomNGetRequest : DicomRequest
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNGetRequest"/> class.
+        /// </summary>
+        /// <param name="command">N-GET request command dataset.</param>
         public DicomNGetRequest(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNGetRequest"/> class.
+        /// </summary>
+        /// <param name="requestedClassUid">Requested SOP class UID.</param>
+        /// <param name="requestedInstanceUid">Requested SOP instance UID.</param>
         public DicomNGetRequest(
             DicomUID requestedClassUid,
             DicomUID requestedInstanceUid)
@@ -18,6 +32,13 @@ namespace Dicom.Network
             SOPInstanceUID = requestedInstanceUid;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the requested SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
@@ -30,11 +51,14 @@ namespace Dicom.Network
             }
         }
 
+        /// <summary>
+        /// Gets the list of attribute identifiers.
+        /// </summary>
         public DicomTag[] Attributes
         {
             get
             {
-                return Command.Get<DicomTag[]>(DicomTag.AttributeIdentifierList);
+                return Command.Get<DicomTag[]>(DicomTag.AttributeIdentifierList, null);
             }
             private set
             {
@@ -42,10 +66,31 @@ namespace Dicom.Network
             }
         }
 
+        #endregion
+
+        #region DELEGATES AND EVENTS
+
+        /// <summary>
+        /// Delegate representing a N-GET RSP received event handler.
+        /// </summary>
+        /// <param name="request">N-GET RQ.</param>
+        /// <param name="response">N-GET RSP.</param>
         public delegate void ResponseDelegate(DicomNGetRequest request, DicomNGetResponse response);
 
+        /// <summary>
+        /// Gets or sets the handler for the N-GET response received event.
+        /// </summary>
         public ResponseDelegate OnResponseReceived;
 
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Invoke the event handler upon receiving a N-GET response.
+        /// </summary>
+        /// <param name="service">Associated DICOM service.</param>
+        /// <param name="response">N-GET response.</param>
         protected internal override void PostResponse(DicomService service, DicomResponse response)
         {
             try
@@ -56,5 +101,7 @@ namespace Dicom.Network
             {
             }
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNGetResponse.cs
+++ b/DICOM/Network/DicomNGetResponse.cs
@@ -3,29 +3,52 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Representation of the N-GET response.
+    /// </summary>
     public sealed class DicomNGetResponse : DicomResponse
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNGetResponse"/> class.
+        /// </summary>
+        /// <param name="command">N-GET response command.</param>
         public DicomNGetResponse(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNGetResponse"/> class.
+        /// </summary>
+        /// <param name="request">Associated N-GET request.</param>
+        /// <param name="status">Response status.</param>
         public DicomNGetResponse(DicomNGetRequest request, DicomStatus status)
             : base(request, status)
         {
             SOPInstanceUID = request.SOPInstanceUID;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID, null);
             }
             private set
             {
                 Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomNSetResponse.cs
+++ b/DICOM/Network/DicomNSetResponse.cs
@@ -3,29 +3,52 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Representation of an N-SET response.
+    /// </summary>
     public sealed class DicomNSetResponse : DicomResponse
     {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNSetResponse"/> class.
+        /// </summary>
+        /// <param name="command">N-SET response command.</param>
         public DicomNSetResponse(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomNSetResponse"/> class.
+        /// </summary>
+        /// <param name="request">Associated N-SET request.</param>
+        /// <param name="status">Response status.</param>
         public DicomNSetResponse(DicomNSetRequest request, DicomStatus status)
             : base(request, status)
         {
             SOPInstanceUID = request.SOPInstanceUID;
         }
 
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets the affected SOP instance UID.
+        /// </summary>
         public DicomUID SOPInstanceUID
         {
             get
             {
-                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID);
+                return Command.Get<DicomUID>(DicomTag.AffectedSOPInstanceUID, null);
             }
             private set
             {
                 Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
             }
         }
+
+        #endregion
     }
 }

--- a/DICOM/Network/DicomPriorityRequest.cs
+++ b/DICOM/Network/DicomPriorityRequest.cs
@@ -3,26 +3,42 @@
 
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Abstract base class for DICOM requests with priority.
+    /// </summary>
     public abstract class DicomPriorityRequest : DicomRequest
     {
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomPriorityRequest"/> base class.
+        /// </summary>
+        /// <param name="command">Command dataset.</param>
         protected DicomPriorityRequest(DicomDataset command)
             : base(command)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomPriorityRequest"/> base class.
+        /// </summary>
+        /// <param name="type">Type of command (command field).</param>
+        /// <param name="requestedClassUid">Requested/affected SOP Class UID</param>
+        /// <param name="priority">Request priority.</param>
         protected DicomPriorityRequest(DicomCommandField type, DicomUID requestedClassUid, DicomPriority priority)
             : base(type, requestedClassUid)
         {
             Priority = priority;
         }
 
+        /// <summary>
+        /// Gets or sets the command priority.
+        /// </summary>
         public DicomPriority Priority
         {
             get
             {
                 return Command.Get<DicomPriority>(DicomTag.Priority);
             }
-            set
+            protected set
             {
                 Command.AddOrUpdate(DicomTag.Priority, (ushort)value);
             }

--- a/DICOM/Network/DicomRequest.cs
+++ b/DICOM/Network/DicomRequest.cs
@@ -14,7 +14,7 @@ namespace Dicom.Network
 
         private static volatile ushort _messageId = 1;
 
-        private static object _lock = new object();
+        private static readonly object _lock = new object();
 
         #endregion
 
@@ -57,7 +57,7 @@ namespace Dicom.Network
             {
                 return Command.Get<ushort>(DicomTag.MessageID);
             }
-            set
+            protected set
             {
                 Command.AddOrUpdate(DicomTag.MessageID, value);
             }
@@ -80,7 +80,7 @@ namespace Dicom.Network
         {
             lock (_lock)
             {
-                if (_messageId == UInt16.MaxValue) _messageId = 1;
+                if (_messageId == ushort.MaxValue) _messageId = 1;
                 return _messageId++;
             }
         }

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -443,6 +443,11 @@ namespace Dicom.Printing
             }
             set
             {
+                if (value.Tag.Equals(DicomTag.ReferencedPresentationLUTSequence))
+                {
+                    throw new InvalidOperationException(
+                        $"Added sequence must be Referenced Presentation LUT Sequence, is: {value.Tag}");
+                }
                 this.AddOrUpdate(value);
             }
         }
@@ -520,7 +525,7 @@ namespace Dicom.Printing
         public bool Initialize()
         {
             //initialization
-            this.Add(new DicomSequence(DicomTag.ReferencedImageBoxSequence));
+            this.AddOrUpdate(new DicomSequence(DicomTag.ReferencedImageBoxSequence));
 
             if (!this.Contains(DicomTag.FilmOrientation))
             {

--- a/DICOM/Printing/FilmSession.cs
+++ b/DICOM/Printing/FilmSession.cs
@@ -167,31 +167,30 @@ namespace Dicom.Printing
         /// <summary>
         /// Construct new film session from scratch
         /// </summary>
+        /// <param name="sopClassUID">Film session SOP Class UID</param>
+        /// <param name="sopInstance">Film session SOP instance UID</param>
+        /// <param name="isColor">Color images?</param>
         public FilmSession(DicomUID sopClassUID, DicomUID sopInstance = null, bool isColor = false)
-            : base()
         {
-            this.InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
+            InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
+
             if (sopClassUID == null)
             {
-                throw new ArgumentNullException("sopClassUID");
+                throw new ArgumentNullException(nameof(sopClassUID));
             }
-
-
             SOPClassUID = sopClassUID;
 
             if (sopInstance == null || sopInstance.UID == string.Empty)
             {
-                SOPInstanceUID = DicomUID.Generate();
+                SOPInstanceUID = DicomUIDGenerator.GenerateDerivedFromUUID();
             }
             else
             {
                 SOPInstanceUID = sopInstance;
-
             }
 
-
-            this.Add(DicomTag.SOPClassUID, SOPClassUID);
-            this.Add(DicomTag.SOPInstanceUID, SOPInstanceUID);
+            Add(DicomTag.SOPClassUID, SOPClassUID);
+            Add(DicomTag.SOPInstanceUID, SOPInstanceUID);
 
             BasicFilmBoxes = new List<FilmBox>();
             PresentationLuts = new List<PresentationLut>();
@@ -202,19 +201,20 @@ namespace Dicom.Printing
         /// <summary>
         /// Construct new film session for specified SOP instance UID
         /// </summary>
+        /// <param name="sopClassUID">Film session SOP Class UID</param>
         /// <param name="sopInstance">Film session SOP instance UID</param>
         /// <param name="dataset">Film session dataset</param>
+        /// <param name="isColor">Color images?</param>
         public FilmSession(DicomUID sopClassUID, DicomUID sopInstance, DicomDataset dataset, bool isColor = false)
-            : this(sopClassUID, sopInstance)
+            : this(sopClassUID, sopInstance, isColor)
         {
             if (dataset == null)
             {
-                throw new ArgumentNullException("dataset");
+                throw new ArgumentNullException(nameof(dataset));
             }
             dataset.CopyTo(this);
 
-            this.InternalTransferSyntax = dataset.InternalTransferSyntax;
-            IsColor = isColor;
+            InternalTransferSyntax = dataset.InternalTransferSyntax;
         }
 
         #endregion

--- a/Setup/version.cmd
+++ b/Setup/version.cmd
@@ -1,1 +1,1 @@
-set version=3.0.0-rc1
+set version=3.0.0-rc2

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -18,5 +18,5 @@ using System.Resources;
 [assembly: NeutralResourcesLanguage("en")]
 
 [assembly: AssemblyVersion("3.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.0.2")]
 [assembly: AssemblyInformationalVersion("3.0.0")]

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="DicomDictionaryTest.cs" />
     <Compile Include="DicomFileMetaInformationTest.cs" />
     <Compile Include="DicomParseableTest.cs" />
+    <Compile Include="DicomUIDGeneratorTest.cs" />
     <Compile Include="Helpers\NLogHelper.cs" />
     <Compile Include="Helpers\PriorityOrderer.cs" />
     <Compile Include="Helpers\TestOutputHelperLogger.cs" />

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Network\DicomCEchoProviderTest.cs" />
     <Compile Include="Network\DicomCGetRequestTest.cs" />
     <Compile Include="Network\DicomClientTest.cs" />
+    <Compile Include="Network\DicomNCreateRequestTest.cs" />
     <Compile Include="Network\DicomNEventReportResponseTest.cs" />
     <Compile Include="Network\DicomNActionResponseTest.cs" />
     <Compile Include="Network\DicomServerTest.cs" />

--- a/Tests/DicomUIDGeneratorTest.cs
+++ b/Tests/DicomUIDGeneratorTest.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Text.RegularExpressions;
+
+using Xunit;
+
+namespace Dicom
+{
+    public class DicomUIDGeneratorTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void GenerateDerivedFromUUID_MultipleValues_AllValuesContainOnlyDigitsAndDecimalDots()
+        {
+            for (var i = 0; i < 1000; ++i)
+            {
+                var uid = DicomUIDGenerator.GenerateDerivedFromUUID();
+                var invalids = Regex.Replace(uid.UID, @"[0-9\.]", "");
+                Assert.Equal(0, invalids.Length);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Network/DicomNCreateRequestTest.cs
+++ b/Tests/Network/DicomNCreateRequestTest.cs
@@ -8,7 +8,7 @@ namespace Dicom.Network
     public class DicomNCreateRequestTest
     {
         [Fact]
-        public void SOPInstanceUIDGetter_SOPInstanceUIDNotDefinedInConstruction_IsDefinedAndConstant()
+        public void SOPInstanceUIDGetter_SOPInstanceUIDNotDefinedInConstruction_IsNotDefinedInRequest()
         {
             var command = new DicomDataset();
             command.Add(DicomTag.CommandField, (ushort)DicomCommandField.NCreateRequest);
@@ -17,10 +17,7 @@ namespace Dicom.Network
 
             var request = new DicomNCreateRequest(command);
             var expected = request.SOPInstanceUID;
-            Assert.NotNull(expected);
-
-            var actual = request.SOPInstanceUID;
-            Assert.Equal(expected, actual);
+            Assert.Null(expected);
         }
     }
 }

--- a/Tests/Network/DicomNCreateRequestTest.cs
+++ b/Tests/Network/DicomNCreateRequestTest.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Xunit;
+
+namespace Dicom.Network
+{
+    public class DicomNCreateRequestTest
+    {
+        [Fact]
+        public void SOPInstanceUIDGetter_SOPInstanceUIDNotDefinedInConstruction_IsDefinedAndConstant()
+        {
+            var command = new DicomDataset();
+            command.Add(DicomTag.CommandField, (ushort)DicomCommandField.NCreateRequest);
+            command.Add(DicomTag.MessageID, (ushort)1);
+            command.Add(DicomTag.RequestedSOPClassUID, "1.2.3");
+
+            var request = new DicomNCreateRequest(command);
+            var expected = request.SOPInstanceUID;
+            Assert.NotNull(expected);
+
+            var actual = request.SOPInstanceUID;
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #353 .

Changes proposed in this pull request:
- `DicomUIDGenerator.GenerateDerivedFromUUID()` should not insert negative numbers.
- Corrected use of *Affected SOP Instance UID* for some DIMSE-N requests and responses.
- Use `DicomDataset.AddOrUpdate` to insert *Referenced Image Box Sequence* in `FilmBox.Initialize()`
- Added `CreateImageQuery` method in `DicomCFindRequest`.
- Minor fine tuning in DICOM message classes.
- Added API documentation in modified classes.
