### PR TITLE
detail message missing #616

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,7 @@
 * Pass through unsupported user data during PDU parsing (#242 #443)
 * Remove warning messages during build (#33 #438)
 * Online and NuGet packages API documentation (#28 #459 #466 #574 #584)
+* Status code in respose got lost and mapped to an internally known status code (#616)
 * WinFormsImage may throw exception on Dispose or on GC (#634)
 * Fix StackOverflowException in Vector3D multiplication (#640)
 

--- a/DICOM/Network/DicomStatus.cs
+++ b/DICOM/Network/DicomStatus.cs
@@ -107,6 +107,22 @@ namespace Dicom.Network
         {
         }
 
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomStatus"/> class.
+        /// </summary>
+        internal DicomStatus(ushort code, DicomStatus baseStatus)
+        {
+            // set the code given by param code...
+            Code = code;
+            // ... and copy all other values from baseStatus 
+            Description = baseStatus.Description;
+            ErrorComment = baseStatus.ErrorComment;
+            Mask = baseStatus.Mask;
+            State = baseStatus.State;
+        }
+
+
         /// <summary>
         /// Returns a <see cref="T:System.String"/> that represents the current <see cref="T:System.Object"/>.
         /// </summary>
@@ -254,7 +270,7 @@ namespace Dicom.Network
         }
 
         /// <summary>
-        /// Looks up the specified code.
+        /// Looks up the specified code and returns a new instance
         /// </summary>
         /// <param name="code">The code.</param>
         /// <returns></returns>
@@ -262,7 +278,7 @@ namespace Dicom.Network
         {
             foreach (DicomStatus status in Entries)
             {
-                if (status.Code == (code & status.Mask)) return status;
+                if (status.Code == (code & status.Mask)) return new DicomStatus(code, status);
             }
             return ProcessingFailure;
         }

--- a/Tests/Desktop/Network/DicomStatusTest.cs
+++ b/Tests/Desktop/Network/DicomStatusTest.cs
@@ -43,8 +43,11 @@ namespace Dicom.Network
         public void Lookup_WithWarning_ReturnsCorrectStatusClass()
         {
             var statusTest = DicomStatus.Lookup(UPSIsAlreadyCompleted.Code);
+            // Code B306 is not in the known list. So the DicomStatus.Lookup shall return
+            // the original code, but a status and Description that matches best one of
+            // the known states.
             Assert.Equal(UPSIsAlreadyCompleted.State, statusTest.State);
-            Assert.NotEqual(UPSIsAlreadyCompleted.Code, statusTest.Code);
+            Assert.Equal(UPSIsAlreadyCompleted.Code, statusTest.Code);
             Assert.NotEqual(UPSIsAlreadyCompleted.Description, statusTest.Description);
         }
 


### PR DESCRIPTION
Fixes #616 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- instead of mapping the status code to one of the known DicomStatus, a new DicomStatus instance is created. the original status code is stored to this instance, but the status type and description is taken from the mapped DicomStatus.
-
-
