### PR TITLE
DicomUIDGenerator refactoring. Connected to #546

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 #### v.3.1.0 (TBD)
 * ReceivingApplicationEntityTitle and SendingApplicationEntityTitle omitted during Save (#563 #569)
 * Downgrade desktop libraries to framework version 4.5 (#561 #562)
+* DicomUIDGenerator.Generate UID Collisions (Non-unique UIDs) (#546 #571)
 * Correct interpolation of rescaled overlay graphics (#545 #558)
 * Private tag is listed out or order (#535 #566)
 * JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)

--- a/Tests/Desktop/DicomUIDGeneratorTest.cs
+++ b/Tests/Desktop/DicomUIDGeneratorTest.cs
@@ -26,7 +26,7 @@ namespace Dicom
         [Fact]
         public void Generate_MultipleInParallel_AllValuesUnique()
         {
-            const int n = 100;
+            const int n = 100000;
             var uids = new string[n];
             var generator = new DicomUIDGenerator();
             Parallel.For(0, n, i => { uids[i] = generator.Generate().UID; });

--- a/Tests/Desktop/DicomUIDGeneratorTest.cs
+++ b/Tests/Desktop/DicomUIDGeneratorTest.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Linq;
 using System.Text.RegularExpressions;
-
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Dicom
@@ -20,6 +21,28 @@ namespace Dicom
                 var invalids = Regex.Replace(uid.UID, @"[0-9\.]", "");
                 Assert.Equal(0, invalids.Length);
             }
+        }
+
+        [Fact]
+        public void Generate_MultipleInParallel_AllValuesUnique()
+        {
+            const int n = 100;
+            var uids = new string[n];
+            var generator = new DicomUIDGenerator();
+            Parallel.For(0, n, i => { uids[i] = generator.Generate().UID; });
+            Assert.Equal(n, uids.Distinct().Count());
+        }
+
+        [Fact]
+        public void Generate_SourceUidKnown_ReturnsMappedDestinationUid()
+        {
+            var generator = new DicomUIDGenerator();
+            var source = generator.Generate();
+
+            var expected = generator.Generate(source);
+            var actual = generator.Generate(source);
+
+            Assert.Equal(expected, actual);
         }
 
         #endregion


### PR DESCRIPTION
Fixes #546 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Modified `InstanceRootUID` to remember generated value when obtained from
network identifier (considerable speed-up).
- Added static method `GenerateNew` for scenario where no source UID is
specified.
- Declared `Generate()` obsolete for future removal.
- Use `ConcurrentDictionary` to store source UIDs and associated destination UIDs, considerably simplifies `Generate(DicomUID)` method.
- Use the suggested code change by @gofal in #546 to ensure that duplicate UIDs are never produced.
