### PR TITLE
Changed RejectReason.ProtocolVersionNotSupported value to 2. Connected to #515

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.0.2 (TBD)
+* Incorrect numerical value on RejectReason.ProtocolVersionNotSupported (#515 #520)
 * Add private creator to private tags when deserializing json (#512 #513)
 * Adding private tags implicitly uses wrong VR (#503 #504)
 * Add option in DicomServiceOptions for max PDVs per PDU (#502 #506)

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -953,7 +953,7 @@ namespace Dicom.Network
         CalledAENotRecognized = 7,
 
         /// <summary>Protocol version not supported (Service provider - ACSE)</summary>
-        ProtocolVersionNotSupported = 1,
+        ProtocolVersionNotSupported = 2,
 
         /// <summary>Temporary congestion (Service provider - Presentation)</summary>
         TemporaryCongestion = 1,


### PR DESCRIPTION
Fixes #515 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/3.0* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- RejectReason.ProtocolVersionNotSupported value changed to 2
