### PR TITLE
Added getters and setters for "new" meta info attributes. Connected to #563

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.1.0 (TBD)
+* ReceivingApplicationEntityTitle and SendingApplicationEntityTitle omitted during Save (#563 #569)
 * Downgrade desktop libraries to framework version 4.5 (#561 #562)
 * Correct interpolation of rescaled overlay graphics (#545 #558)
 * Private tag is listed out or order (#535 #566)

--- a/DICOM/DicomFileMetaInformation.cs
+++ b/DICOM/DicomFileMetaInformation.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using Dicom.Network;
+
 namespace Dicom
 {
-    using Dicom.Network;
-
     /// <summary>
     /// Representation of the file meta information in a DICOM Part 10 file.
     /// </summary>
@@ -27,17 +27,26 @@ namespace Dicom
         /// </param>
         public DicomFileMetaInformation(DicomDataset dataset)
         {
-            this.Version = new byte[] { 0x00, 0x01 };
+            Version = new byte[] { 0x00, 0x01 };
 
-            this.MediaStorageSOPClassUID = dataset.Get<DicomUID>(DicomTag.SOPClassUID);
-            this.MediaStorageSOPInstanceUID = dataset.Get<DicomUID>(DicomTag.SOPInstanceUID);
-            this.TransferSyntax = dataset.InternalTransferSyntax;
+            MediaStorageSOPClassUID = dataset.Get<DicomUID>(DicomTag.SOPClassUID);
+            MediaStorageSOPInstanceUID = dataset.Get<DicomUID>(DicomTag.SOPInstanceUID);
+            TransferSyntax = dataset.InternalTransferSyntax;
 
-            this.ImplementationClassUID = DicomImplementation.ClassUID;
-            this.ImplementationVersionName = DicomImplementation.Version;
+            ImplementationClassUID = DicomImplementation.ClassUID;
+            ImplementationVersionName = DicomImplementation.Version;
 
             var aet = CreateSourceApplicationEntityTitle();
-            if (aet != null) this.SourceApplicationEntityTitle = aet;
+            if (aet != null) SourceApplicationEntityTitle = aet;
+
+            if (dataset.Contains(DicomTag.SendingApplicationEntityTitle))
+                SendingApplicationEntityTitle = dataset.Get<string>(DicomTag.SendingApplicationEntityTitle);
+            if (dataset.Contains(DicomTag.ReceivingApplicationEntityTitle))
+                SendingApplicationEntityTitle = dataset.Get<string>(DicomTag.ReceivingApplicationEntityTitle);
+            if (dataset.Contains(DicomTag.PrivateInformationCreatorUID))
+                PrivateInformationCreatorUID = dataset.Get<DicomUID>(DicomTag.PrivateInformationCreatorUID);
+            if (dataset.Contains(DicomTag.PrivateInformation))
+                PrivateInformation = dataset.Get<byte[]>(DicomTag.PrivateInformation);
         }
 
         /// <summary>
@@ -46,17 +55,26 @@ namespace Dicom
         /// <param name="metaInfo">DICOM file meta information to be updated.</param>
         public DicomFileMetaInformation(DicomFileMetaInformation metaInfo)
         {
-            this.Version = new byte[] { 0x00, 0x01 };
+            Version = new byte[] { 0x00, 0x01 };
 
-            if (metaInfo.Contains(DicomTag.MediaStorageSOPClassUID)) this.MediaStorageSOPClassUID = metaInfo.MediaStorageSOPClassUID;
-            if (metaInfo.Contains(DicomTag.MediaStorageSOPInstanceUID)) this.MediaStorageSOPInstanceUID = metaInfo.MediaStorageSOPInstanceUID;
-            if (metaInfo.Contains(DicomTag.TransferSyntaxUID)) this.TransferSyntax = metaInfo.TransferSyntax;
+            if (metaInfo.Contains(DicomTag.MediaStorageSOPClassUID)) MediaStorageSOPClassUID = metaInfo.MediaStorageSOPClassUID;
+            if (metaInfo.Contains(DicomTag.MediaStorageSOPInstanceUID)) MediaStorageSOPInstanceUID = metaInfo.MediaStorageSOPInstanceUID;
+            if (metaInfo.Contains(DicomTag.TransferSyntaxUID)) TransferSyntax = metaInfo.TransferSyntax;
 
-            this.ImplementationClassUID = DicomImplementation.ClassUID;
-            this.ImplementationVersionName = DicomImplementation.Version;
+            ImplementationClassUID = DicomImplementation.ClassUID;
+            ImplementationVersionName = DicomImplementation.Version;
 
             var aet = CreateSourceApplicationEntityTitle();
-            if (aet != null) this.SourceApplicationEntityTitle = aet;
+            if (aet != null) SourceApplicationEntityTitle = aet;
+
+            if (metaInfo.Contains(DicomTag.SendingApplicationEntityTitle))
+                SendingApplicationEntityTitle = metaInfo.SendingApplicationEntityTitle;
+            if (metaInfo.Contains(DicomTag.ReceivingApplicationEntityTitle))
+                ReceivingApplicationEntityTitle = metaInfo.ReceivingApplicationEntityTitle;
+            if (metaInfo.Contains(DicomTag.PrivateInformationCreatorUID))
+                PrivateInformationCreatorUID = metaInfo.PrivateInformationCreatorUID;
+            if (metaInfo.Contains(DicomTag.PrivateInformation))
+                PrivateInformation = metaInfo.PrivateInformation;
         }
 
         #endregion
@@ -165,6 +183,67 @@ namespace Dicom
             set
             {
                 AddOrUpdate(DicomTag.SourceApplicationEntityTitle, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Sending Application Entity Title.
+        /// </summary>
+        public string SendingApplicationEntityTitle
+        {
+            get
+            {
+                return Get<string>(DicomTag.SendingApplicationEntityTitle, null);
+            }
+            set
+            {
+                AddOrUpdate(DicomTag.SendingApplicationEntityTitle, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Receiving Application Entity Title (optional attribute).
+        /// </summary>
+        public string ReceivingApplicationEntityTitle
+        {
+            get
+            {
+                return Get<string>(DicomTag.ReceivingApplicationEntityTitle, null);
+            }
+            set
+            {
+                AddOrUpdate(DicomTag.ReceivingApplicationEntityTitle, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Private Information Creator UID (optional attribute).
+        /// </summary>
+        public DicomUID PrivateInformationCreatorUID
+        {
+            get
+            {
+                return Get<DicomUID>(DicomTag.PrivateInformationCreatorUID, null);
+            }
+            set
+            {
+                AddOrUpdate(DicomTag.PrivateInformationCreatorUID, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the private information associated with <see cref="PrivateInformationCreatorUID"/>.
+        /// Required if <see cref="PrivateInformationCreatorUID"/> is defined.
+        /// </summary>
+        public byte[] PrivateInformation
+        {
+            get
+            {
+                return Get<byte[]>(DicomTag.PrivateInformation, null);
+            }
+            set
+            {
+                AddOrUpdate(DicomTag.PrivateInformation, value);
             }
         }
 

--- a/Tests/Desktop/DicomFileMetaInformationTest.cs
+++ b/Tests/Desktop/DicomFileMetaInformationTest.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Collections.Generic;
+using System.IO;
+
 namespace Dicom
 {
     using Xunit;
@@ -69,6 +72,38 @@ namespace Dicom
             var metaInfo = new DicomFileMetaInformation();
             var exception = Record.Exception(() => new DicomFileMetaInformation(metaInfo));
             Assert.Null(exception);
+        }
+
+        [Theory]
+        [MemberData(nameof(NewOptionalAttributes))]
+        public void Save_NewOptionalAttributes_SavedWhenExisting(DicomItem item)
+        {
+            var inFile = DicomFile.Open(@"Test Data\CT-MONO2-16-ankle");
+            inFile.FileMetaInfo.Add(item);
+
+            using (var saveStream = new MemoryStream())
+            {
+                inFile.Save(saveStream);
+                saveStream.Seek(0, SeekOrigin.Begin);
+
+                var file = DicomFile.Open(saveStream);
+                Assert.True(file.FileMetaInfo.Contains(item.Tag));
+            }
+        }
+
+        #endregion
+
+        #region Support data
+
+        public static IEnumerable<object[]> NewOptionalAttributes
+        {
+            get
+            {
+                yield return new object[] { new DicomApplicationEntity(DicomTag.SendingApplicationEntityTitle, "SENDING") };
+                yield return new object[] { new DicomApplicationEntity(DicomTag.ReceivingApplicationEntityTitle, "RECEIVING") };
+                yield return new object[] { new DicomUniqueIdentifier(DicomTag.PrivateInformationCreatorUID, "1.2.3") };
+                yield return new object[] { new DicomOtherByte(DicomTag.PrivateInformation, 0x00, 0x01, 0x02, 0x02) };
+            }
         }
 
         #endregion

--- a/Tests/Desktop/DicomFileMetaInformationTest.cs
+++ b/Tests/Desktop/DicomFileMetaInformationTest.cs
@@ -91,6 +91,51 @@ namespace Dicom
             }
         }
 
+        [Fact]
+        public void PrivateInformationCreatorUID_SetterGetter_DataIsMaintained()
+        {
+            var inFile = DicomFile.Open(@"Test Data\CT-MONO2-16-ankle");
+            var expected = "1.2.3";
+            inFile.FileMetaInfo.PrivateInformationCreatorUID = DicomUID.Parse(expected);
+
+            using (var saveStream = new MemoryStream())
+            {
+                inFile.Save(saveStream);
+                saveStream.Seek(0, SeekOrigin.Begin);
+
+                var file = DicomFile.Open(saveStream);
+                Assert.Equal(expected, file.FileMetaInfo.PrivateInformationCreatorUID.UID);
+            }
+        }
+
+        [Fact]
+        public void PrivateInformation_SetterGetter_DataIsMaintained()
+        {
+            var inFile = DicomFile.Open(@"Test Data\CT-MONO2-16-ankle");
+            var expected = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+            inFile.FileMetaInfo.PrivateInformation = expected;
+
+            using (var saveStream = new MemoryStream())
+            {
+                inFile.Save(saveStream);
+                saveStream.Seek(0, SeekOrigin.Begin);
+
+                var file = DicomFile.Open(saveStream);
+                Assert.Equal(expected, file.FileMetaInfo.PrivateInformation);
+            }
+        }
+
+        [Fact]
+        public void NewProperties_Getters_ReturnsNullIfNonExisting()
+        {
+            var file = DicomFile.Open(@"Test Data\CT-MONO2-16-ankle");
+
+            Assert.Null(file.FileMetaInfo.SendingApplicationEntityTitle);
+            Assert.Null(file.FileMetaInfo.ReceivingApplicationEntityTitle);
+            Assert.Null(file.FileMetaInfo.PrivateInformationCreatorUID);
+            Assert.Null(file.FileMetaInfo.PrivateInformation);
+        }
+
         #endregion
 
         #region Support data
@@ -102,7 +147,7 @@ namespace Dicom
                 yield return new object[] { new DicomApplicationEntity(DicomTag.SendingApplicationEntityTitle, "SENDING") };
                 yield return new object[] { new DicomApplicationEntity(DicomTag.ReceivingApplicationEntityTitle, "RECEIVING") };
                 yield return new object[] { new DicomUniqueIdentifier(DicomTag.PrivateInformationCreatorUID, "1.2.3") };
-                yield return new object[] { new DicomOtherByte(DicomTag.PrivateInformation, 0x00, 0x01, 0x02, 0x02) };
+                yield return new object[] { new DicomOtherByte(DicomTag.PrivateInformation, 0x00, 0x01, 0x02, 0x03) };
             }
         }
 


### PR DESCRIPTION
Fixes #563 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Added getters and setters for Sending and Receiving Application Title, Private Information Creator UID and Private Information in `DicomFileMetaInformation` class.
- Updated constructors to sufficiently read these optional attributes from dataset.
