### PR TITLE
Fixing 2 UWP Networking Bugs

### DIFF
--- a/DICOM/Network/WindowsNetworkStream.cs
+++ b/DICOM/Network/WindowsNetworkStream.cs
@@ -406,7 +406,10 @@ namespace Dicom.Network
                 {
                     await reader.LoadAsync((uint)count).AsTask().ConfigureAwait(false);
                     var length = Math.Min((int)reader.UnconsumedBufferLength, count);
-                    reader.ReadBuffer((uint)length).CopyTo(0, buffer, offset, length);
+                    if (length > 0)
+                    {
+                        reader.ReadBuffer((uint)length).CopyTo(0, buffer, offset, length);
+                    }
                     reader.DetachStream();
                     return length;
                 }


### PR DESCRIPTION
* UWP StreamSocketListener cannot bind to 0.0.0.0 #636
* Dont block when create a DicomServer #637
* Get rid of thrown and catched ArgumentException

Fixes #636, #637 

