### PR TITLE
In ColorPixelData24, apply alpha component 0xff. Connected to #421

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 #### v.3.0.0 (TBD)
 * Invalid reference in Universal targets build file (#422 #423)
+* Alpha component is zero for color images on UWP, .NET Core and Xamarin platforms (#421 #428)
 * Print SCP exception due to insufficient DicomDataset.AddOrUpdate refactoring (#353 #420)
 * Invalid decoding of JPEG baseline RGB images with managed JPEG codec (#417 #419)
 * DicomFile.Save throwing an exception in DotNetCore for macOS (#411 #413)

--- a/DICOM/Imaging/Render/PixelData.cs
+++ b/DICOM/Imaging/Render/PixelData.cs
@@ -1213,6 +1213,8 @@ namespace Dicom.Imaging.Render
         /// <inheritdoc />
         public void Render(ILUT lut, int[] output)
         {
+            const int AlphaFF = 0xff << 24;
+
             var data = Data;
             if (lut == null)
             {
@@ -1224,7 +1226,7 @@ namespace Dicom.Imaging.Render
                 {
                     for (int i = Width * y, e = i + Width, p = i * 3; i < e; i++)
                     {
-                        output[i] = (data[p++] << 16) | (data[p++] << 8) | data[p++];
+                        output[i] = AlphaFF | (data[p++] << 16) | (data[p++] << 8) | data[p++];
                     }
                 }
 #if !NET35
@@ -1241,7 +1243,7 @@ namespace Dicom.Imaging.Render
                 {
                     for (int i = Width * y, e = i + Width, p = i * 3; i < e; i++)
                     {
-                        output[i] = (lut[data[p++]] << 16) | (lut[data[p++]] << 8) | lut[data[p++]];
+                        output[i] = AlphaFF | (lut[data[p++]] << 16) | (lut[data[p++]] << 8) | lut[data[p++]];
                     }
                 }
 #if !NET35

--- a/DICOM/Imaging/Render/RgbColorPipeline.cs
+++ b/DICOM/Imaging/Render/RgbColorPipeline.cs
@@ -10,12 +10,7 @@ namespace Dicom.Imaging.Render
     /// </summary>
     public class RgbColorPipeline : IPipeline
     {
-        public ILUT LUT
-        {
-            get
-            {
-                return null;
-            }
-        }
+        /// <inheritdoc />
+        public ILUT LUT => null;
     }
 }


### PR DESCRIPTION
Fixes #421 .

Changes proposed in this pull request:
- In `ColorPixelData24`, apply alpha component 0xff.
- Code cleanup and API documentation in `RgbColorPipeline` and `OverlayGraphic`.