### PR TITLE
fix proposal for #749

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
 * Pass through the timeout parameter from DicomClient.Send to the constructor of DesktopNetworkStream (#732)
 * Added appveyor.yml file for ci by this setting (#729)
 * Bug Fix : anonymized patient name is now encoded with same character set as the original Dicom.
+* Bug Fix : DICOM server may throw DicomDataException on association when non-standard transfer syntax was proposed (#749)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/DICOM/DicomParseable.cs
+++ b/DICOM/DicomParseable.cs
@@ -16,7 +16,7 @@ namespace Dicom
                 throw new DicomDataException("DicomParseable.Parse expects a class derived from DicomParseable");
             }
 
-            var method = typeof(T).GetTypeInfo().GetDeclaredMethods("Parse").Single(m => m.IsPublic && m.IsStatic);
+            var method = typeof(T).GetTypeInfo().GetDeclaredMethods("Parse").Single(m => m.IsPublic && m.IsStatic && m.GetParameters().Length == 1 && m.GetParameters().Single().ParameterType == typeof(string));
             return (T)method.Invoke(null, new object[] { value });
         }
     }

--- a/DICOM/DicomTransferSyntax.cs
+++ b/DICOM/DicomTransferSyntax.cs
@@ -652,7 +652,7 @@ namespace Dicom
         public static DicomTransferSyntax Parse(string uid)
         {
             if (uid == null) throw new ArgumentNullException(nameof(uid));
-            return Lookup(DicomUID.Parse(uid));
+            return Lookup(DicomUID.Parse(s:uid, type: DicomUidType.TransferSyntax));
         }
 
         /// <summary>

--- a/DICOM/DicomUID.cs
+++ b/DICOM/DicomUID.cs
@@ -155,6 +155,11 @@ namespace Dicom
 
         public static DicomUID Parse(string s)
         {
+            return Parse(s, "Unknown", DicomUidType.Unknown);
+        }
+
+        public static DicomUID Parse(string s, string name = "Unknown", DicomUidType type = DicomUidType.Unknown)
+        {
             string u = s.TrimEnd(' ', '\0');
 
             DicomUID uid = null;
@@ -163,7 +168,7 @@ namespace Dicom
             //if (!IsValid(u))
             //	throw new DicomDataException("Invalid characters in UID string ['" + u + "']");
 
-            return new DicomUID(u, "Unknown", DicomUidType.Unknown);
+            return new DicomUID(u, name, type);
         }
 
         private static IDictionary<string, DicomUID> _uids;

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -129,6 +129,7 @@
     <Compile Include="DicomDictionaryTest.cs" />
     <Compile Include="DicomFileMetaInformationTest.cs" />
     <Compile Include="DicomParseableTest.cs" />
+    <Compile Include="DicomTransferSyntaxTest.cs" />
     <Compile Include="DicomUIDGeneratorTest.cs" />
     <Compile Include="Helpers\NLogHelper.cs" />
     <Compile Include="Helpers\PriorityOrderer.cs" />

--- a/Tests/Desktop/DicomTransferSyntaxTest.cs
+++ b/Tests/Desktop/DicomTransferSyntaxTest.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2012-2018 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
+{
+    using Dicom.IO;
+    using Xunit;
+
+    [Collection("General")]
+    public class DicomTransferSyntaxTest
+    {
+        #region Unit tests
+
+        /// <summary>
+        /// Parse can parse string representation of known UID.
+        /// </summary>
+        [Fact]
+        public void CanParseKnownTransferSyntax()
+        {
+            var ts = DicomTransferSyntax.Parse("1.2.840.10008.1.2");
+            Assert.Same(DicomTransferSyntax.ImplicitVRLittleEndian, ts);
+        }
+
+        /// <summary>
+        /// Parse can parse string representation of unknown UID.
+        /// </summary>
+        [Fact]
+        public void CanParseUnkownTransferSyntax()
+        {
+            var ts = DicomTransferSyntax.Parse("1.2.3.4.5.6.7.8.9.0");
+            Assert.Equal(Endian.Little, ts.Endian);
+            Assert.False(ts.IsRetired);
+            Assert.True(ts.IsExplicitVR);
+            Assert.True(ts.IsEncapsulated);
+            Assert.Equal("Unknown", ts.UID.Name);
+            Assert.Equal(DicomUidType.TransferSyntax, ts.UID.Type);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", ts.UID.UID);
+        }
+
+        #endregion Unit tests
+    }
+}

