### PR TITLE
Ipv6 port

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.1 (TBD)
+* internally identify dicom servers by port/ipadress combination instead of only port (#699)
 * Update Json DS validation regex (#643)
 
 #### v.4.0.0-rc1 (5/22/2018)

--- a/Tests/Desktop/Network/DicomServerTest.cs
+++ b/Tests/Desktop/Network/DicomServerTest.cs
@@ -346,6 +346,26 @@ namespace Dicom.Network
         }
 
         [Fact]
+        public void CanCreateIpv4AndIpv6()
+        {
+            var port = Ports.GetNext();
+            using (DicomServer.Create<DicomCEchoProvider>(port))
+            {
+                var e = Record.Exception(
+                    () =>
+                    {
+                        using (DicomServer.Create<DicomCEchoProvider>(NetworkManager.IPv6Any, port))
+                        {
+
+                        }
+                    });
+                Assert.Null(e);
+            }
+
+
+        }
+
+        [Fact]
         public void Create_SubclassedServer_SufficientlyCreated()
         {
             var port = Ports.GetNext();

--- a/Tests/Desktop/Network/DicomServerTest.cs
+++ b/Tests/Desktop/Network/DicomServerTest.cs
@@ -361,8 +361,6 @@ namespace Dicom.Network
                     });
                 Assert.Null(e);
             }
-
-
         }
 
         [Fact]


### PR DESCRIPTION
Fixes # 699.

#### Checklist
- [ x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x ] I have updated API documentation
- [ x] I have included unit tests
- [ ] I have updated the change log
- [ x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Identifies Dicom Server by port and IP address, instead of just port
- Allows creation of ipv4 and ipv6 DicomServer on the same port
-
