### PR TITLE
Correct interpolation of rescaled overlay graphics. Connected to #545

### DIFF
--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -56,6 +56,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DicomVRCode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IClassifiedManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Imaging\Algorithms\BilinearInterpolation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Imaging\Algorithms\NearestNeighborInterpolation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Imaging\BitDepth.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Imaging\Codec\DicomCodecException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Imaging\Codec\DicomCodecExtensions.cs" />

--- a/DICOM/Imaging/Algorithms/NearestNeighborInterpolation.cs
+++ b/DICOM/Imaging/Algorithms/NearestNeighborInterpolation.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+#if !NET35
+using System.Threading.Tasks;
+#endif
+
+namespace Dicom.Imaging.Algorithms
+{
+    public class NearestNeighborInterpolation
+    {
+        public static byte[] RescaleGrayscale(
+            byte[] input,
+            int inputWidth,
+            int inputHeight,
+            int outputWidth,
+            int outputHeight)
+        {
+            var output = new byte[outputWidth * outputHeight];
+
+            var xF = inputWidth / (double)outputWidth;
+            var yF = inputHeight / (double)outputHeight;
+
+            var xMax = inputWidth - 1;
+            var yMax = inputHeight - 1;
+
+            unchecked
+            {
+#if NET35
+                for (var y = 0; y < outputHeight; ++y)
+#else
+                Parallel.For(0, outputHeight, y =>
+#endif
+                {
+                    var oy0 = y * yF;
+                    var oy1 = (int)oy0; // rounds down
+                    var oy2 = oy1 == yMax ? oy1 : oy1 + 1;
+
+                    var dy1 = oy0 - oy1;
+                    var dy2 = 1.0 - dy1;
+
+                    var yo0 = outputWidth * y;
+                    var yo1 = inputWidth * oy1;
+                    var yo2 = inputWidth * oy2;
+
+                    for (var x = 0; x < outputWidth; x++)
+                    {
+                        var ox0 = x * xF;
+                        var ox1 = (int)ox0;
+                        var ox2 = ox1 == xMax ? ox1 : ox1 + 1;
+
+                        var dx1 = ox0 - ox1;
+                        var dx2 = 1.0 - dx1;
+
+                        output[yo0 + x] = dy2 > dy1
+                            ? (dx2 > dx1 ? input[yo1 + ox1] : input[yo1 + ox2])
+                            : (dx2 > dx1 ? input[yo2 + ox1] : input[yo2 + ox2]);
+                    }
+                }
+#if !NET35
+                );
+#endif
+            }
+
+            return output;
+        }
+    }
+}

