### PR TITLE
Deprecate DicomClient.WaitForAssociation and provide association events. Connected to #605

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.0 (TBD)
+* Deprecate DicomClient.WaitForAssociation and provide association events (#605 #609)
 * Subclassing DicomServer (#602 #604)
 * Support CP-1066 (#597 #606)
 * DicomDataset.Add and .AddOrUpdate overloads with Encoding parameter (#596 #607)

--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -178,6 +178,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Media\DicomDirectoryRecordCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Media\DicomDirectoryRecordType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Media\DicomFileScanner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\AsyncManualResetEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomAssociation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomAssociationAbortedException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomAssociationRejectedException.cs" />

--- a/DICOM/Network/AsyncManualResetEvent.cs
+++ b/DICOM/Network/AsyncManualResetEvent.cs
@@ -11,7 +11,7 @@ namespace Dicom.Network
     /// Asynchronous manual reset event class, enabling the possibility to set a return value of <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">Type of value that the event can be set to.</typeparam>
-    internal class AsyncManualResetEvent<T>
+    public class AsyncManualResetEvent<T>
     {
         #region FIELDS
 
@@ -52,6 +52,24 @@ namespace Dicom.Network
         internal AsyncManualResetEvent()
             : this(false, default(T))
         {
+        }
+
+        #endregion
+
+        #region PROPERTIES
+
+        /// <summary>
+        /// Gets whether the event is set or not.
+        /// </summary>
+        internal bool IsSet
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _tcs.Task.IsCompleted;
+                }
+            }
         }
 
         #endregion
@@ -111,7 +129,7 @@ namespace Dicom.Network
     /// <summary>
     /// Asynchronous parameterless manual reset event class.
     /// </summary>
-    internal sealed class AsyncManualResetEvent : AsyncManualResetEvent<object>
+    public sealed class AsyncManualResetEvent : AsyncManualResetEvent<object>
     {
         #region CONSTRUCTORS
 
@@ -125,7 +143,7 @@ namespace Dicom.Network
         }
 
         /// <summary>
-        /// Initializes an instance of the <see cref="AsyncManualResetEvent{T}"/> class.
+        /// Initializes an instance of the <see cref="AsyncManualResetEvent"/> class.
         /// Event is reset upon initialization.
         /// </summary>
         internal AsyncManualResetEvent()

--- a/DICOM/Network/AsyncManualResetEvent.cs
+++ b/DICOM/Network/AsyncManualResetEvent.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) 2012-2017 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+#if !NET35
+
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Asynchronous manual reset event class, enabling the possibility to set a return value of <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of value that the event can be set to.</typeparam>
+    internal class AsyncManualResetEvent<T>
+    {
+        #region FIELDS
+
+        private TaskCompletionSource<T> _tcs;
+
+        private readonly object _lock = new object();
+
+        #endregion
+
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="AsyncManualResetEvent{T}"/> class.
+        /// </summary>
+        /// <param name="isSet">Indicates whether event should be set from start.</param>
+        /// <param name="value">Value of the set event.</param>
+        internal AsyncManualResetEvent(bool isSet, T value)
+        {
+            _tcs = new TaskCompletionSource<T>();
+
+            if (isSet)
+                _tcs.TrySetResult(value);
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="AsyncManualResetEvent{T}"/> class.
+        /// </summary>
+        /// <param name="isSet">Indicates whether event should be set from start. If set, value is set to <code>default(T)</code>.</param>
+        internal AsyncManualResetEvent(bool isSet)
+            : this(isSet, default(T))
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="AsyncManualResetEvent{T}"/> class.
+        /// Event is reset upon initialization.
+        /// </summary>
+        internal AsyncManualResetEvent()
+            : this(false, default(T))
+        {
+        }
+
+        #endregion
+
+        #region METHODS
+
+        /// <summary>
+        /// Set event.
+        /// </summary>
+        /// <param name="value">Value to set for the event.</param>
+        internal void Set(T value)
+        {
+            lock (_lock)
+            {
+                _tcs.TrySetResult(value);
+            }
+        }
+
+        /// <summary>
+        /// Set event to default value of type <typeparamref name="T"/>.
+        /// </summary>
+        internal void Set()
+        {
+            lock (_lock)
+            {
+                _tcs.TrySetResult(default(T));
+            }
+        }
+
+        /// <summary>
+        /// Reset event.
+        /// </summary>
+        internal void Reset()
+        {
+            lock (_lock)
+            {
+                if (_tcs.Task.IsCompleted)
+                    _tcs = new TaskCompletionSource<T>();
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously wait for event to be set.
+        /// </summary>
+        /// <returns>Awaitable <see cref="Task{T}"/>, where result is the set value.</returns>
+        internal Task<T> WaitAsync()
+        {
+            lock (_lock)
+            {
+                return _tcs.Task;
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Asynchronous parameterless manual reset event class.
+    /// </summary>
+    internal sealed class AsyncManualResetEvent : AsyncManualResetEvent<object>
+    {
+        #region CONSTRUCTORS
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="AsyncManualResetEvent"/> class.
+        /// </summary>
+        /// <param name="isSet">Indicates whether event should be set from start.</param>
+        internal AsyncManualResetEvent(bool isSet)
+            : base(isSet, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="AsyncManualResetEvent{T}"/> class.
+        /// Event is reset upon initialization.
+        /// </summary>
+        internal AsyncManualResetEvent()
+            : base(false, null)
+        {
+        }
+
+        #endregion
+    }
+}
+
+#endif

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -419,16 +419,14 @@ namespace Dicom.Network
         {
             try
             {
-                var timedOut = false;
                 using (var cancellationSource = new CancellationTokenSource(millisecondsTimeout))
                 using (cancellationSource.Token.Register(() =>
                 {
                     _associationFlag.Set(false);
                     _completionFlag.Set();
-                    timedOut = true;
                 }, false))
                 {
-                    return await _associationFlag.WaitAsync().ConfigureAwait(false) && !timedOut;
+                    return await _associationFlag.WaitAsync().ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -292,7 +292,7 @@ namespace Dicom.Network
 
             try
             {
-                SendAsync(_networkStream, assoc, millisecondsTimeout).Wait();
+                DoSendAsync(_networkStream, assoc, millisecondsTimeout).Wait();
             }
             catch (AggregateException e)
             {
@@ -330,7 +330,7 @@ namespace Dicom.Network
                 RemotePort = port
             };
 
-            return SendAsync(_networkStream, assoc, millisecondsTimeout);
+            return DoSendAsync(_networkStream, assoc, millisecondsTimeout);
         }
 
         /// <summary>
@@ -355,7 +355,7 @@ namespace Dicom.Network
 
             try
             {
-                SendAsync(stream, assoc, millisecondsTimeout).Wait();
+                DoSendAsync(stream, assoc, millisecondsTimeout).Wait();
             }
             catch (AggregateException e)
             {
@@ -385,7 +385,7 @@ namespace Dicom.Network
                 RemotePort = stream.RemotePort
             };
 
-            return SendAsync(stream, assoc, millisecondsTimeout);
+            return DoSendAsync(stream, assoc, millisecondsTimeout);
         }
 
         /// <summary>
@@ -509,7 +509,7 @@ namespace Dicom.Network
             }
         }
 
-        private async Task SendAsync(INetworkStream stream, DicomAssociation association, int millisecondsTimeout)
+        private async Task DoSendAsync(INetworkStream stream, DicomAssociation association, int millisecondsTimeout)
         {
             try
             {
@@ -522,7 +522,7 @@ namespace Dicom.Network
                     _serviceRunnerTask = _service.RunAsync();
                 }
 
-                await Task.WhenAny(_serviceRunnerTask, DoSendAsync(millisecondsTimeout)).ConfigureAwait(false);
+                await Task.WhenAny(_serviceRunnerTask, SendOrReleaseAsync(millisecondsTimeout)).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -538,24 +538,58 @@ namespace Dicom.Network
             }
         }
 
-        private async Task DoSendAsync(int millisecondsTimeout)
+        private async Task SendOrReleaseAsync(int millisecondsTimeout)
         {
- #pragma warning disable 618
+#pragma warning disable 618
             var associated = await WaitForAssociationAsync(millisecondsTimeout).ConfigureAwait(false);
- #pragma warning restore 618
+#pragma warning restore 618
 
-            bool associateOnly;
+            bool send;
             lock (_lock)
             {
-                associateOnly = associated && _requests.Count == 0;
+                send = associated && _requests.Count > 0;
             }
 
-            if (associateOnly)
+            if (send)
+            {
+                await SendQueuedRequestsAsync().ConfigureAwait(false);
+            }
+            else if (associated)
             {
                 await _service.DoSendAssociationReleaseRequestAsync(millisecondsTimeout).ConfigureAwait(false);
             }
+        }
 
-            await _completionFlag.WaitAsync().ConfigureAwait(false);
+        private async Task SendQueuedRequestsAsync()
+        {
+            var requests = await GetQueuedRequestsAsync().ConfigureAwait(false);
+
+            foreach (var request in requests)
+            {
+                if (_service != null && _service.IsConnected)
+                {
+                    await _service.SendRequestAsync(request).ConfigureAwait(false);
+                }
+                else
+                {
+                    AddRequest(request);
+                }
+            }
+        }
+
+        private async Task<IList<DicomRequest>> GetQueuedRequestsAsync()
+        {
+            await _hasRequestsFlag.WaitAsync().ConfigureAwait(false);
+
+            IList<DicomRequest> requests;
+            lock (_lock)
+            {
+                requests = new List<DicomRequest>(_requests);
+                _requests.Clear();
+                _hasRequestsFlag.Reset();
+            }
+
+            return requests;
         }
 
         private async Task HandleMonitoredExceptionsAsync(bool cleanup)
@@ -600,28 +634,6 @@ namespace Dicom.Network
             {
                 throw completedException;
             }
-        }
-
-        private async Task<IList<DicomRequest>> GetRequestsAsync()
-        {
-            await _hasRequestsFlag.WaitAsync().ConfigureAwait(false);
-
-            IList<DicomRequest> requests;
-            if (await _associationFlag.WaitAsync().ConfigureAwait(false))
-            {
-                lock (_lock)
-                {
-                    requests = new List<DicomRequest>(_requests);
-                    _requests.Clear();
-                    _hasRequestsFlag.Reset();
-                }
-            }
-            else
-            {
-                requests = new List<DicomRequest>();
-            }
-
-            return requests;
         }
 
         #endregion
@@ -731,7 +743,8 @@ namespace Dicom.Network
                 if (_isInitialized) return Task.FromResult(false);
                 _isInitialized = true;
 
-                return Task.WhenAll(base.RunAsync(), SendAssociationRequestAsync(_association), SendRequestsAsync());
+                return Task.WhenAll(base.RunAsync(),
+                    SendAssociationRequestAsync(_association));
             }
 
             /// <inheritdoc />
@@ -793,25 +806,12 @@ namespace Dicom.Network
             protected override async Task OnSendQueueEmptyAsync()
             {
                 await Task.WhenAny(
-                    _client._hasRequestsFlag.WaitAsync(),
+                    _client.SendQueuedRequestsAsync(),
                     _isDisconnectedFlag.WaitAsync()
                         .ContinueWith(_ => SetCompletionFlag(), TaskContinuationOptions.OnlyOnRanToCompletion),
                     Task.Delay(_client.Linger)
                         .ContinueWith(_ => DoSendAssociationReleaseRequestAsync(DefaultReleaseTimeout),
                             TaskContinuationOptions.OnlyOnRanToCompletion)).ConfigureAwait(false);
-            }
-
-            private async Task SendRequestsAsync()
-            {
-                while (IsConnected)
-                {
-                    var requests = await _client.GetRequestsAsync().ConfigureAwait(false);
-
-                    foreach (var request in requests)
-                    {
-                        await SendRequestAsync(request).ConfigureAwait(false);
-                    }
-                }
             }
 
             private void SetAssociationFlag(bool isAssociated)

--- a/DICOM/Network/DicomClient.cs
+++ b/DICOM/Network/DicomClient.cs
@@ -84,12 +84,12 @@ namespace Dicom.Network
         /// <summary>
         /// Representation of the DICOM association accepted event.
         /// </summary>
-        public event EventHandler DicomAssociationAccepted = delegate { };
+        public event EventHandler AssociationAccepted = delegate { };
 
         /// <summary>
         /// Representation of the DICOM association rejected event.
         /// </summary>
-        public event EventHandler DicomAssociationRejected = delegate { };
+        public event EventHandler AssociationRejected = delegate { };
 
         #endregion
 
@@ -328,7 +328,7 @@ namespace Dicom.Network
         /// <param name="millisecondsTimeout">Milliseconds to wait for association to occur.</param>
         /// <returns>True if association is established, false otherwise.</returns>
         [Obsolete(
-            "Use DicomAssociationAccepted and DicomAssociationRejected events to be notified of association status change.")]
+            "Use AssociationAccepted and AssociationRejected events to be notified of association status change.")]
         public bool WaitForAssociation(int millisecondsTimeout = DefaultAssociationTimeout)
         {
             try
@@ -347,8 +347,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="millisecondsTimeout">Milliseconds to wait for association to occur.</param>
         /// <returns>True if association is established, false otherwise.</returns>
-        [Obsolete(
-            "Use DicomAssociationAccepted and DicomAssociationRejected events to be notified of association status change.")]
         public async Task<bool> WaitForAssociationAsync(int millisecondsTimeout = DefaultAssociationTimeout)
         {
             try
@@ -474,9 +472,7 @@ namespace Dicom.Network
 
         private async Task DoSendAsync(int millisecondsTimeout)
         {
-#pragma warning disable 618
             var associated = await WaitForAssociationAsync(millisecondsTimeout).ConfigureAwait(false);
-#pragma warning restore 618
 
             bool send;
             lock (_lock)
@@ -641,7 +637,7 @@ namespace Dicom.Network
 
                 SetAssociationFlag(true);
 
-                _client.DicomAssociationAccepted(_client, EventArgs.Empty);
+                _client.AssociationAccepted(_client, EventArgs.Empty);
             }
 
             /// <inheritdoc />
@@ -653,7 +649,7 @@ namespace Dicom.Network
                 SetAssociationFlag(false);
                 SetCompletionFlag(new DicomAssociationRejectedException(result, source, reason));
 
-                _client.DicomAssociationRejected(_client, EventArgs.Empty);
+                _client.AssociationRejected(_client, EventArgs.Empty);
             }
 
             /// <inheritdoc />

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -315,46 +315,6 @@ namespace Dicom.Network
 
         #region INNER TYPES
 
-        private sealed class AsyncManualResetEvent
-        {
-            private TaskCompletionSource<object> _tcs;
-
-            private readonly object _lock = new object();
-
-            internal AsyncManualResetEvent(bool isSet)
-            {
-                _tcs = new TaskCompletionSource<object>();
-
-                if (isSet)
-                    _tcs.TrySetResult(null);
-            }
-
-            internal void Set()
-            {
-                lock (_lock)
-                {
-                    _tcs.TrySetResult(null);
-                }
-            }
-
-            internal void Reset()
-            {
-                lock (_lock)
-                {
-                    if (_tcs.Task.IsCompleted)
-                        _tcs = new TaskCompletionSource<object>();
-                }
-            }
-
-            internal Task WaitAsync()
-            {
-                lock (_lock)
-                {
-                    return _tcs.Task;
-                }
-            }
-        }
-
         #endregion
     }
 

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -892,6 +892,8 @@ namespace Dicom.Network
 
         private async Task SendNextMessageAsync()
         {
+            var sendQueueEmpty = false;
+
             while (true)
             {
                 DicomMessage msg;
@@ -904,7 +906,7 @@ namespace Dicom.Network
 
                     if (_msgQueue.Count == 0)
                     {
-                        if (_pending.Count == 0) OnSendQueueEmpty();
+                        if (_pending.Count == 0) sendQueueEmpty = true;
                         break;
                     }
 
@@ -928,6 +930,11 @@ namespace Dicom.Network
                 await DoSendMessageAsync(msg).ConfigureAwait(false);
 
                 lock (_lock) _sending = false;
+            }
+
+            if (sendQueueEmpty)
+            {
+                await OnSendQueueEmptyAsync().ConfigureAwait(false);
             }
         }
 
@@ -1263,8 +1270,9 @@ namespace Dicom.Network
         /// <summary>
         /// Action to perform when send queue is empty.
         /// </summary>
-        protected virtual void OnSendQueueEmpty()
+        protected virtual Task OnSendQueueEmptyAsync()
         {
+            return Task.FromResult(false);
         }
 
         #endregion

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -1164,7 +1164,6 @@ namespace Dicom.Network
             }
 
             lock (_lock) _isDisconnectedFlag.Set();
