### PR TITLE
Handle rendering of YBR_*_422 images with uneven number of columns. Connected to #471

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.0 (TBD)
+* Cannot render YBR_FULL/PARTIAL_422 with odd number of columns (#471 #479)
 * Convert .NET Core projects to use VS 2017 .csproj project files (#470 #473)
 * Call to DicomServer.Stop does not remove all clients (#456 #464)
 * Repository re-organization (#445 #446 #447 #448 #451 #452 #455 #462 #463 #465 #467 #468 #469 #476 #477 #478)

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -255,11 +255,22 @@ namespace Dicom.Imaging
             {
                 if (BitsAllocated == 1)
                 {
-                    var bytes = (Width * Height) / 8;
-                    if (((Width * Height) % 8) > 0) bytes++;
+                    var bytes = Width * Height / 8;
+                    if ((Width * Height) % 8 > 0) bytes++;
                     return bytes;
                 }
-                return BytesAllocated * SamplesPerPixel * Width * Height;
+
+                // Issue #471, handle special case with invalid uneven width for YBR_*_422 and YBR_PARTIAL_420 images
+                var actualWidth = Width;
+                if (actualWidth % 2 != 0 &&
+                    (PhotometricInterpretation.Equals(PhotometricInterpretation.YbrFull422) ||
+                     PhotometricInterpretation.Equals(PhotometricInterpretation.YbrPartial422) ||
+                     PhotometricInterpretation.Equals(PhotometricInterpretation.YbrPartial420)))
+                {
+                    ++actualWidth;
+                }
+
+                return BytesAllocated * SamplesPerPixel * actualWidth * Height;
             }
         }
 

--- a/DICOM/Imaging/PixelDataConverter.cs
+++ b/DICOM/Imaging/PixelDataConverter.cs
@@ -91,15 +91,16 @@ namespace Dicom.Imaging
         /// Convert YBR_FULL_422 photometric interpretation pixels to RGB.
         /// </summary>
         /// <param name="data">Array of YBR_FULL_422 photometric interpretation pixels.</param>
+        /// <param name="width">Image width.</param>
         /// <returns>Array of pixel data in RGB photometric interpretation.</returns>
-        public static IByteBuffer YbrFull422ToRgb(IByteBuffer data)
+        public static IByteBuffer YbrFull422ToRgb(IByteBuffer data, int width)
         {
             var oldPixels = data.Data;
             var newPixels = new byte[oldPixels.Length / 4 * 2 * 3];
 
             unchecked
             {
-                for (int n = 0, p = 0; n < oldPixels.Length;)
+                for (int n = 0, p = 0, col = 0; n < oldPixels.Length;)
                 {
                     int y1 = oldPixels[n++];
                     int y2 = oldPixels[n++];
@@ -110,9 +111,19 @@ namespace Dicom.Imaging
                     newPixels[p++] = ToByte(y1 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
                     newPixels[p++] = ToByte(y1 + 1.7720 * (cb - 128) + 0.5);
 
+                    if (++col == width)
+                    {
+                        // Issue #471: for uneven width images (i.e. when col equals width after first of two pixels), 
+                        // ignore last pixel in each row.
+                        col = 0;
+                        continue;
+                    }
+
                     newPixels[p++] = ToByte(y2 + 1.4020 * (cr - 128) + 0.5);
                     newPixels[p++] = ToByte(y2 - 0.3441 * (cb - 128) - 0.7141 * (cr - 128) + 0.5);
                     newPixels[p++] = ToByte(y2 + 1.7720 * (cb - 128) + 0.5);
+
+                    if (++col == width) col = 0;
                 }
             }
 
@@ -123,15 +134,16 @@ namespace Dicom.Imaging
         /// Convert YBR_PARTIAL_422 photometric interpretation pixels to RGB.
         /// </summary>
         /// <param name="data">Array of YBR_PARTIAL_422 photometric interpretation pixels.</param>
+        /// <param name="width">Image width.</param>
         /// <returns>Array of pixel data in RGB photometric interpretation.</returns>
-        public static IByteBuffer YbrPartial422ToRgb(IByteBuffer data)
+        public static IByteBuffer YbrPartial422ToRgb(IByteBuffer data, int width)
         {
             var oldPixels = data.Data;
             var newPixels = new byte[oldPixels.Length / 4 * 2 * 3];
 
             unchecked
             {
-                for (int n = 0, p = 0; n < oldPixels.Length;)
+                for (int n = 0, p = 0, col = 0; n < oldPixels.Length;)
                 {
                     int y1 = oldPixels[n++];
                     int y2 = oldPixels[n++];
@@ -142,9 +154,19 @@ namespace Dicom.Imaging
                     newPixels[p++] = ToByte(1.1644 * (y1 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
                     newPixels[p++] = ToByte(1.1644 * (y1 - 16) + 2.0173 * (cb - 128) + 0.5);
 
+                    if (++col == width)
+                    {
+                        // Issue #471: for uneven width images (i.e. when col equals width after first of two pixels), 
+                        // ignore last pixel in each row.
+                        col = 0;
+                        continue;
+                    }
+
                     newPixels[p++] = ToByte(1.1644 * (y2 - 16) + 1.5960 * (cr - 128) + 0.5);
                     newPixels[p++] = ToByte(1.1644 * (y2 - 16) - 0.3917 * (cb - 128) - 0.8130 * (cr - 128) + 0.5);
                     newPixels[p++] = ToByte(1.1644 * (y2 - 16) + 2.0173 * (cb - 128) + 0.5);
+
+                    if (++col == width) col = 0;
                 }
             }
 

--- a/DICOM/Imaging/Render/PixelData.cs
+++ b/DICOM/Imaging/Render/PixelData.cs
@@ -166,8 +166,8 @@ namespace Dicom.Imaging.Render
                 if (pixelData.PlanarConfiguration == PlanarConfiguration.Planar) buffer = PixelDataConverter.PlanarToInterleaved24(buffer);
 
                 if (pi == PhotometricInterpretation.YbrFull) buffer = PixelDataConverter.YbrFullToRgb(buffer);
-                else if (pi == PhotometricInterpretation.YbrFull422) buffer = PixelDataConverter.YbrFull422ToRgb(buffer);
-                else if (pi == PhotometricInterpretation.YbrPartial422) buffer = PixelDataConverter.YbrPartial422ToRgb(buffer);
+                else if (pi == PhotometricInterpretation.YbrFull422) buffer = PixelDataConverter.YbrFull422ToRgb(buffer, pixelData.Width);
+                else if (pi == PhotometricInterpretation.YbrPartial422) buffer = PixelDataConverter.YbrPartial422ToRgb(buffer, pixelData.Width);
 
                 return new ColorPixelData24(pixelData.Width, pixelData.Height, buffer);
             }


### PR DESCRIPTION
Fixes #471 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- `DicomPixelData.UncompressedFrameSize` accounts for uneven number of columns for YBR_*_422/420 images.
- `PixelDataConverter` methods for YBR to RGB skips the last pixel per row if the number of columns is uneven.
