### PR TITLE
query/register/unregister transfer syntax

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
 * Pass through the timeout parameter from DicomClient.Send to the constructor of DesktopNetworkStream (#732)
 * Added appveyor.yml file for ci by this setting (#729)
 * Bug Fix : anonymized patient name is now encoded with same character set as the original Dicom.
+* allow Query/Register/Unregister transfer syntax.
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/DICOM/DicomTransferSyntax.cs
+++ b/DICOM/DicomTransferSyntax.cs
@@ -683,6 +683,85 @@ namespace Dicom
             throw new DicomDataException("UID: {0} is not a transfer syntax type.", uid);
         }
 
+        /// <summary>
+        /// register transfer syntax into internal dictionary, assuming Little Endian and Explicit VR.
+        /// </summary>
+        /// <param name="uid"></param>
+        /// <returns></returns>
+        public static DicomTransferSyntax Register(DicomUID uid)
+        {
+            return Register(uid, Endian.Little, true, true);
+        }
+
+        /// <summary>
+        /// register transfer syntax into internal dictionary.
+        /// </summary>
+        /// <param name="uid"></param>
+        /// <param name="endian"></param>
+        /// <param name="isExplicitVR"></param>
+        /// <returns></returns>
+        public static DicomTransferSyntax Register(DicomUID uid, Endian endian, bool isExplicitVR = true, bool isEncapsulated = true)
+        {
+            lock (Entries)
+            {
+                DicomTransferSyntax tx;
+
+                //  return cached transfer syntax from internal dictionary.
+                if (Entries.TryGetValue(uid, out tx)) return tx;
+
+                if (uid == null) throw new ArgumentNullException(nameof(uid));
+                if (uid.Type != DicomUidType.TransferSyntax) throw new DicomDataException("UID: {0} is not a transfer syntax type.", uid);
+
+                //  cache transfer syntax into internal dictionary.
+                tx = new DicomTransferSyntax(uid)
+                {
+                    IsRetired = uid.IsRetired,
+                    IsExplicitVR = isExplicitVR,
+                    IsEncapsulated = isEncapsulated,
+                    Endian = endian
+                };
+                Entries.Add(uid, tx);
+
+                return tx;
+            }
+        }
+
+        /// <summary>
+        /// unregister transfer syntax from internal dictionary.
+        /// </summary>
+        /// <param name="uid"></param>
+        /// <returns></returns>
+        public static bool Unregister(DicomUID uid)
+        {
+            lock (Entries)
+            {
+                return Entries.Remove(uid);
+            }
+        }
+
+        /// <summary>
+        /// unregister transfer syntax from internal dictionary.
+        /// </summary>
+        /// <param name="ts"></param>
+        /// <returns></returns>
+        public static bool Unregister(DicomTransferSyntax ts)
+        {
+            return Unregister(ts.UID);
+        }
+
+        /// <summary>
+        /// Query DicomTransferSyntax by UID. returns null if not found.
+        /// </summary>
+        public static DicomTransferSyntax Query(DicomUID uid)
+        {
+            lock (Entries)
+            {
+                DicomTransferSyntax ts;
+                Entries.TryGetValue(uid, out ts);
+                return ts;
+            }
+        }
+
         #endregion
     }
 }

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -129,6 +129,7 @@
     <Compile Include="DicomDictionaryTest.cs" />
     <Compile Include="DicomFileMetaInformationTest.cs" />
     <Compile Include="DicomParseableTest.cs" />
+    <Compile Include="DicomTransferSyntaxTest.cs" />
     <Compile Include="DicomUIDGeneratorTest.cs" />
     <Compile Include="Helpers\NLogHelper.cs" />
     <Compile Include="Helpers\PriorityOrderer.cs" />

