### PR TITLE
Ensure that DicomClient.Logger is always non-null. Connected to #426

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (TBD)
+* Adding too many presentation contexts causes null reference exception in DicomClient.Send (#426 #429)
 * Serialize to XML according to DICOM standard PS 3.19, Section A (#425)
 * Invalid reference in Universal targets build file (#422 #423)
 * Alpha component is zero for color images on UWP, .NET Core and Xamarin platforms (#421 #428)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -37,6 +37,8 @@ namespace Dicom.Network
 
         private bool aborted;
 
+        private Logger _logger;
+
         #endregion
 
         #region CONSTRUCTORS
@@ -86,7 +88,17 @@ namespace Dicom.Network
         /// <summary>
         /// Gets or sets logger that is passed to the underlying <see cref="DicomService"/> implementation.
         /// </summary>
-        public Logger Logger { get; set; }
+        public Logger Logger
+        {
+            get
+            {
+                return _logger ?? (_logger = LogManager.GetLogger("Dicom.Network"));
+            }
+            set
+            {
+                _logger = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets options to control behavior of <see cref="DicomService"/> base class.

--- a/Tests/Bugs/GH426.cs
+++ b/Tests/Bugs/GH426.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Dicom.Network;
+
+using Xunit;
+
+namespace Dicom.Bugs
+{
+    [Collection("Network"), Trait("Category", "Network")]
+    public class GH426
+    {
+        #region Unit tests
+
+        [Fact]
+        public void DicomClientSend_TooManyPresentationContexts_YieldsInformativeException()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<DicomCEchoProvider>(port))
+            {
+                var client = new DicomClient();
+
+                // this just illustrates the issue of too many presentation contexts, not real world application.
+                var pcs =
+                    DicomPresentationContext.GetScpRolePresentationContextsFromStorageUids(
+                        DicomStorageCategory.None,
+                        DicomTransferSyntax.ImplicitVRLittleEndian);
+
+                client.AdditionalPresentationContexts.AddRange(pcs);
+
+                var exception = Record.Exception(() => client.Send("localhost", port, false, "SCU", "SCP"));
+                Assert.IsType<DicomNetworkException>(exception);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Bugs\GH265.cs" />
     <Compile Include="Bugs\GH306.cs" />
     <Compile Include="Bugs\GH364.cs" />
+    <Compile Include="Bugs\GH426.cs" />
     <Compile Include="DicomDatasetExtensionsTest.cs" />
     <Compile Include="DicomDatasetTest.cs" />
     <Compile Include="DicomDatasetWalkerTest.cs" />


### PR DESCRIPTION
Fixes #426 .

Changes proposed in this pull request:
- A `null` `Logger` caused an irrelevant exception to be forwarded. `Logger` getter modified to ensure that it always returns a non-`null` `Logger`.
