### PR TITLE
Add extra encodings for .NET Core (#481)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
 * Added optional parameter for use in extended DicomService (#348 #441)
 * Remove warning messages during build (#33 #438)
 * Online and NuGet packages API documentation (#28 #459 #466)
+* Added missing encodings for .NET Core (#481)
 
 #### v.3.0.2 (TBD)
 * N-CREATE response constructor throws when request command does not contain SOP Instance UID (#484 #485)

--- a/Contributors.md
+++ b/Contributors.md
@@ -28,3 +28,4 @@
 * [Ed55](https://github.com/Ed55)
 * [zcr01](https://github.com/zcr01)
 * [JustSomeHack](https://github.com/deyung)
+* [Nick Nelson](https://github.com/npnelson)

--- a/DICOM/DicomEncoding.cs
+++ b/DICOM/DicomEncoding.cs
@@ -18,6 +18,13 @@ namespace Dicom
         /// </summary>
         public static readonly Encoding Default = IOManager.BaseEncoding;
 
+#if NETSTANDARD
+        static DicomEncoding()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+#endif
+
         /// <summary>
         /// Get encoding from charset.
         /// </summary>

--- a/Platform/NetCore/DICOM.NetCore.csproj
+++ b/Platform/NetCore/DICOM.NetCore.csproj
@@ -136,6 +136,7 @@
     <PackageReference Include="System.Net.Security" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Numerics" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
   </ItemGroup>
   

--- a/Tests/Desktop/DicomEncodingTest.cs
+++ b/Tests/Desktop/DicomEncodingTest.cs
@@ -25,5 +25,13 @@ namespace Dicom
             var actual = DicomEncoding.GetEncoding("GBK").CodePage;
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void GetEncoding_GB18030_Desktop() //https://github.com/fo-dicom/fo-dicom/issues/481
+        {
+            var expected = Encoding.GetEncoding("GB18030").CodePage;
+            var actual = DicomEncoding.GetEncoding("GB18030").CodePage;
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/Tests/NetCore/DicomEncodingTest.cs
+++ b/Tests/NetCore/DicomEncodingTest.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
+{
+    using System.Text;
+
+    using Xunit;
+
+    [Collection("General")]
+    public class DicomEncodingTest
+    {       
+        [Fact]
+        public void GetEncoding_GB18030_NetCore() //https://github.com/fo-dicom/fo-dicom/issues/481
+        {
+            var actual = DicomEncoding.GetEncoding("GB18030").CodePage; //note that if you put the call to expected before actual, it won't work because the GB18030 code page isn't loaded explicitly in the test project
+            var expected = Encoding.GetEncoding("GB18030").CodePage;           
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #481.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
Added static constructor in DICOMEncoding to load extra encodings not included by default in .NET Core
