### PR TITLE
Pass through unsupported user data during PDU parsing. Connected to #242

### DIFF
--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -61,6 +61,13 @@ using Dicom.Log;
 
 namespace Dicom.Network
 {
+
+	/// <summary>
+	/// Delegate for passing byte array
+	/// </summary>
+	/// <param name="unsupportedBytes">byte array to be passed to the delegate.</param>
+	public delegate void HandleBytesDelegate(byte[] unsupportedBytes);
+
     /// <summary>
     /// Base class for DICOM network services.
     /// </summary>
@@ -182,6 +189,12 @@ namespace Dicom.Network
         /// Gets the <see cref="Task"/> that listens for PDUs.
         /// </summary>
         protected Task PduListener { get; }
+
+	/// <summary>
+	/// Event to pass unsupported byte arrays back
+	/// </summary>
+	public HandleBytesDelegate HandlePDUBytes;
+
 
         #endregion
 
@@ -399,6 +412,11 @@ namespace Dicom.Network
                     }
 
                     var raw = new RawPDU(buffer);
+
+		    if (HandlePDUBytes != null)
+		    {
+			raw.HandlePDUBytes += HandlePDUBytes;
+		    }
 
                     switch (raw.Type)
                     {

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -408,6 +408,11 @@ namespace Dicom.Network
     {
         private DicomAssociation _assoc;
 
+	/// <summary>
+	/// Event to pass unsupported byte arrays back
+	/// </summary>
+	public HandleBytesDelegate HandlePDUBytes;
+
         /// <summary>
         /// Initializes new A-ASSOCIATE-RQ
         /// </summary>
@@ -644,8 +649,15 @@ namespace Dicom.Network
                         }
                         else
                         {
-                            raw.SkipBytes("Unhandled User Item", ul);
-                        }
+			    if (HandlePDUBytes != null)
+			    {
+				HandlePDUBytes(raw.ReadBytes("Unhandled User Item", ul));
+			    }
+			    else
+			    {
+				raw.SkipBytes("Unhandled User Item", ul);
+			    }
+			}
                     }
                 }
             }


### PR DESCRIPTION
Fixes #242 

Changes proposed in this pull request:
- Added delegate to pass bytes back to the implementer.
-
-
