### PR TITLE
Catch all exceptions in AcceptNetworkStreamAsync implementations. Connected to #495

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 * Add option in DicomServiceOptions for max PDVs per PDU (#502 #506)
 * DicomResponse.ErrorComment is always added in the DicomResponse.Status setter, even for successes (#501 #505)
 * DicomStatus.Lookup does not consider priority in matching (#499 #498)
+* DesktopNetworkListener can throw an exception which causes DicomServer to stop listening (#495 #519)
 * Cannot parse dicom files if the last tag is a private sequence containing only empty sequence items (#487 #518)
 * If the connection is closed by the host, DicomClient will keep trying to send (#472 #489)
 * N-CREATE response constructor throws when request command does not contain SOP Instance UID (#484 #485)

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -91,7 +91,7 @@ namespace Dicom.Network
 
                 return null;
             }
-            catch (TaskCanceledException)
+            catch
             {
                 return null;
             }

--- a/DICOM/Network/WindowsNetworkListener.cs
+++ b/DICOM/Network/WindowsNetworkListener.cs
@@ -91,7 +91,7 @@ namespace Dicom.Network
                 this.handle.Wait(token);
                 networkStream = this.socket == null ? null : new WindowsNetworkStream(this.socket);
             }
-            catch (OperationCanceledException)
+            catch
             {
                 networkStream = null;
             }


### PR DESCRIPTION
Fixes #495 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/3.0* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Catch all exceptions, not only task cancellation related, in `AcceptNetworkStreamAsync` implementations, to avoid that server stops listening due to failed connection attempt.
