### PR TITLE
Resolve that GenerateDerivedFromUUID converts created Guid incorrectly to a UUID (#762)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
 * add DicomUID.IsVolumeStorage.
 * Bug Fix : DICOM server may throw DicomDataException on association when non-standard transfer syntax was proposed (#749)
 * allow Query/Register/Unregister transfer syntax.
+* Bug fix : DicomUIDGenerator.GenerateDerivedFromUUID converts Guids incorrectly to the DICOM "2.25." + UUID format (#762)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/Contributors.md
+++ b/Contributors.md
@@ -37,3 +37,4 @@
 * [Volkan Özdemir](https://github.com/volkans80)
 * [idubnori](https://github.com/idubnori)
 * [Pressacco](https://github.com/pressacco)
+* [Victor Derks](https://github.com/vbaderks)

--- a/DICOM/DicomUID.cs
+++ b/DICOM/DicomUID.cs
@@ -117,6 +117,12 @@ namespace Dicom
             _uids.Add(uid.UID, uid);
         }
 
+        public static DicomUID Generate()
+        {
+            return DicomUIDGenerator.GenerateDerivedFromUUID();
+        }
+
+        [Obsolete("This method may return statistically non-unique UIDs and is deprecated, use the method Generate()")]
         public static DicomUID Generate(string name)
         {
             if (string.IsNullOrEmpty(RootUID))
@@ -127,12 +133,6 @@ namespace Dicom
             var uid = $"{RootUID}.{DateTime.UtcNow}.{DateTime.UtcNow.Ticks}";
 
             return new DicomUID(uid, name, DicomUidType.SOPInstance);
-        }
-
-        public static DicomUID Generate()
-        {
-            var generator = new DicomUIDGenerator();
-            return DicomUIDGenerator.GenerateNew();
         }
 
         public static DicomUID Append(DicomUID baseUid, long nextSeq)

--- a/DICOM/DicomUIDGenerator.cs
+++ b/DICOM/DicomUIDGenerator.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 
 using Dicom.Network;
@@ -63,7 +65,7 @@ namespace Dicom
         }
 
         /// <summary>
-        /// If <paramref name="sourceUid"/> is known, return associated destination UID, otherwise generate and return 
+        /// If <paramref name="sourceUid"/> is known, return associated destination UID, otherwise generate and return
         /// a new destination UID for the specified <paramref name="sourceUid"/>.
         /// </summary>
         /// <param name="sourceUid">Source UID.</param>
@@ -99,6 +101,7 @@ namespace Dicom
         /// Generate a new DICOM UID.
         /// </summary>
         /// <returns>Generated UID.</returns>
+        [Obsolete("This method may return statistically non-unique UIDs and is deprecated, use the method GenerateDerivedFromUUID()")]
         public static DicomUID GenerateNew()
         {
             lock (_lock)
@@ -122,13 +125,30 @@ namespace Dicom
         /// </summary>
         /// <returns>A new UID with 2.25 prefix.</returns>
         public static DicomUID GenerateDerivedFromUUID()
-        {            
-            var guid = Guid.NewGuid().ToByteArray();
-            var bigint = new System.Numerics.BigInteger(guid);
-            if (bigint < 0) bigint = -bigint;
-            var uid = "2.25." + bigint;
+        {
+            var guid = Guid.NewGuid();
+            return new DicomUID(ConvertGuidToUuidInteger(ref guid), "Local UID", DicomUidType.Unknown);
+        }
 
-            return new DicomUID(uid, "Local UID", DicomUidType.Unknown);
+        /// <summary>
+        /// Converts a .NET Guid to a UUID in OID format.
+        /// </summary>
+        /// <remarks>Method is internal to support access to unit tests.</remarks>
+        internal static string ConvertGuidToUuidInteger(ref Guid value)
+        {
+            // ISO/IEC 9834-8, paragraph 6.3 (referenced by DICOM PS 3.5, B.2) defines how
+            // to convert a UUID to a single integer value that can be converted back into a UUID.
+
+            // The Guid.ToByteArray Method returns the array in a strange order (see .NET docs),
+            // BigInteger expects the input array in little endian order.
+            // The last byte controls the sign, add an additional zero to ensure
+            // the array is parsed as a positive number.
+            var octets = value.ToByteArray();
+            var littleEndianOrder = new byte[]
+                { octets[15], octets[14], octets[13], octets[12], octets[11], octets[10], octets[9], octets[8],
+                  octets[6], octets[7], octets[4], octets[5], octets[0], octets[1], octets[2], octets[3], 0 };
+
+            return "2.25." + new BigInteger(littleEndianOrder).ToString(CultureInfo.InvariantCulture);
         }
 
         #endregion

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -65,6 +65,7 @@
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="WindowsBase" />

--- a/Tests/Desktop/DicomUIDGeneratorTest.cs
+++ b/Tests/Desktop/DicomUIDGeneratorTest.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) 2012-2018 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System;
+using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
@@ -24,6 +27,42 @@ namespace Dicom
         }
 
         [Fact]
+        public void ConvertGuidToUuidInteger_RoundTripConversion()
+        {
+            var expected = new Guid("11223344-5566-7788-9900-aabbccddeeff");
+            string converted = DicomUIDGenerator.ConvertGuidToUuidInteger(ref expected);
+            var actual = ConvertDicomUidToGuid(converted);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ConvertGuidToUuidInteger_RoundTripConversionMaximumValue()
+        {
+            var expected = new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff");
+            string converted = DicomUIDGenerator.ConvertGuidToUuidInteger(ref expected);
+            var actual = ConvertDicomUidToGuid(converted);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ConvertGuidToUuidInteger_RoundTripConversionEmpty()
+        {
+            var expected = new Guid();
+            string converted = DicomUIDGenerator.ConvertGuidToUuidInteger(ref expected);
+            var actual = ConvertDicomUidToGuid(converted);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ConvertGuidToUuidInteger_Iso9834Sample()
+        {
+            // Sample value of ISO/IEC 9834-8, paragraph 8 and wiki.ihe.net
+            var sampleValue = new Guid("f81d4fae-7dec-11d0-a765-00a0c91e6bf6");
+            string actual = DicomUIDGenerator.ConvertGuidToUuidInteger(ref sampleValue);
+            Assert.Equal("2.25.329800735698586629295641978511506172918", actual);
+        }
+
+        [Fact]
         public void Generate_MultipleInParallel_AllValuesUnique()
         {
             const int n = 100000;
@@ -42,6 +81,23 @@ namespace Dicom
             var actual = generator.Generate(source);
 
             Assert.Equal(expected, actual);
+        }
+
+
+        private static Guid ConvertDicomUidToGuid(string value)
+        {
+            // Remove "2.25." OID root prefix
+            string valueWithoutRoot = value.Substring(5);
+
+            var bigInteger = BigInteger.Parse(valueWithoutRoot, CultureInfo.InvariantCulture);
+            var hex = bigInteger.ToString("x32", CultureInfo.InvariantCulture);
+            if (hex.Length > 32)
+            {
+                // BigInteger will return additional leading 0 when top byte > 7 to indicate positive value, remove it.
+                hex = hex.Substring(1);
+            }
+
+            return new Guid(hex);
         }
 
         #endregion

--- a/Tests/Desktop/DicomUIDTest.cs
+++ b/Tests/Desktop/DicomUIDTest.cs
@@ -38,6 +38,26 @@ namespace Dicom
             Assert.True(DicomUID.EnhancedUSVolumeStorage.IsVolumeStorage);
         }
 
+        [Fact]
+        public void Generate_ReturnsValidUid()
+        {
+            var uid = DicomUID.Generate();
+
+            Assert.True(DicomUID.IsValid(uid.UID));
+            Assert.True(uid.UID.Length <= 64); // Currently not checked by DicomUID.IsValid
+        }
+
+        [Fact]
+        public void Generate_ReturnsDifferentUidsEachTime()
+        {
+            // Note: it is statistically not possible to verify that all returned Uids
+            // are unique in a unit test. Just verify that 2 calls result in 2 different values.
+            var uidA = DicomUID.Generate();
+            var uidB = DicomUID.Generate();
+
+            Assert.NotEqual(uidA, uidB);
+        }
+
         /// <summary>
         /// Parse can parse string UID.
         /// </summary>


### PR DESCRIPTION
The byte array returned by Guid.ToByteArray() needs to be converted before it can be passed to BigInteger to get a valid encoded UUID. This to ensure that the created DicomUID can be converted back to the identical Guid by fo-dicom or another DICOM implementation.

Note: 'in' instead of ref cannot be used as C# 7.0 is the current language level target.

This solves one of the problems reported with #762

Fixes # .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-
-
-