-
             Logger.Info("Connection closed");
 
             if (exception != null) throw exception;

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -487,13 +487,13 @@ namespace Dicom.Network
             var port = Ports.GetNext();
             using (DicomServer.Create<DicomCEchoProvider>(port))
             {
-                var client = new DicomClient { Linger = 0 };
+                var client = new DicomClient();
                 client.AddRequest(new DicomCEchoRequest());
                 Assert.True(client.IsSendRequired);
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
+                Thread.Sleep(100);
 
                 client.AddRequest(new DicomCEchoRequest());
-                Thread.Sleep(100);
 
                 Assert.True(client.IsSendRequired);
             }

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -368,6 +368,26 @@ namespace Dicom.Network
         }
 
         [Fact]
+        public void AssociationReleased_SuccessfulSend_IsInvoked()
+        {
+            var port = Ports.GetNext();
+            using (DicomServer.Create<DicomCEchoProvider>(port))
+            {
+                var client = new DicomClient();
+
+                var released = false;
+                var handle = new ManualResetEventSlim();
+                client.AssociationReleased += (sender, args) => { released = true; handle.Set(); };
+
+                client.AddRequest(new DicomCEchoRequest());
+                client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
+
+                handle.Wait(1000);
+                Assert.True(released);
+            }
+        }
+
+        [Fact]
         public void Release_AfterAssociation_SendIsCompleted()
         {
             int port = Ports.GetNext();

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -331,6 +331,43 @@ namespace Dicom.Network
         }
 
         [Fact]
