### PR TITLE
Removed warnings, structs compared to null is always false

### DIFF
--- a/DICOM/IO/Endian.cs
+++ b/DICOM/IO/Endian.cs
@@ -261,7 +261,7 @@ namespace Dicom.IO
         public static BinaryReader Create(Stream input, Endian endian)
         {
             if (input == null) throw new ArgumentNullException("input");
-            if (endian == null) throw new ArgumentNullException("endian");
+			// struct comparison to null is alway false if (endian == null) throw new ArgumentNullException("endian");
 
             if (BitConverter.IsLittleEndian)
             {
@@ -291,7 +291,7 @@ namespace Dicom.IO
         {
             if (encoding == null) return Create(input, endian);
             if (input == null) throw new ArgumentNullException("input");
-            if (endian == null) throw new ArgumentNullException("endian");
+            // struct comparison to null is alway false if (endian == null) throw new ArgumentNullException("endian");
 
             if (BitConverter.IsLittleEndian)
             {
@@ -509,7 +509,7 @@ namespace Dicom.IO
         public static BinaryWriter Create(Stream output, Endian endian)
         {
             if (output == null) throw new ArgumentNullException("output");
-            if (endian == null) throw new ArgumentNullException("endian");
+            // struct comparison to null is alway false if (endian == null) throw new ArgumentNullException("endian");
 
             if (BitConverter.IsLittleEndian)
             {
@@ -539,7 +539,7 @@ namespace Dicom.IO
         {
             if (encoding == null) return Create(output, endian);
             if (output == null) throw new ArgumentNullException("output");
-            if (endian == null) throw new ArgumentNullException("endian");
+            // struct comparison to null is alway false  if (endian == null) throw new ArgumentNullException("endian");
 
             if (BitConverter.IsLittleEndian)
             {

--- a/DICOM/IO/Writer/DicomWriter.cs
+++ b/DICOM/IO/Writer/DicomWriter.cs
@@ -164,8 +164,6 @@ namespace Dicom.IO.Writer
         /// <remarks>On false return value, the method will invoke the callback method passed in <see cref="IDicomDatasetWalker.OnBeginWalk"/> before returning.</remarks>
         public bool OnEndSequenceItem()
         {
-            DicomSequence sequence = _sequences.Peek();
-
             if (!_options.ExplicitLengthSequenceItems)
             {
                 WriteTagHeader(DicomTag.ItemDelimitationItem, DicomVR.NONE, 0);

--- a/DICOM/Imaging/Codec/DicomJpeg2000CodecImpl.cs
+++ b/DICOM/Imaging/Codec/DicomJpeg2000CodecImpl.cs
@@ -48,7 +48,7 @@ namespace Dicom.Imaging.Codec
                            && !jparams.EncodeSignedPixelValuesAsUnsigned;
                 var comps = new int[nc][];
 
-                var colorSpace = GetJpegColorSpace(oldPixelData.PhotometricInterpretation);
+                // var colorSpace = GetJpegColorSpace(oldPixelData.PhotometricInterpretation);
 
                 for (var c = 0; c < nc; c++)
                 {

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -292,7 +292,7 @@ namespace Dicom.Imaging
             if (!Dataset.Contains(DicomTag.RedPaletteColorLookupTableDescriptor)) throw new DicomImagingException("Palette Color LUT missing from dataset.");
 
             int size = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 0);
-            int first = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 1);
+            // int first = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 1);
             int bits = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 2);
 
             var r = Dataset.Get<byte[]>(DicomTag.RedPaletteColorLookupTableData);

--- a/DICOM/Imaging/Mathematics/Geometry3D.cs
+++ b/DICOM/Imaging/Mathematics/Geometry3D.cs
@@ -1008,7 +1008,10 @@ namespace Dicom.Imaging.Mathematics
 
         public Point3D Project(Point3D point)
         {
-            Point3D p = Plane.ClosestPoint(point);
+            // Assigned but not used Point3D p = 
+
+			Plane.ClosestPoint(point);
+
             //normal vector?
             throw new NotImplementedException();
             //return p;

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -716,7 +716,7 @@ namespace Dicom.Network
                         return true;
                     }
                 }
-                catch (TaskCanceledException e)
+                catch
                 {
                     return false;
                 }

--- a/DICOM/Setup.cs
+++ b/DICOM/Setup.cs
@@ -18,7 +18,7 @@ namespace Dicom
         /// <summary>
         /// Potential names of the fo-dicom platform-specific assemblies.
         /// </summary>
-        private static readonly string[] PlatformAssemblyNames = { "Dicom.Platform", "Dicom.Platform.Imaging" };
+        // private static readonly string[] PlatformAssemblyNames = { "Dicom.Platform", "Dicom.Platform.Imaging" };
 
         #endregion
 


### PR DESCRIPTION
Fixes # structs compared to nulls are alway false. 

Changes proposed in this pull request:
- comment out un-used variables
-
-
