### PR TITLE
Update item's tag when private tag item is added to dataset. Connected to #570

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.3.1.0 (TBD)
+* Private group not added to tag when private tag item is added to dataset (#570 #577)
 * ReceivingApplicationEntityTitle and SendingApplicationEntityTitle omitted during Save (#563 #569)
 * Downgrade desktop libraries to framework version 4.5 (#561 #562)
 * DicomUIDGenerator.Generate UID Collisions (Non-unique UIDs) (#546 #571)

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Dicom.IO.Buffer;
+using Dicom.StructuredReport;
+
 namespace Dicom
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-
-    using Dicom.IO.Buffer;
-    using Dicom.StructuredReport;
-
-
     /// <summary>
     /// A collection of <see cref="DicomItem">DICOM items</see>.
     /// </summary>
@@ -19,7 +18,7 @@ namespace Dicom
     {
         #region FIELDS
 
-        private IDictionary<DicomTag, DicomItem> _items;
+        private readonly IDictionary<DicomTag, DicomItem> _items;
 
         private DicomTransferSyntax _syntax;
 
@@ -548,14 +547,28 @@ namespace Dicom
                 {
                     foreach (var item in items.Where(i => i != null))
                     {
-                        _items[item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag] = item;
+                        var tag = item.Tag;
+                        if (tag.IsPrivate)
+                        {
+                            tag = GetPrivateTag(tag);
+                            item.Tag = tag;
+                        }
+
+                        _items[tag] = item;
                     }
                 }
                 else
                 {
                     foreach (var item in items.Where(i => i != null))
                     {
-                        _items.Add(item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag, item);
+                        var tag = item.Tag;
+                        if (tag.IsPrivate)
+                        {
+                            tag = GetPrivateTag(tag);
+                            item.Tag = tag;
+                        }
+
+                        _items.Add(tag, item);
                     }
                 }
             }
@@ -572,13 +585,20 @@ namespace Dicom
         {
             if (item != null)
             {
+                var tag = item.Tag;
+                if (tag.IsPrivate)
+                {
+                    tag = GetPrivateTag(tag);
+                    item.Tag = tag;
+                }
+
                 if (allowUpdate)
                 {
-                    _items[item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag] = item;
+                    _items[tag] = item;
                 }
                 else
                 {
-                    _items.Add(item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag, item);
+                    _items.Add(tag, item);
                 }
             }
             return this;

--- a/DICOM/DicomItem.cs
+++ b/DICOM/DicomItem.cs
@@ -5,37 +5,67 @@ using System;
 
 namespace Dicom
 {
+    /// <summary>
+    /// Abstract base class for representing one DICOM item.
+    /// </summary>
     public abstract class DicomItem : IComparable<DicomItem>, IComparable
     {
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomItem"/> class.
+        /// </summary>
+        /// <param name="tag">Tag associated with the item.</param>
         protected DicomItem(DicomTag tag)
         {
             Tag = tag;
-
-            //DicomDictionaryEntry entry = DicomDictionary.Default[Tag];
-            //if (entry != null && !entry.ValueRepresentations.Contains(ValueRepresentation))
-            //	throw new DicomDataException("{0} is not a valid value representation for {1}", ValueRepresentation, Tag);
         }
 
-        public DicomTag Tag { get; protected set; }
+        /// <summary>
+        /// Gets the DICOM tag associated with the item.
+        /// </summary>
+        public DicomTag Tag { get; internal set; }
 
+        /// <summary>
+        /// Gets the Value Representation of the item.
+        /// </summary>
         public abstract DicomVR ValueRepresentation { get; }
 
+        /// <summary>
+        /// Compare this <see cref="DicomItem"/> with the <paramref name="other"/>. 
+        /// Comparison is purely based on the item's tag.
+        /// </summary>
+        /// <param name="other">DICOM item to compare against.</param>
+        /// <returns>Value less than zero if this item's tag is less than <paramref name="other"/>'s, zero if the items' tags are equal and
+        /// value greater than zero if this item's tag is greater than <paramref name="other"/>'s.</returns>
         public int CompareTo(DicomItem other)
         {
+            if (other == null) throw new ArgumentNullException(nameof(other));
             return Tag.CompareTo(other.Tag);
         }
 
+        /// <summary>
+        /// Compare this <see cref="DicomItem"/> with <paramref name="obj"/>.
+        /// Comparison will only succeed if <paramref name="obj"/> also is a <see cref="DicomItem"/>. Otherwise method throws.
+        /// </summary>
+        /// <param name="obj">Object to compare against, required to be a <see cref="DicomItem"/>.</param>
+        /// <returns>If <paramref name="obj"/> is a <see cref="DicomItem"/>, value less than zero if this item's tag is less than 
+        /// <paramref name="obj"/>'s, zero if the items' tags are equal and value greater than zero if this item's tag is greater than 
+        /// <paramref name="obj"/>'s.</returns>
         public int CompareTo(object obj)
         {
-            if (obj == null) throw new ArgumentNullException("obj");
-            if (!(obj is DicomItem)) throw new ArgumentException("Passed non-DicomItem to comparer", "obj");
-            return CompareTo(obj as DicomItem);
+            if (obj == null) throw new ArgumentNullException(nameof(obj));
+            if (!(obj is DicomItem)) throw new ArgumentException("Only comparison with DICOM items is supported.", nameof(obj));
+            return CompareTo((DicomItem)obj);
         }
 
+        /// <summary>
+        /// Returns a string summary of the DICOM item.
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
-            if (Tag.DictionaryEntry != null) return String.Format("{0} {1} {2}", Tag, ValueRepresentation, Tag.DictionaryEntry.Name);
-            return String.Format("{0} {1} Unknown", Tag, ValueRepresentation);
+            return Tag.DictionaryEntry != null
+                ? $"{Tag} {ValueRepresentation} {Tag.DictionaryEntry.Name}"
+                : $"{Tag} {ValueRepresentation} Unknown";
         }
     }
 }

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -400,6 +400,29 @@ namespace Dicom
         }
 
         [Fact]
+        public void Add_DicomItemOnNonExistingPrivateTag_PrivateGroupShouldCorrespondToPrivateCreator()
+        {
+            var dataset = new DicomDataset();
+
+            var tag1 = new DicomTag(0x3001, 0x08, "PRIVATE");
+            var tag2 = new DicomTag(0x3001, 0x12, "PRIVATE");
+            var tag3 = new DicomTag(0x3001, 0x08, "ALSOPRIVATE");
+
+            // By using the .Add(DicomTag, ...) method, private tags get automatically updated so that a private
+            // creator group number is generated (if private creator is new) and inserted into the tag element.
+            dataset.Add(tag1, 1);
+            dataset.Add(tag2, 3.14);
+
+            // Should confirm that element of the tag is not updated to include the private creator group number.
+            dataset.Add(new DicomIntegerString(tag3, 50));
+
+            var tag3Private = dataset.GetPrivateTag(tag3);
+            var contained = dataset.SingleOrDefault(item => item.Tag.Group == tag3Private.Group &&
+                                                        item.Tag.Element == tag3Private.Element);
+            Assert.NotNull(contained);
+        }
+
+        [Fact]
         public void AddOrUpdate_DicomItemOnExistingPrivateTag_PrivateGroupShouldCorrespondToPrivateCreator()
         {
             var dataset = new DicomDataset();

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -420,6 +420,9 @@ namespace Dicom
             var contained = dataset.SingleOrDefault(item => item.Tag.Group == tag3Private.Group &&
                                                         item.Tag.Element == tag3Private.Element);
             Assert.NotNull(contained);
+
+            var fifthItem = dataset.ElementAt(4);
+            Assert.Equal(fifthItem, contained);
         }
 
         [Fact]
@@ -448,6 +451,9 @@ namespace Dicom
             contained = dataset.SingleOrDefault(item => item.Tag.Group == tag1Private.Group &&
                                                         item.Tag.Element == tag1Private.Element);
             Assert.NotNull(contained);
+
+            var thirdItem = dataset.ElementAt(2);
+            Assert.Equal(thirdItem, contained);
         }
 
         #endregion

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -219,7 +219,7 @@ namespace Dicom
 
             var element = new DicomOtherDouble(DicomTag.DoubleFloatPixelData, testValues);
 
-            TestAddElementToDatasetAsByteBuffer<double>(element, testValues);
+            TestAddElementToDatasetAsByteBuffer(element, testValues);
         }
 
         [Fact]
@@ -399,6 +399,34 @@ namespace Dicom
             Assert.Equal(loCreator, firstCreator);
         }
 
