### PR TITLE
Remove ErrorComment when setting DicomResponse statuses without ErrorComment. Connected to #501

### DIFF
--- a/DICOM/Network/DicomResponse.cs
+++ b/DICOM/Network/DicomResponse.cs
@@ -71,7 +71,10 @@ namespace Dicom.Network
             set
             {
                 Command.AddOrUpdate(DicomTag.Status, value.Code);
-                Command.AddOrUpdate(DicomTag.ErrorComment, value.ErrorComment);
+                if (!string.IsNullOrWhiteSpace(value.ErrorComment))
+                {
+                    Command.AddOrUpdate(DicomTag.ErrorComment, value.ErrorComment);
+                }
             }
         }
 

--- a/DICOM/Network/DicomResponse.cs
+++ b/DICOM/Network/DicomResponse.cs
@@ -71,7 +71,11 @@ namespace Dicom.Network
             set
             {
                 Command.AddOrUpdate(DicomTag.Status, value.Code);
-                if (!string.IsNullOrWhiteSpace(value.ErrorComment))
+                if (string.IsNullOrWhiteSpace(value.ErrorComment))
+                {
+                    Command.Remove(DicomTag.ErrorComment);
+                }
+                else
                 {
                     Command.AddOrUpdate(DicomTag.ErrorComment, value.ErrorComment);
                 }

--- a/Tests/Desktop/Network/DicomNActionResponseTest.cs
+++ b/Tests/Desktop/Network/DicomNActionResponseTest.cs
@@ -56,6 +56,23 @@ namespace Dicom.Network
             Assert.False(x.Command.Contains(DicomTag.ErrorComment));
         }
 
+        [Fact]
+        public void StatusSetter_ChangesFromStatusWithCommentToWithout_UpdatesErrorComment()
+        {
+            var comment = "This is a comment";
+            DicomResponse x = new DicomNActionResponse(new DicomDataset());
+            var status = new DicomStatus(
+                             "C303",
+                             DicomState.Failure,
+                             "Refused: The UPS may only become SCHEDULED via N-CREATE, not N-SET or N-ACTION",
+                             comment);
+            x.Status = status;
+            Assert.Equal(x.Command.Get<string>(DicomTag.ErrorComment), comment);
+
+            x.Status = DicomStatus.Success;
+            Assert.False(x.Command.Contains(DicomTag.ErrorComment));
+        }
+
         #endregion
     }
 }

--- a/Tests/Desktop/Network/DicomNActionResponseTest.cs
+++ b/Tests/Desktop/Network/DicomNActionResponseTest.cs
@@ -48,6 +48,14 @@ namespace Dicom.Network
             Assert.Null(exception);
         }
 
+        [Fact]
+        public void StatusSetter_SetWithoutErrorComment_DoesNotAddErrorComment()
+        {
+            DicomResponse x = new DicomNActionResponse(new DicomDataset());
+            x.Status = DicomStatus.Success;
+            Assert.False(x.Command.Contains(DicomTag.ErrorComment));
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #501  .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Not adding ErrorComment in DicomResponse.Status setter if the new status has no ErrorComment.
- Removing ErrorComment in DicomResponse.Status setter if the new status has no ErrorComment.