+        public void AssociationAccepted_SuccessfulSend_IsInvoked()
+        {
+            var port = Ports.GetNext();
+            using (DicomServer.Create<MockCEchoProvider>(port))
+            {
+                var client = new DicomClient();
+
+                var accepted = false;
+                client.AssociationAccepted += (sender, args) => accepted = true;
+
+                client.AddRequest(new DicomCEchoRequest());
+                client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
+
+                Assert.True(accepted);
+            }
+        }
+
+        [Fact]
+        public void AssociationRejected_AssociationNotAllowed_IsInvoked()
+        {
+            var port = Ports.GetNext();
+            using (DicomServer.Create<MockCEchoProvider>(port))
+            {
+                var client = new DicomClient();
+
+                var rejected = false;
+                client.AssociationRejected += (sender, args) => rejected = true;
+
+                client.AddRequest(new DicomCEchoRequest());
+                var exception = Record.Exception(() => client.Send("127.0.0.1", port, false, "SCU", "NOTACCEPTEDSCP"));
+
+                Assert.True(rejected);
+                Assert.NotNull(exception);
+            }
+        }
+
+        [Fact]
         public void Release_AfterAssociation_SendIsCompleted()
         {
             int port = Ports.GetNext();

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -272,10 +272,10 @@ namespace Dicom.Network
             {
                 var client = new DicomClient();
                 client.AddRequest(new DicomCEchoRequest());
-                var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
+                client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
                 client.Abort();
-                var actual = client.WaitForAssociation(500);
+                var actual = client.WaitForAssociation(1000);
 
                 Assert.Equal(false, actual);
             }

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -356,13 +356,13 @@ namespace Dicom.Network
             {
                 var client = new DicomClient();
 
-                var rejected = false;
-                client.AssociationRejected += (sender, args) => rejected = true;
+                var reason = DicomRejectReason.NoReasonGiven;
+                client.AssociationRejected += (sender, args) => reason = args.Reason;
 
                 client.AddRequest(new DicomCEchoRequest());
                 var exception = Record.Exception(() => client.Send("127.0.0.1", port, false, "SCU", "NOTACCEPTEDSCP"));
 
-                Assert.True(rejected);
+                Assert.Equal(DicomRejectReason.CalledAENotRecognized, reason);
                 Assert.NotNull(exception);
             }
         }
