### PR TITLE
Make use of .NET 4.6 support in Unity build. Connected to #560

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 * Private group not added to tag when private tag item is added to dataset (#570 #577)
 * ReceivingApplicationEntityTitle and SendingApplicationEntityTitle omitted during Save (#563 #569)
 * Downgrade desktop libraries to framework version 4.5 (#561 #562)
+* Add support for Unity 2017.1 platform (#560 #585)
 * DicomImage is not thread safe (#552 #582)
 * DicomUIDGenerator.Generate UID Collisions (Non-unique UIDs) (#546 #571)
 * Correct interpolation of rescaled overlay graphics (#545 #558)

--- a/DICOM.Unity.sln
+++ b/DICOM.Unity.sln
@@ -9,8 +9,11 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "DICOM.Shared", "DICOM\DICOM
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DICOM.Hololens", "Platform\Hololens\DICOM.Hololens.csproj", "{7656C9EE-4DAE-4E51-BD52-A17FFA8875D8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DICOM.Unity2017", "Platform\Unity2017\DICOM.Unity2017.csproj", "{405F0C04-33D4-445D-82E3-50EB64175E78}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		DICOM\DICOM.Shared.projitems*{405f0c04-33d4-445d-82e3-50eb64175e78}*SharedItemsImports = 4
 		DICOM\DICOM.Shared.projitems*{7656c9ee-4dae-4e51-bd52-a17ffa8875d8}*SharedItemsImports = 4
 		DICOM\DICOM.Shared.projitems*{e51c520c-dcbc-472d-ab81-ddfa29a704de}*SharedItemsImports = 4
 		DICOM\DICOM.Shared.projitems*{f9539369-1ad0-43b0-a35c-b82f6755c247}*SharedItemsImports = 13
@@ -58,6 +61,22 @@ Global
 		{7656C9EE-4DAE-4E51-BD52-A17FFA8875D8}.Release|x64.Build.0 = Release|x64
 		{7656C9EE-4DAE-4E51-BD52-A17FFA8875D8}.Release|x86.ActiveCfg = Release|x86
 		{7656C9EE-4DAE-4E51-BD52-A17FFA8875D8}.Release|x86.Build.0 = Release|x86
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|ARM.Build.0 = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|x64.Build.0 = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Debug|x86.Build.0 = Debug|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|ARM.ActiveCfg = Release|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|ARM.Build.0 = Release|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|x64.ActiveCfg = Release|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|x64.Build.0 = Release|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|x86.ActiveCfg = Release|Any CPU
+		{405F0C04-33D4-445D-82E3-50EB64175E78}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DICOM/Imaging/Codec/DicomJpegLsLosslessCodec.cs
+++ b/DICOM/Imaging/Codec/DicomJpegLsLosslessCodec.cs
@@ -18,7 +18,7 @@ namespace Dicom.Imaging.Codec
             DicomPixelData newPixelData,
             DicomCodecParams parameters)
         {
-#if NETFX_CORE
+#if NETFX_CORE && !HOLOLENS
             DicomJpegLsNativeCodec.Encode(
                 oldPixelData.ToNativePixelData(),
                 newPixelData.ToNativePixelData(),
@@ -33,7 +33,7 @@ namespace Dicom.Imaging.Codec
             DicomPixelData newPixelData,
             DicomCodecParams parameters)
         {
-#if NETFX_CORE
+#if NETFX_CORE && !HOLOLENS
             DicomJpegLsNativeCodec.Decode(
                 oldPixelData.ToNativePixelData(),
                 newPixelData.ToNativePixelData(),

--- a/DICOM/Imaging/Codec/DicomJpegLsNearLosslessCodec.cs
+++ b/DICOM/Imaging/Codec/DicomJpegLsNearLosslessCodec.cs
@@ -18,7 +18,7 @@ namespace Dicom.Imaging.Codec
             DicomPixelData newPixelData,
             DicomCodecParams parameters)
         {
-#if NETFX_CORE
+#if NETFX_CORE && !HOLOLENS
             DicomJpegLsNativeCodec.Encode(
                 oldPixelData.ToNativePixelData(),
                 newPixelData.ToNativePixelData(),
@@ -33,7 +33,7 @@ namespace Dicom.Imaging.Codec
             DicomPixelData newPixelData,
             DicomCodecParams parameters)
         {
-#if NETFX_CORE
+#if NETFX_CORE && !HOLOLENS
             DicomJpegLsNativeCodec.Decode(
                 oldPixelData.ToNativePixelData(),
                 newPixelData.ToNativePixelData(),

--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -304,14 +304,15 @@ namespace Dicom.Imaging
             bool create;
             lock (_lock) create = _pipeline == null;
 
-            var tuple = create ? CreatePipeline(_dataset, _pixelData) : null;
+            var tuple = create ? CreatePipelineData(_dataset, _pixelData) : null;
 
             lock (_lock)
             {
                 if (_pipeline == null)
                 {
-                    _pipeline = tuple.Item1;
-                    _renderOptions = tuple.Item2;
+                    // ReSharper disable once PossibleNullReferenceException
+                    _pipeline = tuple.Pipeline;
+                    _renderOptions = tuple.RenderOptions;
                 }
             }
         }
@@ -397,7 +398,7 @@ namespace Dicom.Imaging
         /// Create image rendering pipeline according to the <see cref="DicomPixelData.PhotometricInterpretation">photometric interpretation</see>
         /// of the pixel data.
         /// </summary>
-        private static Tuple<IPipeline, GrayscaleRenderOptions> CreatePipeline(DicomDataset dataset, DicomPixelData pixelData)
+        private static PipelineData CreatePipelineData(DicomDataset dataset, DicomPixelData pixelData)
         {
             var pi = pixelData.PhotometricInterpretation;
             var samples = dataset.Get<ushort>(DicomTag.SamplesPerPixel, 0, 0);
@@ -449,7 +450,22 @@ namespace Dicom.Imaging
                 throw new DicomImagingException("Unsupported pipeline photometric interpretation: {0}", pi);
             }
 
-            return Tuple.Create(pipeline, renderOptions);
+            return new PipelineData { Pipeline = pipeline, RenderOptions = renderOptions };
+        }
+
+        #endregion
+
+        #region INNER TYPES
+
+        private class PipelineData
+        {
+            #region PROPERTIES
+
+            internal IPipeline Pipeline { get; set; }
+
+            internal GrayscaleRenderOptions RenderOptions { get; set; }
+
+            #endregion
         }
 
         #endregion

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Text;
+
+#if !NET35
 using System.Threading.Tasks;
+#endif
 
 using Dicom.Log;
 
@@ -25,6 +28,7 @@ namespace Dicom.Network
         {
         }
 
+#if !NET35
         /// <inheritdoc />
         public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
         {
@@ -43,6 +47,7 @@ namespace Dicom.Network
         {
             return SendAssociationReleaseResponseAsync();
         }
+#endif
 
         /// <inheritdoc />
         public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)

--- a/DICOM/Network/IDicomServiceProvider.cs
+++ b/DICOM/Network/IDicomServiceProvider.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+#if !NET35
 using System.Threading.Tasks;
+#endif
 
 namespace Dicom.Network
 {
@@ -10,6 +12,7 @@ namespace Dicom.Network
     /// </summary>
     public interface IDicomServiceProvider : IDicomService
     {
+#if !NET35
         /// <summary>
         /// Callback to invoke when receiving an association request.
         /// </summary>
@@ -20,5 +23,6 @@ namespace Dicom.Network
         /// Callback to invoke when receiving an association release request.
         /// </summary>
         Task OnReceiveAssociationReleaseRequestAsync();
+#endif
     }
 }

--- a/DICOM/Network/IDicomServiceRunner.cs
+++ b/DICOM/Network/IDicomServiceRunner.cs
@@ -1,7 +1,9 @@
 // Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+#if !NET35
 using System.Threading.Tasks;
+#endif
 
 namespace Dicom.Network
 {
@@ -10,10 +12,12 @@ namespace Dicom.Network
     /// </summary>
     public interface IDicomServiceRunner
     {
+#if !NET35
         /// <summary>
         /// Setup long-running operations that the DICOM service manages.
         /// </summary>
         /// <returns>Awaitable task maintaining the long-running operation(s).</returns>
         Task RunAsync();
+#endif
     }
 }

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -406,10 +406,12 @@ namespace Dicom.Network
 
         #region EVENTS
 
+#if !NET35
         /// <summary>
         /// Event to handle unsupported PDU bytes.
         /// </summary>
         public event PDUBytesHandler HandlePDUBytes;
+#endif
 
         #endregion
 
@@ -635,6 +637,7 @@ namespace Dicom.Network
                         }
                         else
                         {
+#if !NET35
                             if (HandlePDUBytes != null)
                             {
                                 HandlePDUBytes(raw.ReadBytes("Unhandled User Item", ul));
@@ -643,6 +646,9 @@ namespace Dicom.Network
                             {
                                 raw.SkipBytes("Unhandled User Item", ul);
                             }
+#else
+                            raw.SkipBytes("Unhandled User Item", ul);
+#endif
                         }
                     }
                 }

--- a/Platform/Desktop/Properties/AssemblyInfo.cs
+++ b/Platform/Desktop/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Runtime.CompilerServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Dicom.Platform")]
-[assembly: AssemblyDescription(".NET specific assembly for fo-dicom")]
+[assembly: AssemblyTitle("Dicom.Core")]
+[assembly: AssemblyDescription("Platform specific assembly for fo-dicom")]
 [assembly: AssemblyConfiguration("")]
 
 [assembly: InternalsVisibleTo("DICOM [Unit Tests], PublicKey=" +

--- a/Platform/Hololens/DICOM.Hololens.csproj
+++ b/Platform/Hololens/DICOM.Hololens.csproj
@@ -107,6 +107,33 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpeg2000CodecImpl.cs">
+      <Link>Imaging\Codec\DicomJpeg2000CodecImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpeg2000LosslessCodec.cs">
+      <Link>Imaging\Codec\DicomJpeg2000LosslessCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpeg2000LossyCodec.cs">
+      <Link>Imaging\Codec\DicomJpeg2000LossyCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegCodecImpl.cs">
+      <Link>Imaging\Codec\DicomJpegCodecImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegLsCodecImpl.cs">
+      <Link>Imaging\Codec\DicomJpegLsCodecImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegLsLosslessCodec.cs">
+      <Link>Imaging\Codec\DicomJpegLsLosslessCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegLsNearLosslessCodec.cs">
+      <Link>Imaging\Codec\DicomJpegLsNearLosslessCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegProcess1Codec.Mono.cs">
+      <Link>Imaging\Codec\DicomJpegProcess1Codec.Mono.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegProcess4Codec.Mono.cs">
+      <Link>Imaging\Codec\DicomJpegProcess4Codec.Mono.cs</Link>
+    </Compile>
     <Compile Include="..\..\dicom\imaging\codec\DicomRleCodecImpl.Mono.cs">
       <Link>Imaging\Codec\DicomRleCodecImpl.Mono.cs</Link>
     </Compile>
@@ -130,6 +157,15 @@
     </Compile>
     <Compile Include="..\..\DICOM\IO\DesktopPath.cs">
       <Link>IO\DesktopPath.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Network\WindowsNetworkListener.cs">
+      <Link>Network\WindowsNetworkListener.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Network\WindowsNetworkManager.cs">
+      <Link>Network\WindowsNetworkManager.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Network\WindowsNetworkStream.cs">
+      <Link>Network\WindowsNetworkStream.cs</Link>
     </Compile>
     <Compile Include="..\..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>

--- a/Platform/Hololens/project.json
+++ b/Platform/Hololens/project.json
@@ -1,6 +1,9 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.3"
+    "cscharls": "0.1.1",
+    "CSJ2K": "3.0.0-alpha",
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.3",
+    "Portable.LibJpeg.NET": "1.5.1.1"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Platform/Unity2017/DICOM.Unity2017.csproj
+++ b/Platform/Unity2017/DICOM.Unity2017.csproj
@@ -34,6 +34,10 @@
       <HintPath>..\..\packages\Portable.LibJpeg.NET.1.5.1.1\lib\netstandard1.0\BitMiracle.LibJpeg.NetCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="cscharls, Version=0.1.0.0, Culture=neutral, PublicKeyToken=982ce2dbcc5f1651, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\cscharls.0.1.1\lib\net452\cscharls.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="CSJ2K, Version=2.8.0.0, Culture=neutral, PublicKeyToken=0ca7be2ec378a773, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CSJ2K.3.0.0-alpha\lib\net40-client\CSJ2K.dll</HintPath>
       <Private>True</Private>
@@ -63,6 +67,15 @@
     </Compile>
     <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegCodecImpl.cs">
       <Link>Imaging\Codec\DicomJpegCodecImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegLsCodecImpl.cs">
+      <Link>Imaging\Codec\DicomJpegLsCodecImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegLsLosslessCodec.cs">
+      <Link>Imaging\Codec\DicomJpegLsLosslessCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegLsNearLosslessCodec.cs">
+      <Link>Imaging\Codec\DicomJpegLsNearLosslessCodec.cs</Link>
     </Compile>
     <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegProcess1Codec.Mono.cs">
       <Link>Imaging\Codec\DicomJpegProcess1Codec.Mono.cs</Link>

--- a/Platform/Unity2017/DICOM.Unity2017.csproj
+++ b/Platform/Unity2017/DICOM.Unity2017.csproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{405F0C04-33D4-445D-82E3-50EB64175E78}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Dicom</RootNamespace>
+    <AssemblyName>Dicom.Core</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BitMiracle.LibJpeg.NetCore, Version=1.5.1.0, Culture=neutral, PublicKeyToken=d69f732e552243f5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Portable.LibJpeg.NET.1.5.1.1\lib\netstandard1.0\BitMiracle.LibJpeg.NetCore.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="CSJ2K, Version=2.8.0.0, Culture=neutral, PublicKeyToken=0ca7be2ec378a773, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CSJ2K.3.0.0-alpha\lib\net40-client\CSJ2K.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpeg2000CodecImpl.cs">
+      <Link>Imaging\Codec\DicomJpeg2000CodecImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpeg2000LosslessCodec.cs">
+      <Link>Imaging\Codec\DicomJpeg2000LosslessCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpeg2000LossyCodec.cs">
+      <Link>Imaging\Codec\DicomJpeg2000LossyCodec.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegCodecImpl.cs">
+      <Link>Imaging\Codec\DicomJpegCodecImpl.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegProcess1Codec.Mono.cs">
+      <Link>Imaging\Codec\DicomJpegProcess1Codec.Mono.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomJpegProcess4Codec.Mono.cs">
+      <Link>Imaging\Codec\DicomJpegProcess4Codec.Mono.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\DicomRleCodecImpl.Mono.cs">
+      <Link>Imaging\Codec\DicomRleCodecImpl.Mono.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\Codec\MonoTranscoderManager.cs">
+      <Link>Imaging\Codec\MonoTranscoderManager.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\UnityImage.cs">
+      <Link>Imaging\UnityImage.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Imaging\UnityImageManager.cs">
+      <Link>Imaging\UnityImageManager.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\IO\DesktopDirectoryReference.cs">
+      <Link>IO\DesktopDirectoryReference.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\IO\DesktopFileReference.cs">
+      <Link>IO\DesktopFileReference.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\IO\DesktopIOManager.cs">
+      <Link>IO\DesktopIOManager.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\IO\DesktopPath.cs">
+      <Link>IO\DesktopPath.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Log\ConsoleExtensions.cs">
+      <Link>Log\ConsoleExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Log\ConsoleLogger.cs">
+      <Link>Log\ConsoleLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Network\DesktopNetworkListener.cs">
+      <Link>Network\DesktopNetworkListener.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Network\DesktopNetworkManager.cs">
+      <Link>Network\DesktopNetworkManager.cs</Link>
+    </Compile>
+    <Compile Include="..\..\DICOM\Network\DesktopNetworkStream.cs">
+      <Link>Network\DesktopNetworkStream.cs</Link>
+    </Compile>
+    <Compile Include="..\..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\Desktop\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="..\..\DICOM\DICOM.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Platform/Unity2017/DICOM.Unity2017.csproj
+++ b/Platform/Unity2017/DICOM.Unity2017.csproj
@@ -44,6 +44,9 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\..\..\..\..\Program Files\Unity 2017.1.0f3\Editor\Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Platform/Unity2017/packages.config
+++ b/Platform/Unity2017/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="cscharls" version="0.1.1" targetFramework="net46" />
   <package id="CSJ2K" version="3.0.0-alpha" targetFramework="net46" />
   <package id="Portable.LibJpeg.NET" version="1.5.1.1" targetFramework="net46" />
 </packages>

--- a/Platform/Unity2017/packages.config
+++ b/Platform/Unity2017/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CSJ2K" version="3.0.0-alpha" targetFramework="net46" />
+  <package id="Portable.LibJpeg.NET" version="1.5.1.1" targetFramework="net46" />
+</packages>


### PR DESCRIPTION
Fixes #560 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Added separate project for compiling a Unity build targeting Unity 2017.1 and later Mono 4.6 (experimental) support, allowing for asynchronous and network operations on Unity.
- Updated Hololens project to support networking and compressed codecs.
- Minor refactorings to allow .NET 3.5 based Unity project to build, given the recent commits on asynchronous networking and multithreaded imaging.
