### PR TITLE
Fixed some bad character conversion possibilities for ToUpper method

### DIFF
--- a/DICOM/Imaging/LUT/VOILUT.cs
+++ b/DICOM/Imaging/LUT/VOILUT.cs
@@ -159,7 +159,7 @@ namespace Dicom.Imaging.LUT
         /// <returns></returns>
         public static VOILUT Create(GrayscaleRenderOptions options)
         {
-            switch (options.VOILUTFunction.ToUpper())
+            switch (options.VOILUTFunction.ToUpperInvariant())
             {
                 case "SIGMOID":
                     return new VOISigmoidLUT(options);

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -69,7 +69,7 @@ namespace Dicom.Network
                     case DicomQueryRetrieveLevel.Study:
                     case DicomQueryRetrieveLevel.Series:
                     case DicomQueryRetrieveLevel.Image:
-                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpperInvariant());
                         break;
                     default:
                         Dataset.Remove(DicomTag.QueryRetrieveLevel);

--- a/DICOM/Network/DicomCGetRequest.cs
+++ b/DICOM/Network/DicomCGetRequest.cs
@@ -111,7 +111,7 @@ namespace Dicom.Network
                     case DicomQueryRetrieveLevel.Study:
                     case DicomQueryRetrieveLevel.Series:
                     case DicomQueryRetrieveLevel.Image:
-                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpperInvariant());
                         break;
                     default:
                         Dataset.Remove(DicomTag.QueryRetrieveLevel);

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -100,7 +100,7 @@ namespace Dicom.Network
                     case DicomQueryRetrieveLevel.Study:
                     case DicomQueryRetrieveLevel.Series:
                     case DicomQueryRetrieveLevel.Image:
-                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpper());
+                        Dataset.AddOrUpdate(DicomTag.QueryRetrieveLevel, value.ToString().ToUpperInvariant());
                         break;
                     default:
                         Dataset.Remove(DicomTag.QueryRetrieveLevel);

--- a/DICOM/StructuredReport/DicomContentItem.cs
+++ b/DICOM/StructuredReport/DicomContentItem.cs
@@ -329,7 +329,7 @@ namespace Dicom.StructuredReport
         public DicomContinuity Continuity
         {
             get => Dataset.GetValueOrDefault(DicomTag.ContinuityOfContent, 0, DicomContinuity.None);
-            private set => Dataset.AddOrUpdate(DicomTag.ContinuityOfContent, value.ToString().ToUpper());
+            private set => Dataset.AddOrUpdate(DicomTag.ContinuityOfContent, value.ToString().ToUpperInvariant());
         }
 
         public IEnumerable<DicomContentItem> Children()

--- a/Tools/DICOM Dump/MainForm.cs
+++ b/Tools/DICOM Dump/MainForm.cs
@@ -201,7 +201,7 @@ namespace Dicom.Dump
                 var tag = String.Format(
                     "{0}{1}  {2}",
                     Indent,
-                    element.Tag.ToString().ToUpper(),
+                    element.Tag.ToString().ToUpperInvariant(),
                     element.Tag.DictionaryEntry.Name);
 
                 string value = "<large value not displayed>";
@@ -230,7 +230,7 @@ namespace Dicom.Dump
                 var tag = String.Format(
                     "{0}{1}  {2}",
                     Indent,
-                    sequence.Tag.ToString().ToUpper(),
+                    sequence.Tag.ToString().ToUpperInvariant(),
                     sequence.Tag.DictionaryEntry.Name);
 
                 Form.AddItem(tag, "SQ", String.Empty, String.Empty);
@@ -266,7 +266,7 @@ namespace Dicom.Dump
                 var tag = String.Format(
                     "{0}{1}  {2}",
                     Indent,
-                    fragment.Tag.ToString().ToUpper(),
+                    fragment.Tag.ToString().ToUpperInvariant(),
                     fragment.Tag.DictionaryEntry.Name);
 
                 Form.AddItem(tag, fragment.ValueRepresentation.Code, String.Empty, String.Empty);


### PR DESCRIPTION
Replaced some ToUpper methods to ToUpperInvariant method because bad
character conversion occured on some non english culture machines. For
example on Turkish locale machine "i" character converted to "İ" character
and then "Series" string converted to "SERİES". Because of this
situation when you are using CreateSeriesQuery on Turkish locale machine
it sends QueryRetrieveLevel tag in query like "SER?ES" and query always
fails. When we set tag manually to "SERIES" it works normally.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
