### PR TITLE
System.Text.Encoding.Default causes some unit tests fail to compile on .netstandard(.netcore)

### DIFF
--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -497,7 +497,11 @@ namespace Dicom
                 new DicomIntegerString(
                     DicomTag.SeriesNumber,
                     new MemoryByteBuffer(
+#if NETSTANDARD
+                        Encoding.GetEncoding(0).GetBytes("1.0")
+#else
                         Encoding.Default.GetBytes("1.0")
+#endif
                     )
                 )
             );
@@ -512,7 +516,11 @@ namespace Dicom
                 new DicomIntegerString(
                     DicomTag.SeriesNumber,
                     new MemoryByteBuffer(
+#if NETSTANDARD
+                        Encoding.GetEncoding(0).GetBytes("1.0")
+#else
                         Encoding.Default.GetBytes("1.0")
+#endif
                     )
                 )
             );
@@ -527,7 +535,11 @@ namespace Dicom
                 new DicomIntegerString(
                     DicomTag.SeriesNumber,
                     new MemoryByteBuffer(
+#if NETSTANDARD
+                        Encoding.GetEncoding(0).GetBytes("1.0")
+#else
                         Encoding.Default.GetBytes("1.0")
+#endif
                     )
                 )
             );


### PR DESCRIPTION
System.Text.Encoding.Default is available since .netstandard 2.0 or later.
use System.Text.Encoding.GetEncoding(0) instead for prior versions.

Fixes breakage caused by #767 .

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- thanks to @JuergenDick, reported some unit tests fail to compile due to System.Text.Encoding.Default, as discussed in #776.
- the failure is caused by #767. sorry for breakage.
