### PR TITLE
Gh 682

### DIFF
--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -800,6 +800,7 @@ namespace Dicom
                 {
                     _formats = new[]
                     {
+                        "yyyyMMddHHmmss",
                         "yyyyMMddHHmmsszzz",
                         "yyyyMMddHHmmsszz",
                         "yyyyMMddHHmmssz",
@@ -809,7 +810,6 @@ namespace Dicom
                         "yyyyMMddHHmmss.fff",
                         "yyyyMMddHHmmss.ff",
                         "yyyyMMddHHmmss.f",
-                        "yyyyMMddHHmmss",
                         "yyyyMMddHHmm",
                         "yyyyMMddHH",
                         "yyyyMMdd",

--- a/Tests/Desktop/Bugs/GH328.cs
+++ b/Tests/Desktop/Bugs/GH328.cs
@@ -10,14 +10,23 @@ namespace Dicom.Bugs
     [Collection("General")]
     public class GH328
     {
+
         [Fact]
         public void DicomDateTime_FractionalSecondsAndTimezone_SupportedFormat()
         {
             var dt = DateTime.Now.ToString("yyyyMMddHHmmss.ffffffzzz");
+            if (dt.Contains("-"))
+            {
+                // the test is currently executed in a time zone with negative offset.
+                // negative time offset are not allowed in DateTimeRange since the "-" is
+                // reserved for the range-delimiter
+                dt = dt.Replace('-', '+');
+            }
             var dataset = new DicomDataset { new DicomDateTime(DicomTag.ScheduledProcedureStepStartDateTime, dt) };
 
             var exception = Record.Exception(() => dataset.Get<DicomDateRange>(DicomTag.ScheduledProcedureStepStartDateTime));
             Assert.Null(exception);
         }
+
     }
 }

--- a/Tests/Desktop/DicomDateRangeTest.cs
+++ b/Tests/Desktop/DicomDateRangeTest.cs
@@ -86,8 +86,7 @@ namespace Dicom
                 DicomTag.AcquisitionDateTime,
                 new DicomDateRange(new DateTime(2016, 4, 20, 10, 20, 30), new DateTime(2016, 4, 21, 8, 50, 5)));
 
-            var zone = new DateTime(2016, 4, 20).ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
-            var expected = $"20160420102030{zone}-20160421085005{zone}";
+            var expected = $"20160420102030-20160421085005";
             var actual = dataset.Get<string>(DicomTag.AcquisitionDateTime);
 
             Assert.Equal(expected, actual);

--- a/Tests/Desktop/DicomDateTimeTest.cs
+++ b/Tests/Desktop/DicomDateTimeTest.cs
@@ -17,9 +17,8 @@ namespace Dicom
                     new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage),
                     new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3"),
                     new DicomDateTime(DicomTag.AcquisitionDateTime, new DateTime(2016, 4, 20, 10, 20, 30)));
-
-            var zone = new DateTime(2016, 4, 20).ToString("yyyyMMddHHmmsszzz").Substring(14).Replace(":", string.Empty);
-            var expected = $"20160420102030{zone}";
+            
+            var expected = $"20160420102030";
             var actual = dataset.Get<string>(DicomTag.AcquisitionDateTime);
 
             Assert.Equal(expected, actual);

--- a/Tests/Desktop/Network/DicomClientTest.cs
+++ b/Tests/Desktop/Network/DicomClientTest.cs
@@ -162,7 +162,7 @@ namespace Dicom.Network
                 for (var i = 0; i < expected; ++i) client.AddRequest(new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref actual) });
 
                 var task = client.SendAsync("127.0.0.1", port, false, "SCU", "ANY-SCP");
-                await Task.WhenAny(task, Task.Delay(10000));
+                await Task.WhenAny(task, Task.Delay(30000));
 
                 Assert.Equal(expected, actual);
             }


### PR DESCRIPTION
Fixes #682 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- when adding a DateTime dicom tag to a DicomDataset, this is now internally stored by default without the optional time zone offset. This is specially important with DateTimeRanges.
- A unit test, that tests up to 1000 CEcho-Requests, flickers because of the timeout of 10 seconds. This timeout is increased.
