### PR TITLE
Return VR > 1 as a single string when requested

### DIFF
--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -461,6 +461,11 @@ namespace Dicom
                     throw new DicomDataException("Element empty or index: {0} exceeds element count: {1}", n, element.Count);
                 }
 
+				if (element.ValueRepresentation.IsMultiValue && typeof(T) == typeof(string))
+				{
+					return (T)(object)string.Join("\\", element.Get<string[]>());
+				}
+
                 return element.Get<T>(n);
             }
 


### PR DESCRIPTION
Fixes # .

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- If type of string is passed and tag is multi-valued then values are concatenated into one string
-
-
