### PR TITLE
Correct sorting of private tags. Connected to #535

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 #### v.3.1.0 (TBD)
 * Downgrade desktop libraries to framework version 4.5 (#561 #562)
 * Correct interpolation of rescaled overlay graphics (#545 #558)
+* Private tag is listed out or order (#535 #566)
 * JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)
 * DicomDictionary.GetEnumerator() is very slow (#532 #534)
 * DicomPixelData.BitsAllocated setter removed (#528 #564)

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -348,7 +348,7 @@ namespace Dicom
             {
                 var privateTag = GetPrivateTag(tag, false);
                 if (privateTag == null) return false;
-                return _items.ContainsKey(privateTag);
+                return _items.Any(kv => kv.Key.Equals(privateTag));
             }
             return _items.ContainsKey(tag);
         }

--- a/DICOM/DicomTag.cs
+++ b/DICOM/DicomTag.cs
@@ -107,19 +107,18 @@ namespace Dicom
         {
             if (Group != other.Group) return Group.CompareTo(other.Group);
 
+            if (Element != other.Element) return Element.CompareTo(other.Element);
+
             // sort by private creator only if element values are equal
             if (PrivateCreator != null || other.PrivateCreator != null)
             {
-                var elemCompare = (Element & 0xff).CompareTo(other.Element & 0xff);
-                if (elemCompare != 0) return elemCompare;
-
                 if (PrivateCreator == null) return -1;
                 if (other.PrivateCreator == null) return 1;
 
                 return PrivateCreator.CompareTo(other.PrivateCreator);
             }
 
-            return Element.CompareTo(other.Element);
+            return 0;
         }
 
         public int CompareTo(object obj)

--- a/DICOM/DicomTag.cs
+++ b/DICOM/DicomTag.cs
@@ -110,12 +110,13 @@ namespace Dicom
             // sort by private creator only if element values are equal
             if (PrivateCreator != null || other.PrivateCreator != null)
             {
+                var elemCompare = (Element & 0xff).CompareTo(other.Element & 0xff);
+                if (elemCompare != 0) return elemCompare;
+
                 if (PrivateCreator == null) return -1;
                 if (other.PrivateCreator == null) return 1;
 
-                if (PrivateCreator != other.PrivateCreator) return PrivateCreator.CompareTo(other.PrivateCreator);
-
-                return (Element & 0xff).CompareTo(other.Element & 0xff);
+                return PrivateCreator.CompareTo(other.PrivateCreator);
             }
 
             return Element.CompareTo(other.Element);

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -380,11 +380,13 @@ namespace Dicom
         /// Associated with Github issue #535.
         /// </summary>
         [Theory]
-        [InlineData(0x0019, 0x1153, 0x1006, "", "HOLOLOGIC")]
-        [InlineData(0x0019, 0x1053, 0x1006, "HOLOLOGIC", "HOLOLOGIC")]
-        [InlineData(0x0019, 0x1053, 0x1006, "DICOM", "HOLOLOGIC")]
-        [InlineData(0x0019, 0x1006, 0x1006, "HOLOLOGIC", "DICOM")]
-        public void Add_PrivateTags_ShouldBeSortedInGroupLowByteElementCreatorOrder(ushort group, ushort hiElem,
+        [InlineData(0x0019, 0x1153, 0x1006, "", "PRIVATE")]
+        [InlineData(0x0019, 0x1053, 0x1006, "PRIVATE", "PRIVATE")]
+        [InlineData(0x0019, 0x1106, 0x1053, "PRIVATE", "PRIVATE")]
+        [InlineData(0x0019, 0x1106, 0x1053, "PRIVATE", "")]
+        [InlineData(0x0019, 0x1053, 0x1006, "ALSOPRIVATE", "PRIVATE")]
+        [InlineData(0x0019, 0x1006, 0x1006, "PRIVATE", "ALSOPRIVATE")]
+        public void Add_PrivateTags_ShouldBeSortedInGroupByteElementCreatorOrder(ushort group, ushort hiElem,
             ushort loElem, string hiCreator, string loCreator)
         {
             var dataset = new DicomDataset();

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -360,6 +360,43 @@ namespace Dicom
             Assert.Equal(DicomVR.CS, ds.Get<DicomVR>(dictEntry.Tag));
         }
 
+        /// <summary>
+        /// Associated with Github issue #535.
+        /// </summary>
+        [Theory]
+        [InlineData(0x0016, 0x1106, 0x1053)]
+        [InlineData(0x0016, 0x1053, 0x1006)]
+        public void Add_RegularTags_ShouldBeSortedInGroupElementOrder(ushort group, ushort hiElem, ushort loElem)
+        {
+            var dataset = new DicomDataset();
+            dataset.Add(new DicomTag(group, hiElem), 2);
+            dataset.Add(new DicomTag(group, loElem), 1);
+
+            var firstElem = dataset.First().Tag.Element;
+            Assert.Equal(loElem, firstElem);
+        }
+
+        /// <summary>
+        /// Associated with Github issue #535.
+        /// </summary>
+        [Theory]
+        [InlineData(0x0019, 0x1153, 0x1006, "", "HOLOLOGIC")]
+        [InlineData(0x0019, 0x1053, 0x1006, "HOLOLOGIC", "HOLOLOGIC")]
+        [InlineData(0x0019, 0x1053, 0x1006, "DICOM", "HOLOLOGIC")]
+        [InlineData(0x0019, 0x1006, 0x1006, "HOLOLOGIC", "DICOM")]
+        public void Add_PrivateTags_ShouldBeSortedInGroupLowByteElementCreatorOrder(ushort group, ushort hiElem,
+            ushort loElem, string hiCreator, string loCreator)
+        {
+            var dataset = new DicomDataset();
+            dataset.Add(new DicomTag(group, hiElem, hiCreator), 2);
+            dataset.Add(new DicomTag(group, loElem, loCreator), 1);
+
+            var firstElem = dataset.First().Tag.Element;
+            var firstCreator = dataset.First().Tag.PrivateCreator.Creator;
+            Assert.Equal(loElem, firstElem);
+            Assert.Equal(loCreator, firstCreator);
+        }
+
         #endregion
 
         #region Support methods


### PR DESCRIPTION
Fixes #535.

Also connected to issue #319 and PR #351.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Revert `DicomTag.CompareTo(DicomTag)` to previous implementation.
- In `DicomDataset.Contains()`, when comparing private tags, use `DicomTag.Equals` to ensure that high byte in tag element is ignored (#319 / #351).
