### PR TITLE
Add non-null security profile patient name and ID after anonymization. Connected to #575

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
-#### v.3.1.0 (TBD)
+#### v.4.0.0 (TBD)
+* DicomAnonymizer ignores the PatientName and PatientID in the SecurityProfile (#575 #592)
 * Private group not added to tag when private tag item is added to dataset (#570 #577)
 * ReceivingApplicationEntityTitle and SendingApplicationEntityTitle omitted during Save (#563 #569)
 * Downgrade desktop libraries to framework version 4.5 (#561 #562)

--- a/DICOM/DicomAnonymizer.cs
+++ b/DICOM/DicomAnonymizer.cs
@@ -10,6 +10,9 @@ using System.Text.RegularExpressions;
 
 namespace Dicom
 {
+    /// <summary>
+    /// Class for performing anonymization actions on DICOM file or dataset based on selected confidentiality profile.
+    /// </summary>
     public class DicomAnonymizer
     {
         #region Fields
@@ -20,8 +23,8 @@ namespace Dicom
 
         #region Embedded types
 
-        /// <summary>Profile options as described in DICOM PS 3.15-2011</summary>
-        /// <see>ftp://medical.nema.org/medical/dicom/2011/11_15pu.pdf</see>
+        /// <summary>Profile options as described in DICOM PS 3.15</summary>
+        /// <see>http://dicom.nema.org/medical/dicom/current/output/chtml/part15/PS3.15.html</see>
         /// <remarks>The order of the flags are mapped to the profile's CSV file</remarks>
         [Flags]
         public enum SecurityProfileOptions : short
@@ -47,24 +50,40 @@ namespace Dicom
             CleanGraph = 512
         }
 
-        /// <summary>Profile actions per tag as described in DICOM PS 3.15-2011</summary>
-        /// <see>ftp://medical.nema.org/medical/dicom/2011/11_15pu.pdf</see>
+        /// <summary>Profile actions per tag as described in DICOM PS 3.15</summary>
+        /// <see>http://dicom.nema.org/medical/dicom/current/output/chtml/part15/PS3.15.html</see>
+        [Flags]
         public enum SecurityProfileActions : byte
         {
-            D = 1, // Replace with a non-zero length value that may be a dummy value and consistent with the VR
+            /// <summary>
+            /// Replace with a non-zero length value that may be a dummy value and consistent with the VR
+            /// </summary>
+            D = 1,
 
+            /// <summary>
+            /// Replace with a zero length value, or a non-zero length value that may be a dummy value and consistent with the VR
+            /// </summary>
             Z = 2,
-            // Replace with a zero length value, or a non-zero length value that may be a dummy value and consistent with the VR
 
-            X = 4, // Remove
+            /// <summary>
+            /// Remove
+            /// </summary>
+            X = 4,
 
-            K = 8, // Keep (unchanged for non-sequence attributes, cleaned for sequences)
+            /// <summary>
+            /// Keep (unchanged for non-sequence attributes, cleaned for sequences)
+            /// </summary>
+            K = 8,
 
+            /// <summary>
+            /// Clean, that is replace with values of similar meaning known not to contain identifying information and consistent with the VR
+            /// </summary>
             C = 16,
-            // Clean, that is replace with values of similar meaning known not to contain identifying information and consistent with the VR
 
-            U = 32
-            // Replace with a non-zero length UID that is internally consistent within a set of Instances            
+            /// <summary>
+            /// Replace with a non-zero length UID that is internally consistent within a set of Instances
+            /// </summary>
+            U = 32           
         }
 
         /// <summary>Security profile container</summary>
@@ -429,15 +448,6 @@ namespace Dicom
 
                 if (element == null) continue;
 
-                if (element.Tag.Equals(DicomTag.PatientName) && Profile.PatientName != null)
-                {
-                    ReplaceString(dataset, element, Profile.PatientName);
-                }
-                else if (element.Tag.Equals(DicomTag.PatientID) && Profile.PatientID != null)
-                {
-                    ReplaceString(dataset, element, Profile.PatientID);
-                }
-
                 var parenthesis = new[] { '(', ')' };
                 var tag = item.Tag.ToString().Trim(parenthesis);
                 var action = Profile.FirstOrDefault(pair => pair.Key.IsMatch(tag));
@@ -465,6 +475,15 @@ namespace Dicom
                         default:
                             throw new ArgumentOutOfRangeException();
                     }
+                }
+
+                if (element.Tag.Equals(DicomTag.PatientName) && Profile.PatientName != null)
+                {
+                    ReplaceString(dataset, element, Profile.PatientName);
+                }
+                else if (element.Tag.Equals(DicomTag.PatientID) && Profile.PatientID != null)
+                {
+                    ReplaceString(dataset, element, Profile.PatientID);
                 }
             }
 

--- a/Tests/Desktop/DicomAnonymizerTest.cs
+++ b/Tests/Desktop/DicomAnonymizerTest.cs
@@ -85,7 +85,7 @@ namespace Dicom
         [Fact]
         public void Anonymize_UsePredefinedPatientNameAndId_ShouldBeSetInAnonymizedDataset()
         {
-            const string fileName = "CT-MONO2-16-ankle";
+            const string fileName = "CT1_J2KI";
 #if NETFX_CORE
             var dataset = Dicom.Helpers.ApplicationContent.OpenDicomFileAsync($"Data/{fileName}").Result.Dataset;
 #else

--- a/Tests/Desktop/DicomAnonymizerTest.cs
+++ b/Tests/Desktop/DicomAnonymizerTest.cs
@@ -82,6 +82,31 @@ namespace Dicom
             Assert.NotEqual(expected, actualNew);
         }
 
-#endregion
+        [Fact]
+        public void Anonymize_UsePredefinedPatientNameAndId_ShouldBeSetInAnonymizedDataset()
+        {
+            const string fileName = "CT-MONO2-16-ankle";
+#if NETFX_CORE
+            var dataset = Dicom.Helpers.ApplicationContent.OpenDicomFileAsync($"Data/{fileName}").Result.Dataset;
+#else
+            var dataset = DicomFile.Open($"./Test Data/{fileName}").Dataset;
+#endif
+            const string expectedName = "fo-dicom";
+            const string expectedId = "GH-575";
+
+            var anonymizer = new DicomAnonymizer();
+            anonymizer.Profile.PatientName = expectedName;
+            anonymizer.Profile.PatientID = expectedId;
+
+            var newDataset = anonymizer.Anonymize(dataset);
+
+            var actualName = newDataset.Get<string>(DicomTag.PatientName);
+            var actualId = newDataset.Get<string>(DicomTag.PatientID);
+
+            Assert.Equal(expectedName, actualName);
+            Assert.Equal(expectedId, actualId);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #575 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add non-null security profile patient name and ID after anonymization.
