### PR TITLE
DicomPixelData.BitsAllocated setter removed. Connected to #528

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 * Correct interpolation of rescaled overlay graphics (#545 #558)
 * JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)
 * DicomDictionary.GetEnumerator() is very slow (#532 #534)
+* DicomPixelData.BitsAllocated setter removed (#528 #564)
 * CStore-SCU always adds a PC with LEExplicit and LEImplicit (#524 #541)
 * Updated JPEG-LS to latest CharLS commit (#517)
 * Support for anonymization, deflated and compressed transfer syntaxes on Unity (#496)

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -28,12 +28,21 @@ namespace Dicom
         #region CONSTRUCTORS
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DicomDataset"/> class with <see cref="InternalTransferSyntax"/>
+        /// set to Explicit VR Little Endian (DICOM default transfer syntax).
+        /// </summary>
+        public DicomDataset() : this(DicomTransferSyntax.ExplicitVRLittleEndian)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DicomDataset"/> class.
         /// </summary>
-        public DicomDataset()
+        /// <param name="internalTransferSyntax">Internal transfer syntax representation of the dataset.</param>
+        public DicomDataset(DicomTransferSyntax internalTransferSyntax)
         {
             _items = new SortedDictionary<DicomTag, DicomItem>();
-            InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
+            InternalTransferSyntax = internalTransferSyntax;
         }
 
         /// <summary>

--- a/DICOM/Imaging/Codec/DicomJpegNativeCodec.cs
+++ b/DICOM/Imaging/Codec/DicomJpegNativeCodec.cs
@@ -26,7 +26,7 @@ namespace Dicom.Imaging.Codec
             if (oldPixelData.BitsAllocated == 16 && oldPixelData.BitsStored <= 8)
             {
                 // check for embedded overlays?
-                newPixelData.BitsAllocated = 8;
+                newPixelData.Dataset.AddOrUpdate(DicomTag.BitsAllocated, (ushort)8);
             }
 
             var jparams = parameters as DicomJpegParams ?? GetDefaultParameters() as DicomJpegParams;
@@ -53,7 +53,7 @@ namespace Dicom.Imaging.Codec
             if (newPixelData.BitsAllocated == 16 && newPixelData.BitsStored <= 8)
             {
                 // check for embedded overlays here or below?
-                newPixelData.BitsAllocated = 8;
+                newPixelData.Dataset.AddOrUpdate(DicomTag.BitsAllocated, (ushort)8);
             }
 
             var jparams = parameters as DicomJpegParams ?? GetDefaultParameters() as DicomJpegParams;
@@ -79,7 +79,8 @@ namespace Dicom.Imaging.Codec
                 precision = oldPixelData.BitsStored;
             }
 
-            if (newPixelData.BitsStored <= 8 && precision > 8) newPixelData.BitsAllocated = 16; // embedded overlay?
+            if (newPixelData.BitsStored <= 8 && precision > 8)
+                newPixelData.Dataset.AddOrUpdate(DicomTag.BitsAllocated, (ushort)16); // embedded overlay?
 
             var codec = GetCodec(precision, jparams);
 

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -80,7 +80,7 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Gets new instance of <seealso cref="BitDepth"/> using dataset information
+        /// Gets new instance of <seealso cref="BitDepth"/> using dataset information.
         /// </summary>
         public BitDepth BitDepth => new BitDepth(
             BitsAllocated,
@@ -89,7 +89,7 @@ namespace Dicom.Imaging
             PixelRepresentation == PixelRepresentation.Signed);
 
         /// <summary>
-        /// Number of bits allocated per pixel sample (0028,0100)
+        /// Gets number of bits allocated per pixel sample (0028,0100).
         /// </summary>
         public ushort BitsAllocated => Dataset.Get<ushort>(DicomTag.BitsAllocated);
 

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -14,7 +14,7 @@ namespace Dicom.Imaging
     public abstract class DicomPixelData
     {
         /// <summary>
-        /// Initialize new instance of <seealso cref="DicomPixelData"/> using passed <paramref name="dataset"/>
+        /// Initializes new instance of <see cref="DicomPixelData"/> using passed <paramref name="dataset"/>.
         /// </summary>
         /// <param name="dataset"></param>
         protected DicomPixelData(DicomDataset dataset)
@@ -24,17 +24,17 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Dicom Dataset
+        /// Gets the DICOM Dataset containing the pixel data.
         /// </summary>
-        public DicomDataset Dataset { get; private set; }
+        public DicomDataset Dataset { get; }
 
         /// <summary>
-        /// The transfer syntax used to encode the DICOM iamge pixel data
+        /// Gets the transfer syntax used to encode the DICOM iamge pixel data
         /// </summary>
         public DicomTransferSyntax Syntax { get; private set; }
 
         /// <summary>
-        /// DICOM image width (columns) in pixels
+        /// Gets or sets the DICOM image width (columns) in pixels.
         /// </summary>
         public ushort Width
         {
@@ -49,7 +49,7 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// DICOM image height (rows) in pixels
+        /// Gets or sets the DICOM image height (rows) in pixels.
         /// </summary>
         public ushort Height
         {
@@ -65,13 +65,13 @@ namespace Dicom.Imaging
 
 
         /// <summary>
-        /// DICOM image Number of frames. This value usually equals 1 for single frame images
+        /// Gets or sets DICOM image Number of frames. This value usually equals 1 for single frame images.
         /// </summary>
         public int NumberOfFrames
         {
             get
             {
-                return Dataset.Get<ushort>(DicomTag.NumberOfFrames, 0, 1);
+                return Dataset.Get<ushort>(DicomTag.NumberOfFrames, 1);
             }
             set
             {
@@ -80,37 +80,21 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Return new instance of <seealso cref="BitDepth"/> using dataset information
+        /// Gets new instance of <seealso cref="BitDepth"/> using dataset information
         /// </summary>
-        public BitDepth BitDepth
-        {
-            get
-            {
-                return new BitDepth(
-                    BitsAllocated,
-                    BitsStored,
-                    HighBit,
-                    PixelRepresentation == PixelRepresentation.Signed);
-            }
-        }
+        public BitDepth BitDepth => new BitDepth(
+            BitsAllocated,
+            BitsStored,
+            HighBit,
+            PixelRepresentation == PixelRepresentation.Signed);
 
         /// <summary>
         /// Number of bits allocated per pixel sample (0028,0100)
         /// </summary>
-        public ushort BitsAllocated
-        {
-            get
-            {
-                return Dataset.Get<ushort>(DicomTag.BitsAllocated);
-            }
-            set
-            {
-                Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.BitsAllocated, value));
-            }
-        }
+        public ushort BitsAllocated => Dataset.Get<ushort>(DicomTag.BitsAllocated);
 
         /// <summary>
-        /// Number of bits stored per pixel sample (0028,0101)
+        /// Gets or sets number of bits stored per pixel sample (0028,0101).
         /// </summary>
         public ushort BitsStored
         {
@@ -120,12 +104,15 @@ namespace Dicom.Imaging
             }
             set
             {
+                if (value > BitsAllocated)
+                    throw new DicomImagingException($"Value: {value} > Bits Allocated: {BitsAllocated}");
+
                 Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.BitsStored, value));
             }
         }
 
         /// <summary>
-        /// Index of the most signficant bit (MSB) of pixel sample(0028,0102)
+        /// Gets or sets index of the most signficant bit (MSB) of pixel sample(0028,0102).
         /// </summary>
         public ushort HighBit
         {
@@ -135,18 +122,22 @@ namespace Dicom.Imaging
             }
             set
             {
+                if (value >= BitsAllocated)
+                    throw new DicomImagingException(
+                        $"Value: {value} >= Bits Allocated: {BitsAllocated}");
+
                 Dataset.AddOrUpdate(new DicomUnsignedShort(DicomTag.HighBit, value));
             }
         }
 
         /// <summary>
-        /// Number of samples per pixel (0028,0002), usually 1 for grayscale and 3 for color (RGB and YBR)
+        /// Gets or sets number of samples per pixel (0028,0002), usually 1 for grayscale and 3 for color (RGB and YBR.
         /// </summary> 
         public ushort SamplesPerPixel
         {
             get
             {
-                return Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 0, 1);
+                return Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 1);
             }
             set
             {
@@ -155,7 +146,7 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Pixel Representation (0028,0103) represents signed/unsigned data of the pixel samples 
+        /// Gets or sets, pixel Representation (0028,0103), represents signed/unsigned data of the pixel samples.
         /// </summary>
         public PixelRepresentation PixelRepresentation
         {
@@ -170,8 +161,8 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Planar Configuration (0028,0006) indicates whether the color pixel data are sent color-by-plane
-        /// or color-by-pixel
+        /// Gets or sets planar Configuration (0028,0006), indicates whether the color pixel data are sent color-by-plane
+        /// or color-by-pixel.
         /// </summary>
         public PlanarConfiguration PlanarConfiguration
         {
@@ -186,7 +177,7 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Photometric Interpretation
+        /// Gets or sets photometric Interpretation.
         /// </summary>
         public PhotometricInterpretation PhotometricInterpretation
         {
@@ -201,53 +192,35 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Lossy image compression (0028,2110), returns true if stored value is "01"
+        /// Gets lossy image compression (0028,2110) status, returns true if stored value is "01".
         /// </summary>
-        public bool IsLossy
-        {
-            get
-            {
-                return Dataset.Get<string>(DicomTag.LossyImageCompression, "00") == "01";
-            }
-        }
+        public bool IsLossy => Dataset.Get<string>(DicomTag.LossyImageCompression, "00") == "01";
 
         /// <summary>
-        /// Lossy image compression method (0028,2114)
+        /// Gets lossy image compression method (0028,2114).
         /// </summary>
-        public string LossyCompressionMethod
-        {
-            get
-            {
-                return Dataset.Get<string>(DicomTag.LossyImageCompressionMethod);
-            }
-        }
+        public string LossyCompressionMethod => Dataset.Get<string>(DicomTag.LossyImageCompressionMethod);
 
         /// <summary>
-        /// Lossy image compression ration (0028,2112)
+        /// Gets lossy image compression ratio (0028,2112).
         /// </summary>
-        public decimal LossyCompressionRatio
-        {
-            get
-            {
-                return Dataset.Get<decimal>(DicomTag.LossyImageCompressionRatio);
-            }
-        }
+        public decimal LossyCompressionRatio => Dataset.Get<decimal>(DicomTag.LossyImageCompressionRatio);
 
         /// <summary>
-        /// Number of bytes allocated per pixel sample
+        /// Gets number of bytes allocated per pixel sample.
         /// </summary>
         public int BytesAllocated
         {
             get
             {
-                int bytes = BitsAllocated / 8;
-                if ((BitsAllocated % 8) > 0) bytes++;
+                var bytes = BitsAllocated / 8;
+                if (BitsAllocated % 8 > 0) bytes++;
                 return bytes;
             }
         }
 
         /// <summary>
-        /// Uncompressed frame size in bytes
+        /// Gets uncompressed frame size in bytes.
         /// </summary>
         public int UncompressedFrameSize
         {
@@ -275,19 +248,9 @@ namespace Dicom.Imaging
         }
 
         /// <summary>
-        /// Plaette color LUT, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
+        /// Gets palette color LUT, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
         /// </summary>
-        public Color32[] PaletteColorLUT
-        {
-            get
-            {
-                return GetPaletteColorLUT();
-            }
-            set
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public Color32[] PaletteColorLUT => GetPaletteColorLUT();
 
         /// <summary>
         /// Extracts the palette color LUT from DICOM dataset, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
@@ -302,8 +265,8 @@ namespace Dicom.Imaging
 
             if (!Dataset.Contains(DicomTag.RedPaletteColorLookupTableDescriptor)) throw new DicomImagingException("Palette Color LUT missing from dataset.");
 
-            int size = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 0);
-            int bits = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 2);
+            var size = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 0);
+            var bits = Dataset.Get<int>(DicomTag.RedPaletteColorLookupTableDescriptor, 2);
 
             var r = Dataset.Get<byte[]>(DicomTag.RedPaletteColorLookupTableData);
             var g = Dataset.Get<byte[]>(DicomTag.GreenPaletteColorLookupTableData);
@@ -317,19 +280,19 @@ namespace Dicom.Imaging
             if (r.Length == size)
             {
                 // 8-bit LUT entries
-                for (int i = 0; i < size; i++) lut[i] = new Color32(0xff, r[i], g[i], b[i]);
+                for (var i = 0; i < size; i++) lut[i] = new Color32(0xff, r[i], g[i], b[i]);
             }
             else
             {
                 // 16-bit LUT entries... we only support 8-bit until someone can find a sample image with a 16-bit palette
 
                 // 8-bit entries with 16-bits allocated
-                int offset = 0;
+                var offset = 0;
 
                 // 16-bit entries with 8-bits stored
                 if (bits == 16) offset = 1;
 
-                for (int i = 0; i < size; i++, offset += 2) lut[i] = new Color32(0xff, r[offset], g[offset], b[offset]);
+                for (var i = 0; i < size; i++, offset += 2) lut[i] = new Color32(0xff, r[offset], g[offset], b[offset]);
             }
 
             return lut;
@@ -343,9 +306,9 @@ namespace Dicom.Imaging
         public abstract IByteBuffer GetFrame(int frame);
 
         /// <summary>
-        /// Abstract AddFrame method to add new frame into dataset pixel dataset. new frame will be appended to existing frames
+        /// Abstract AddFrame method to add new frame into dataset pixel dataset. New frame will be appended to existing frames.
         /// </summary>
-        /// <param name="data">Frame byte buffer</param>
+        /// <param name="data">Frame byte buffer.</param>
         public abstract void AddFrame(IByteBuffer data);
 
         /// <summary>
@@ -364,23 +327,26 @@ namespace Dicom.Imaging
             if (newPixelData)
             {
                 if (syntax == DicomTransferSyntax.ImplicitVRLittleEndian) return new OtherWordPixelData(dataset, true);
-
                 if (syntax.IsEncapsulated) return new EncapsulatedPixelData(dataset, true);
 
-                if (dataset.Get<ushort>(DicomTag.BitsAllocated) == 16) return new OtherWordPixelData(dataset, true);
-                else return new OtherBytePixelData(dataset, true);
-            }
-            else
-            {
-                var item = dataset.Get<DicomItem>(DicomTag.PixelData);
-                if (item == null) throw new DicomImagingException("DICOM dataset is missing pixel data element.");
+                var bitsAllocated = dataset.Get<ushort>(DicomTag.BitsAllocated);
+                if (bitsAllocated > 16)
+                    throw new DicomImagingException(
+                        $"Cannot represent non-encapsulated data with Bits Allocated: {bitsAllocated} > 16");
 
-                if (item is DicomOtherByte) return new OtherBytePixelData(dataset, false);
-                if (item is DicomOtherWord) return new OtherWordPixelData(dataset, false);
-                if (item is DicomOtherByteFragment || item is DicomOtherWordFragment) return new EncapsulatedPixelData(dataset, false);
-
-                throw new DicomImagingException("Unexpected or unhandled pixel data element type: {0}", item.GetType());
+                return bitsAllocated > 8
+                    ? (DicomPixelData) new OtherWordPixelData(dataset, true)
+                    : new OtherBytePixelData(dataset, true);
             }
+
+            var item = dataset.Get<DicomItem>(DicomTag.PixelData);
+            if (item == null) throw new DicomImagingException("DICOM dataset is missing pixel data element.");
+
+            if (item is DicomOtherByte) return new OtherBytePixelData(dataset, false);
+            if (item is DicomOtherWord) return new OtherWordPixelData(dataset, false);
+            if (item is DicomOtherByteFragment || item is DicomOtherWordFragment) return new EncapsulatedPixelData(dataset, false);
+
+            throw new DicomImagingException("Unexpected or unhandled pixel data element type: {0}", item.GetType());
         }
 
         /// <summary>
@@ -408,13 +374,13 @@ namespace Dicom.Imaging
             /// <summary>
             /// The pixel data other byte (OB) element
             /// </summary>
-            public DicomOtherByte Element { get; private set; }
+            private DicomOtherByte Element { get; }
 
             public override IByteBuffer GetFrame(int frame)
             {
                 if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
 
-                int offset = UncompressedFrameSize * frame;
+                var offset = UncompressedFrameSize * frame;
                 return new RangeByteBuffer(Element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
             }
 
@@ -422,7 +388,7 @@ namespace Dicom.Imaging
             {
                 if (!(Element.Buffer is CompositeByteBuffer)) throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer");
 
-                CompositeByteBuffer buffer = Element.Buffer as CompositeByteBuffer;
+                var buffer = (CompositeByteBuffer)Element.Buffer;
                 buffer.Buffers.Add(data);
 
                 NumberOfFrames++;
@@ -454,13 +420,13 @@ namespace Dicom.Imaging
             /// <summary>
             /// The pixel data other word (OW) element
             /// </summary>
-            public DicomOtherWord Element { get; private set; }
+            private DicomOtherWord Element { get; }
 
             public override IByteBuffer GetFrame(int frame)
             {
                 if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
 
-                int offset = UncompressedFrameSize * frame;
+                var offset = UncompressedFrameSize * frame;
                 IByteBuffer buffer = new RangeByteBuffer(Element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
 
                 // mainly for GE Private Implicit VR Big Endian
@@ -473,7 +439,7 @@ namespace Dicom.Imaging
             {
                 if (!(Element.Buffer is CompositeByteBuffer)) throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer.");
 
-                CompositeByteBuffer buffer = Element.Buffer as CompositeByteBuffer;
+                var buffer = (CompositeByteBuffer)Element.Buffer;
 
                 if (Syntax.SwapPixelData) data = new SwapByteBuffer(data, 2);
 
@@ -508,7 +474,7 @@ namespace Dicom.Imaging
             /// <summary>
             /// The pixel data framgent sequence element
             /// </summary>
-            public DicomFragmentSequence Element { get; private set; }
+            private DicomFragmentSequence Element { get; }
 
             public override IByteBuffer GetFrame(int frame)
             {
@@ -524,15 +490,15 @@ namespace Dicom.Imaging
                 else if (Element.Fragments.Count == NumberOfFrames) buffer = Element.Fragments[frame];
                 else if (Element.OffsetTable.Count == NumberOfFrames)
                 {
-                    uint start = Element.OffsetTable[frame];
-                    uint stop = (Element.OffsetTable.Count == (frame + 1))
+                    var start = Element.OffsetTable[frame];
+                    var stop = (Element.OffsetTable.Count == (frame + 1))
                                     ? uint.MaxValue
                                     : Element.OffsetTable[frame + 1];
 
                     var composite = new CompositeByteBuffer();
 
                     uint pos = 0;
-                    int frag = 0;
+                    var frag = 0;
 
                     while (pos < start && frag < Element.Fragments.Count)
                     {
@@ -572,7 +538,7 @@ namespace Dicom.Imaging
             {
                 NumberOfFrames++;
 
-                long pos = Element.Fragments.Sum(x => (long)x.Size + 8);
+                var pos = Element.Fragments.Sum(x => (long)x.Size + 8);
                 if (pos < uint.MaxValue)
                 {
                     Element.OffsetTable.Add((uint)pos);

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -71,7 +71,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                return Dataset.Get<ushort>(DicomTag.NumberOfFrames, 1);
+                return Dataset.Get(DicomTag.NumberOfFrames, (ushort)1);
             }
             set
             {
@@ -137,7 +137,7 @@ namespace Dicom.Imaging
         {
             get
             {
-                return Dataset.Get<ushort>(DicomTag.SamplesPerPixel, 1);
+                return Dataset.Get(DicomTag.SamplesPerPixel, (ushort)1);
             }
             set
             {

--- a/Native/Desktop/Dicom.Imaging.Codec.Jpeg.cpp
+++ b/Native/Desktop/Dicom.Imaging.Codec.Jpeg.cpp
@@ -22,7 +22,7 @@ namespace Dicom {
 				// IJG eats the extra padding bits. Is there a better way to test for this?
 				if (oldPixelData->BitsAllocated == 16 && oldPixelData->BitsStored <= 8) {
 					// check for embedded overlays?
-					newPixelData->BitsAllocated = 8;
+					newPixelData->Dataset->AddOrUpdate(DicomTag::BitsAllocated, (unsigned short)8);
 				}
 
 				if (parameters == nullptr || parameters->GetType() != DicomJpegParams::typeid)
@@ -45,7 +45,7 @@ namespace Dicom {
 				// IJG eats the extra padding bits. Is there a better way to test for this?
 				if (newPixelData->BitsAllocated == 16 && newPixelData->BitsStored <= 8) {
 					// check for embedded overlays here or below?
-					newPixelData->BitsAllocated = 8;
+					newPixelData->Dataset->AddOrUpdate(DicomTag::BitsAllocated, (unsigned short)8);
 				}
 
 				if (parameters == nullptr || parameters->GetType() != DicomJpegParams::typeid)
@@ -71,7 +71,7 @@ namespace Dicom {
 				}
 
 				if (newPixelData->BitsStored <= 8 && precision > 8)
-					newPixelData->BitsAllocated = 16; // embedded overlay?
+					newPixelData->Dataset->AddOrUpdate(DicomTag::BitsAllocated, (unsigned short)16); // embedded overlay?
 
 				JpegNativeCodec^ codec = GetCodec(precision, jparams);
 

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Imaging\ColorTableTest.cs" />
     <Compile Include="Imaging\DicomImageTest.cs" />
     <Compile Include="Imaging\DicomOverlayDataTest.cs" />
+    <Compile Include="Imaging\DicomPixelDataTest.cs" />
     <Compile Include="Imaging\GrayscaleRenderOptionsTest.cs" />
     <Compile Include="Imaging\ImageManagerTest.cs" />
     <Compile Include="Imaging\LUT\OutputLUTTest.cs" />

--- a/Tests/Desktop/Imaging/DicomPixelDataTest.cs
+++ b/Tests/Desktop/Imaging/DicomPixelDataTest.cs
@@ -1,0 +1,117 @@
+﻿// // Copyright (c) 2012-2017 fo-dicom contributors.
+// // Licensed under the Microsoft Public License (MS-PL).
+// 
+
+using Xunit;
+
+namespace Dicom.Imaging
+{
+    public class DicomPixelDataTest
+    {
+        [Fact]
+        public void Create_TransferSyntaxImplicitLE_ReturnsOtherWordPixelDataObject()
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ImplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, (ushort)8);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            Assert.Equal("OtherWordPixelData", pixelData.GetType().Name);
+        }
+
+        [Fact]
+        public void Create_TransferSyntaxExplicitLEBitsAllocatedGreaterThan16_Throws()
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, (ushort)17);
+            var exception = Record.Exception(() => DicomPixelData.Create(dataset, true));
+
+            Assert.NotNull(exception);
+        }
+
+        [Theory]
+        [InlineData(9)]
+        [InlineData(11)]
+        [InlineData(14)]
+        [InlineData(16)]
+        public void Create_TransferSyntaxExplicitLEBitsAllocatedGreaterThan8_ReturnsOtherWordPixelDataObject(ushort bitsAllocated)
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            Assert.Equal("OtherWordPixelData", pixelData.GetType().Name);
+        }
+
+        [Theory]
+        [InlineData(8)]
+        [InlineData(4)]
+        [InlineData(2)]
+        [InlineData(1)]
+        public void Create_TransferSyntaxExplicitLEBitsAllocatedLessThanOrEqualTo8_ReturnsOtherBytePixelDataObject(ushort bitsAllocated)
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            Assert.Equal("OtherBytePixelData", pixelData.GetType().Name);
+        }
+
+        [Theory]
+        [InlineData(8, 8)]
+        [InlineData(8, 7)]
+        [InlineData(16, 16)]
+        [InlineData(16, 12)]
+        public void BitsStored_Setter_SmallerThanOrEqualToBitsAllocatedIsAllowed(ushort bitsAllocated, ushort bitsStored)
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            var exception = Record.Exception(() => pixelData.BitsStored = bitsStored);
+            Assert.Null(exception);
+            Assert.Equal(bitsStored, pixelData.BitsStored);
+        }
+
+        [Theory]
+        [InlineData(8, 9)]
+        [InlineData(16, 17)]
+        public void BitsStored_Setter_GreaterThanBitsAllocatedIsNotAllowed(ushort bitsAllocated, ushort bitsStored)
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            var exception = Record.Exception(() => pixelData.BitsStored = bitsStored);
+            Assert.NotNull(exception);
+        }
+
+        [Theory]
+        [InlineData(8, 7)]
+        [InlineData(16, 12)]
+        public void HighBit_Setter_SmallerThanBitsAllocatedIsAllowed(ushort bitsAllocated, ushort highBit)
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            var exception = Record.Exception(() => pixelData.HighBit = highBit);
+            Assert.Null(exception);
+            Assert.Equal(highBit, pixelData.HighBit);
+        }
+
+        [Theory]
+        [InlineData(8, 8)]
+        [InlineData(8, 9)]
+        [InlineData(16, 16)]
+        [InlineData(16, 17)]
+        public void HighBit_Setter_GreaterThanOrEqualToBitsAllocatedIsNotAllowed(ushort bitsAllocated, ushort highBit)
+        {
+            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            var exception = Record.Exception(() => pixelData.HighBit = highBit);
+            Assert.NotNull(exception);
+        }
+    }
+}

--- a/Tests/Desktop/Imaging/DicomPixelDataTest.cs
+++ b/Tests/Desktop/Imaging/DicomPixelDataTest.cs
@@ -11,7 +11,7 @@ namespace Dicom.Imaging
         [Fact]
         public void Create_TransferSyntaxImplicitLE_ReturnsOtherWordPixelDataObject()
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ImplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ImplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, (ushort)8);
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -21,7 +21,7 @@ namespace Dicom.Imaging
         [Fact]
         public void Create_TransferSyntaxExplicitLEBitsAllocatedGreaterThan16_Throws()
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, (ushort)17);
             var exception = Record.Exception(() => DicomPixelData.Create(dataset, true));
 
@@ -35,7 +35,7 @@ namespace Dicom.Imaging
         [InlineData(16)]
         public void Create_TransferSyntaxExplicitLEBitsAllocatedGreaterThan8_ReturnsOtherWordPixelDataObject(ushort bitsAllocated)
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -49,7 +49,7 @@ namespace Dicom.Imaging
         [InlineData(1)]
         public void Create_TransferSyntaxExplicitLEBitsAllocatedLessThanOrEqualTo8_ReturnsOtherBytePixelDataObject(ushort bitsAllocated)
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -63,7 +63,7 @@ namespace Dicom.Imaging
         [InlineData(16, 12)]
         public void BitsStored_Setter_SmallerThanOrEqualToBitsAllocatedIsAllowed(ushort bitsAllocated, ushort bitsStored)
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -77,7 +77,7 @@ namespace Dicom.Imaging
         [InlineData(16, 17)]
         public void BitsStored_Setter_GreaterThanBitsAllocatedIsNotAllowed(ushort bitsAllocated, ushort bitsStored)
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -90,7 +90,7 @@ namespace Dicom.Imaging
         [InlineData(16, 12)]
         public void HighBit_Setter_SmallerThanBitsAllocatedIsAllowed(ushort bitsAllocated, ushort highBit)
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
             var pixelData = DicomPixelData.Create(dataset, true);
 
@@ -106,7 +106,7 @@ namespace Dicom.Imaging
         [InlineData(16, 17)]
         public void HighBit_Setter_GreaterThanOrEqualToBitsAllocatedIsNotAllowed(ushort bitsAllocated, ushort highBit)
         {
-            var dataset = new DicomDataset { InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian };
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
             var pixelData = DicomPixelData.Create(dataset, true);
 

--- a/Tests/NetCore/DICOM.Tests.NetCore.csproj
+++ b/Tests/NetCore/DICOM.Tests.NetCore.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Desktop\Imaging\DicomPixelDataTest.cs" Link="Imaging\DicomPixelDataTest.cs" />
     <Compile Include="..\Desktop\Log\TextWriterLoggerTest.cs" Link="Log\TextWriterLoggerTest.cs" />
     <Compile Include="..\Desktop\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
@@ -69,6 +70,7 @@
 
   <ItemGroup>
     <Folder Include="Log\" />
+    <Folder Include="Imaging\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Universal/DICOM.Tests.Universal.csproj
+++ b/Tests/Universal/DICOM.Tests.Universal.csproj
@@ -109,6 +109,9 @@
     <Compile Include="..\Desktop\DicomAnonymizerTest.cs">
       <Link>DicomAnonymizerTest.cs</Link>
     </Compile>
+    <Compile Include="..\Desktop\Imaging\DicomPixelDataTest.cs">
+      <Link>Imaging\DicomPixelDataTest.cs</Link>
+    </Compile>
     <Compile Include="..\Desktop\Log\TextWriterLoggerTest.cs">
       <Link>Log\TextWriterLoggerTest.cs</Link>
     </Compile>
@@ -150,6 +153,7 @@
       <Name>DICOM.Universal</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #528 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- `DicomPixelData.BitsAllocated` setter removed.
- `DicomPixelData.Create(DicomDataset, newPixelData: true)` returns `OtherWordPixelData` class whenever *Bits Allocated* exceed 8, not only for 16 allocated bits.
- `Create` throws if bits allocated exceed 16.
- `BitsStored` setter throws if new value is greater than `BitsAllocated`.
- `HighBit` setter throws if new value is greater than or equal to `BitsAllocated`.
- Added convenience constructor `DicomDataset(DicomTransferSyntax)` for setting the dataset transfer syntax to non-default value.