### PR TITLE
Bug Fix : Strings in anonymized Dicom (e.g. PatientName) now use original Dicom encoding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 * Fix bug in .net core when a image is both flipped in x and y direction (#721)
 * Pass through the timeout parameter from DicomClient.Send to the constructor of DesktopNetworkStream (#732)
 * Added appveyor.yml file for ci by this setting (#729)
+* Bug Fix : anonymized patient name is now encoded with same character set as the original Dicom.
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec


### PR DESCRIPTION
#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [X] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- The previous implementation of `DicomAnonymizer` ignored the original Dicom's encoding... it simply defaulted to: `Encoding.ASCII`.  This was problematic when:
  1. the original Dicom encoding (as defined by: `DicomTag.SpecificCharacterSet`) was not `Encoding.ASCII`, and
  2. the anonymized `PatientName` contained non-ASCII characters.

At present, the default character encoding is determined as follows:
- `DicomEncoding.Default` <<< `IOManager.BaseEncoding` <<< `DesktopIOManager.BaseEncodingImpl`
