### PR TITLE
Support for IPv6 server listening and generic DicomServer.Create for derived classes. Connected to #588 Connected #602

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 #### v.4.0.0 (TBD)
+* Subclassing DicomServer (#602 #604)
 * Code generator support for anonymization data (#594 #595)
+* DicomServer to listen on IPv6 socket (#588 #604)
 * DicomAnonymizer blank DicomDate/DicomDateTime to DateTime.MinValue instead of empty value (#576 #593)
 * DicomAnonymizer ignores the PatientName and PatientID in the SecurityProfile (#575 #592)
 * Private group not added to tag when private tag item is added to dataset (#570 #577)

--- a/DICOM/Network/DesktopNetworkManager.cs
+++ b/DICOM/Network/DesktopNetworkManager.cs
@@ -36,9 +36,7 @@ namespace Dicom.Network
 
         #region PROPERTIES
 
-        /// <summary>
-        /// Implementation of the machine name getter.
-        /// </summary>
+        /// <inheritdoc />
         protected override string MachineNameImpl
         {
             get
@@ -55,37 +53,19 @@ namespace Dicom.Network
 
         #region METHODS
 
-        /// <summary>
-        /// Platform-specific implementation to create a network listener object.
-        /// </summary>
-        /// <param name="port">Network port to listen to.</param>
-        /// <returns>Network listener implementation.</returns>
-        protected override INetworkListener CreateNetworkListenerImpl(int port)
+        /// <inheritdoc />
+        protected override INetworkListener CreateNetworkListenerImpl(string ipAddress, int port)
         {
-            return new DesktopNetworkListener(port);
+            return new DesktopNetworkListener(ipAddress, port);
         }
 
-        /// <summary>
-        /// Platform-specific implementation to create a network stream object.
-        /// </summary>
-        /// <param name="host">Network host.</param>
-        /// <param name="port">Network port.</param>
-        /// <param name="useTls">Use TLS layer?</param>
-        /// <param name="noDelay">No delay?</param>
-        /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
-        /// <returns>Network stream implementation.</returns>
+        /// <inheritdoc />
         protected override INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
             return new DesktopNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
 
-        /// <summary>
-        /// Platform-specific implementation to check whether specified <paramref name="exception"/> represents a socket exception.
-        /// </summary>
-        /// <param name="exception">Exception to validate.</param>
-        /// <param name="errorCode">Error code, valid if <paramref name="exception"/> is socket exception.</param>
-        /// <param name="errorDescriptor">Error descriptor, valid if <paramref name="exception"/> is socket exception.</param>
-        /// <returns>True if <paramref name="exception"/> is socket exception, false otherwise.</returns>
+        /// <inheritdoc />
         protected override bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor)
         {
             var socketEx = exception as SocketException;
@@ -105,11 +85,7 @@ namespace Dicom.Network
             return false;
         }
 
-        /// <summary>
-        /// Platform-specific implementation to attempt to obtain a unique network identifier, e.g. based on a MAC address.
-        /// </summary>
-        /// <param name="identifier">Unique network identifier, if found.</param>
-        /// <returns>True if network identifier could be obtained, false otherwise.</returns>
+        /// <inheritdoc />
         protected override bool TryGetNetworkIdentifierImpl(out DicomUID identifier)
         {
             var interfaces = NetworkInterface.GetAllNetworkInterfaces();

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -36,8 +36,6 @@ namespace Dicom.Network
 
         private string _certificateName;
 
-        private DicomServiceOptions _options;
-
         private Encoding _fallbackEncoding;
 
         private bool _isIpAddressSet;
@@ -113,6 +111,8 @@ namespace Dicom.Network
         /// <inheritdoc />
         public Exception Exception { get; protected set; }
 
+        public DicomServiceOptions Options { get; protected set; }
+
         /// <inheritdoc />
         public Logger Logger
         {
@@ -133,7 +133,7 @@ namespace Dicom.Network
         {
             get
             {
-                var maxClientsAllowed = _options?.MaxClientsAllowed ?? DicomServiceOptions.Default.MaxClientsAllowed;
+                var maxClientsAllowed = Options?.MaxClientsAllowed ?? DicomServiceOptions.Default.MaxClientsAllowed;
                 return maxClientsAllowed > 0 && _services.Count >= maxClientsAllowed;
             }
         }
@@ -155,7 +155,8 @@ namespace Dicom.Network
             IPAddress = string.IsNullOrEmpty(ipAddress?.Trim()) ? NetworkManager.IPv4Any : ipAddress;
             Port = port;
 
-            _options = options;
+            Options = options;
+
             _userState = userState;
             _certificateName = certificateName;
             _fallbackEncoding = fallbackEncoding;
@@ -228,7 +229,7 @@ namespace Dicom.Network
             INetworkListener listener = null;
             try
             {
-                var noDelay = _options?.TcpNoDelay ?? DicomServiceOptions.Default.TcpNoDelay;
+                var noDelay = Options?.TcpNoDelay ?? DicomServiceOptions.Default.TcpNoDelay;
 
                 listener = NetworkManager.CreateNetworkListener(IPAddress, Port);
                 await listener.StartAsync().ConfigureAwait(false);
@@ -245,9 +246,9 @@ namespace Dicom.Network
                     if (networkStream != null)
                     {
                         var scp = CreateScp(networkStream);
-                        if (_options != null)
+                        if (Options != null)
                         {
-                            scp.Options = _options;
+                            scp.Options = Options;
                         }
 
                         _services.Add(scp.RunAsync());

--- a/DICOM/Network/IDicomServer.cs
+++ b/DICOM/Network/IDicomServer.cs
@@ -52,13 +52,13 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="ipAddress">IP address(es) for the server to listen to.</param>
         /// <param name="port">Port to which the servier should be litening.</param>
-        /// <param name="userState">User state to be shared with the connected services.</param>
         /// <param name="certificateName">Certificate name for secure connections.</param>
-        /// <param name="options">Service options.</param>
         /// <param name="fallbackEncoding">Encoding to apply if no encoding is identified.</param>
+        /// <param name="options">Service options.</param>
+        /// <param name="userState">User state to be shared with the connected services.</param>
         /// <returns>Awaitable <see cref="Task"/>.</returns>
-        Task StartAsync(string ipAddress, int port, object userState, string certificateName,
-            DicomServiceOptions options, Encoding fallbackEncoding);
+        Task StartAsync(string ipAddress, int port, string certificateName, Encoding fallbackEncoding,
+            DicomServiceOptions options, object userState);
 
         /// <summary>
         /// Stop server from further listening.

--- a/DICOM/Network/IDicomServer.cs
+++ b/DICOM/Network/IDicomServer.cs
@@ -39,6 +39,12 @@ namespace Dicom.Network
         Exception Exception { get; }
 
         /// <summary>
+        /// Gets the options to control behavior of <see cref="DicomService"/> base class.
+        /// Gets the port to which the server is listening.
+        /// </summary>
+        DicomServiceOptions Options { get; }
+
+        /// <summary>
         /// Gets the logger used by <see cref="DicomServer{T}"/>
         /// </summary>
         Logger Logger { get; set; }

--- a/DICOM/Network/IDicomServer.cs
+++ b/DICOM/Network/IDicomServer.cs
@@ -18,6 +18,11 @@ namespace Dicom.Network
         #region PROPERTIES
 
         /// <summary>
+        /// Gets the IP address(es) the server listens to.
+        /// </summary>
+        string IPAddress { get; }
+
+        /// <summary>
         /// Gets the port to which the server is listening.
         /// </summary>
         int Port { get; }

--- a/DICOM/Network/IDicomServer.cs
+++ b/DICOM/Network/IDicomServer.cs
@@ -29,11 +29,6 @@ namespace Dicom.Network
         int Port { get; }
 
         /// <summary>
-        /// Gets the logger used by <see cref="DicomServer{T}"/>
-        /// </summary>
-        Logger Logger { get; set; }
-
-        /// <summary>
         /// Gets a value indicating whether the server is actively listening for client connections.
         /// </summary>
         bool IsListening { get; }
@@ -44,16 +39,16 @@ namespace Dicom.Network
         Exception Exception { get; }
 
         /// <summary>
-        /// Gets the <see cref="Task"/> managing the background listening and unused client removal processes.
+        /// Gets the logger used by <see cref="DicomServer{T}"/>
         /// </summary>
-        Task BackgroundWorker { get; }
+        Logger Logger { get; set; }
 
         #endregion
 
         #region METHODS
 
         /// <summary>
-        /// Starts the DICOM server.
+        /// Starts the DICOM server listening for connections on the specified IP address(es) and port.
         /// </summary>
         /// <param name="ipAddress">IP address(es) for the server to listen to.</param>
         /// <param name="port">Port to which the servier should be litening.</param>
@@ -61,9 +56,9 @@ namespace Dicom.Network
         /// <param name="certificateName">Certificate name for secure connections.</param>
         /// <param name="options">Service options.</param>
         /// <param name="fallbackEncoding">Encoding to apply if no encoding is identified.</param>
-        /// <returns>Await:able instance.</returns>
+        /// <returns>Awaitable <see cref="Task"/>.</returns>
         Task StartAsync(string ipAddress, int port, object userState, string certificateName,
-            DicomServiceOptions options, Encoding fallbackEncoding = null);
+            DicomServiceOptions options, Encoding fallbackEncoding);
 
         /// <summary>
         /// Stop server from further listening.
@@ -72,6 +67,15 @@ namespace Dicom.Network
 
         #endregion
     }
+
+    /// <summary>
+    /// Helper interface to ensure type safety when creating DICOM server objects via <code>DicomServer.Create</code> overloads.
+    /// </summary>
+    /// <typeparam name="T">DICOM service class consumed by the DICOM server object.</typeparam>
+    public interface IDicomServer<T> : IDicomServer where T : DicomService, IDicomServiceProvider
+    {
+    }
+
 }
 
 #endif

--- a/DICOM/Network/IDicomServer.cs
+++ b/DICOM/Network/IDicomServer.cs
@@ -4,6 +4,7 @@
 #if !NET35
 
 using System;
+using System.Text;
 using System.Threading.Tasks;
 
 using Dicom.Log;
@@ -30,12 +31,7 @@ namespace Dicom.Network
         /// <summary>
         /// Gets the logger used by <see cref="DicomServer{T}"/>
         /// </summary>
-        Logger Logger { get; }
-
-        /// <summary>
-        /// Gets the options to control behavior of <see cref="DicomService"/> base class.
-        /// </summary>
-        DicomServiceOptions Options { get; }
+        Logger Logger { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether the server is actively listening for client connections.
@@ -55,6 +51,19 @@ namespace Dicom.Network
         #endregion
 
         #region METHODS
+
+        /// <summary>
+        /// Starts the DICOM server.
+        /// </summary>
+        /// <param name="ipAddress">IP address(es) for the server to listen to.</param>
+        /// <param name="port">Port to which the servier should be litening.</param>
+        /// <param name="userState">User state to be shared with the connected services.</param>
+        /// <param name="certificateName">Certificate name for secure connections.</param>
+        /// <param name="options">Service options.</param>
+        /// <param name="fallbackEncoding">Encoding to apply if no encoding is identified.</param>
+        /// <returns>Await:able instance.</returns>
+        Task StartAsync(string ipAddress, int port, object userState, string certificateName,
+            DicomServiceOptions options, Encoding fallbackEncoding = null);
 
         /// <summary>
         /// Stop server from further listening.

--- a/DICOM/Network/NetworkManager.cs
+++ b/DICOM/Network/NetworkManager.cs
@@ -13,6 +13,26 @@ namespace Dicom.Network
         #region FIELDS
 
         /// <summary>
+        /// String representation of the "Any" IPv4 address, i.e. specifying the listener to listen to all applicable IPv4 addresses.
+        /// </summary>
+        public const string IPv4Any = "0.0.0.0";
+
+        /// <summary>
+        /// String representation of the "Any" IPv6 address, i.e. specifying the listener to listen to all applicable IPv6 addresses.
+        /// </summary>
+        public const string IPv6Any = "::";
+
+        /// <summary>
+        /// String representation of the "Loopback" IPv4 address, i.e. specifying the listener to listen to the local IPv4 host.
+        /// </summary>
+        public const string IPv4Loopback = "127.0.0.1";
+
+        /// <summary>
+        /// String representation of the "Loopback" IPv6 address, i.e. specifying the listener to listen to the local IPv6 host.
+        /// </summary>
+        public const string IPv6Loopback = "::1";
+
+        /// <summary>
         /// Network manager implementation in current use.
         /// </summary>
         private static NetworkManager _implementation;
@@ -57,13 +77,25 @@ namespace Dicom.Network
         }
 
         /// <summary>
-        /// Create a network listener object.
+        /// Create a network listener object, listening to all IPv4 addressess.
         /// </summary>
         /// <param name="port">Network port to listen to.</param>
         /// <returns>Network listener implementation.</returns>
+        [Obsolete("Use the CreateNetworkListener(string, int) overload with IPv4Any in string argument.")]
         public static INetworkListener CreateNetworkListener(int port)
         {
-            return _implementation.CreateNetworkListenerImpl(port);
+            return CreateNetworkListener(IPv4Any, port);
+        }
+
+        /// <summary>
+        /// Create a network listener object.
+        /// </summary>
+        /// <param name="ipAddress">IP address(es) to listen to.</param>
+        /// <param name="port">Network port to listen to.</param>
+        /// <returns>Network listener implementation.</returns>
+        public static INetworkListener CreateNetworkListener(string ipAddress, int port)
+        {
+            return _implementation.CreateNetworkListenerImpl(ipAddress, port);
         }
 
         /// <summary>
@@ -105,9 +137,10 @@ namespace Dicom.Network
         /// <summary>
         /// Platform-specific implementation to create a network listener object.
         /// </summary>
+        /// <param name="ipAddress">IP address(es) to listen to.</param>
         /// <param name="port">Network port to listen to.</param>
         /// <returns>Network listener implementation.</returns>
-        protected abstract INetworkListener CreateNetworkListenerImpl(int port);
+        protected abstract INetworkListener CreateNetworkListenerImpl(string ipAddress, int port);
 
         /// <summary>
         /// Platform-specific implementation to create a network stream object.

--- a/DICOM/Network/WindowsNetworkManager.cs
+++ b/DICOM/Network/WindowsNetworkManager.cs
@@ -38,9 +38,7 @@ namespace Dicom.Network
 
         #region PROPERTIES
 
-        /// <summary>
-        /// Implementation of the machine name getter.
-        /// </summary>
+        /// <inheritdoc />
         protected override string MachineNameImpl
         {
             get
@@ -90,37 +88,19 @@ namespace Dicom.Network
 
         #region METHODS
 
-        /// <summary>
-        /// Platform-specific implementation to create a network listener object.
-        /// </summary>
-        /// <param name="port">Network port to listen to.</param>
-        /// <returns>Network listener implementation.</returns>
-        protected override INetworkListener CreateNetworkListenerImpl(int port)
+        /// <inheritdoc />
+        protected override INetworkListener CreateNetworkListenerImpl(string ipAddress, int port)
         {
-            return new WindowsNetworkListener(port);
+            return new WindowsNetworkListener(ipAddress, port);
         }
 
-        /// <summary>
-        /// Platform-specific implementation to create a network stream object.
-        /// </summary>
-        /// <param name="host">Network host.</param>
-        /// <param name="port">Network port.</param>
-        /// <param name="useTls">Use TLS layer?</param>
-        /// <param name="noDelay">No delay?</param>
-        /// <param name="ignoreSslPolicyErrors">Ignore SSL policy errors?</param>
-        /// <returns>Network stream implementation.</returns>
+        /// <inheritdoc />
         protected override INetworkStream CreateNetworkStreamImpl(string host, int port, bool useTls, bool noDelay, bool ignoreSslPolicyErrors)
         {
             return new WindowsNetworkStream(host, port, useTls, noDelay, ignoreSslPolicyErrors);
         }
 
-        /// <summary>
-        /// Platform-specific implementation to check whether specified <paramref name="exception"/> represents a socket exception.
-        /// </summary>
-        /// <param name="exception">Exception to validate.</param>
-        /// <param name="errorCode">Error code, valid if <paramref name="exception"/> is socket exception.</param>
-        /// <param name="errorDescriptor">Error descriptor, valid if <paramref name="exception"/> is socket exception.</param>
-        /// <returns>True if <paramref name="exception"/> is socket exception, false otherwise.</returns>
+        /// <inheritdoc />
         protected override bool IsSocketExceptionImpl(Exception exception, out int errorCode, out string errorDescriptor)
         {
             var socketEx = exception as SocketException;
@@ -136,11 +116,7 @@ namespace Dicom.Network
             return false;
         }
 
-        /// <summary>
-        /// Platform-specific implementation to attempt to obtain a unique network identifier.
-        /// </summary>
-        /// <param name="identifier">Unique network identifier, if found.</param>
-        /// <returns>True if network identifier could be obtained, false otherwise.</returns>
+        /// <inheritdoc />
         protected override bool TryGetNetworkIdentifierImpl(out DicomUID identifier)
         {
             var profile = NetworkInformation.GetInternetConnectionProfile();

--- a/Tests/Desktop/Network/DicomServerTest.cs
+++ b/Tests/Desktop/Network/DicomServerTest.cs
@@ -310,7 +310,6 @@ namespace Dicom.Network
             var port = Ports.GetNext();
             using (DicomServer.Create<SimpleCStoreProvider>(NetworkManager.IPv6Any, port))
             {
-                DicomStatus status = null;
                 var request = new DicomCStoreRequest(@".\Test Data\CT-MONO2-16-ankle");
 
                 var client = new DicomClient();
@@ -328,7 +327,6 @@ namespace Dicom.Network
             var port = Ports.GetNext();
             using (DicomServer.Create<SimpleCStoreProvider>(NetworkManager.IPv4Any, port))
             {
-                DicomStatus status = null;
                 var request = new DicomCStoreRequest(@".\Test Data\CT-MONO2-16-ankle");
 
                 var client = new DicomClient();

--- a/Tests/Desktop/Network/DicomServerTest.cs
+++ b/Tests/Desktop/Network/DicomServerTest.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Linq;
 using System.Net.Sockets;
+using System.Threading;
+
+using Xunit;
 
 using Dicom.Helpers;
 
 namespace Dicom.Network
 {
-    using System.Linq;
-    using System.Threading;
-
-    using Xunit;
-
     [Collection("Network"), Trait("Category", "Network"), TestCaseOrderer("Dicom.Helpers.PriorityOrderer", "DICOM [Unit Tests]")]
     public class DicomServerTest
     {
+        #region Unit Tests
+
         [Fact]
         public void Constructor_EstablishTwoWithSamePort_ShouldYieldAccessibleException()
         {
@@ -338,5 +339,48 @@ namespace Dicom.Network
                 Assert.IsType<SocketException>(exception);
             }
         }
+
+        [Fact]
+        public void Create_SubclassedServer_SufficientlyCreated()
+        {
+            var port = Ports.GetNext();
+
+            using (var server = DicomServer.Create<DicomCEchoProvider, DicomCEchoProviderServer>(null, port))
+            {
+                Assert.IsType<DicomCEchoProviderServer>(server);
+                Assert.Equal(DicomServer.GetInstance(port), server);
+
+                var status = DicomStatus.UnrecognizedOperation;
+                var handle = new ManualResetEventSlim();
+
+                var client = new DicomClient();
+                client.AddRequest(new DicomCEchoRequest
+                {
+                    OnResponseReceived = (req, rsp) =>
+                    {
+                        status = rsp.Status;
+                        handle.Set();
+                    }
+                });
+                client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
+
+                handle.Wait(1000);
+                Assert.Equal(DicomStatus.Success, status);
+            }
+        }
+
+        #endregion
+
+        #region Support Types
+
+        public class DicomCEchoProviderServer : DicomServer<DicomCEchoProvider>
+        {
+            protected override DicomCEchoProvider CreateScp(INetworkStream stream)
+            {
+                return new DicomCEchoProvider(stream, null, null);
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #588 Fixes #602.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Added listener IP address(es) property to `IDicomServer`.
- Moved start of server listening to separate method `StartAsync`.
- Added `DicomServer.Create` overloads for handling user-defined listener IP addresses and subclassed `DicomServer<T>` implementations.

#### End-user API Changes
Type | Old | New | Comments
--- | --- | --- | ---
IDicomServer | Task BackgroundWorker<br /> { get; } | <nbsp /> | Redundant due to addition of StartAsync method
<nbsp /> | <nbsp /> | string IPAddress<br /> { get; } | IP address(es) that the server should listen to for connections
<nbsp /> | <nbsp /> | Task StartAsync(string, int, string, Encoding, DicomServiceOptions, object) | Service listening task, automatically started by DicomServer.Create overloads
IDicomServer&lt;T&gt; | <nbsp /> | <nbsp /> | New empty interface, added to register custom DICOM server objects via DicomServer.Create&lt;T, TServer&gt; method, not necessarily subclassed from DicomServer&lt;T&gt;.
DicomServer&lt;T&gt; | ctor(int port, object userState, string certificateName, DicomServiceOptions, Encoding, Logger) | ctor() | Initialization of background listener has been moved to StartAsync() method
DicomServer | <nbsp /> | IDicomServer Create&lt;T&gt;(string ipAddress, int port, object userState, string certificateName, DicomServiceOptions,  Encoding, Logger) | Enables creation of DicomServer&lt;T&gt; instance where server listens to custom network interface (IPv4Any is default when IPAddress is null)
<nbsp /> | <nbsp /> | IDicomServer Create&lt;T, TServer&gt;(string ipAddress, int port, object userState, string certificateName, DicomServiceOptions,  Encoding, Logger) | Enables creation an instance of custom DICOM server type TServer where server listens to custom network interface.<br />**Note!** TServer is required to implement a parameterless constructor.
NetworkManager | <nbsp /> | IPv4Any | IPv4 Any address (0.0.0.0)
<nbsp /> | <nbsp /> | IPv4Loopback | IPv4 Loopback address (127.0.0.1)
<nbsp /> | <nbsp /> | IPv6Any | IPv6 Any address (::)
<nbsp /> | <nbsp /> | IPv6Loopback | IPv6 Loopback address (::1)
<nbsp /> | INetworkListener CreateNetworkListener(int port) | [Obsolete]<br />INetworkListener CreateNetworkListener(int port) | Functionally replaced by overloaded method
<nbsp /> | <nbsp /> | INetworkListener CreateNetworkListener(string ipAddress, int port) | <nbsp />