+        [Fact]
+        public void AddOrUpdate_DicomItemOnExistingPrivateTag_PrivateGroupShouldCorrespondToPrivateCreator()
+        {
+            var dataset = new DicomDataset();
+
+            var tag1 = new DicomTag(0x3001, 0x08, "PRIVATE");
+            var tag2 = new DicomTag(0x3001, 0x12, "PRIVATE");
+            var tag3 = new DicomTag(0x3001, 0x08, "ALSOPRIVATE");
+
+            // By using the .Add(DicomTag, ...) method, private tags get automatically updated so that a private
+            // creator group number is generated (if private creator is new) and inserted into the tag element.
+            dataset.Add(tag1, 1);
+            dataset.Add(tag2, 3.14);
+            dataset.Add(tag3, "COOL");
+
+            var tag1Private = dataset.GetPrivateTag(tag1);
+            var contained = dataset.SingleOrDefault(item => item.Tag.Group == tag1Private.Group &&
+                                                            item.Tag.Element == tag1Private.Element);
+            Assert.NotNull(contained);
+
+            // Should confirm that element of the tag is not updated to include the private creator group number.
+            dataset.AddOrUpdate(new DicomIntegerString(tag1, 50));
+
+            contained = dataset.SingleOrDefault(item => item.Tag.Group == tag1Private.Group &&
+                                                        item.Tag.Element == tag1Private.Element);
+            Assert.NotNull(contained);
+        }
+
         #endregion
 
         #region Support methods
