### PR TITLE
TryGet* should return false instead of throwing exception

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@
 * add DicomUID.IsVolumeStorage.
 * Bug Fix : DICOM server may throw DicomDataException on association when non-standard transfer syntax was proposed (#749)
 * allow Query/Register/Unregister transfer syntax.
-* Bug Fix : TryGetValue, TryGetValues, TryGetSingleValue should return false instead of throw exception.
+* Bug Fix : TryGetValue, TryGetValues, TryGetSingleValue should return false instead of throw exception. (#746)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
 * add DicomUID.IsVolumeStorage.
 * Bug Fix : DICOM server may throw DicomDataException on association when non-standard transfer syntax was proposed (#749)
 * allow Query/Register/Unregister transfer syntax.
+* Bug Fix : TryGetValue, TryGetValues, TryGetSingleValue should return false instead of throw exception.
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -346,7 +346,7 @@ namespace Dicom
                     elementValue = element.Get<T>(index);
                     return true;
                 }
-                catch (DicomDataException)
+                catch
                 {
                     elementValue = default(T);
                     return false;

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -508,7 +508,7 @@ namespace Dicom
                     value = element.Get<T>(0);
                     return true;
                 }
-                catch (DicomDataException)
+                catch
                 {
                     value = default(T);
                     return false;

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -432,7 +432,7 @@ namespace Dicom
                     values = element.Get<T[]>(-1);
                     return true;
                 }
-                catch(DicomDataException)
+                catch
                 {
                     values = null;
                     return false;

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -519,6 +519,21 @@ namespace Dicom
             Assert.False(dataset.TryGetValues(DicomTag.SeriesNumber, out int[] _));
         }
 
+        [Fact]
+        public void TryGetSingleValue_MustNotThrowOnVRViolation()
+        {
+            //  #746
+            var dataset = new DicomDataset(
+                new DicomIntegerString(
+                    DicomTag.SeriesNumber,
+                    new MemoryByteBuffer(
+                        Encoding.Default.GetBytes("1.0")
+                    )
+                )
+            );
+            Assert.False(dataset.TryGetSingleValue(DicomTag.SeriesNumber, out int _));
+        }
+
         #endregion
 
         #region Support methods

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -504,6 +504,21 @@ namespace Dicom
             Assert.False(dataset.TryGetValue(DicomTag.SeriesNumber, 0, out int _));
         }
 
+        [Fact]
+        public void TryGetValues_MustNotThrowOnVRViolation()
+        {
+            //  related #746
+            var dataset = new DicomDataset(
+                new DicomIntegerString(
+                    DicomTag.SeriesNumber,
+                    new MemoryByteBuffer(
+                        Encoding.Default.GetBytes("1.0")
+                    )
+                )
+            );
+            Assert.False(dataset.TryGetValues(DicomTag.SeriesNumber, out int[] _));
+        }
+
         #endregion
 
         #region Support methods

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -489,6 +489,21 @@ namespace Dicom
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void TryGetValue_MustNotThrowOnVRViolation()
+        {
+            //  related #746
+            var dataset = new DicomDataset(
+                new DicomIntegerString(
+                    DicomTag.SeriesNumber,
+                    new MemoryByteBuffer(
+                        Encoding.Default.GetBytes("1.0")
+                    )
+                )
+            );
+            Assert.False(dataset.TryGetValue(DicomTag.SeriesNumber, 0, out int _));
+        }
+
         #endregion
 
         #region Support methods


### PR DESCRIPTION
Fixes #746.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- TryGetValue, TryGetValues and TryGetSingleValue should return false when exception was thrown inside function.
- as TryGetString seems not to throw exception, it is untouched.
- just wrapping counterpart function (e.g. GetValue for TryGetValue) by try-catch might be better.
- #746 has labeled enhancement, changelog.md has described as bug fix.