--- a/Tests/Desktop/DicomTransferSyntaxTest.cs
+++ b/Tests/Desktop/DicomTransferSyntaxTest.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) 2012-2018 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom
+{
+    using Xunit;
+
+    /// <summary>
+    /// unit test for DicomTransferSyntax
+    /// note that Register may leave extra item into internal static dictionary
+    /// which may cause unit test to fail.
+    /// </summary>
+    [Collection("General")]
+    public class DicomTransferSyntaxTest
+    {
+        #region Unit tests
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void LookupReturnsKnownTransferSyntax()
+        {
+            var ts = DicomTransferSyntax.Lookup(DicomUID.ImplicitVRLittleEndian);
+            Assert.NotNull(ts);
+            Assert.Equal(DicomUID.ImplicitVRLittleEndian, ts.UID);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void LookupReturnsAdHocTransferSyntax()
+        {
+            var uid = new DicomUID("0", "testing", DicomUidType.TransferSyntax);
+
+            var ts = DicomTransferSyntax.Lookup(uid);
+            Assert.NotNull(ts);
+            Assert.Equal(uid, ts.UID);
+
+            //  Lookup must not auto-register, as it is invoked from DicomServer.
+            //  auto-registration may cause DoS by sending crafted transfer syntaxes repeatedly,
+            //  which causes internal static dictionary to hold all the transfer syntaxes.
+            Assert.Null(DicomTransferSyntax.Query(uid));
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void LookupThrowsOnInvalidUidType()
+        {
+            var uid = DicomUID.ComputedRadiographyImageStorage;
+            Assert.Throws<DicomDataException>(
+                () => DicomTransferSyntax.Lookup(uid)
+            );
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void QueryReturnsKnownTransferSyntax()
+        {
+            var uid = DicomUID.ImplicitVRLittleEndian;
+            var ts = DicomTransferSyntax.Query(uid);
+            Assert.NotNull(ts);
+            Assert.Equal(uid, ts.UID);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void QueryReturnsRegisteredTransferSyntax()
+        {
+            var uid = new DicomUID("0", "testing", DicomUidType.TransferSyntax);
+            DicomTransferSyntax.Register(uid);
+
+            var ts = DicomTransferSyntax.Query(uid);
+            Assert.NotNull(ts);
+            Assert.Equal(uid, ts.UID);
+
+            DicomTransferSyntax.Unregister(uid);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void QueryReturnsNullIfNotRegistered()
+        {
+            var uid = new DicomUID("0", "testing", DicomUidType.TransferSyntax);
+
+            var ts = DicomTransferSyntax.Query(uid);
+            Assert.Null(ts);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void RegisterRegistersTransferSyntax()
+        {
+            var uid = new DicomUID("0", "testing", DicomUidType.TransferSyntax);
+
+            Assert.Null(DicomTransferSyntax.Query(uid));
+
+            var ts1 = DicomTransferSyntax.Register(uid);
+            Assert.NotNull(ts1);
+
+            var ts2 = DicomTransferSyntax.Query(uid);
+            Assert.Equal(uid, ts2.UID);
+
+            DicomTransferSyntax.Unregister(uid);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void RegisterHandlesMultipleRegistrations()
+        {
+            var uid = new DicomUID("0", "testing", DicomUidType.TransferSyntax);
+
+            //  should not matter if 2 instances are same.
+            Assert.NotNull(DicomTransferSyntax.Register(uid));
+            Assert.NotNull(DicomTransferSyntax.Register(uid));
+
+            //  just to be sure
+            DicomTransferSyntax.Unregister(uid);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void UnregisterUnregistersTransferSyntax()
+        {
+            var uid = new DicomUID("0", "testing", DicomUidType.TransferSyntax);
+
+            DicomTransferSyntax.Register(uid);
+            Assert.NotNull(DicomTransferSyntax.Query(uid));
+
+            DicomTransferSyntax.Unregister(uid);
+            Assert.Null(DicomTransferSyntax.Query(uid));
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        private void UnregisterHandleMultipleUnregistrations()
+        {
+            var uid = new DicomUID("0", "testing", DicomUidType.TransferSyntax);
+
+            DicomTransferSyntax.Register(uid);
+            Assert.NotNull(DicomTransferSyntax.Query(uid));
+
+            Assert.True(DicomTransferSyntax.Unregister(uid));
+            Assert.Null(DicomTransferSyntax.Query(uid));
+
+            Assert.False(DicomTransferSyntax.Unregister(uid));
+            Assert.Null(DicomTransferSyntax.Query(uid));
+        }
+
+        #endregion Unit tests
+    }
+}


### PR DESCRIPTION
Fixes #749

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- related to #749 discussion
- allow Query/Register/Unregister transfer syntaxes.
- may conflict with #753 on DicomTransferSyntaxTest and changelog. might be better to join 2 pull requests in 1.
