### PR TITLE
Client should not send if association rejected. Connected to #433

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.0 (TBD)
+* Client should not send if association rejected (#433 #434)
 * Deploy error for Unity based applications on Hololens (#431 #432)
 * Add method "AddOrUpdatePixelData" to the DicomDataset (#427 #430)
 * Adding too many presentation contexts causes null reference exception in DicomClient.Send (#426 #429)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -389,12 +389,12 @@ namespace Dicom.Network
                     service = new DicomServiceUser(this, stream, association, Options, FallbackEncoding, Logger);
                 }
 
-                await associateNotifier.Task.ConfigureAwait(false);
+                var associated = await associateNotifier.Task.ConfigureAwait(false);
 
-                var send = false;
+                bool send;
                 lock (locker)
                 {
-                    send = requests.Count > 0;
+                    send = associated && requests.Count > 0;
                 }
 
                 if (send)
@@ -411,7 +411,7 @@ namespace Dicom.Network
                         service.SendRequest(request);
                     }
                 }
-                else
+                else if (associated)
                 {
                     await service.DoSendAssociationReleaseRequestAsync().ConfigureAwait(false);
                 }

--- a/Tests/Bugs/GH433.cs
+++ b/Tests/Bugs/GH433.cs
@@ -33,14 +33,7 @@ namespace Dicom.Bugs
                                     lock (locker) actual = rsp.Status;
                                 }
                         });
-
-                try
-                {
-                    client.Send("localhost", port, false, "SCU", "ANY-SCP");
-                }
-                catch
-                {
-                }
+                client.Send("localhost", port, false, "SCU", "ANY-SCP");
 
                 Assert.Equal(expected, actual);
             }

--- a/Tests/Bugs/GH433.cs
+++ b/Tests/Bugs/GH433.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Dicom.Network;
+
+using Xunit;
+
+namespace Dicom.Bugs
+{
+    [Collection("Network"), Trait("Category", "Network")]
+    public class GH433
+    {
+        #region Unit tests
+
+        [Fact]
+        public void DicomClientSend_ToAcceptedAssociation_ShouldSendRequest()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<DicomClientTest.MockCEchoProvider>(port))
+            {
+                var locker = new object();
+
+                var expected = DicomStatus.Success;
+                DicomStatus actual = null;
+
+                var client = new DicomClient();
+                client.AddRequest(
+                    new DicomCEchoRequest
+                        {
+                            OnResponseReceived = (rq, rsp) =>
+                                {
+                                    lock (locker) actual = rsp.Status;
+                                }
+                        });
+
+                try
+                {
+                    client.Send("localhost", port, false, "SCU", "ANY-SCP");
+                }
+                catch
+                {
+                }
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        public void DicomClientSend_ToRejectedAssociation_ShouldNotSendRequest()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<DicomClientTest.MockCEchoProvider>(port))
+            {
+                var locker = new object();
+                DicomStatus status = null;
+
+                var client = new DicomClient();
+                client.AddRequest(
+                    new DicomCEchoRequest
+                    {
+                        OnResponseReceived = (rq, rsp) =>
+                        {
+                            lock (locker) status = rsp.Status;
+                        }
+                    });
+
+                try
+                {
+                    client.Send("localhost", port, false, "SCU", "WRONG-SCP");
+                }
+                catch
+                {
+                }
+
+                Assert.Null(status);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Bugs\GH306.cs" />
     <Compile Include="Bugs\GH364.cs" />
     <Compile Include="Bugs\GH426.cs" />
+    <Compile Include="Bugs\GH433.cs" />
     <Compile Include="DicomDatasetExtensionsTest.cs" />
     <Compile Include="DicomDatasetTest.cs" />
     <Compile Include="DicomDatasetWalkerTest.cs" />


### PR DESCRIPTION
Fixes #433 .

Changes proposed in this pull request:
- Do not send request if the association has been rejected.
- Refactoring of `DicomClient.WaitForAssociationAsync` for more responsive API.