### PR TITLE
Compare C-STORE transfer syntax against all proposed syntaxes in presentation context. Connected to #590 Connected to #543

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@
 * DicomUIDGenerator.Generate UID Collisions (Non-unique UIDs) (#546 #571)
 * Correct interpolation of rescaled overlay graphics (#545 #558)
 * Some getters of optional sequences do not account for missing sequence (#544 #572)
-* A-ASSOCIATE-AC PDU parsing incorrect (#543 #583)
+* A-ASSOCIATE-AC PDU parsing incorrect (#543 #583 #590 #591)
 * DicomCFindRequest is unsuitable for "Search for Unified Procedure Step (C-FIND)" (#540 #580)
 * Private tag is listed out or order (#535 #566)
 * JsonDicomConverter.ParseTag is very slow for keyword lookups (#533 #531)

--- a/DICOM/Network/DicomPresentationContextCollection.cs
+++ b/DICOM/Network/DicomPresentationContextCollection.cs
@@ -112,7 +112,7 @@ namespace Dicom.Network
                 }
                 else
                 {
-                    pcs = pcs.Where(x => x.AcceptedTransferSyntax == cstore.TransferSyntax);
+                    pcs = pcs.Where(x => x.HasTransferSyntax(cstore.TransferSyntax));
                 }
 
                 var pc = pcs.FirstOrDefault();


### PR DESCRIPTION
Fixes #590 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Use `HasTransferSyntax` instead of equivalence comparison with (potentially `null`) `AcceptedTransferSyntax` when picking presentation context for C-STORE request.

This was an oversight when refactoring `DicomPresentationContext.AcceptedTransferSyntax` initialization in #583.
