### PR TITLE
Reliably select correct association reject reason w.r.t. reject source. Connected to #516

### DIFF
--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -938,28 +938,33 @@ namespace Dicom.Network
     }
 
     /// <summary>Rejection reason</summary>
+    /// <remarks>The underlying value is a hexadecimal combination of the <see cref="DicomRejectSource"/> and the rejection
+    /// reason code given in Table 9-21 of DICOM Standard PS 3.8.</remarks>
     public enum DicomRejectReason
     {
         /// <summary>No reason given (Service user)</summary>
-        NoReasonGiven = 1,
+        NoReasonGiven = 0x11,
 
         /// <summary>Application context not supported (Service user)</summary>
-        ApplicationContextNotSupported = 2,
+        ApplicationContextNotSupported = 0x12,
 
         /// <summary>Calling AE not recognized (Service user)</summary>
-        CallingAENotRecognized = 3,
+        CallingAENotRecognized = 0x13,
 
         /// <summary>Called AE not recognized (Service user)</summary>
-        CalledAENotRecognized = 7,
+        CalledAENotRecognized = 0x17,
+
+        /// <summary>No reason given (Service provider - ACSE)</summary>
+        NoReasonGiven_ = 0x21,
 
         /// <summary>Protocol version not supported (Service provider - ACSE)</summary>
-        ProtocolVersionNotSupported = 2,
+        ProtocolVersionNotSupported = 0x22,
 
         /// <summary>Temporary congestion (Service provider - Presentation)</summary>
-        TemporaryCongestion = 1,
+        TemporaryCongestion = 0x31,
 
         /// <summary>Local limit exceeded (Service provider - Presentation)</summary>
-        LocalLimitExceeded = 2
+        LocalLimitExceeded = 0x32
     }
 
     /// <summary>A-ASSOCIATE-RJ</summary>
@@ -1027,13 +1032,16 @@ namespace Dicom.Network
         /// Writes A-ASSOCIATE-RJ to PDU buffer
         /// </summary>
         /// <returns>PDU buffer</returns>
+        /// <remarks>When writing the rejection reason to the <see cref="RawPDU"/> object, the <see cref="DicomRejectSource"/>
+        /// specification in the underlying value is masked out, to ensure that the reason code matches the codes specified
+        /// in Table 9-21 of DICOM Standard PS 3.8.</remarks>
         public RawPDU Write()
         {
             RawPDU pdu = new RawPDU((byte)0x03);
             pdu.Write("Reserved", (byte)0x00);
             pdu.Write("Result", (byte)_rt);
             pdu.Write("Source", (byte)_so);
-            pdu.Write("Reason", (byte)_rn);
+            pdu.Write("Reason", (byte)((byte)_rn & 0xf));
             return pdu;
         }
 
@@ -1041,12 +1049,15 @@ namespace Dicom.Network
         /// Reads A-ASSOCIATE-RJ from PDU buffer
         /// </summary>
         /// <param name="raw">PDU buffer</param>
+        /// <remarks>When reading the rejection reason, the previously read <see cref="DicomRejectSource"/> value is
+        /// combined with the numerical reject reason from the <see cref="RawPDU"/> object to yield numerical
+        /// values that matches the members of the <see cref="DicomRejectReason"/> enumeration.</remarks>
         public void Read(RawPDU raw)
         {
             raw.ReadByte("Reserved");
             _rt = (DicomRejectResult)raw.ReadByte("Result");
             _so = (DicomRejectSource)raw.ReadByte("Source");
-            _rn = (DicomRejectReason)raw.ReadByte("Reason");
+            _rn = (DicomRejectReason)((byte)_so << 4 | raw.ReadByte("Reason"));
         }
     }
 

--- a/Tests/Network/PDUTest.cs
+++ b/Tests/Network/PDUTest.cs
@@ -164,8 +164,8 @@ namespace Dicom.Network
             {
                 new byte[] {0x03, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x02, 0x01},
                 new AAssociateRJ(DicomRejectResult.Permanent, DicomRejectSource.ServiceProviderACSE,
-                    DicomRejectReason.NoReasonGiven),
-                nameof(DicomRejectReason.NoReasonGiven)
+                    DicomRejectReason.NoReasonGiven_),
+                nameof(DicomRejectReason.NoReasonGiven_)
             },
             new object[]
             {


### PR DESCRIPTION
Fixes #516 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/3.0* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Underlying values of `DicomRejectReason` are uniquely numbered through a hexadecimal combination of corresponding rejection source and rejection reason codes defined in the DICOM Standard (Table 9-21, PS 3.8).
- Added new member `DicomRejectReason.NoReasonGiven_` (no reason given, ACSE service provider) to identifiably separate from `NoReasonGiven` for service users.
- When reading `DicomRejectReason` from `RawPDU` combine read reason code with read rejection source to yield corresponding `DicomRejectReason` member.
- When writing `DicomRejectReason` to `RawPDU` object, mask away the rejection source from the numerical value to ensure that the written code matches reason codes in the DICOM standard.