### PR TITLE
Forced connection close for some exceptions in DicomService. Connected to #472

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 * Online and NuGet packages API documentation (#28 #459 #466)
 
 #### v.3.0.2 (TBD)
+* If the connection is closed by the host, DicomClient will keep trying to send (#472 #489)
 * N-CREATE response constructor throws when request command does not contain SOP Instance UID (#484 #485)
 * Cannot render YBR_FULL/PARTIAL_422 with odd number of columns (#471 #479)
 


### PR DESCRIPTION
Fixes #472 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- For `IOException?, `ObjectDisposedException` and `NullReferenceException` during reading or writing PDUs in `DicomService`, force connection to close by clearing the message, pending and PDU queues.
