### PR TITLE
Speed up DicomDictionary.GetEnumerator(). Connected to #532

### DIFF
--- a/DICOM/DicomDictionary.cs
+++ b/DICOM/DicomDictionary.cs
@@ -7,6 +7,7 @@ namespace Dicom
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.IO;
     using System.IO.Compression;
     using System.Linq;
     using System.Reflection;
@@ -344,8 +345,7 @@ namespace Dicom
 
         public IEnumerator<DicomDictionaryEntry> GetEnumerator()
         {
-            return _entries.Values.Concat(_masked.OrderBy(x => x.MaskTag.Mask)).GetEnumerator();
-            //return _entries.Values.Concat(_masked).GetEnumerator();
+            return _entries.Values.Concat(_masked).GetEnumerator();
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/DICOM/DicomDictionary.cs
+++ b/DICOM/DicomDictionary.cs
@@ -7,7 +7,6 @@ namespace Dicom
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.IO;
     using System.IO.Compression;
     using System.Linq;
     using System.Reflection;
@@ -77,10 +76,7 @@ namespace Dicom
 
         private ConcurrentDictionary<DicomTag, DicomDictionaryEntry> _entries;
 
-        private object _maskedLock;
-        private List<DicomDictionaryEntry> _masked;
-
-        private bool _maskedNeedsSort;
+        private ConcurrentBag<DicomDictionaryEntry> _masked;
 
         #endregion
 
@@ -91,18 +87,14 @@ namespace Dicom
             _creators = new ConcurrentDictionary<string, DicomPrivateCreator>();
             _private = new ConcurrentDictionary<DicomPrivateCreator, DicomDictionary>();
             _entries = new ConcurrentDictionary<DicomTag, DicomDictionaryEntry>();
-            _masked = new List<DicomDictionaryEntry>();
-            _maskedLock = new object();
-            _maskedNeedsSort = false;
+            _masked = new ConcurrentBag<DicomDictionaryEntry>();
         }
 
         private DicomDictionary(DicomPrivateCreator creator)
         {
             _privateCreator = creator;
             _entries = new ConcurrentDictionary<DicomTag, DicomDictionaryEntry>();
-            _masked = new List<DicomDictionaryEntry>();
-            _maskedLock = new object();
-            _maskedNeedsSort = false;
+            _masked = new ConcurrentBag<DicomDictionaryEntry>();
         }
 
         #endregion
@@ -280,12 +272,9 @@ namespace Dicom
                 if (_entries.TryGetValue(tag, out entry)) return entry;
 
                 // this is faster than LINQ query
-                lock (_maskedLock)
+                foreach (var x in _masked)
                 {
-                    foreach (var x in _masked)
-                    {
-                        if (x.MaskTag.IsMatch(tag)) return x;
-                    }
+                    if (x.MaskTag.IsMatch(tag)) return x;
                 }
 
                 return UnknownTag;
@@ -319,11 +308,7 @@ namespace Dicom
             }
             else
             {
-                lock (_maskedLock)
-                {
-                    _masked.Add(entry);
-                    _maskedNeedsSort = true;
-                }
+                _masked.Add(entry);
             }
         }
 
