### PR TITLE
Downgrade desktop libraries to .NET Framework version 4.5. Connected to #561

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.1.0 (TBD)
+* Downgrade desktop libraries to framework version 4.5 (#561 #562)
 * Correct interpolation of rescaled overlay graphics (#545 #558)
 * JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)
 * DicomDictionary.GetEnumerator() is very slow (#532 #534)

--- a/Logging/Log4Net.Desktop/DICOM.Log4Net.Desktop.csproj
+++ b/Logging/Log4Net.Desktop/DICOM.Log4Net.Desktop.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dicom.Log</RootNamespace>
     <AssemblyName>Dicom.Log4Net</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Logging/Log4Net.Desktop/packages.config
+++ b/Logging/Log4Net.Desktop/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.8" targetFramework="net452" />
+  <package id="log4net" version="2.0.8" targetFramework="net45" />
 </packages>

--- a/Logging/NLog.Desktop/DICOM.NLog.Desktop.csproj
+++ b/Logging/NLog.Desktop/DICOM.NLog.Desktop.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dicom.Log</RootNamespace>
     <AssemblyName>Dicom.NLog</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Logging/NLog.Desktop/packages.config
+++ b/Logging/NLog.Desktop/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.4.7" targetFramework="net452" />
+  <package id="NLog" version="4.4.7" targetFramework="net45" />
 </packages>

--- a/Logging/Serilog.Desktop/DICOM.Serilog.Desktop.csproj
+++ b/Logging/Serilog.Desktop/DICOM.Serilog.Desktop.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dicom.Log</RootNamespace>
     <AssemblyName>Dicom.Serilog</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Logging/Serilog.Desktop/packages.config
+++ b/Logging/Serilog.Desktop/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="2.4.0" targetFramework="net452" />
+  <package id="Serilog" version="2.4.0" targetFramework="net45" />
 </packages>

--- a/Native/Desktop/DICOM.Native.vcxproj
+++ b/Native/Desktop/DICOM.Native.vcxproj
@@ -12,11 +12,11 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C6148839-334D-4894-BDB9-E2D57438CF8A}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>Dicom.Imaging.Codec</RootNamespace>
     <ProjectName>DICOM.Native</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Native/Desktop/DICOM.Native64.vcxproj
+++ b/Native/Desktop/DICOM.Native64.vcxproj
@@ -12,11 +12,11 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{FA9C7678-B9D9-46BC-8921-8152FD6787CA}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>DICOM.Imaging.Codec</RootNamespace>
     <ProjectName>DICOM.Native64</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/Native/Desktop/libijg12.x64.vcxproj
+++ b/Native/Desktop/libijg12.x64.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1B3557D4-1146-428A-AEC9-12CADF994527}</ProjectGuid>
     <RootNamespace>libijg12x64</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/Native/Desktop/libijg12.x86.vcxproj
+++ b/Native/Desktop/libijg12.x86.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{0331D451-7C7A-4DB7-A11D-61708F2E8D05}</ProjectGuid>
     <RootNamespace>libijg12x86</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Native/Desktop/libijg16.x64.vcxproj
+++ b/Native/Desktop/libijg16.x64.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DD846D57-B93B-46C8-BFFF-AE4C11E408B3}</ProjectGuid>
     <RootNamespace>libijg16x64</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/Native/Desktop/libijg16.x86.vcxproj
+++ b/Native/Desktop/libijg16.x86.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{63088DEC-9F99-404C-B4E8-D823D2A0018F}</ProjectGuid>
     <RootNamespace>libijg16x86</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Native/Desktop/libijg8.x64.vcxproj
+++ b/Native/Desktop/libijg8.x64.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{808528F3-15DC-4CC6-A15A-0F91CBDB54E6}</ProjectGuid>
     <RootNamespace>libijg8x64</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/Native/Desktop/libijg8.x86.vcxproj
+++ b/Native/Desktop/libijg8.x86.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{8DC28743-3826-453A-B400-B0AE7B2C04E7}</ProjectGuid>
     <RootNamespace>libijg8x86</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Platform/Desktop/DICOM.Desktop.csproj
