### PR TITLE
Dicom Server listener consumes large amount of memory if http request is sent to listener. Connected to #327

### DIFF
--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -369,29 +369,32 @@ namespace Dicom.Network
                     length = Endian.Swap(length);
 
                     _readLength = length;
-
-                    Array.Resize(ref buffer, length + 6);
-
-                    count = await stream.ReadAsync(buffer, 6, length).ConfigureAwait(false);
-
+                    
                     // Read PDU
-                    do
+                    using (var ms = new MemoryStream())
                     {
-                        if (count == 0)
+                        ms.Write(buffer, 0, buffer.Length);
+                        while (_readLength > 0)
                         {
-                            // disconnected
-                            TryCloseConnection();
-                            return;
+                            int bytesToRead = Math.Min(_readLength, 1024);
+                            var tempBuffer = new byte[bytesToRead];
+                            count = await stream.ReadAsync(tempBuffer, 0, bytesToRead)
+                                    .ConfigureAwait(false);
+
+                            if (count == 0)
+                            {
+                                // disconnected
+                                TryCloseConnection();
+                                return;
+                            }
+
+                            ms.Write(tempBuffer, 0, count);
+
+                            _readLength -= count;
                         }
 
-                        _readLength -= count;
-                        if (_readLength > 0)
-                        {
-                            count =
-                                await stream.ReadAsync(buffer, buffer.Length - _readLength, _readLength)
-                                    .ConfigureAwait(false);
-                        }
-                    } while (_readLength > 0);
+                        buffer = ms.ToArray();
+                    }
 
                     var raw = new RawPDU(buffer);
 

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -96,6 +96,8 @@ namespace Dicom.Network
 
         private readonly ManualResetEventSlim _pduQueueWatcher;
 
+        private const int MaxBytesToRead = 16384;
+
         #endregion
 
         #region CONSTRUCTORS
@@ -376,7 +378,7 @@ namespace Dicom.Network
                         ms.Write(buffer, 0, buffer.Length);
                         while (_readLength > 0)
                         {
-                            int bytesToRead = Math.Min(_readLength, 1024);
+                            int bytesToRead = Math.Min(_readLength, MaxBytesToRead);
                             var tempBuffer = new byte[bytesToRead];
                             count = await stream.ReadAsync(tempBuffer, 0, bytesToRead)
                                     .ConfigureAwait(false);


### PR DESCRIPTION
Fixes #327 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
instead of resizing the array based on the length in the PDU we try to read the the complete length in chunks of 1K so we only allocate the full length if we read that amount of data from the network stream