### PR TITLE
Handle getters for optional sequences, and PresentationLut class refactoring. Connected to #544

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 * Downgrade desktop libraries to framework version 4.5 (#561 #562)
 * DicomUIDGenerator.Generate UID Collisions (Non-unique UIDs) (#546 #571)
 * Correct interpolation of rescaled overlay graphics (#545 #558)
+* Some getters of optional sequences do not account for missing sequence (#544 #572)
 * Private tag is listed out or order (#535 #566)
 * JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)
 * DicomDictionary.GetEnumerator() is very slow (#532 #534)

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -127,7 +127,7 @@ namespace Dicom.Printing
         /// </item>
         /// </list>
         /// </remarks>
-        public string FilmOrienation
+        public string FilmOrientation
         {
             get
             {
@@ -529,7 +529,7 @@ namespace Dicom.Printing
 
             if (!this.Contains(DicomTag.FilmOrientation))
             {
-                FilmOrienation = "PORTRAIT";
+                FilmOrientation = "PORTRAIT";
             }
             if (!this.Contains(DicomTag.FilmSizeID))
             {

--- a/DICOM/Printing/FilmBox.cs
+++ b/DICOM/Printing/FilmBox.cs
@@ -439,7 +439,7 @@ namespace Dicom.Printing
         {
             get
             {
-                return this.Get<DicomSequence>(DicomTag.ReferencedPresentationLUTSequence);
+                return this.Get<DicomSequence>(DicomTag.ReferencedPresentationLUTSequence, null);
             }
             set
             {

--- a/DICOM/Printing/ImageBox.cs
+++ b/DICOM/Printing/ImageBox.cs
@@ -50,11 +50,11 @@ namespace Dicom.Printing
                 DicomSequence seq = null;
                 if (SOPClassUID == ColorSOPClassUID || this.Contains(DicomTag.BasicColorImageSequence))
                 {
-                    seq = this.Get<DicomSequence>(DicomTag.BasicColorImageSequence);
+                    seq = this.Get<DicomSequence>(DicomTag.BasicColorImageSequence, null);
                 }
                 if (seq == null)
                 {
-                    seq = this.Get<DicomSequence>(DicomTag.BasicGrayscaleImageSequence);
+                    seq = this.Get<DicomSequence>(DicomTag.BasicGrayscaleImageSequence, null);
                 }
 
                 if (seq != null && seq.Items.Count > 0)

--- a/DICOM/Printing/PresentationLut.cs
+++ b/DICOM/Printing/PresentationLut.cs
@@ -10,21 +10,19 @@ namespace Dicom.Printing
 
         public static readonly DicomUID SopClassUid = DicomUID.PresentationLUTSOPClass;
 
-        public DicomUID SopInstanceUid { get; private set; }
+        public DicomUID SopInstanceUid { get; }
 
         public DicomDataset LutSequence
         {
             get
             {
-                var lutSequence = this.Get<DicomSequence>(DicomTag.PresentationLUTSequence);
+                var lutSequence = Get<DicomSequence>(DicomTag.PresentationLUTSequence, null);
                 if (lutSequence != null)
                 {
                     return lutSequence.Items[0];
                 }
-                else
-                {
-                    return null;
-                }
+
+                return null;
             }
         }
 
@@ -36,10 +34,8 @@ namespace Dicom.Printing
                 {
                     return LutSequence.Get<ushort[]>(DicomTag.LUTDescriptor);
                 }
-                else
-                {
-                    return new ushort[0];
-                }
+
+                return new ushort[0];
             }
             set
             {
@@ -62,10 +58,8 @@ namespace Dicom.Printing
                 {
                     return LutSequence.Get(DicomTag.LUTDescriptor, string.Empty);
                 }
-                else
-                {
-                    return string.Empty;
-                }
+
+                return string.Empty;
             }
             set
             {
@@ -88,10 +82,8 @@ namespace Dicom.Printing
                 {
                     return LutSequence.Get<ushort[]>(DicomTag.LUTData);
                 }
-                else
-                {
-                    return new ushort[0];
-                }
+
+                return new ushort[0];
             }
             set
             {
@@ -110,28 +102,21 @@ namespace Dicom.Printing
         {
             get
             {
-                return this.Get(DicomTag.PresentationLUTShape, string.Empty);
+                return Get(DicomTag.PresentationLUTShape, string.Empty);
             }
             set
             {
-                this.AddOrUpdate(DicomTag.PresentationLUTShape, value);
+                AddOrUpdate(DicomTag.PresentationLUTShape, value);
             }
         }
 
         #region Constrctuors
 
         public PresentationLut(DicomUID sopInstance = null)
-            : base()
         {
-            this.InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
-            if (sopInstance == null || sopInstance.UID == string.Empty)
-            {
-                SopInstanceUid = DicomUID.Generate();
-            }
-            else
-            {
-                SopInstanceUid = sopInstance;
-            }
+            InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
+            SopInstanceUid = sopInstance == null || sopInstance.UID == string.Empty ? DicomUID.Generate() : sopInstance;
+
             CreateLutSequence();
         }
 
@@ -139,17 +124,19 @@ namespace Dicom.Printing
         {
             if (dataset == null)
             {
-                throw new ArgumentNullException("dataset");
+                throw new ArgumentNullException(nameof(dataset));
             }
             dataset.CopyTo(this);
 
+            SopInstanceUid = sopInstance == null || sopInstance.UID == string.Empty ? DicomUID.Generate() : sopInstance;
+            AddOrUpdate(DicomTag.SOPInstanceUID, SopInstanceUid);
         }
 
         public void CreateLutSequence()
         {
             var lutSequence = new DicomSequence(DicomTag.PresentationLUTSequence);
             lutSequence.Items.Add(new DicomDataset());
-            this.Add(lutSequence);
+            Add(lutSequence);
         }
 
         #endregion

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Network\PDVTest.cs" />
     <Compile Include="Network\Ports.cs" />
     <Compile Include="Printing\FilmBoxTest.cs" />
+    <Compile Include="Printing\ImageBoxTest.cs" />
+    <Compile Include="Printing\PresentationLutTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serialization\JsonDicomConverterTest.cs" />
     <Compile Include="Serialization\XmlDicomConverterTest.cs" />

--- a/Tests/Desktop/Printing/FilmBoxTest.cs
+++ b/Tests/Desktop/Printing/FilmBoxTest.cs
@@ -50,6 +50,15 @@ namespace Dicom.Printing
             Assert.True(loaded.BasicImageBoxes.Count > 0);
         }
 
+        [Fact]
+        private void PresentationLut_NoReferencedPresentationLutSequence_GetterReturnsNull()
+        {
+            var session = new FilmSession(DicomUID.BasicFilmSessionSOPClass);
+            var box = new FilmBox(session, null, DicomTransferSyntax.ImplicitVRLittleEndian);
+
+            Assert.Null(box.PresentationLut);
+        }
+
         #endregion
     }
 }

--- a/Tests/Desktop/Printing/ImageBoxTest.cs
+++ b/Tests/Desktop/Printing/ImageBoxTest.cs
@@ -1,0 +1,39 @@
+﻿// // Copyright (c) 2012-2017 fo-dicom contributors.
+// // Licensed under the Microsoft Public License (MS-PL).
+// 
+
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dicom.Printing
+{
+    public class ImageBoxTest
+    {
+        #region Unit tests
+
+        [Theory]
+        [MemberData(nameof(SopClassUids))]
+        public void ImageSequence_NoSequenceInImageBox_ReturnsNull(DicomUID sopClassUid)
+        {
+            var session = new FilmSession(DicomUID.BasicFilmSessionSOPClass);
+            var filmBox = new FilmBox(session, null, DicomTransferSyntax.ImplicitVRLittleEndian);
+            var imageBox = new ImageBox(filmBox, sopClassUid, null);
+
+            Assert.Null(imageBox.ImageSequence);
+        }
+
+        #endregion
+
+        #region Support data
+
+        public static readonly IEnumerable<object[]> SopClassUids = new[]
+        {
+            new object[] { ImageBox.GraySOPClassUID },
+            new object[] { ImageBox.ColorSOPClassUID } 
+        };
+
+        #endregion
+    }
+}
+

--- a/Tests/Desktop/Printing/PresentationLutTest.cs
+++ b/Tests/Desktop/Printing/PresentationLutTest.cs
@@ -2,7 +2,6 @@
 // // Licensed under the Microsoft Public License (MS-PL).
 // 
 
-using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
@@ -12,11 +11,60 @@ namespace Dicom.Printing
     {
         #region Unit tests
 
-        [Fact]
-        public void LutSequence_NoPresentationLutSequenceInDataset_GetterReturnsNull()
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void LutSequence_InitialObject_IsAlwaysDefined(PresentationLut presentationLut)
         {
-            var presentationLut = new PresentationLut(null, new DicomDataset());
-            Assert.Null(presentationLut.LutSequence);
+            Assert.NotNull(presentationLut.LutSequence);
+        }
+
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void LutDescriptor_InitialObject_IsEmpty(PresentationLut presentationLut)
+        {
+            Assert.Equal(0, presentationLut.LutDescriptor.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void LutData_InitialObject_IsEmpty(PresentationLut presentationLut)
+        {
+            Assert.Equal(0, presentationLut.LutData.Length);
+        }
+
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void LutDescriptor_InitialObject_SetterDoesNotThrow(PresentationLut presentationLut)
+        {
+            var exception = Record.Exception(() => presentationLut.LutDescriptor = new ushort[] { 10, 0, 12 });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void LutExplanation_InitialObject_SetterDoesNotThrow(PresentationLut presentationLut)
+        {
+            var exception = Record.Exception(() => presentationLut.LutExplanation = "Some dummy explanation");
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void LutData_InitialObject_SetterDoesNotThrow(PresentationLut presentationLut)
+        {
+            var exception = Record.Exception(() => presentationLut.LutData = new ushort[] { 1, 2, 3, 4 });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void LutExplanation_Getter_ReturnsSetValue(PresentationLut presentationLut)
+        {
+            const string expected = "Explanation";
+            presentationLut.LutExplanation = expected;
+            var actual = presentationLut.LutExplanation;
+
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
@@ -40,11 +88,19 @@ namespace Dicom.Printing
 
         #region Support data
 
-        public static readonly IEnumerable<object[]> PresentationLuts = new[]
+        public static IEnumerable<object[]> PresentationLuts
         {
-            new object[] { new PresentationLut() },
-            new object[] { new PresentationLut(null, new DicomDataset()) }
-        };
+            get
+            {
+                yield return new object[] { new PresentationLut() };
+                yield return new object[] { new PresentationLut(null, new DicomDataset()) };
+                yield return new object[]
+                {
+                    new PresentationLut(null,
+                        new DicomDataset { new DicomSequence(DicomTag.PresentationLUTSequence, new DicomDataset()) })
+                };
+            }
+        }
 
         #endregion
     }

--- a/Tests/Desktop/Printing/PresentationLutTest.cs
+++ b/Tests/Desktop/Printing/PresentationLutTest.cs
@@ -1,0 +1,52 @@
+﻿// // Copyright (c) 2012-2017 fo-dicom contributors.
+// // Licensed under the Microsoft Public License (MS-PL).
+// 
+
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Dicom.Printing
+{
+    public class PresentationLutTest
+    {
+        #region Unit tests
+
+        [Fact]
+        public void LutSequence_NoPresentationLutSequenceInDataset_GetterReturnsNull()
+        {
+            var presentationLut = new PresentationLut(null, new DicomDataset());
+            Assert.Null(presentationLut.LutSequence);
+        }
+
+        [Fact]
+        public void Constructor_FromDataset_SopInstanceUidMaintained()
+        {
+            var expected = DicomUID.Generate();
+            var presentationLut = new PresentationLut(expected, new DicomDataset());
+            var actual = presentationLut.SopInstanceUid;
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(PresentationLuts))]
+        public void Constructor_WithNullSopInstanceUid_GetterReturnsNonNull(PresentationLut presentationLut)
+        {
+            var actual = presentationLut.SopInstanceUid;
+            Assert.NotNull(actual);
+        }
+
+        #endregion
+
+        #region Support data
+
+        public static readonly IEnumerable<object[]> PresentationLuts = new[]
+        {
+            new object[] { new PresentationLut() },
+            new object[] { new PresentationLut(null, new DicomDataset()) }
+        };
+
+        #endregion
+    }
+}
+


### PR DESCRIPTION
Fixes #544 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Use default values in `DicomDataset.Get<DicomSequence>()` calls in `FilmBox` and `ImageBox` classes.
- Major refactoring of `PresentationLut` class:
  * Corrected `LutExplanation` getter and setter (previously accessed LUT Descriptor tag).
  * Presentation LUT Sequence with one item always included if not present when initializing.
  * Since sequence always available, getters and setters simplified.
  * Use default values when accessing LUTDescriptor and LUTData tags.
  * `CreateLutSequence` method declared private.
  * Added API documentation.