--- a/Tests/Desktop/DicomUIDTest.cs
+++ b/Tests/Desktop/DicomUIDTest.cs
@@ -31,6 +31,90 @@ namespace Dicom
             Assert.Equal(isRetired, found.IsRetired);
         }
 
+        /// <summary>
+        /// Parse can parse string UID.
+        /// </summary>
+        [Fact]
+        public void CanParse()
+        {
+            var uid = DicomUID.Parse("1.2.3.4.5.6.7.8.9.0");
+            Assert.Equal("Unknown", uid.Name);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", uid.UID);
+            Assert.Equal(DicomUidType.Unknown, uid.Type);
+        }
+
+        /// <summary>
+        /// Parse can parse string with trailing space into UID
+        /// </summary>
+        [Fact]
+        public void CanParseStringWithTrailingBlank()
+        {
+            var uid = DicomUID.Parse("1.2.3.4.5.6.7.8.9.0 ");
+            Assert.Equal("Unknown", uid.Name);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", uid.UID);
+            Assert.Equal(DicomUidType.Unknown, uid.Type);
+        }
+
+        /// <summary>
+        /// Parse can parse string with trailing null into UID
+        /// </summary>
+        [Fact]
+        public void CanParseStringWithTrailingNull()
+        {
+            var uid = DicomUID.Parse("1.2.3.4.5.6.7.8.9.0\0");
+            Assert.Equal("Unknown", uid.Name);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", uid.UID);
+            Assert.Equal(DicomUidType.Unknown, uid.Type);
+        }
+
+        /// <summary>
+        /// Parse can parse UID with name.
+        /// </summary>
+        [Fact]
+        public void CanParseWithName()
+        {
+            var uid = DicomUID.Parse(s: "1.2.3.4.5.6.7.8.9.0", name: "UidName");
+            Assert.Equal("UidName", uid.Name);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", uid.UID);
+            Assert.Equal(DicomUidType.Unknown, uid.Type);
+        }
+
+        /// <summary>
+        /// Parse can parse UID with type.
+        /// </summary>
+        [Fact]
+        public void CanParseWithType()
+        {
+            var uid = DicomUID.Parse(s: "1.2.3.4.5.6.7.8.9.0", type: DicomUidType.TransferSyntax);
+            Assert.Equal("Unknown", uid.Name);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", uid.UID);
+            Assert.Equal(DicomUidType.TransferSyntax, uid.Type);
+        }
+
+        /// <summary>
+        /// Parse can parse UID with type.
+        /// </summary>
+        [Fact]
+        public void CanParseWithNameAndType()
+        {
+            var uid = DicomUID.Parse(s: "1.2.3.4.5.6.7.8.9.0", name: "UidName", type: DicomUidType.TransferSyntax);
+            Assert.Equal("UidName", uid.Name);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", uid.UID);
+            Assert.Equal(DicomUidType.TransferSyntax, uid.Type);
+        }
+
+        /// <summary>
+        /// Parse can parse UID with type.
+        /// </summary>
+        [Fact]
+        public void CanParseGeneric()
+        {
+            var uid = DicomUID.Parse<DicomUID>("1.2.3.4.5.6.7.8.9.0");
+            Assert.Equal("Unknown", uid.Name);
+            Assert.Equal("1.2.3.4.5.6.7.8.9.0", uid.UID);
+            Assert.Equal(DicomUidType.Unknown, uid.Type);
+        }
+
         #endregion
 
         #region Support data


### PR DESCRIPTION
Fixes #749.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- DicomUID.Parse now accepts name and type for UID.
- DicomTransferSyntax.Parse invokes DicomUID.Parse with property UID type.
- DicomParseable.Parse must not throw exception when Parse was overloaded. it might be better to change new overload of DicomUID.Parse to something like DicomUID.ParseWithType or such, I prefer to use simple Parse though.
