### PR TITLE
Support CP-1066. Connected to #597

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 #### v.4.0.0 (TBD)
 * Subclassing DicomServer (#602 #604)
+* Support CP-1066 (#597 #606)
 * Code generator support for anonymization data (#594 #595)
 * DicomServer to listen on IPv6 socket (#588 #604)
 * DicomAnonymizer blank DicomDate/DicomDateTime to DateTime.MinValue instead of empty value (#576 #593)

--- a/DICOM/IO/Writer/DicomWriter.cs
+++ b/DICOM/IO/Writer/DicomWriter.cs
@@ -280,6 +280,12 @@ namespace Dicom.IO.Writer
 
             if (_syntax.IsExplicitVR && vr != DicomVR.NONE)
             {
+                // Comply with CP-1066 (#597)
+                if (vr.Is16bitLength && length > 0xfffe)
+                {
+                    vr = DicomVR.UN;
+                }
+
                 _target.Write((byte)vr.Code[0]);
                 _target.Write((byte)vr.Code[1]);
 

--- a/Tests/Desktop/Bugs/GH597.cs
+++ b/Tests/Desktop/Bugs/GH597.cs
@@ -31,6 +31,8 @@ namespace Dicom.Bugs
                 var file = new DicomFile(dataset);
                 file.Save(stream);
 
+                // Checking that UN value representation has been written to raw stream;
+                // when DICOM file is re-read, the value representation is automatically set to the known tag's VR.
                 stream.Seek(0, SeekOrigin.Begin);
                 var streamString = Encoding.UTF8.GetString(stream.GetBuffer());
                 Assert.True(streamString.Contains("UN"), "streamString.Contains('UN')");

--- a/Tests/Desktop/Bugs/GH597.cs
+++ b/Tests/Desktop/Bugs/GH597.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using Xunit;
+
+namespace Dicom.Bugs
+{
+    public class GH597
+    {
+        [Fact]
+        public void DicomFileSave_LargeData16BitLength_ConvertsVRToUN()
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian)
+            {
+                new DicomUniqueIdentifier(DicomTag.SOPClassUID, "1.2.3"),
+                new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.4")
+            };
+
+            const int length = 0x10000;
+            var sb = new StringBuilder();
+            sb.Append('0', length);
+            dataset.Add(DicomTag.ContourData, sb.ToString());
+
+            using (var stream = new MemoryStream())
+            {
+                var file = new DicomFile(dataset);
+                file.Save(stream);
+
+                stream.Seek(0, SeekOrigin.Begin);
+                var newDataset = DicomFile.Open(stream).Dataset;
+                var contourDataItem = (DicomElement)newDataset.ElementAt(2);
+
+                Assert.Equal((uint)length, contourDataItem.Length);
+
+                var expected = DicomVR.UN;
+                var actual = contourDataItem.ValueRepresentation;
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+}

--- a/Tests/Desktop/Bugs/GH597.cs
+++ b/Tests/Desktop/Bugs/GH597.cs
@@ -20,10 +20,11 @@ namespace Dicom.Bugs
                 new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.4")
             };
 
-            const int length = 0x10000;
+            const uint expectedLength = 0x10000;
             var sb = new StringBuilder();
-            sb.Append('0', length);
-            dataset.Add(DicomTag.ContourData, sb.ToString());
+            sb.Append('0', (int)expectedLength);
+            var expectedValue = sb.ToString();
+            dataset.Add(DicomTag.ContourData, expectedValue);
 
             using (var stream = new MemoryStream())
             {
@@ -31,14 +32,17 @@ namespace Dicom.Bugs
                 file.Save(stream);
 
                 stream.Seek(0, SeekOrigin.Begin);
+                var streamString = Encoding.UTF8.GetString(stream.GetBuffer());
+                Assert.True(streamString.Contains("UN"), "streamString.Contains('UN')");
+
                 var newDataset = DicomFile.Open(stream).Dataset;
                 var contourDataItem = (DicomElement)newDataset.ElementAt(2);
 
-                Assert.Equal((uint)length, contourDataItem.Length);
+                var actualLength = contourDataItem.Length;
+                var actualValue = contourDataItem.Get<string>(0);
 
-                var expected = DicomVR.UN;
-                var actual = contourDataItem.ValueRepresentation;
-                Assert.Equal(expected, actual);
+                Assert.Equal(expectedLength, actualLength);
+                Assert.Equal(expectedValue, actualValue);
             }
         }
     }

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Bugs\GH526.cs" />
     <Compile Include="Bugs\GH549.cs" />
     <Compile Include="Bugs\GH553.cs" />
+    <Compile Include="Bugs\GH597.cs" />
     <Compile Include="Bugs\VideoCStoreProvider.cs" />
     <Compile Include="DicomAnonymizerTest.cs" />
     <Compile Include="DicomDatasetExtensionsTest.cs" />


### PR DESCRIPTION
Fixes #597 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Comply to CP-1066 when writing large (string based) data with explicit VR; when VR marks value length using 16 bits and value length is larger than 2^16-2, change VR to UN in written data stream.
