### PR TITLE
Add unit tests covering private tags

### DIFF
--- a/Tests/Desktop/Network/DicomServiceTest.cs
+++ b/Tests/Desktop/Network/DicomServiceTest.cs
@@ -39,6 +39,64 @@ namespace Dicom.Network
             }
         }
 
+
+        [Fact]
+        public void Send_PrivateTags_DataSufficientlyTransported()
+        {
+            var port = Ports.GetNext();
+            using (DicomServer.Create<SimpleCStoreProvider>(port))
+            {
+                DicomDataset command = null, requestDataset = null, responseDataset = null;
+                var request = new DicomCStoreRequest(new DicomDataset
+                {
+                    { DicomTag.CommandField, (ushort)DicomCommandField.CStoreRequest },
+                    { DicomTag.AffectedSOPClassUID, DicomUID.CTImageStorage },
+                    { DicomTag.MessageID, (ushort)1 },
+                    { DicomTag.AffectedSOPInstanceUID, "1.2.3" },
+                });
+
+                var privateCreator = DicomDictionary.Default.GetPrivateCreator("Testing");
+                var privTag1 = new DicomTag(4013, 0x008, privateCreator);
+                var privTag2 = new DicomTag(4013, 0x009, privateCreator);
+                DicomDictionary.Default.Add(new DicomDictionaryEntry(privTag1, "testTag1", "testKey1", DicomVM.VM_1, false, DicomVR.CS));
+                DicomDictionary.Default.Add(new DicomDictionaryEntry(privTag2, "testTag2", "testKey2", DicomVM.VM_1, false, DicomVR.CS));
+
+                request.Dataset = new DicomDataset();
+                request.Dataset.Add(DicomTag.Modality, "CT");
+                request.Dataset.Add(privTag1, "test1");
+                request.Dataset.Add(new DicomCodeString(privTag2, "test2"));
+                //{
+                //    { DicomTag.Modality, "CT" },
+                //    new DicomCodeString(privTag1, "test1"),
+                //    { privTag2, "test2" },
+                //};
+
+                request.OnResponseReceived = (req, res) =>
+                {
+                    command = req.Command;
+                    requestDataset = req.Dataset;
+                    responseDataset = res.Dataset;
+                };
+
+                var client = new DicomClient();
+                client.AddRequest(request);
+
+                client.Send("127.0.0.1", port, false, "SCU", "ANY-SCP");
+
+                Assert.Equal((ushort)1, command.Get<ushort>(DicomTag.CommandField));
+
+                Assert.Equal("CT", requestDataset.Get<string>(DicomTag.Modality));
+                Assert.Equal("test2", requestDataset.Get<string>(privTag2, null));
+                Assert.Equal("test1", requestDataset.Get<string>(privTag1, null));
+
+                Assert.Equal("CT", responseDataset.Get<string>(DicomTag.Modality));
+               // Assert.Equal("test1", responseDataset.Get<DicomCodeString>(privTag1).Get<string>());
+                Assert.Equal("test2", responseDataset.Get<string>(privTag2,-1, null));
+                Assert.Equal("test1", responseDataset.Get<string>(privTag1, null));
+            }
+        }
+
+
         [Fact]
         public async Task SendAsync_SingleRequest_DataSufficientlyTransported()
         {

--- a/Tests/Desktop/Network/SimpleCStoreProvider.cs
+++ b/Tests/Desktop/Network/SimpleCStoreProvider.cs
@@ -75,7 +75,10 @@ namespace Dicom.Network
             Logger.Info(tempName);
             request.File.Save(tempName);
 
-            return new DicomCStoreResponse(request, DicomStatus.Success);
+            return new DicomCStoreResponse(request, DicomStatus.Success)
+            {
+                Dataset = request.Dataset
+            };
         }
 
         public void OnCStoreRequestException(string tempFileName, Exception e)

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -582,5 +582,28 @@ namespace Dicom.Serialization
             var x = BuildAllTypesNullDataset_();
             VerifyJsonTripleTrip(x);
         }
+
+
+        [Fact]
+        public static void TestPrivateTagsDeserialization()
+        {
+            var privateCreator = DicomDictionary.Default.GetPrivateCreator("Testing");
+            var privTag1 = new DicomTag(4013, 0x008, privateCreator);
+            var privTag2 = new DicomTag(4013, 0x009, privateCreator);
+
+            var ds = new DicomDataset
+            {
+                { DicomTag.Modality, "CT" },
+                new DicomCodeString(privTag1, "test1"),
+                { privTag2, "test2" },
+            };
+
+            var json = JsonConvert.SerializeObject(ds, new JsonDicomConverter());
+            var ds2 = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+
+            Assert.Equal(ds.Get<string>(privTag1), ds2.Get<string>(privTag1));
+            Assert.Equal(ds.Get<string>(privTag2), ds2.Get<string>(privTag2));
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #671 and #672 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- add unit tests that verify that the VR does not get lost when sending through store scp
- add unit test to verify that private tags are not lost when json serialized and deserialized
