### PR TITLE
add convenient function to create MemoryByteBuffer.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
 * add DicomUID.IsVolumeStorage.
 * Bug Fix : DICOM server may throw DicomDataException on association when non-standard transfer syntax was proposed (#749)
 * allow Query/Register/Unregister transfer syntax.
+* add convenient function to create MemoryByteBuffer (#760)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/DICOM/IO/Buffer/MemoryByteBuffer.cs
+++ b/DICOM/IO/Buffer/MemoryByteBuffer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System;
+using System.Linq;
 
 namespace Dicom.IO.Buffer
 {
@@ -37,6 +38,31 @@ namespace Dicom.IO.Buffer
             byte[] buffer = new byte[count];
             Array.Copy(Data, offset, buffer, 0, count);
             return buffer;
+        }
+
+        /// <summary>
+        /// equivalent to MemoryByteBuffer's constructor
+        /// for symmetricity.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static MemoryByteBuffer Create(byte[] bytes)
+        {
+            return new MemoryByteBuffer(bytes);
+        }
+
+        /// <summary>
+        /// create memory buffer from ushort(word) array.
+        /// words are assumed to be machine-local byte order.
+        /// should be consistent with EndianByteBuffer.
+        /// </summary>
+        /// <param name="words"></param>
+        /// <returns></returns>
+        public static MemoryByteBuffer Create(ushort[] words)
+        {
+            return Create(
+                words.AsParallel().SelectMany(BitConverter.GetBytes).ToArray()
+            );
         }
     }
 }

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Imaging\WinFormsImageTest.cs" />
     <Compile Include="Imaging\WPFImageTest.cs" />
     <Compile Include="IO\Buffer\EvenLengthBufferTest.cs" />
+    <Compile Include="IO\Buffer\MemoryByteBufferTest.cs" />
     <Compile Include="IO\Buffer\TempFileBufferTest.cs" />
     <Compile Include="IO\DesktopFileReferenceTest.cs" />
     <Compile Include="IO\DesktopPathTest.cs" />

--- a/Tests/Desktop/IO/Buffer/MemoryByteBufferTest.cs
+++ b/Tests/Desktop/IO/Buffer/MemoryByteBufferTest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2012-2018 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using Xunit;
+
+namespace Dicom.IO.Buffer
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public class MemoryByteBufferTest
+    {
+        /// <summary>
+        /// create from bytes
+        /// </summary>
+        [Fact]
+        public void Create_From_Bytes()
+        {
+            byte[] bytes = { 0x01, 0x02, 0x03, 0x04 };
+            var buffer = MemoryByteBuffer.Create(bytes);
+            Assert.Equal(bytes, buffer.Data);
+        }
+
+        /// <summary>
+        /// create from words in 'natural' byte order
+        /// </summary>
+        [Fact]
+        public void Create_From_Words()
+        {
+            ushort[] words = { 0x0102, 0x0304, 0x0506, 0x0708 };
+            var buffer = MemoryByteBuffer.Create(words);
+
+            if (Endian.LocalMachine == Endian.Little)
+            {
+                Assert.Equal(new byte[] { 0x02, 0x01, 0x04, 0x03, 0x06, 0x05, 0x08, 0x07 }, buffer.Data);
+            }
+            else
+            {
+                Assert.Equal(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 }, buffer.Data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #760 .

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- #760 enhancement.
- might be better to add MemoryByteBufferFactory.
- might be better to add overload Create(ushort[] words, Endian endian)
- might be better to hide constructor.
