### PR TITLE
Do not transform JPEG encoded YBR images, and apply correct rounding …

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@
 * Added optional parameter for use in extended DicomService (#348 #441)
 * Remove warning messages during build (#33 #438)
 
+#### v.3.0.1 (TBD)
+* YBR_FULL_422 JPEG Process 14 SV1 compressed image incorrectly decoded (#453 #454)
+
 #### v.3.0.0 (2/15/2017)
 * DICOM Anonymizer preview (#410 #437)
 * Client should not send if association rejected (#433 #434)

--- a/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Dicom.Imaging.Codec.Jpeg.i
@@ -457,11 +457,7 @@ void JPEGCODEC::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelDat
         if (jpeg_read_header(&dinfo, TRUE) == JPEG_SUSPENDED)
             throw gcnew DicomCodecException("Unable to decompress JPEG: Suspended");
             
-        if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422 || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422)
-            newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
-        else
-            newPixelData->PhotometricInterpretation = oldPixelData->PhotometricInterpretation;
-
+        newPixelData->PhotometricInterpretation = oldPixelData->PhotometricInterpretation;
         if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
             if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
                 throw gcnew DicomCodecException("JPEG codec unable to perform colorspace conversion on signed pixel data");
@@ -474,9 +470,6 @@ void JPEGCODEC::Decode(DicomPixelData^ oldPixelData, DicomPixelData^ newPixelDat
             dinfo.out_color_space = JCS_UNKNOWN;
         }
         
-        if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull)
-            newPixelData->PlanarConfiguration = PlanarConfiguration::Planar;
-
         jpeg_calc_output_dimensions(&dinfo);
         jpeg_start_decompress(&dinfo);
 

--- a/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
+++ b/DICOM.Native/Windows/Dicom.Imaging.Codec.Jpeg.i
@@ -473,11 +473,7 @@ void JPEGCODEC::Decode(NativePixelData^ oldPixelData, NativePixelData^ newPixelD
         if (jpeg_read_header(&dinfo, TRUE) == JPEG_SUSPENDED)
             throw ref new FailureException("Unable to decompress JPEG: Suspended");
         
-        if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull422 || newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrPartial422)
-            newPixelData->PhotometricInterpretation = PhotometricInterpretation::YbrFull;
-        else
-            newPixelData->PhotometricInterpretation = oldPixelData->PhotometricInterpretation;
-
+        newPixelData->PhotometricInterpretation = oldPixelData->PhotometricInterpretation;
         if (params->ConvertColorspaceToRGB && (dinfo.out_color_space == JCS_YCbCr || dinfo.out_color_space == JCS_RGB)) { 
             if (oldPixelData->PixelRepresentation == PixelRepresentation::Signed) 
                 throw ref new FailureException("JPEG codec unable to perform colorspace conversion on signed pixel data");
@@ -490,9 +486,6 @@ void JPEGCODEC::Decode(NativePixelData^ oldPixelData, NativePixelData^ newPixelD
             dinfo.out_color_space = JCS_UNKNOWN;
         }
     
-        if (newPixelData->PhotometricInterpretation == PhotometricInterpretation::YbrFull)
-            newPixelData->PlanarConfiguration = PlanarConfiguration::Planar;
-
         jpeg_calc_output_dimensions(&dinfo);
         jpeg_start_decompress(&dinfo);
 

--- a/DICOM/Imaging/Codec/DicomJpegCodecImpl.cs
+++ b/DICOM/Imaging/Codec/DicomJpegCodecImpl.cs
@@ -197,23 +197,6 @@ namespace Dicom.Imaging.Codec
                 newPixelData.PlanarConfiguration = PlanarConfiguration.Interleaved;
             }
 
-            if (newPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrIct
-                || newPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrRct)
-            {
-                newPixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
-            }
-
-            if (newPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull422
-                || newPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrPartial422)
-            {
-                newPixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull;
-            }
-
-            if (newPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull)
-            {
-                newPixelData.PlanarConfiguration = PlanarConfiguration.Planar;
-            }
-
             for (var frame = 0; frame < oldPixelData.NumberOfFrames; frame++)
             {
                 var jpegData = oldPixelData.GetFrame(frame);
@@ -231,7 +214,7 @@ namespace Dicom.Imaging.Codec
 
                     for (var c = 0; c < decoder.ComponentsPerSample; c++)
                     {
-                        var pos = newPixelData.PlanarConfiguration == PlanarConfiguration.Planar ? (c * pixelCount) : c;
+                        var pos = newPixelData.PlanarConfiguration == PlanarConfiguration.Planar ? c * pixelCount : c;
                         var offset = newPixelData.PlanarConfiguration == PlanarConfiguration.Planar
                                          ? 1
                                          : decoder.ComponentsPerSample;

--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -311,16 +311,14 @@ namespace Dicom.Imaging
                 decodedPixelData.PhotometricInterpretation = PhotometricInterpretation.Rgb;
             }
 
-            // temporary fix for JPEG lossless and JPEG2000 compressed YBR images
-            if ((inputTransferSyntax == DicomTransferSyntax.JPEGProcess14
-                 || inputTransferSyntax == DicomTransferSyntax.JPEGProcess14SV1
-                 || inputTransferSyntax == DicomTransferSyntax.JPEG2000Lossless
+            // temporary fix for JPEG2000 compressed YBR images
+            if ((inputTransferSyntax == DicomTransferSyntax.JPEG2000Lossless
                  || inputTransferSyntax == DicomTransferSyntax.JPEG2000Lossy)
                 && (decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull
                     || decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrFull422
                     || decodedPixelData.PhotometricInterpretation == PhotometricInterpretation.YbrPartial422))
             {
-                // For JPEG lossless YBR type images in Dicom.Imaging.Codec.Jpeg.i and JPEG2000 YBR type images in Dicom.Imaging.Codec.Jpeg2000.cpp, 
+                // For JPEG2000 YBR type images in Dicom.Imaging.Codec.Jpeg2000.cpp, 
                 // YBR_FULL is applied and PlanarConfiguration is set to Planar
                 decodedPixelData.PhotometricInterpretation = PhotometricInterpretation.YbrFull;
                 decodedPixelData.PlanarConfiguration = PlanarConfiguration.Planar;

--- a/DICOM/Imaging/PixelDataConverter.cs
+++ b/DICOM/Imaging/PixelDataConverter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Runtime.CompilerServices;
+
 using Dicom.IO.Buffer;
 
 namespace Dicom.Imaging
@@ -17,17 +19,17 @@ namespace Dicom.Imaging
         /// <returns>Pixels data in planar format (RRR...GGG...BBB...)</returns>
         public static IByteBuffer InterleavedToPlanar24(IByteBuffer data)
         {
-            byte[] oldPixels = data.Data;
-            byte[] newPixels = new byte[oldPixels.Length];
-            int pixelCount = newPixels.Length / 3;
+            var oldPixels = data.Data;
+            var newPixels = new byte[oldPixels.Length];
+            var pixelCount = newPixels.Length / 3;
 
             unchecked
             {
-                for (int n = 0; n < pixelCount; n++)
+                for (var n = 0; n < pixelCount; n++)
                 {
-                    newPixels[n + (pixelCount * 0)] = oldPixels[(n * 3) + 0];
-                    newPixels[n + (pixelCount * 1)] = oldPixels[(n * 3) + 1];
-                    newPixels[n + (pixelCount * 2)] = oldPixels[(n * 3) + 2];
+                    newPixels[n + pixelCount * 0] = oldPixels[n * 3 + 0];
+                    newPixels[n + pixelCount * 1] = oldPixels[n * 3 + 1];
+                    newPixels[n + pixelCount * 2] = oldPixels[n * 3 + 2];
                 }
             }
 
@@ -41,100 +43,118 @@ namespace Dicom.Imaging
         /// <returns>Pixels data in interleaved format (RGB)</returns>
         public static IByteBuffer PlanarToInterleaved24(IByteBuffer data)
         {
-            byte[] oldPixels = data.Data;
-            byte[] newPixels = new byte[oldPixels.Length];
-            int pixelCount = newPixels.Length / 3;
+            var oldPixels = data.Data;
+            var newPixels = new byte[oldPixels.Length];
+            var pixelCount = newPixels.Length / 3;
 
             unchecked
             {
-                for (int n = 0; n < pixelCount; n++)
+                for (var n = 0; n < pixelCount; n++)
                 {
-                    newPixels[(n * 3) + 0] = oldPixels[n + (pixelCount * 0)];
-                    newPixels[(n * 3) + 1] = oldPixels[n + (pixelCount * 1)];
-                    newPixels[(n * 3) + 2] = oldPixels[n + (pixelCount * 2)];
+                    newPixels[n * 3 + 0] = oldPixels[n + pixelCount * 0];
+                    newPixels[n * 3 + 1] = oldPixels[n + pixelCount * 1];
+                    newPixels[n * 3 + 2] = oldPixels[n + pixelCount * 2];
                 }
             }
 
             return new MemoryByteBuffer(newPixels);
         }
 
+        /// <summary>
+        /// Convert YBR_FULL photometric interpretation pixels to RGB.
+        /// </summary>
+        /// <param name="data">Array of YBR_FULL photometric interpretation pixels.</param>
+        /// <returns>Array of pixel data in RGB photometric interpretation.</returns>
         public static IByteBuffer YbrFullToRgb(IByteBuffer data)
         {
-            byte[] oldPixels = data.Data;
-            byte[] newPixels = new byte[oldPixels.Length];
+            var oldPixels = data.Data;
+            var newPixels = new byte[oldPixels.Length];
 
             unchecked
             {
-                int y, b, r;
-                for (int n = 0; n < newPixels.Length; n += 3)
+                for (var n = 0; n < newPixels.Length; n += 3)
                 {
-                    y = oldPixels[n + 0];
-                    b = oldPixels[n + 1];
-                    r = oldPixels[n + 2];
+                    int y = oldPixels[n + 0];
+                    int b = oldPixels[n + 1];
+                    int r = oldPixels[n + 2];
 
-                    newPixels[n + 0] = (byte)(y + 1.4020 * (r - 128) + 0.5);
-                    newPixels[n + 1] = (byte)(y - 0.3441 * (b - 128) - 0.7141 * (r - 128) + 0.5);
-                    newPixels[n + 2] = (byte)(y + 1.7720 * (b - 128) + 0.5);
+                    newPixels[n + 0] = ToByte(y + 1.4020 * (r - 128) + 0.5);
+                    newPixels[n + 1] = ToByte(y - 0.3441 * (b - 128) - 0.7141 * (r - 128) + 0.5);
+                    newPixels[n + 2] = ToByte(y + 1.7720 * (b - 128) + 0.5);
                 }
             }
 
             return new MemoryByteBuffer(newPixels);
         }
 
+        /// <summary>
+        /// Convert YBR_FULL_422 photometric interpretation pixels to RGB.
+        /// </summary>
+        /// <param name="data">Array of YBR_FULL_422 photometric interpretation pixels.</param>
+        /// <returns>Array of pixel data in RGB photometric interpretation.</returns>
         public static IByteBuffer YbrFull422ToRgb(IByteBuffer data)
         {
-            byte[] oldPixels = data.Data;
-            byte[] newPixels = new byte[(oldPixels.Length / 4) * 2 * 3];
+            var oldPixels = data.Data;
+            var newPixels = new byte[oldPixels.Length / 4 * 2 * 3];
 
             unchecked
             {
-                int y1, y2, cb, cr;
                 for (int n = 0, p = 0; n < oldPixels.Length;)
                 {
-                    y1 = oldPixels[n++];
-                    y2 = oldPixels[n++];
-                    cb = oldPixels[n++];
-                    cr = oldPixels[n++];
+                    int y1 = oldPixels[n++];
+                    int y2 = oldPixels[n++];
+                    int cb = oldPixels[n++];
+                    int cr = oldPixels[n++];
 
-                    newPixels[p++] = (byte)(y1 + 1.4020 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(y1 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(y1 + 1.7720 * (cb - 128) + 0.5);
+                    newPixels[p++] = ToByte(y1 + 1.4020 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(y1 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(y1 + 1.7720 * (cb - 128) + 0.5);
 
-                    newPixels[p++] = (byte)(y2 + 1.4020 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(y2 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(y2 + 1.7720 * (cb - 128) + 0.5);
+                    newPixels[p++] = ToByte(y2 + 1.4020 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(y2 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(y2 + 1.7720 * (cb - 128) + 0.5);
                 }
             }
 
             return new MemoryByteBuffer(newPixels);
         }
 
+        /// <summary>
+        /// Convert YBR_PARTIAL_422 photometric interpretation pixels to RGB.
+        /// </summary>
+        /// <param name="data">Array of YBR_PARTIAL_422 photometric interpretation pixels.</param>
+        /// <returns>Array of pixel data in RGB photometric interpretation.</returns>
         public static IByteBuffer YbrPartial422ToRgb(IByteBuffer data)
         {
-            byte[] oldPixels = data.Data;
-            byte[] newPixels = new byte[(oldPixels.Length / 4) * 2 * 3];
+            var oldPixels = data.Data;
+            var newPixels = new byte[oldPixels.Length / 4 * 2 * 3];
 
             unchecked
             {
-                int y1, y2, cb, cr;
                 for (int n = 0, p = 0; n < oldPixels.Length;)
                 {
-                    y1 = oldPixels[n++];
-                    y2 = oldPixels[n++];
-                    cb = oldPixels[n++];
-                    cr = oldPixels[n++];
+                    int y1 = oldPixels[n++];
+                    int y2 = oldPixels[n++];
+                    int cb = oldPixels[n++];
+                    int cr = oldPixels[n++];
 
-                    newPixels[p++] = (byte)(1.1644 * (y1 - 16) + 1.5960 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(1.1644 * (y1 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(1.1644 * (y1 - 16) + 2.0173 * (cb - 128) + 0.5);
+                    newPixels[p++] = ToByte(1.1644 * (y1 - 16) + 1.5960 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(1.1644 * (y1 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(1.1644 * (y1 - 16) + 2.0173 * (cb - 128) + 0.5);
 
-                    newPixels[p++] = (byte)(1.1644 * (y2 - 16) + 1.5960 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(1.1644 * (y2 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
-                    newPixels[p++] = (byte)(1.1644 * (y2 - 16) + 2.0173 * (cb - 128) + 0.5);
+                    newPixels[p++] = ToByte(1.1644 * (y2 - 16) + 1.5960 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(1.1644 * (y2 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
+                    newPixels[p++] = ToByte(1.1644 * (y2 - 16) + 2.0173 * (cb - 128) + 0.5);
                 }
             }
 
             return new MemoryByteBuffer(newPixels);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte ToByte(double x)
+        {
+            return (byte)(x < 0.0 ? 0.0 : x > 255.0 ? 255.0 : x);
         }
 
         private static readonly byte[] BitReverseTable =
@@ -170,8 +190,8 @@ namespace Dicom.Imaging
         /// <summary>
         /// Reverses bits for each byte in buffer.
         /// </summary>
-        /// <param name="data"></param>
-        /// <returns></returns>
+        /// <param name="data">Original data subject to reversal.</param>
+        /// <returns>Buffer of reversed data.</returns>
         public static IByteBuffer ReverseBits(IByteBuffer data)
         {
             byte[] oldPixels = data.Data;
@@ -179,7 +199,7 @@ namespace Dicom.Imaging
 
             unchecked
             {
-                for (int n = 0; n < oldPixels.Length; n++)
+                for (var n = 0; n < oldPixels.Length; n++)
                 {
                     newPixels[n] = BitReverseTable[oldPixels[n]];
                 }


### PR DESCRIPTION
…in YBR->RGB conversion. Fixes #453 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Do not transform JPEG encoded YBR images.
- Use [0..255] guard when converting YBR pixels to RGB bytes.
- Updated API documentation in *PixelDataConverter.cs*.
