### PR TITLE
DicomCFindRequest should allow defnition of Query Retrieve Information Model

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
 * add DicomUID.IsVolumeStorage.
 * Bug Fix : DICOM server may throw DicomDataException on association when non-standard transfer syntax was proposed (#749)
 * allow Query/Register/Unregister transfer syntax.
+* DicomCFindRequest should allow defnition of Query Retrieve Information Model (#708)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -51,6 +51,30 @@ namespace Dicom.Network
             Dataset = new DicomDataset();
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomCFindRequest"/> class.
+        /// </summary>
+        /// <param name="affectedSopClassUid">Affected SOP Class UID.</param>
+        /// <param name="level">Query/Retrieve level.</param>
+        /// <param name="priority">Command priority.</param>
+        public DicomCFindRequest(DicomUID affectedSopClassUid, DicomQueryRetrieveLevel level, DicomPriority priority = DicomPriority.Medium)
+            : base(DicomCommandField.CFindRequest, affectedSopClassUid, priority)
+        {
+            //  should we check combination between affectedSopClassUid and level?
+            //  should we allow PatientRoot and StudyRoot only ?
+            if (affectedSopClassUid != DicomUID.ModalityWorklistInformationModelFIND
+            && affectedSopClassUid != DicomUID.PatientRootQueryRetrieveInformationModelFIND
+            && affectedSopClassUid != DicomUID.StudyRootQueryRetrieveInformationModelFIND
+            && affectedSopClassUid != DicomUID.UnifiedProcedureStepPullSOPClass
+            && affectedSopClassUid != DicomUID.UnifiedProcedureStepWatchSOPClass)
+            {
+                throw new DicomNetworkException("Overloaded constructor does not support Affected SOP Class UID: {0}", affectedSopClassUid.Name);
+            }
+
+            Dataset = new DicomDataset();
+            Level = level;
+        }
+
         #endregion
 
         #region PROPERTIES

--- a/Tests/Desktop/Network/DicomCFindRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCFindRequestTest.cs
@@ -25,6 +25,22 @@ namespace Dicom.Network
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void Constructor_CreatesPatientRootQuery()
+        {
+            var query = new DicomCFindRequest(DicomUID.PatientRootQueryRetrieveInformationModelFIND, DicomQueryRetrieveLevel.Patient);
+            Assert.Equal(DicomQueryRetrieveLevel.Patient, query.Level);
+            Assert.Equal(DicomUID.PatientRootQueryRetrieveInformationModelFIND, query.SOPClassUID);
+        }
+
+        [Fact]
+        public void Constructor_CreatesStudyRootQuery()
+        {
+            var query = new DicomCFindRequest(DicomUID.StudyRootQueryRetrieveInformationModelFIND, DicomQueryRetrieveLevel.Study);
+            Assert.Equal(DicomQueryRetrieveLevel.Study, query.Level);
+            Assert.Equal(DicomUID.StudyRootQueryRetrieveInformationModelFIND, query.SOPClassUID);
+        }
+
         #endregion
 
         #region Support Data


### PR DESCRIPTION
Fixes #708.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- DicomCFindRequest now allows to specify AffectedSOPClassUID.
- may need to add static method  overloads?
- overloading constructor would accept any combination of SOPClassUID and QueryRetrieveLevel, might be too permissive.
