### PR TITLE
Excluded IsSocketExceptionImpl. Connected to #431

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (TBD)
+* Deploy error for Unity based applications on Hololens (#431 #432)
 * Add method "AddOrUpdatePixelData" to the DicomDataset (#427 #430)
 * Adding too many presentation contexts causes null reference exception in DicomClient.Send (#426 #429)
 * Serialize to XML according to DICOM standard PS 3.19, Section A (#425)

--- a/DICOM/Network/DesktopNetworkManager.cs
+++ b/DICOM/Network/DesktopNetworkManager.cs
@@ -79,7 +79,6 @@ namespace Dicom.Network
         {
             return new DesktopNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
-#endif
 
         /// <summary>
         /// Platform-specific implementation to check whether specified <paramref name="exception"/> represents a socket exception.
@@ -106,6 +105,7 @@ namespace Dicom.Network
             errorDescriptor = null;
             return false;
         }
+#endif
 
         /// <summary>
         /// Platform-specific implementation to attempt to obtain a unique network identifier, e.g. based on a MAC address.

--- a/DICOM/Network/NetworkManager.cs
+++ b/DICOM/Network/NetworkManager.cs
@@ -86,7 +86,6 @@ namespace Dicom.Network
         {
             return implementation.CreateNetworkStreamImpl(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
-#endif
 
         /// <summary>
         /// Checks whether specified <paramref name="exception"/> represents a socket exception.
@@ -99,6 +98,7 @@ namespace Dicom.Network
         {
             return implementation.IsSocketExceptionImpl(exception, out errorCode, out errorDescriptor);
         }
+#endif
 
         /// <summary>
         /// Attempt to obtain a unique network identifier, e.g. based on a MAC address.
@@ -128,7 +128,6 @@ namespace Dicom.Network
         /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
         /// <returns>Network stream implementation.</returns>
         protected abstract INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors);
-#endif
 
         /// <summary>
         /// Platform-specific implementation to check whether specified <paramref name="exception"/> represents a socket exception.
@@ -138,6 +137,7 @@ namespace Dicom.Network
         /// <param name="errorDescriptor">Error descriptor, valid if <paramref name="exception"/> is socket exception.</param>
         /// <returns>True if <paramref name="exception"/> is socket exception, false otherwise.</returns>
         protected abstract bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor);
+#endif
 
         /// <summary>
         /// Platform-specific implementation to attempt to obtain a unique network identifier, e.g. based on a MAC address.


### PR DESCRIPTION
Fixes #431 .

Changes proposed in this pull request:
- Exclude `IsSocketExceptionImpl` from `NetworkManager` API for Unity class library.