@@ -475,7 +503,7 @@ namespace Dicom
             return testValue.ToString("J", null);
         }
 
-        private void TestAddElementToDatasetAsByteBuffer<T>(DicomElement element, T[] testValues)
+        private static void TestAddElementToDatasetAsByteBuffer<T>(DicomElement element, T[] testValues)
         {
             DicomDataset ds = new DicomDataset();
 

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -574,7 +574,7 @@ namespace Dicom.Serialization
                          new DicomDecimalString(DicomTag.GantryAngle, 36)
                      };
             var json = JsonConvert.SerializeObject(ds, new JsonDicomConverter(writeTagsAsKeywords: true));
-            Assert.Equal("{\"00030010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"00031002\":{\"vr\":\"AE\",\"Value\":[\"AETITLE\"]},\"00031003\":{\"vr\":\"UN\",\"InlineBinary\":\"V0hBVElTVEhJUw==\"},\"00030010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"GantryAngle\":{\"vr\":\"DS\",\"Value\":[36]}}",
+            Assert.Equal("{\"00030010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"00031002\":{\"vr\":\"AE\",\"Value\":[\"AETITLE\"]},\"00031003\":{\"vr\":\"UN\",\"InlineBinary\":\"V0hBVElTVEhJUw==\"},\"00031010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"GantryAngle\":{\"vr\":\"DS\",\"Value\":[36]}}",
                 json);
         }
 


### PR DESCRIPTION
Fixes #570 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When a `DicomItem` with a private tag is explicitly added to a dataset, update the tag of the item before inserting it into the dataset.
