### PR TITLE
Added check for existing SourceAET when constructing DicomFileMetaInf…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,6 +45,7 @@
 * Pass through unsupported user data during PDU parsing (#242 #443)
 * Remove warning messages during build (#33 #438)
 * Online and NuGet packages API documentation (#28 #459 #466 #574 #584)
+* DicomFileMetaInformation now uses pre-existing SourceAET where possible 
 
 #### v.3.0.2 (4/20/2017)
 * DicomRejectReason enumerables should be parsed w.r.t. source (#516 #521)

--- a/Contributors.md
+++ b/Contributors.md
@@ -29,3 +29,4 @@
 * [zcr01](https://github.com/zcr01)
 * [JustSomeHack](https://github.com/deyung)
 * [Nick Nelson](https://github.com/npnelson)
+* [Niall O'Donnell] (https://github.com/nodonnell)

--- a/DICOM/DicomFileMetaInformation.cs
+++ b/DICOM/DicomFileMetaInformation.cs
@@ -36,7 +36,8 @@ namespace Dicom
             ImplementationClassUID = DicomImplementation.ClassUID;
             ImplementationVersionName = DicomImplementation.Version;
 
-            var aet = CreateSourceApplicationEntityTitle();
+            var aet = dataset.Contains(DicomTag.SourceApplicationEntityTitle) ?
+                dataset.Get<string>(DicomTag.SourceApplicationEntityTitle) : CreateSourceApplicationEntityTitle();
             if (aet != null) SourceApplicationEntityTitle = aet;
 
             if (dataset.Contains(DicomTag.SendingApplicationEntityTitle))
@@ -64,7 +65,8 @@ namespace Dicom
             ImplementationClassUID = DicomImplementation.ClassUID;
             ImplementationVersionName = DicomImplementation.Version;
 
-            var aet = CreateSourceApplicationEntityTitle();
+            var aet = metaInfo.Contains(DicomTag.SourceApplicationEntityTitle) ?
+                metaInfo.SourceApplicationEntityTitle : CreateSourceApplicationEntityTitle();
             if (aet != null) SourceApplicationEntityTitle = aet;
 
             if (metaInfo.Contains(DicomTag.SendingApplicationEntityTitle))

--- a/Tests/Desktop/DicomFileMetaInformationTest.cs
+++ b/Tests/Desktop/DicomFileMetaInformationTest.cs
@@ -67,6 +67,20 @@ namespace Dicom
         }
 
         [Fact]
+        public void SourceApplicationEntityTitle_GetterWhenAttributeAlreadyExists_ReturnsValue()
+        {
+            var metaInfo =
+                new DicomFileMetaInformation(
+                    new DicomDataset(
+                        new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage),
+                        new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3"))
+                        .Add(DicomTag.SourceApplicationEntityTitle, "ABCDEFG"));
+
+            var exception = Record.Exception(() => { Assert.Equal(metaInfo.SourceApplicationEntityTitle, "ABGDEFG"); });
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void Constructor_FromFileMetaInformation_ShouldNotThrow()
         {
             var metaInfo = new DicomFileMetaInformation();


### PR DESCRIPTION
#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Where SourceApplicationEntityTitle already exists in a DICOM dataset or DICOM file meta information, the DicomFileMetaInformation constructor will now use this, instead of generating a new Source AET from the machine name on Save() calls.