### PR TITLE
Only Implicit LE is default in association negotiation. Connected to #524

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 #### v.3.1.0 (TBD)
+* JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)
+* DicomDictionary.GetEnumerator() is very slow (#532 #534)
+* CStore-SCU always adds a PC with LEExplicit and LEImplicit (#524 #541)
 * Updated JPEG-LS to latest CharLS commit (#517)
 * Support for anonymization, deflated and compressed transfer syntaxes on Unity (#496)
 * Support for up to 16 bit JPEG 2000 codecs on Android, iOS, Mono and .NET Core (#496)

--- a/DICOM/Network/DicomPresentationContextCollection.cs
+++ b/DICOM/Network/DicomPresentationContextCollection.cs
@@ -121,7 +121,6 @@ namespace Dicom.Network
                     var tx = new List<DicomTransferSyntax>();
                     if (cstore.TransferSyntax != DicomTransferSyntax.ImplicitVRLittleEndian) tx.Add(cstore.TransferSyntax);
                     if (cstore.AdditionalTransferSyntaxes != null) tx.AddRange(cstore.AdditionalTransferSyntaxes);
-                    tx.Add(DicomTransferSyntax.ExplicitVRLittleEndian);
                     tx.Add(DicomTransferSyntax.ImplicitVRLittleEndian);
 
                     Add(cstore.SOPClassUID, tx.ToArray());
@@ -141,7 +140,7 @@ namespace Dicom.Network
                     {
                         var transferSyntaxes = request.PresentationContext.GetTransferSyntaxes().ToArray();
                         if (!transferSyntaxes.Any())
-                            transferSyntaxes = new[] { DicomTransferSyntax.ExplicitVRLittleEndian, DicomTransferSyntax.ImplicitVRLittleEndian };
+                            transferSyntaxes = new[] { DicomTransferSyntax.ImplicitVRLittleEndian };
                         Add(
                             request.PresentationContext.AbstractSyntax,
                             request.PresentationContext.UserRole,
@@ -153,10 +152,7 @@ namespace Dicom.Network
                 {
                     var pc = _pc.Values.FirstOrDefault(x => x.AbstractSyntax == request.SOPClassUID);
                     if (pc == null)
-                        Add(
-                            request.SOPClassUID,
-                            DicomTransferSyntax.ExplicitVRLittleEndian,
-                            DicomTransferSyntax.ImplicitVRLittleEndian);
+                        Add(request.SOPClassUID, DicomTransferSyntax.ImplicitVRLittleEndian);
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![Stories in Ready](https://badge.waffle.io/fo-dicom/fo-dicom.svg?label=ready&title=Ready)](http://waffle.io/fo-dicom/fo-dicom)
 [![Join the chat at https://gitter.im/fo-dicom/fo-dicom](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fo-dicom/fo-dicom?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-If you like *fo-dicom* and want to contribute to its continued success, please consider making a small monetary contribution:
+### Support Us!
+If *fo-dicom* is a vital component in your open-source or commercial application and you want to contribute to its continued success, please consider making a small monetary contribution.
 <table>
 <tr>
 <th>€25</th>

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -538,7 +538,7 @@ namespace Dicom.Network
             {
                 foreach (var pc in association.PresentationContexts)
                 {
-                    pc.AcceptTransferSyntaxes(DicomTransferSyntax.ExplicitVRLittleEndian);
+                    pc.AcceptTransferSyntaxes(DicomTransferSyntax.ImplicitVRLittleEndian);
                 }
 
                 if (association.CalledAE.Equals("ANY-SCP", StringComparison.OrdinalIgnoreCase))
@@ -580,7 +580,7 @@ namespace Dicom.Network
         /// Artificial C-STORE provider, only supporting Explicit LE transfer syntax for the purpose of
         /// testing <see cref="Send_ToExplicitOnlyProvider_NotAccepted"/>.
         /// </summary>
-        internal class ExplicitLECStoreProvider : DicomService, IDicomServiceProvider, IDicomCStoreProvider
+        private class ExplicitLECStoreProvider : DicomService, IDicomServiceProvider, IDicomCStoreProvider
         {
             private static readonly DicomTransferSyntax[] AcceptedTransferSyntaxes =
                 {


### PR DESCRIPTION
Fixes #524 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When adding transfer syntaxes to the presentation context collection, do not include *Explicit Little Endian* by default.