+++ b/Platform/Desktop/DICOM.Desktop.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Dicom</RootNamespace>
     <AssemblyName>Dicom.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This library is licensed under the [Microsoft Public License (MS-PL)](http://ope
 
 ### Features
 * Portable Class Library (PCL)
-* Targets .NET 4.5.2 and higher, .NET Core (.NET Standard 1.3 and higher), Universal Windows Platform, Xamarin iOS, Xamarin Android, Mono and Unity
+* Targets .NET 4.5 and higher, .NET Core (.NET Standard 1.3 and higher), Universal Windows Platform, Xamarin iOS, Xamarin Android, Mono and Unity
 * DICOM dictionary version 2017c
 * High-performance, fully asynchronous `async`/`await` API
 * JPEG (including lossless), JPEG-LS, JPEG2000, and RLE image compression (limited on .NET Core, Xamarin, Mono and Unity platforms)

--- a/Setup/fo-dicom.Desktop.nuspec
+++ b/Setup/fo-dicom.Desktop.nuspec
@@ -13,11 +13,11 @@
         <language>en-US</language>
     </metadata>
     <files>
-        <file src="Targets\fo-dicom.Desktop.targets" target="build\net452" />
-        <file src="..\Native\Desktop\bin\x86\Release\DICOM.Native\Dicom.Native.dll" target="build\net452" />
-        <file src="..\Native\Desktop\bin\x64\Release\DICOM.Native64\Dicom.Native64.dll" target="build\net452" />
-        <file src="..\Platform\Desktop\bin\Release\Dicom.Core.dll" target="lib\net452" />
-        <file src="..\Platform\Desktop\bin\Release\Dicom.Core.pdb" target="lib\net452" />
-        <file src="..\Platform\Desktop\bin\Release\Dicom.Core.xml" target="lib\net452" />
+        <file src="Targets\fo-dicom.Desktop.targets" target="build\net45" />
+        <file src="..\Native\Desktop\bin\x86\Release\DICOM.Native\Dicom.Native.dll" target="build\net45" />
+        <file src="..\Native\Desktop\bin\x64\Release\DICOM.Native64\Dicom.Native64.dll" target="build\net45" />
+        <file src="..\Platform\Desktop\bin\Release\Dicom.Core.dll" target="lib\net45" />
+        <file src="..\Platform\Desktop\bin\Release\Dicom.Core.pdb" target="lib\net45" />
+        <file src="..\Platform\Desktop\bin\Release\Dicom.Core.xml" target="lib\net45" />
     </files>
 </package>

--- a/Setup/fo-dicom.NLog.nuspec
+++ b/Setup/fo-dicom.NLog.nuspec
@@ -17,8 +17,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="..\Logging\NLog.Desktop\bin\Release\Dicom.NLog.dll" target="lib\net452" />
-        <file src="..\Logging\NLog.Desktop\bin\Release\Dicom.NLog.pdb" target="lib\net452" />
-        <file src="..\Logging\NLog.Desktop\bin\Release\Dicom.NLog.xml" target="lib\net452" />
+        <file src="..\Logging\NLog.Desktop\bin\Release\Dicom.NLog.dll" target="lib\net45" />
+        <file src="..\Logging\NLog.Desktop\bin\Release\Dicom.NLog.pdb" target="lib\net45" />
+        <file src="..\Logging\NLog.Desktop\bin\Release\Dicom.NLog.xml" target="lib\net45" />
     </files>
 </package>

--- a/Setup/fo-dicom.Serilog.nuspec
+++ b/Setup/fo-dicom.Serilog.nuspec
@@ -17,8 +17,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="..\Logging\Serilog.Desktop\bin\Release\Dicom.Serilog.dll" target="lib\net452" />
-        <file src="..\Logging\Serilog.Desktop\bin\Release\Dicom.Serilog.pdb" target="lib\net452" />
-        <file src="..\Logging\Serilog.Desktop\bin\Release\Dicom.Serilog.xml" target="lib\net452" />
+        <file src="..\Logging\Serilog.Desktop\bin\Release\Dicom.Serilog.dll" target="lib\net45" />
+        <file src="..\Logging\Serilog.Desktop\bin\Release\Dicom.Serilog.pdb" target="lib\net45" />
+        <file src="..\Logging\Serilog.Desktop\bin\Release\Dicom.Serilog.xml" target="lib\net45" />
     </files>
 </package>

--- a/Setup/fo-dicom.log4net.nuspec
+++ b/Setup/fo-dicom.log4net.nuspec
@@ -17,8 +17,8 @@
         </dependencies>
     </metadata>
     <files>
-        <file src="..\Logging\Log4Net.Desktop\bin\Release\Dicom.log4net.dll" target="lib\net452" />
-        <file src="..\Logging\Log4Net.Desktop\bin\Release\Dicom.log4net.pdb" target="lib\net452" />
-        <file src="..\Logging\Log4Net.Desktop\bin\Release\Dicom.log4net.xml" target="lib\net452" />
+        <file src="..\Logging\Log4Net.Desktop\bin\Release\Dicom.log4net.dll" target="lib\net45" />
+        <file src="..\Logging\Log4Net.Desktop\bin\Release\Dicom.log4net.pdb" target="lib\net45" />
+        <file src="..\Logging\Log4Net.Desktop\bin\Release\Dicom.log4net.xml" target="lib\net45" />
     </files>
 </package>

--- a/Setup/fo-dicom.nuspec
+++ b/Setup/fo-dicom.nuspec
@@ -18,7 +18,7 @@
 			<group targetFramework="netstandard1.3">
 				<dependency id="fo-dicom.NetCore" version="$version$" />
 			</group>
-			<group targetFramework="net452">
+			<group targetFramework="net45">
 				<dependency id="fo-dicom.Desktop" version="$version$" />
 			</group>
 			<group targetFramework="uap">

--- a/Tests/Desktop/packages.config
+++ b/Tests/Desktop/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
-  <package id="NLog" version="4.4.7" targetFramework="net452" />
-  <package id="xunit" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
-  <package id="xunit.assert" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" developmentDependency="true" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="NLog" version="4.4.7" targetFramework="net45" />
+  <package id="xunit" version="2.2.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/Tools/DICOM Dump/packages.config
+++ b/Tools/DICOM Dump/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="cscharls" version="0.1.1" targetFramework="net45" />
-  <package id="CSJ2K" version="3.0.0-alpha" targetFramework="net452" />
-  <package id="Portable.LibJpeg.NET" version="1.5.1.1" targetFramework="net452" />
+  <package id="CSJ2K" version="3.0.0-alpha" targetFramework="net45" />
+  <package id="Portable.LibJpeg.NET" version="1.5.1.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes #561 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Downgraded Windows desktop C# projects to framework version 4.5.
- Downgraded desktop C/C++ projects to framework version 4.5 and Windows SDK version 8.1.
- Changed references from *net452* to *net45* where applicable in .nuspec files.