--- a/DICOM/Imaging/Algorithms/NearestNeighborInterpolation.cs
+++ b/DICOM/Imaging/Algorithms/NearestNeighborInterpolation.cs
@@ -7,8 +7,21 @@ using System.Threading.Tasks;
 
 namespace Dicom.Imaging.Algorithms
 {
-    public class NearestNeighborInterpolation
+    /// <summary>
+    /// 2D interpolation methods using the nearest neighbor algorithm.
+    /// </summary>
+    public static class NearestNeighborInterpolation
     {
+        /// <summary>
+        /// Rescale 2D 8-bit "grayscale" image using nearest neighbor interpolation.
+        /// </summary>
+        /// <param name="input">Input 8-bit 2D "grayscale" image grid.</param>
+        /// <param name="inputWidth">Width of ipnut grid.</param>
+        /// <param name="inputHeight">Height of input grid.</param>
+        /// <param name="outputWidth">Requested width of output grid.</param>
+        /// <param name="outputHeight">Requested height of output grid.</param>
+        /// <returns>Nearest neighbor interpolated grid with output <paramref name="outputWidth">width</paramref>
+        /// and <paramref name="outputHeight">height</paramref>.</returns>
         public static byte[] RescaleGrayscale(
             byte[] input,
             int inputWidth,
@@ -18,49 +31,36 @@ namespace Dicom.Imaging.Algorithms
         {
             var output = new byte[outputWidth * outputHeight];
 
-            var xF = inputWidth / (double)outputWidth;
-            var yF = inputHeight / (double)outputHeight;
+            var xF = inputWidth / (double) outputWidth;
+            var yF = inputHeight / (double) outputHeight;
 
             var xMax = inputWidth - 1;
             var yMax = inputHeight - 1;
 
-            unchecked
-            {
 #if NET35
-                for (var y = 0; y < outputHeight; ++y)
+            for (var y = 0; y < outputHeight; ++y)
 #else
-                Parallel.For(0, outputHeight, y =>
+            Parallel.For(0, outputHeight, y =>
 #endif
                 {
-                    var oy0 = y * yF;
-                    var oy1 = (int)oy0; // rounds down
-                    var oy2 = oy1 == yMax ? oy1 : oy1 + 1;
+                    var iy0 = y * yF;
+                    var iy1 = (int) iy0; // rounds down
+                    var iy2 = iy1 == yMax ? iy1 : iy1 + 1;
+                    var iyx0 = inputWidth * (iy0 - iy1 < 0.5 ? iy1 : iy2);
 
-                    var dy1 = oy0 - oy1;
-                    var dy2 = 1.0 - dy1;
-
-                    var yo0 = outputWidth * y;
-                    var yo1 = inputWidth * oy1;
-                    var yo2 = inputWidth * oy2;
-
-                    for (var x = 0; x < outputWidth; x++)
+                    for (int yx = outputWidth * y, x = 0; x < outputWidth; x++, yx++)
                     {
-                        var ox0 = x * xF;
-                        var ox1 = (int)ox0;
-                        var ox2 = ox1 == xMax ? ox1 : ox1 + 1;
+                        var ix0 = x * xF;
+                        var ix1 = (int) ix0;
+                        var ix2 = ix1 == xMax ? ix1 : ix1 + 1;
+                        var ix = ix0 - ix1 < 0.5 ? ix1 : ix2;
 
-                        var dx1 = ox0 - ox1;
-                        var dx2 = 1.0 - dx1;
-
-                        output[yo0 + x] = dy2 > dy1
-                            ? (dx2 > dx1 ? input[yo1 + ox1] : input[yo1 + ox2])
-                            : (dx2 > dx1 ? input[yo2 + ox1] : input[yo2 + ox2]);
+                        output[yx] = input[iyx0 + ix];
                     }
                 }
 #if !NET35
-                );
+            );
 #endif
-            }
 
             return output;
         }

--- a/DICOM/Imaging/Render/OverlayGraphic.cs
+++ b/DICOM/Imaging/Render/OverlayGraphic.cs
@@ -87,13 +87,11 @@ namespace Dicom.Imaging.Render
 #endif
             {
                 if (oy + y >= height) return;
-                for (int i = _scaledData.Width * y, e = i + _scaledData.Width, x = 0; i < e; i++, x++)
+                for (int i = _scaledData.Width * y, e = i + _scaledData.Width, p = (oy + y) * width + ox, x = 0; i < e; i++, p++, x++)
                 {
                     if (data[i] > 0)
                     {
-                        //this is wrong, when scaling is active
-                        //if ((ox + x) >= width) break;
-                        var p = oy * width + ox + i;
+                        if (ox + x >= width) break;
                         pixels[p] |= _color;
                     }
                 }

--- a/DICOM/Imaging/Render/PixelData.cs
+++ b/DICOM/Imaging/Render/PixelData.cs
@@ -227,7 +227,7 @@ namespace Dicom.Imaging.Render
         /// <param name="width">Pixel data width.</param>
         /// <param name="height">Pixel data height.</param>
         /// <param name="data">Data byte array.</param>
-        protected GrayscalePixelDataU8(int width, int height, byte[] data)
+        protected internal GrayscalePixelDataU8(int width, int height, byte[] data)
         {
             Width = width;
             Height = height;
@@ -284,7 +284,7 @@ namespace Dicom.Imaging.Render
         }
 
         /// <inheritdoc />
-        public IPixelData Rescale(double scale)
+        public virtual IPixelData Rescale(double scale)
         {
             if (scale == 1.0) return this;
             var w = (int)(Width * scale);
@@ -389,6 +389,16 @@ namespace Dicom.Imaging.Render
         #endregion
 
         #region Public Methods
+
+        /// <inheritdoc />
+        public override IPixelData Rescale(double scale)
+        {
+            if (scale == 1.0) return this;
+            var w = (int)(Width * scale);
+            var h = (int)(Height * scale);
+            var data = NearestNeighborInterpolation.RescaleGrayscale(Data, Width, Height, w, h);
+            return new GrayscalePixelDataU8(w, h, data);
+        }
 
         /// <inheritdoc />
         public override Histogram GetHistogram(int channel)

--- a/Tools/DICOM Dump/MainForm.Designer.cs
+++ b/Tools/DICOM Dump/MainForm.Designer.cs
@@ -60,6 +60,7 @@
             this.error10ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.rLELosslessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportPixelDataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuItemAnonymize = new System.Windows.Forms.ToolStripMenuItem();
             this.lvDicom = new System.Windows.Forms.ListView();
             this.columnHeaderTag = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeaderVR = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -112,6 +113,7 @@
             this.menuItemTools.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuItemView,
             this.menuItemSyntax,
+            this.menuItemAnonymize,
             this.exportPixelDataToolStripMenuItem});
             this.menuItemTools.Name = "menuItemTools";
             this.menuItemTools.Size = new System.Drawing.Size(47, 20);
@@ -364,6 +366,14 @@
             this.exportPixelDataToolStripMenuItem.Text = "Export Pixel Data";
             this.exportPixelDataToolStripMenuItem.Click += new System.EventHandler(this.OnClickExportPixelData);
             // 
+            // menuItemAnonymize
+            // 
+            this.menuItemAnonymize.Enabled = false;
+            this.menuItemAnonymize.Name = "menuItemAnonymize";
+            this.menuItemAnonymize.Size = new System.Drawing.Size(161, 22);
+            this.menuItemAnonymize.Text = "&Anonymize";
+            this.menuItemAnonymize.Click += new System.EventHandler(this.OnClickAnonymize);
+            // 
             // lvDicom
             // 
             this.lvDicom.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
@@ -491,6 +501,7 @@
         private System.Windows.Forms.ToolStripMenuItem quality50ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem copyTagToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportPixelDataToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem menuItemAnonymize;
     }
 }
 

--- a/Tools/DICOM Dump/MainForm.cs
+++ b/Tools/DICOM Dump/MainForm.cs
@@ -22,6 +22,7 @@ namespace Dicom.Dump
     public partial class MainForm : Form
     {
         private DicomFile _file;
+        private DicomAnonymizer _anonymizer;
 
         public MainForm()
         {
@@ -31,6 +32,7 @@ namespace Dicom.Dump
         protected override void OnLoad(EventArgs e)
         {
             DicomDictionary.EnsureDefaultDictionariesLoaded(ModifierKeys != Keys.Shift);
+            _anonymizer = new DicomAnonymizer();
 
             var args = Environment.GetCommandLineArgs();
             if (args.Length > 1)
@@ -45,6 +47,7 @@ namespace Dicom.Dump
         {
             lvDicom.Items.Clear();
             menuItemView.Enabled = false;
+            menuItemAnonymize.Enabled = false;
         }
 
         private delegate void AddItemDelegate(string tag, string vr, string length, string value);
@@ -102,7 +105,11 @@ namespace Dicom.Dump
                 new DicomDatasetWalker(_file.FileMetaInfo).Walk(new DumpWalker(this));
                 new DicomDatasetWalker(_file.Dataset).Walk(new DumpWalker(this));
 
-                if (_file.Dataset.Contains(DicomTag.PixelData) || IsStructuredReport) menuItemView.Enabled = true;
+                if (_file.Dataset.Contains(DicomTag.PixelData) || IsStructuredReport)
+                {
+                    menuItemView.Enabled = true;
+                    menuItemAnonymize.Enabled = true;
+                }
                 menuItemSyntax.Enabled = true;
                 menuItemSave.Enabled = true;
 
@@ -534,6 +541,12 @@ namespace Dicom.Dump
             {
                 e.Effect = DragDropEffects.None;
             }
+        }
+
+        private void OnClickAnonymize(object sender, EventArgs e)
+        {
+            var file = _anonymizer.Anonymize(_file);
+            OpenFile(file);
         }
     }
 }


### PR DESCRIPTION
Fixes #545 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Corrected coordinate transformation in overlay rendering.
- Use nearest-neighbor interpolation for overlay-based pixel rescaling.
- Added anonymization option to *DICOM Dump* sample application.
