### PR TITLE
Add runtime directives to enable .NET Native builds for UWP. Connected to #424

### DIFF
--- a/DICOM.Platform/Windows/DICOM.Universal.csproj
+++ b/DICOM.Platform/Windows/DICOM.Universal.csproj
@@ -194,7 +194,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <EmbeddedResource Include="Properties\Dicom.Platform.rd.xml" />
+    <EmbeddedResource Include="Properties\Dicom.Core.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DICOM.Native\Windows\DICOM.Native.Windows.vcxproj">

--- a/DICOM.Platform/Windows/Properties/Dicom.Core.rd.xml
+++ b/DICOM.Platform/Windows/Properties/Dicom.Core.rd.xml
@@ -27,7 +27,10 @@
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Library Name="Dicom.Core">
 
-    <!-- add directives for your library here -->
+    <Type Name="System.Collections.Generic.IDictionary{Dicom.DicomTag, Dicom.DicomItem}" MarshalStructure="Excluded" />
+    <Type Name="System.Collections.Generic.IList{Dicom.DicomDataset}" MarshalStructure="Excluded" />
+    <Type Name="System.Collections.Generic.IList{Dicom.IO.Buffer.IByteBuffer}" MarshalStructure="Excluded" />
+    <Type Name="System.Collections.Generic.IList{System.UInt32}" MarshalStructure="Excluded" />
 
   </Library>
 </Directives>

--- a/DICOM.Platform/Windows/Properties/Dicom.Core.rd.xml
+++ b/DICOM.Platform/Windows/Properties/Dicom.Core.rd.xml
@@ -25,9 +25,9 @@
     http://go.microsoft.com/fwlink/?LinkID=391919
 -->
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Library Name="DICOM.Windows">
+  <Library Name="Dicom.Core">
 
-  	<!-- add directives for your library here -->
+    <!-- add directives for your library here -->
 
   </Library>
 </Directives>


### PR DESCRIPTION
Fixes #424 .

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-Corrected referenced assembly name in runtime directives file.
- Added exclude directives to enable .NET Native building.
