### PR TITLE
Handle empty patient ID and name when creating DICOM directory. Connected to #488

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-#### v.3.0.2 (TBD)
+#### v.3.0.2 (4/20/2017)
 * DicomRejectReason enumerables should be parsed w.r.t. source (#516 #521)
 * Incorrect numerical value on RejectReason.ProtocolVersionNotSupported (#515 #520)
 * Add private creator to private tags when deserializing json (#512 #513)
@@ -7,6 +7,7 @@
 * DicomResponse.ErrorComment is always added in the DicomResponse.Status setter, even for successes (#501 #505)
 * DicomStatus.Lookup does not consider priority in matching (#499 #498)
 * DesktopNetworkListener can throw an exception which causes DicomServer to stop listening (#495 #519)
+* Cannot create DICOMDIR after anonymizing images (#488 #522)
 * Cannot parse dicom files if the last tag is a private sequence containing only empty sequence items (#487 #518)
 * If the connection is closed by the host, DicomClient will keep trying to send (#472 #489)
 * N-CREATE response constructor throws when request command does not contain SOP Instance UID (#484 #485)

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -580,14 +580,19 @@ namespace Dicom.Media
 
         private DicomDirectoryRecord CreatePatientRecord(DicomDataset dataset)
         {
+            var patientId = dataset.Get(DicomTag.PatientID, string.Empty);
+            var patientName = dataset.Get(DicomTag.PatientName, string.Empty);
+
             var currentPatient = RootDirectoryRecord;
-            var patientId = dataset.Get<string>(DicomTag.PatientID);
-            var patientName = dataset.Get<string>(DicomTag.PatientName);
+            string currPatId = null, currPatName = null;
 
             while (currentPatient != null)
             {
-                if (currentPatient.Get<string>(DicomTag.PatientID) == patientId
-                    && currentPatient.Get<string>(DicomTag.PatientName) == patientName)
+                currPatId = currPatId ?? currentPatient.Get(DicomTag.PatientID, string.Empty);
+                currPatName = currPatName ?? currentPatient.Get(DicomTag.PatientName, string.Empty);
+
+                if (currPatId == patientId
+                    && currPatName == patientName)
                 {
                     return currentPatient;
                 }
@@ -602,6 +607,7 @@ namespace Dicom.Media
                     break;
                 }
             }
+
             var newPatient = CreateRecordSequenceItem(DicomDirectoryRecordType.Patient, dataset);
             if (currentPatient != null)
             {
@@ -613,6 +619,7 @@ namespace Dicom.Media
                 //no patients record found under root record
                 RootDirectoryRecord = newPatient;
             }
+
             return newPatient;
         }
 

--- a/DICOM/Media/DicomDirectory.cs
+++ b/DICOM/Media/DicomDirectory.cs
@@ -584,15 +584,13 @@ namespace Dicom.Media
             var patientName = dataset.Get(DicomTag.PatientName, string.Empty);
 
             var currentPatient = RootDirectoryRecord;
-            string currPatId = null, currPatName = null;
 
             while (currentPatient != null)
             {
-                currPatId = currPatId ?? currentPatient.Get(DicomTag.PatientID, string.Empty);
-                currPatName = currPatName ?? currentPatient.Get(DicomTag.PatientName, string.Empty);
+                var currPatId = currentPatient.Get(DicomTag.PatientID, string.Empty);
+                var currPatName = currentPatient.Get(DicomTag.PatientName, string.Empty);
 
-                if (currPatId == patientId
-                    && currPatName == patientName)
+                if (currPatId == patientId && currPatName == patientName)
                 {
                     return currentPatient;
                 }

--- a/Tests/DICOM.Tests.csproj
+++ b/Tests/DICOM.Tests.csproj
@@ -62,6 +62,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="WindowsBase" />

--- a/Tests/Media/DicomDirectoryTest.cs
+++ b/Tests/Media/DicomDirectoryTest.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
-using NLog.Internal;
 
 namespace Dicom.Media
 {
@@ -85,7 +84,7 @@ namespace Dicom.Media
         }
 
         [Fact]
-        public void AddFile_Anonymized_DoesNotThrow()
+        public void AddFile_AnonymizedSeries_AllFilesAddedToSameStudySeriesNode()
         {
             var dicomFiles = GetDicomFilesFromWebZip(
                 "https://www.creatis.insa-lyon.fr/~jpr/PUBLIC/gdcm/gdcmSampleData/Philips_Medical_Images/mr711-mr712/abd1.zip");
@@ -104,7 +103,9 @@ namespace Dicom.Media
                 dicomDir.AddFile(dicomFile);
             }
 
-            Assert.Equal(dicomFiles.Count, dicomDir.RootDirectoryRecordCollection.Count());
+            var imageNodes = dicomDir.RootDirectoryRecord.LowerLevelDirectoryRecord.LowerLevelDirectoryRecord
+                .LowerLevelDirectoryRecordCollection;
+            Assert.Equal(dicomFiles.Count, imageNodes.Count());
         }
 
         private static IList<DicomFile> GetDicomFilesFromWebZip(string url)

--- a/Tests/Media/DicomDirectoryTest.cs
+++ b/Tests/Media/DicomDirectoryTest.cs
@@ -1,6 +1,12 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using NLog.Internal;
+
 namespace Dicom.Media
 {
     using System.IO;
@@ -76,6 +82,63 @@ namespace Dicom.Media
                 var actual = dir.FileMetaInfo.MediaStorageSOPClassUID.UID;
                 Assert.Equal(expected, actual);
             }
+        }
+
+        [Fact]
+        public void AddFile_Anonymized_DoesNotThrow()
+        {
+            var dicomFiles = GetDicomFilesFromWebZip(
+                "https://www.creatis.insa-lyon.fr/~jpr/PUBLIC/gdcm/gdcmSampleData/Philips_Medical_Images/mr711-mr712/abd1.zip");
+
+            // Anonymize all files
+            var anonymizer = new DicomAnonymizer();
+            foreach (var dicomFile in dicomFiles)
+            {
+                anonymizer.AnonymizeInPlace(dicomFile);
+            }
+
+            // Create DICOM directory
+            var dicomDir = new DicomDirectory();
+            foreach (var dicomFile in dicomFiles)
+            {
+                dicomDir.AddFile(dicomFile);
+            }
+
+            Assert.Equal(dicomFiles.Count, dicomDir.RootDirectoryRecordCollection.Count());
+        }
+
+        private static IList<DicomFile> GetDicomFilesFromWebZip(string url)
+        {
+            var dicomFiles = new List<DicomFile>();
+
+            using (var webClient = new WebClient())
+            {
+                var bytes = webClient.DownloadData(url);
+
+                using (var stream = new MemoryStream(bytes))
+                using (var zipper = new ZipArchive(stream))
+                {
+                    foreach (var entry in zipper.Entries)
+                    {
+                        try
+                        {
+                            using (var entryStream = entry.Open())
+                            using (var duplicate = new MemoryStream())
+                            {
+                                entryStream.CopyTo(duplicate);
+                                duplicate.Seek(0, SeekOrigin.Begin);
+                                var dicomFile = DicomFile.Open(duplicate);
+                                dicomFiles.Add(dicomFile);
+                            }
+                        }
+                        catch
+                        {
+                        }
+                    }
+                }
+            }
+
+            return dicomFiles;
         }
 
         #endregion


### PR DESCRIPTION
Fixes #488 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/3.0* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Account for potential empty values in Patient ID and Name tags when creating patient records
