### PR TITLE
Remove SOP Instance UID from Command if setter argument is null. Connected to #484

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.2 (TBD)
+* N-CREATE response constructor throws when request command does not contain SOP Instance UID (#484 #485)
 * Cannot render YBR_FULL/PARTIAL_422 with odd number of columns (#471 #479)
 
 #### v.3.0.1 (3/06/2017)

--- a/DICOM/Network/DicomNCreateResponse.cs
+++ b/DICOM/Network/DicomNCreateResponse.cs
@@ -37,6 +37,7 @@ namespace Dicom.Network
         /// <summary>
         /// Gets the affected SOP instance UID.
         /// </summary>
+        /// <remarks>In the N-CREATE response, Affected SOP Instance UID is optional, and <code>null</code> can thus be returned.</remarks>
         public DicomUID SOPInstanceUID
         {
             get
@@ -45,7 +46,14 @@ namespace Dicom.Network
             }
             private set
             {
-                Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
+                if (value == null)
+                {
+                    Command.Remove(DicomTag.AffectedSOPInstanceUID);
+                }
+                else
+                {
+                    Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
+                }
             }
         }
 

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Network\DicomCGetRequestTest.cs" />
     <Compile Include="Network\DicomClientTest.cs" />
     <Compile Include="Network\DicomNCreateRequestTest.cs" />
+    <Compile Include="Network\DicomNCreateResponseTest.cs" />
     <Compile Include="Network\DicomNEventReportResponseTest.cs" />
     <Compile Include="Network\DicomNActionResponseTest.cs" />
     <Compile Include="Network\DicomServerTest.cs" />

--- a/Tests/Network/DicomNCreateRequestTest.cs
+++ b/Tests/Network/DicomNCreateRequestTest.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Dicom.Network
 {
+    [Collection("Network"), Trait("Category", "Network")]
     public class DicomNCreateRequestTest
     {
         [Fact]
@@ -13,7 +14,7 @@ namespace Dicom.Network
             var command = new DicomDataset();
             command.Add(DicomTag.CommandField, (ushort)DicomCommandField.NCreateRequest);
             command.Add(DicomTag.MessageID, (ushort)1);
-            command.Add(DicomTag.RequestedSOPClassUID, "1.2.3");
+            command.Add(DicomTag.AffectedSOPClassUID, "1.2.3");
 
             var request = new DicomNCreateRequest(command);
             var expected = request.SOPInstanceUID;

--- a/Tests/Network/DicomNCreateResponseTest.cs
+++ b/Tests/Network/DicomNCreateResponseTest.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Xunit;
+
+namespace Dicom.Network
+{
+    [Collection("Network"), Trait("Category", "Network")]
+    public class DicomNCreateResponseTest
+    {
+        [Fact]
+        public void Constructor_FromRequestWithoutSopInstanceUid_ShouldNotThrow()
+        {
+            var request =
+                new DicomNCreateRequest(new DicomDataset
+                {
+                    {DicomTag.CommandField, (ushort) DicomCommandField.NCreateRequest},
+                    {DicomTag.MessageID, (ushort) 1},
+                    {DicomTag.AffectedSOPClassUID, "1.2.3"}
+                });
+
+            DicomNCreateResponse response = null;
+            var exception = Record.Exception(() => response = new DicomNCreateResponse(request, DicomStatus.Success));
+
+            Assert.Null(exception);
+            Assert.Null(response.SOPInstanceUID);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #484 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/3.0* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- In `DicomNCreateResponse.SOPInstanceUID` setter, if `value` is `null` remove Affected SOP Instance UID from command dataset instead of trying to set the value to `null`.