### PR TITLE
DicomDataset.Add(OrUpdate) overloads with Encoding parameter. Connected to #596

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 #### v.4.0.0 (TBD)
 * Subclassing DicomServer (#602 #604)
 * Support CP-1066 (#597 #606)
+* DicomDataset.Add and .AddOrUpdate overloads with Encoding parameter (#596 #607)
 * Code generator support for anonymization data (#594 #595)
 * DicomServer to listen on IPv6 socket (#588 #604)
 * DicomAnonymizer blank DicomDate/DicomDateTime to DateTime.MinValue instead of empty value (#576 #593)

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) 2012-2017 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System.Text;
+
+using Dicom.IO.Buffer;
+
 namespace Dicom
 {
     using System;
@@ -454,6 +458,36 @@ namespace Dicom
 
             var thirdItem = dataset.ElementAt(2);
             Assert.Equal(thirdItem, contained);
+        }
+
+        [Fact]
+        public void Get_ByteArrayFromStringElement_ReturnsValidArray()
+        {
+            var encoding = Encoding.GetEncoding("SHIFT_JIS");
+            var tag = DicomTag.AdditionalPatientHistory;
+            const string expected = "YamadaTarou山田太郎ﾔﾏﾀﾞﾀﾛｳ";
+
+            var dataset = new DicomDataset
+            {
+                new DicomLongText(tag, encoding, expected)
+            };
+
+            var actual = encoding.GetString(dataset.Get<byte[]>(tag));
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void AddOrUpdate_NonDefaultEncodedStringElement_StringIsPreserved()
+        {
+            var encoding = Encoding.GetEncoding("SHIFT_JIS");
+            var tag = DicomTag.AdditionalPatientHistory;
+            const string expected = "YamadaTarou山田太郎ﾔﾏﾀﾞﾀﾛｳ";
+
+            var dataset = new DicomDataset();
+            dataset.AddOrUpdate(tag, /* encoding, */ expected);
+
+            var actual = encoding.GetString(dataset.Get<byte[]>(tag));
+            Assert.Equal(expected, actual);
         }
 
         #endregion

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -484,7 +484,7 @@ namespace Dicom
             const string expected = "YamadaTarou山田太郎ﾔﾏﾀﾞﾀﾛｳ";
 
             var dataset = new DicomDataset();
-            dataset.AddOrUpdate(tag, /* encoding, */ expected);
+            dataset.AddOrUpdate(tag, encoding, expected);
 
             var actual = encoding.GetString(dataset.Get<byte[]>(tag));
             Assert.Equal(expected, actual);


### PR DESCRIPTION
Fixes #596.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- New `DicomDataset.Add` and `DicomDataset.AddOrUpdate` overloads that take `Encoding` as a separate parameter.
