### PR TITLE
Added AffectedSOP Class UID constructor to DicomCFindRequest. Connected to #540

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 * DicomUIDGenerator.Generate UID Collisions (Non-unique UIDs) (#546 #571)
 * Correct interpolation of rescaled overlay graphics (#545 #558)
 * Some getters of optional sequences do not account for missing sequence (#544 #572)
+* DicomCFindRequest is unsuitable for "Search for Unified Procedure Step (C-FIND)" (#540 #580)
 * Private tag is listed out or order (#535 #566)
 * JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)
 * DicomDictionary.GetEnumerator() is very slow (#532 #534)

--- a/DICOM/Network/DicomCGetRequest.cs
+++ b/DICOM/Network/DicomCGetRequest.cs
@@ -104,12 +104,22 @@ namespace Dicom.Network
         {
             get
             {
-                return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
+                return Dataset.Get(DicomTag.QueryRetrieveLevel, DicomQueryRetrieveLevel.NotApplicable);
             }
-            set
+            private set
             {
-                Dataset.Remove(DicomTag.QueryRetrieveLevel);
-                if (value != DicomQueryRetrieveLevel.Worklist) Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+                switch (value)
+                {
+                    case DicomQueryRetrieveLevel.Patient:
+                    case DicomQueryRetrieveLevel.Study:
+                    case DicomQueryRetrieveLevel.Series:
+                    case DicomQueryRetrieveLevel.Image:
+                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+                        break;
+                    default:
+                        Dataset.Remove(DicomTag.QueryRetrieveLevel);
+                        break;
+                }
             }
         }
 

--- a/DICOM/Network/DicomCGetRequest.cs
+++ b/DICOM/Network/DicomCGetRequest.cs
@@ -104,7 +104,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Dataset.Get(DicomTag.QueryRetrieveLevel, DicomQueryRetrieveLevel.NotApplicable);
+                return Dataset.Get <DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
             }
             private set
             {

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -93,7 +93,7 @@ namespace Dicom.Network
         {
             get
             {
-                return Dataset.Get(DicomTag.QueryRetrieveLevel, DicomQueryRetrieveLevel.NotApplicable);
+                return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
             }
             private set
             {

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -93,12 +93,22 @@ namespace Dicom.Network
         {
             get
             {
-                return Dataset.Get<DicomQueryRetrieveLevel>(DicomTag.QueryRetrieveLevel);
+                return Dataset.Get(DicomTag.QueryRetrieveLevel, DicomQueryRetrieveLevel.NotApplicable);
             }
             private set
             {
-                Dataset.Remove(DicomTag.QueryRetrieveLevel);
-                if (value != DicomQueryRetrieveLevel.Worklist) Dataset.Add(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+                switch (value)
+                {
+                    case DicomQueryRetrieveLevel.Patient:
+                    case DicomQueryRetrieveLevel.Study:
+                    case DicomQueryRetrieveLevel.Series:
+                    case DicomQueryRetrieveLevel.Image:
+                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+                        break;
+                    default:
+                        Dataset.Remove(DicomTag.QueryRetrieveLevel);
+                        break;
+                }
             }
         }
 

--- a/DICOM/Network/DicomQueryRetrieveLevel.cs
+++ b/DICOM/Network/DicomQueryRetrieveLevel.cs
@@ -1,18 +1,45 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System;
+
 namespace Dicom.Network
 {
+    /// <summary>
+    /// Query&#47;Retrieve level of DICOM command messages, applicable to C-FIND, C-GET and C-MOVE.
+    /// <seealso cref="DicomTag.QueryRetrieveLevel"/>
+    /// </summary>
     public enum DicomQueryRetrieveLevel
     {
+        /// <summary>
+        /// Patient level, associated with Patient Q&#47;R queries.
+        /// </summary>
         Patient,
 
+        /// <summary>
+        /// Study level, associated with Study Q&#47;R queries.
+        /// </summary>
         Study,
 
+        /// <summary>
+        /// Series level, associated with Study Q&#47;R queries.
+        /// </summary>
         Series,
 
+        /// <summary>
+        /// Image level, associated with Study Q&#47;R queries.
+        /// </summary>
         Image,
 
-        Worklist
+        /// <summary>
+        /// Worklist level.
+        /// </summary>
+        [Obsolete("Artificial Q/R level, use DicomQueryRetrieveLevel.NotApplicable instead.")]
+        Worklist,
+
+        /// <summary>
+        /// Q&#47;R level not applicable in given context.
+        /// </summary>
+        NotApplicable = -1
     }
 }

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -166,8 +166,10 @@
     <Compile Include="IO\Reader\DicomDatasetReaderObserverTest.cs" />
     <Compile Include="Media\DicomFileScannerTest.cs" />
     <Compile Include="Network\DicomCEchoProviderTest.cs" />
+    <Compile Include="Network\DicomCFindRequestTest.cs" />
     <Compile Include="Network\DicomCGetRequestTest.cs" />
     <Compile Include="Network\DicomClientTest.cs" />
+    <Compile Include="Network\DicomCMoveRequestTest.cs" />
     <Compile Include="Network\DicomStatusTest.cs" />
     <Compile Include="Network\DicomNCreateRequestTest.cs" />
     <Compile Include="Network\DicomNCreateResponseTest.cs" />

--- a/Tests/Desktop/Network/DicomCFindRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCFindRequestTest.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace Dicom.Network
+{
+    public class DicomCFindRequestTest
+    {
+        #region Unit Tests
+
+        [Theory, MemberData(nameof(AffectedSopClassUids))]
+        public void Constructor_AffectedSopClassUid_ThrowWhenNotSupported(DicomUID affectedSopClassUid, bool throws)
+        {
+            var exception = Record.Exception(() => new DicomCFindRequest(affectedSopClassUid));
+            Assert.Equal(throws, exception != null);
+        }
+
+        [Theory, MemberData(nameof(InstancesLevels))]
+        public void Level_Getter_ReturnsCorrectQueryRetrieveLevel(DicomCFindRequest request, DicomQueryRetrieveLevel expected)
+        {
+            var actual = request.Level;
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+
+        #region Support Data
+
+        public static readonly IEnumerable<object[]> AffectedSopClassUids = new[]
+        {
+            new object[] { DicomUID.PatientRootQueryRetrieveInformationModelFIND, true },
+            new object[] { DicomUID.StudyRootQueryRetrieveInformationModelFIND, true },
+            new object[] { DicomUID.ModalityWorklistInformationModelFIND, false },
+            new object[] { DicomUID.UnifiedProcedureStepPullSOPClass, false },
+            new object[] { DicomUID.UnifiedProcedureStepWatchSOPClass, false },
+            new object[] { DicomUID.UnifiedProcedureStepPushSOPClass, true }
+        };
+
+        public static readonly IEnumerable<object[]> InstancesLevels = new[]
+        {
+            new object[] { DicomCFindRequest.CreatePatientQuery("Doe^John"), DicomQueryRetrieveLevel.Patient },
+            new object[] { DicomCFindRequest.CreateStudyQuery("Doe^John"), DicomQueryRetrieveLevel.Study },
+            new object[] { DicomCFindRequest.CreateSeriesQuery("1.2.3"), DicomQueryRetrieveLevel.Series },
+            new object[] { DicomCFindRequest.CreateImageQuery("1.2.3", "2.3.4"), DicomQueryRetrieveLevel.Image },
+            new object[] { DicomCFindRequest.CreateWorklistQuery(), DicomQueryRetrieveLevel.NotApplicable },
+            new object[] { new DicomCFindRequest(DicomQueryRetrieveLevel.Patient), DicomQueryRetrieveLevel.Patient },
+            new object[] { new DicomCFindRequest(DicomQueryRetrieveLevel.Study), DicomQueryRetrieveLevel.Study },
+            new object[] { new DicomCFindRequest(DicomQueryRetrieveLevel.Series), DicomQueryRetrieveLevel.Series },
+            new object[] { new DicomCFindRequest(DicomQueryRetrieveLevel.Image), DicomQueryRetrieveLevel.Image },
+            new object[] { new DicomCFindRequest(DicomQueryRetrieveLevel.Worklist), DicomQueryRetrieveLevel.NotApplicable },
+            new object[] { new DicomCFindRequest(DicomUID.ModalityWorklistInformationModelFIND), DicomQueryRetrieveLevel.NotApplicable },
+            new object[] { new DicomCFindRequest(DicomUID.UnifiedProcedureStepPullSOPClass), DicomQueryRetrieveLevel.NotApplicable },
+            new object[] { new DicomCFindRequest(DicomUID.UnifiedProcedureStepWatchSOPClass), DicomQueryRetrieveLevel.NotApplicable }
+        };
+
+        #endregion
+    }
+}

--- a/Tests/Desktop/Network/DicomCGetRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCGetRequestTest.cs
@@ -84,6 +84,14 @@ namespace Dicom.Network
             Assert.Equal(140, counter);
         }
 
+        [Fact]
+        public void Level_GetterOnRequestCreatedFromCommand_Throws()
+        {
+            var request = new DicomCGetRequest(new DicomDataset());
+            var exception = Record.Exception(() => request.Level);
+            Assert.NotNull(exception);
+        }
+
         [Theory, MemberData(nameof(InstancesLevels))]
         public void Level_Getter_ReturnsCorrectQueryRetrieveLevel(DicomCGetRequest request, DicomQueryRetrieveLevel expected)
         {

--- a/Tests/Desktop/Network/DicomCGetRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCGetRequestTest.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Collections.Generic;
+using System.Threading;
+
+using Xunit;
+
 namespace Dicom.Network
 {
-    using System.Threading;
-
-    using Xunit;
-
     public class DicomCGetRequestTest
     {
+        #region Unit tests
+
         [Fact(Skip = "Require running Q/R SCP containing CT-MONO2-16-ankle image")]
         public void DicomCGetRequest_OneImageInSeries_Received()
         {
@@ -80,5 +83,25 @@ namespace Dicom.Network
 
             Assert.Equal(140, counter);
         }
+
+        [Theory, MemberData(nameof(InstancesLevels))]
+        public void Level_Getter_ReturnsCorrectQueryRetrieveLevel(DicomCGetRequest request, DicomQueryRetrieveLevel expected)
+        {
+            var actual = request.Level;
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+
+        #region Support Data
+
+        public static readonly IEnumerable<object[]> InstancesLevels = new[] 
+        {
+            new object[] { new DicomCGetRequest("1.2.3"), DicomQueryRetrieveLevel.Study },
+            new object[] { new DicomCGetRequest("1.2.3", "2.3.4"), DicomQueryRetrieveLevel.Series },
+            new object[] { new DicomCGetRequest("1.2.3", "2.3.4", "3.4.5"), DicomQueryRetrieveLevel.Image },
+        };
+
+        #endregion
     }
 }

--- a/Tests/Desktop/Network/DicomCMoveRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCMoveRequestTest.cs
@@ -12,6 +12,14 @@ namespace Dicom.Network
     {
         #region Unit Tests
 
+        [Fact]
+        public void Level_GetterOnRequestCreatedFromCommand_Throws()
+        {
+            var request = new DicomCMoveRequest(new DicomDataset());
+            var exception = Record.Exception(() => request.Level);
+            Assert.NotNull(exception);
+        }
+
         [Theory, MemberData(nameof(InstancesLevels))]
         public void Level_Getter_ReturnsCorrectQueryRetrieveLevel(DicomCMoveRequest request, DicomQueryRetrieveLevel expected)
         {

--- a/Tests/Desktop/Network/DicomCMoveRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCMoveRequestTest.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Collections.Generic;
+using System.Threading;
+
+using Xunit;
+
+namespace Dicom.Network
+{
+    public class DicomCMoveRequestTest
+    {
+        #region Unit Tests
+
+        [Theory, MemberData(nameof(InstancesLevels))]
+        public void Level_Getter_ReturnsCorrectQueryRetrieveLevel(DicomCMoveRequest request, DicomQueryRetrieveLevel expected)
+        {
+            var actual = request.Level;
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
+
+        #region Support Data
+
+        public static readonly IEnumerable<object[]> InstancesLevels = new[]
+        {
+            new object[] { new DicomCMoveRequest("SOMESCP", "2.3.4"), DicomQueryRetrieveLevel.Study },
+            new object[] { new DicomCMoveRequest("SOMESCP", "2.3.4", "3.4.5"), DicomQueryRetrieveLevel.Series },
+            new object[] { new DicomCMoveRequest("SOMESCP", "2.3.4", "3.4.5", "4.5.6"), DicomQueryRetrieveLevel.Image },
+        };
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #540 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- New constructor in `DicomCFindRequest` taking an *Affected SOP Class UID* argument, for explicit usage in *Unified Procedure Step* and *Modality Worklist* queries.
- Added `DicomQueryRetrieveLevel.NotApplicable` enum to be associated with *Unified Procedure Step* and *Modality Worklist* queries.
- Declared `DicomQueryRetrieveLevel.Worklist` obsolete.
- `Level` getter in `DicomCFindRequest` returns `NotApplicable` for *Unified Procedure Step* and *Modality Worklist* queries.
