### PR TITLE
fix rendering of image with color palette.

### DIFF
--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -294,6 +294,8 @@ namespace Dicom
 
             if (item is DicomElement element)
             {
+                if (typeof(IByteBuffer).GetTypeInfo().IsAssignableFrom(typeof(T).GetTypeInfo())) { return (T)(object)element.Buffer; }
+
                 if (index >= element.Count )
                 {
                     throw new DicomDataException($"Index out of range: index {index} for Tag {tag} must be less than value count {element.Count}");
@@ -387,6 +389,8 @@ namespace Dicom
 
             if (item is DicomElement element)
             {
+                if (typeof(T[]) == typeof(byte[])) { return (T[])(object)element.Buffer.Data; }
+
                 return element.Get<T[]>(-1);
             }
             else
@@ -458,6 +462,8 @@ namespace Dicom
 
             if (item is DicomElement element)
             {
+                if (typeof(IByteBuffer).GetTypeInfo().IsAssignableFrom(typeof(T).GetTypeInfo())) { return (T)(object)element.Buffer; }
+
                 if (element.Count != 1) { throw new DicomDataException("DICOM element must contains a single value"); }
 
                 return element.Get<T>(0);

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -227,6 +227,9 @@
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="Test Data\10200904.dcm">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Test Data\D_CLUNIE_CT1_RLE_FRAGS.dcm">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Tests/Desktop/Imaging/DicomImageTest.cs
+++ b/Tests/Desktop/Imaging/DicomImageTest.cs
@@ -75,6 +75,20 @@ namespace Dicom.Imaging
             }
         }
 
+
+        [Fact]
+        public void RenderImage_ColorPalette()
+        {
+            lock (_lock)
+            {
+                ImageManager.SetImplementation(WinFormsImageManager.Instance);
+                var file = new DicomImage(@".\Test Data\10200904.dcm");
+                var image = file.RenderImage(0);
+                Assert.IsAssignableFrom<Bitmap>(image.As<Bitmap>());
+            }
+        }
+
+
         #endregion
     }
 }


### PR DESCRIPTION
Fixes #734  .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When reading the color palette, the data is read as byte[]. The old DicomDataset.Get<T> method had a special handling if getting byte array or IByteBuffer. This special handling was not included in the new DicomDataset.GetValues<T> and DicomDataset.GetValue<T> methods. Is is now done.
-
-