@@ -487,13 +487,13 @@ namespace Dicom.Network
             var port = Ports.GetNext();
             using (DicomServer.Create<DicomCEchoProvider>(port))
             {
-                var client = new DicomClient();
-                client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Thread.Sleep(100) });
+                var client = new DicomClient { Linger = 0 };
+                client.AddRequest(new DicomCEchoRequest());
                 Assert.True(client.IsSendRequired);
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
                 Thread.Sleep(100);
-                client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Thread.Sleep(100) });
+                client.AddRequest(new DicomCEchoRequest());
 
                 Assert.True(client.IsSendRequired);
             }

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -492,8 +492,8 @@ namespace Dicom.Network
                 Assert.True(client.IsSendRequired);
                 client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
 
-                Thread.Sleep(100);
                 client.AddRequest(new DicomCEchoRequest());
+                Thread.Sleep(100);
 
                 Assert.True(client.IsSendRequired);
             }


### PR DESCRIPTION
Fixes #605 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Deprecated `DicomCleint.WaitForAssociation` and `WaitForAssociationAsync`.
- Added events `AssociationAccepted`, `AssociationRejected` and `AssociationReleased`.
- Improved inner workings of `DicomClient`, in particular replaced `DicomServiceUser.LingerAsync` task and refactored `OnSendQueueEmpty` override to asynchronous method.