@@ -359,19 +344,8 @@ namespace Dicom
 
         public IEnumerator<DicomDictionaryEntry> GetEnumerator()
         {
-            List<DicomDictionaryEntry> items = new List<DicomDictionaryEntry>();
-            items.AddRange(_entries.Values.OrderBy(x => x.Tag));
-
-            lock (_maskedLock)
-            {
-                if (_maskedNeedsSort)
-                {
-                    _masked.Sort((a, b) => a.MaskTag.Mask.CompareTo(b.MaskTag.Mask));
-                    _maskedNeedsSort = false;
-                }
-                items.AddRange(_masked);
-            }
-            return items.GetEnumerator();
+            return _entries.Values.Concat(_masked.OrderBy(x => x.MaskTag.Mask)).GetEnumerator();
+            //return _entries.Values.Concat(_masked).GetEnumerator();
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()

--- a/Tests/Desktop/DicomDictionaryTest.cs
+++ b/Tests/Desktop/DicomDictionaryTest.cs
@@ -57,19 +57,29 @@ namespace Dicom
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public void TimeGetEnumerator()
+        private double TimeCall(int numCalls, Action call)
         {
             var start = DateTime.UtcNow;
-            var N = 10000;
-            for (int i = 0; i < N; i++)
-            {
-                Assert.NotNull(DicomDictionary.Default.First());
-            }
+
+            for (int i = 0; i < numCalls; i++) call();
 
             var end = DateTime.UtcNow;
 
-            output_.WriteLine($"GetEnumerator: {(end - start).TotalMilliseconds / N} ms per call");
+            var millisecondsPerCall = (end - start).TotalMilliseconds / numCalls;
+
+            return millisecondsPerCall;
+        }
+
+        [Fact]
+        public void TimeGetEnumerator()
+        {
+            var millisecondsPerCall = TimeCall(100, () => Assert.NotNull(DicomDictionary.Default.Last()));
+
+            var referenceTime = TimeCall(100, () => Assert.NotNull(Enumerable.Range(0, 1000).Last()));
+
+            output_.WriteLine($"GetEnumerator: {millisecondsPerCall} ms per call, reference time: {referenceTime} ms per call");
+
+            Assert.InRange(millisecondsPerCall, 0, referenceTime * 100);
         }
 
 

--- a/Tests/Desktop/DicomDictionaryTest.cs
+++ b/Tests/Desktop/DicomDictionaryTest.cs
@@ -82,7 +82,7 @@ namespace Dicom
 
             output_.WriteLine($"GetEnumerator: {millisecondsPerCall} ms per call, reference time: {referenceTime} ms per call");
 
-            Assert.InRange(millisecondsPerCall, 0, referenceTime * 5);
+            Assert.InRange(millisecondsPerCall, 0, (1 + referenceTime) * 5);
         }
 
 

--- a/Tests/Desktop/DicomDictionaryTest.cs
+++ b/Tests/Desktop/DicomDictionaryTest.cs
@@ -11,6 +11,7 @@ namespace Dicom
     using System.Threading.Tasks;
 
     using Xunit;
+    using Xunit.Abstractions;
 
     [Collection("General")]
     public class DicomDictionaryTest : IDisposable
@@ -55,6 +56,22 @@ namespace Dicom
             var actual = dict[DicomTag.FileSetID].ValueRepresentations.Single();
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void TimeGetEnumerator()
+        {
+            var start = DateTime.UtcNow;
+            var N = 10000;
+            for (int i = 0; i < N; i++)
+            {
+                Assert.NotNull(DicomDictionary.Default.First());
+            }
+
+            var end = DateTime.UtcNow;
+
+            output_.WriteLine($"GetEnumerator: {(end - start).TotalMilliseconds / N} ms per call");
+        }
+
 
 #if !NETSTANDARD
 
@@ -260,6 +277,7 @@ namespace Dicom
 
         private static int index = 0;
         private readonly AppDomain testDomain;
+        private ITestOutputHelper output_;
 
         public void Dispose()
         {
@@ -271,11 +289,12 @@ namespace Dicom
             }
         }
 
-        public DicomDictionaryTest()
+        public DicomDictionaryTest(ITestOutputHelper output)
         {
             var name = string.Concat("DicomDictionary test appdomain #", ++index);
             testDomain = AppDomain.CreateDomain(name, AppDomain.CurrentDomain.Evidence, AppDomain.CurrentDomain.SetupInformation);
             System.Diagnostics.Trace.WriteLine(string.Format("[{0}] Created.", testDomain.FriendlyName));
+            output_ = output;
 
         }
 


### PR DESCRIPTION
Fixes #532 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Remove lock on DicomDictionary._masked and replace the List by a ConcurrentBag
- Don't copy _entries.Values and _masked to create an enumerator - use Linq instead. 
- The test DicomDictionaryTest.TimeGetEnumerator measures the average time for the call and asserts that it is reasonable.
