### PR TITLE
Fixes #743: use type long instead of int for position in file stream to allow reading of very large files

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.1 (TBD)
+* change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)
 * internally identify dicom servers by port/ipadress combination instead of only port (#699)
 * Update Json DS validation regex (#643)
 * Add option to DicomFile.Open how to deal with large tags (#617)

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -33,7 +33,7 @@ namespace Dicom
         {
             get
             {
-                if (Buffer != null) return Buffer.Size;
+                if (Buffer != null) return (uint)Buffer.Size;
                 return 0;
             }
         }

--- a/DICOM/IO/Buffer/BulkDataUriByteBuffer.cs
+++ b/DICOM/IO/Buffer/BulkDataUriByteBuffer.cs
@@ -24,10 +24,7 @@ namespace Dicom.IO.Buffer
         /// <summary>
         /// Gets whether data is buffered in memory or not.
         /// </summary>
-        public bool IsMemory
-        {
-            get { return _buffer != null; }
-        }
+        public bool IsMemory => _buffer != null;
 
         /// <summary>
         /// The URI for retrieving the referenced bulk data.
@@ -39,18 +36,9 @@ namespace Dicom.IO.Buffer
         /// </summary>
         public virtual byte[] Data
         {
-            get
-            {
-                if (_buffer == null)
-                    throw new InvalidOperationException(
-                        "BulkDataUriByteBuffer cannot provide Data until either GetData() has been called.");
-                return _buffer;
-            }
-
-            set
-            {
-                _buffer = value;
-            }
+            get => _buffer
+                ?? throw new InvalidOperationException("BulkDataUriByteBuffer cannot provide Data until either GetData() has been called.");
+            set => _buffer = value;
         }
 
         /// <summary>
@@ -59,30 +47,25 @@ namespace Dicom.IO.Buffer
         /// <param name="offset">Offset from beginning of data array.</param>
         /// <param name="count">Number of bytes to return.</param>
         /// <returns>Requested sub-range of the <see name="Data"/> array.</returns>
-        public virtual byte[] GetByteRange(int offset, int count)
+        public virtual byte[] GetByteRange(long offset, int count)
         {
             if (_buffer == null)
                 throw new InvalidOperationException(
                     "BulkDataUriByteBuffer cannot provide GetByteRange data until the Data property has been set.");
 
             var range = new byte[count];
-            Array.Copy(Data, offset, range, 0, count);
+            Array.Copy(Data, (int)offset, range, 0, count);
             return range;
         }
 
         /// <summary>
         /// Gets the size of the buffered data. Throws an InvalidOperationException if the Data has not been set.
         /// </summary>
-        public virtual uint Size
+        public virtual long Size
         {
-            get
-            {
-                if (_buffer == null)
-                    throw new InvalidOperationException(
-                        "BulkDataUriByteBuffer cannot provide Size until the Data property has been set.");
-
-                return (uint)_buffer.Length;
-            }
+            get => _buffer?.Length
+                ?? throw new InvalidOperationException("BulkDataUriByteBuffer cannot provide Size until the Data property has been set.");
         }
+
     }
 }

--- a/DICOM/IO/Buffer/CompositeByteBuffer.cs
+++ b/DICOM/IO/Buffer/CompositeByteBuffer.cs
@@ -45,7 +45,7 @@ namespace Dicom.IO.Buffer
         public bool IsMemory => true;
 
         /// <inheritdoc />
-        public uint Size => (uint)Buffers.Sum(x => x.Size);
+        public long Size => Buffers.Sum(x => x.Size);
 
         /// <inheritdoc />
         public byte[] Data
@@ -68,22 +68,22 @@ namespace Dicom.IO.Buffer
         #region METHODS
 
         /// <inheritdoc />
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             var pos = 0;
-            for (; pos < Buffers.Count && offset > Buffers[pos].Size; pos++) offset -= (int)Buffers[pos].Size;
+            for (; pos < Buffers.Count && offset > Buffers[pos].Size; pos++) offset -= Buffers[pos].Size;
 
             var offset2 = 0;
             var data = new byte[count];
             for (; pos < Buffers.Count && count > 0; pos++)
             {
-                var remain = Math.Min((int)Buffers[pos].Size - offset, count);
+                var remain = (int)Math.Min(Buffers[pos].Size - offset, count);
 
                 if (Buffers[pos].IsMemory)
                 {
                     try
                     {
-                        System.Buffer.BlockCopy(Buffers[pos].Data, offset, data, offset2, remain);
+                        System.Buffer.BlockCopy(Buffers[pos].Data, (int)offset, data, offset2, remain);
                     }
                     catch (Exception)
                     {

--- a/DICOM/IO/Buffer/EmptyBuffer.cs
+++ b/DICOM/IO/Buffer/EmptyBuffer.cs
@@ -14,29 +14,17 @@ namespace Dicom.IO.Buffer
             Data = new byte[0];
         }
 
-        public bool IsMemory
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool IsMemory => true;
 
         public byte[] Data { get; private set; }
 
-        public uint Size
-        {
-            get
-            {
-                return 0;
-            }
-        }
+        public long Size => 0;
 
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             if (offset != 0 || count != 0)
                 throw new ArgumentOutOfRangeException(
-                    "offset",
+                    nameof(offset),
                     "Offset and count cannot be greater than 0 in EmptyBuffer");
             return Data;
         }

--- a/DICOM/IO/Buffer/EndianByteBuffer.cs
+++ b/DICOM/IO/Buffer/EndianByteBuffer.cs
@@ -40,7 +40,7 @@ namespace Dicom.IO.Buffer
         public bool IsMemory => Internal.IsMemory;
 
         /// <inheritdoc />
-        public uint Size => Internal.Size;
+        public long Size => Internal.Size;
 
         /// <inheritdoc />
         public byte[] Data
@@ -65,7 +65,7 @@ namespace Dicom.IO.Buffer
         }
 
         /// <inheritdoc />
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             var data = Internal.GetByteRange(offset, count);
 

--- a/DICOM/IO/Buffer/EvenLengthBuffer.cs
+++ b/DICOM/IO/Buffer/EvenLengthBuffer.cs
@@ -34,7 +34,7 @@ namespace Dicom.IO.Buffer
         /// <summary>
         /// Gets the size of the even length buffer, which is always equal to the underlying (uneven length) buffer plus 1.
         /// </summary>
-        public uint Size => Buffer.Size + 1;
+        public long Size => Buffer.Size + 1;
 
         /// <summary>
         /// Gets the buffer data, which is equal to the underlying buffer data plus a padding byte at the end.
@@ -56,10 +56,10 @@ namespace Dicom.IO.Buffer
         /// <param name="count">Number of bytes to return.</param>
         /// <returns>Requested sub-range of the <see name="Data"/> array.</returns>
         /// <remarks>Allows for reach to the padded byte at the end of the even length buffer.</remarks>
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             var data = new byte[count];
-            System.Buffer.BlockCopy(Buffer.Data, offset, data, 0, Math.Min((int)Buffer.Size - offset, count));
+            System.Buffer.BlockCopy(Buffer.Data, (int)offset, data, 0, (int)Math.Min(Buffer.Size - offset, count));
             return data;
         }
 

--- a/DICOM/IO/Buffer/FileByteBuffer.cs
+++ b/DICOM/IO/Buffer/FileByteBuffer.cs
@@ -6,35 +6,26 @@ namespace Dicom.IO.Buffer
     public sealed class FileByteBuffer : IByteBuffer
     {
 
-        public FileByteBuffer(IFileReference file, long position, uint length)
+        public FileByteBuffer(IFileReference file, long position, long length)
         {
             File = file;
             Position = position;
             Size = length;
         }
 
-        public bool IsMemory
-        {
-            get => false;
-        }
+        public bool IsMemory => false;
 
         public IFileReference File { get; private set; }
 
         public long Position { get; private set; }
 
-        public uint Size { get; private set; }
+        public long Size { get; private set; }
 
-        public byte[] Data
-        {
-            get
-            {
-                return File.GetByteRange((int)Position, (int)Size);
-            }
-        }
+        public byte[] Data => File.GetByteRange(Position, (int)Size);
 
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
-            return File.GetByteRange((int)Position + offset, count);
+            return File.GetByteRange(Position + offset, count);
         }
 
     }

--- a/DICOM/IO/Buffer/IByteBuffer.cs
+++ b/DICOM/IO/Buffer/IByteBuffer.cs
@@ -16,7 +16,7 @@ namespace Dicom.IO.Buffer
         /// <summary>
         /// Gets the size of the buffered data.
         /// </summary>
-        uint Size { get; }
+        long Size { get; }
 
         /// <summary>
         /// Gets the data.
@@ -29,6 +29,6 @@ namespace Dicom.IO.Buffer
         /// <param name="offset">Offset from beginning of data array.</param>
         /// <param name="count">Number of bytes to return.</param>
         /// <returns>Requested sub-range of the <see name="Data"/> array.</returns>
-        byte[] GetByteRange(int offset, int count);
+        byte[] GetByteRange(long offset, int count);
     }
 }

--- a/DICOM/IO/Buffer/MemoryByteBuffer.cs
+++ b/DICOM/IO/Buffer/MemoryByteBuffer.cs
@@ -14,28 +14,16 @@ namespace Dicom.IO.Buffer
             System.Buffer.BlockCopy(Data, 0, this.Data, 0, len);
         }
 
-        public bool IsMemory
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool IsMemory => true;
 
         public byte[] Data { get; private set; }
 
-        public uint Size
-        {
-            get
-            {
-                return (uint)Data.Length;
-            }
-        }
+        public long Size => Data.Length;
 
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             byte[] buffer = new byte[count];
-            Array.Copy(Data, offset, buffer, 0, count);
+            Array.Copy(Data, (int)offset, buffer, 0, count);
             return buffer;
         }
     }

--- a/DICOM/IO/Buffer/RangeByteBuffer.cs
+++ b/DICOM/IO/Buffer/RangeByteBuffer.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) 2012-2018 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using System;
+
 namespace Dicom.IO.Buffer
 {
+
     public class RangeByteBuffer : IByteBuffer
     {
-        public RangeByteBuffer(IByteBuffer buffer, uint offset, uint length)
+
+        public RangeByteBuffer(IByteBuffer buffer, long offset, int length)
         {
             Internal = buffer;
             Offset = offset;
@@ -14,37 +18,19 @@ namespace Dicom.IO.Buffer
 
         public IByteBuffer Internal { get; private set; }
 
-        public uint Offset { get; private set; }
+        public long Offset { get; private set; }
 
-        public uint Length { get; private set; }
+        public int Length { get; private set; }
 
-        public bool IsMemory
+        public bool IsMemory => Internal.IsMemory;
+
+        public long Size => Length;
+
+        public byte[] Data => Internal.GetByteRange(Offset, Length);
+
+        public byte[] GetByteRange(long offset, int count)
         {
-            get
-            {
-                return Internal.IsMemory;
-            }
-        }
-
-        public uint Size
-        {
-            get
-            {
-                return Length;
-            }
-        }
-
-        public byte[] Data
-        {
-            get
-            {
-                return Internal.GetByteRange((int)Offset, (int)Length);
-            }
-        }
-
-        public byte[] GetByteRange(int offset, int count)
-        {
-            return Internal.GetByteRange((int)Offset + offset, count);
+            return Internal.GetByteRange(Offset + offset, count);
         }
     }
 }

--- a/DICOM/IO/Buffer/StreamByteBuffer.cs
+++ b/DICOM/IO/Buffer/StreamByteBuffer.cs
@@ -8,7 +8,7 @@ namespace Dicom.IO.Buffer
     public sealed class StreamByteBuffer : IByteBuffer
     {
 
-        public StreamByteBuffer(Stream stream, long position, uint length)
+        public StreamByteBuffer(Stream stream, long position, long length)
         {
             Stream = stream;
             Position = position;
@@ -21,7 +21,7 @@ namespace Dicom.IO.Buffer
 
         public long Position { get; private set; }
 
-        public uint Size { get; private set; }
+        public long Size { get; private set; }
 
         public byte[] Data
         {
@@ -35,7 +35,7 @@ namespace Dicom.IO.Buffer
             }
         }
 
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             if (!Stream.CanRead) throw new DicomIoException("cannot read from stream - maybe closed");
             byte[] buffer = new byte[count];

--- a/DICOM/IO/Buffer/SwapByteBuffer.cs
+++ b/DICOM/IO/Buffer/SwapByteBuffer.cs
@@ -15,21 +15,9 @@ namespace Dicom.IO.Buffer
 
         public int UnitSize { get; private set; }
 
-        public bool IsMemory
-        {
-            get
-            {
-                return Internal.IsMemory;
-            }
-        }
+        public bool IsMemory => Internal.IsMemory;
 
-        public uint Size
-        {
-            get
-            {
-                return Internal.Size;
-            }
-        }
+        public long Size=> Internal.Size;
 
         public byte[] Data
         {
@@ -52,7 +40,7 @@ namespace Dicom.IO.Buffer
             }
         }
 
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             byte[] data = Internal.GetByteRange(offset, count);
             Endian.SwapBytes(UnitSize, data);

--- a/DICOM/IO/Buffer/TempFileBuffer.cs
+++ b/DICOM/IO/Buffer/TempFileBuffer.cs
@@ -12,7 +12,7 @@ namespace Dicom.IO.Buffer
     {
         #region FIELDS
 
-        private readonly IFileReference file;
+        private readonly IFileReference _file;
 
         #endregion
 
@@ -24,12 +24,12 @@ namespace Dicom.IO.Buffer
         /// <param name="data">Byte array subject to buffering.</param>
         public TempFileBuffer(byte[] data)
         {
-            this.file = TemporaryFile.Create();
-            this.Size = (uint)data.Length;
+            _file = TemporaryFile.Create();
+            Size = data.Length;
 
-            using (var stream = this.file.OpenWrite())
+            using (var stream = _file.OpenWrite())
             {
-                stream.Write(data, 0, (int)this.Size);
+                stream.Write(data, 0, (int)Size);
             }
         }
 
@@ -40,29 +40,17 @@ namespace Dicom.IO.Buffer
         /// <summary>
         /// Gets whether data is buffered in memory or not.
         /// </summary>
-        public bool IsMemory
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public bool IsMemory => false;
 
         /// <summary>
         /// Gets the size of the buffered data.
         /// </summary>
-        public uint Size { get; private set; }
+        public long Size { get; private set; }
 
         /// <summary>
         /// Gets the data.
         /// </summary>
-        public byte[] Data
-        {
-            get
-            {
-                return this.GetByteRange(0, (int)this.Size);
-            }
-        }
+        public byte[] Data => GetByteRange(0, (int)Size);
 
         #endregion
 
@@ -74,11 +62,11 @@ namespace Dicom.IO.Buffer
         /// <param name="offset">Offset from beginning of data array.</param>
         /// <param name="count">Number of bytes to return.</param>
         /// <returns>Requested sub-range of the <see name="Data"/> array.</returns>
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             var buffer = new byte[count];
 
-            using (var fs = this.file.OpenRead())
+            using (var fs = _file.OpenRead())
             {
                 fs.Seek(offset, SeekOrigin.Begin);
                 fs.Read(buffer, 0, count);

--- a/DICOM/IO/ByteConverter.cs
+++ b/DICOM/IO/ByteConverter.cs
@@ -54,8 +54,8 @@ namespace Dicom.IO
 #else
             uint size = (uint)Marshal.SizeOf(typeof(T));
 #endif
-            uint padding = buffer.Size % size;
-            uint count = buffer.Size / size;
+            uint padding = (uint)(buffer.Size % size);
+            uint count = (uint)(buffer.Size / size);
             T[] values = new T[count];
             System.Buffer.BlockCopy(buffer.Data, 0, values, 0, (int)(buffer.Size - padding));
             return values;

--- a/DICOM/IO/DesktopFileReference.cs
+++ b/DICOM/IO/DesktopFileReference.cs
@@ -10,7 +10,7 @@ namespace Dicom.IO
     /// </summary>
     public sealed class DesktopFileReference : IFileReference
     {
-        private bool isTempFile;
+        private bool _isTempFile;
 
         /// <summary>
         /// Initializes a <see cref="DesktopFileReference"/> object.
@@ -18,8 +18,8 @@ namespace Dicom.IO
         /// <param name="fileName">File name.</param>
         public DesktopFileReference(string fileName)
         {
-            this.Name = fileName;
-            this.IsTempFile = false;
+            Name = fileName;
+            IsTempFile = false;
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Dicom.IO
         /// </summary>
         ~DesktopFileReference()
         {
-            if (this.IsTempFile)
+            if (IsTempFile)
             {
                 TemporaryFileRemover.Delete(this);
             }
@@ -41,22 +41,13 @@ namespace Dicom.IO
         /// <summary>
         /// Gets whether the file exist or not.
         /// </summary>
-        public bool Exists
-        {
-            get
-            {
-                return File.Exists(this.Name);
-            }
-        }
+        public bool Exists => File.Exists(Name);
 
         /// <summary>Gets and sets whether the file is temporary or not.</summary>
         /// <remarks>Temporary file will be deleted when object is <c>Disposed</c>.</remarks>
         public bool IsTempFile
         {
-            get
-            {
-                return this.isTempFile;
-            }
+            get => _isTempFile;
             set
             {
                 if (value && this.Exists)
@@ -65,7 +56,7 @@ namespace Dicom.IO
                     {
                         // set temporary file attribute so that the file system
                         // will attempt to keep all of the data in memory
-                        File.SetAttributes(this.Name, File.GetAttributes(this.Name) | FileAttributes.Temporary);
+                        File.SetAttributes(Name, File.GetAttributes(Name) | FileAttributes.Temporary);
                     }
                     catch
                     {
@@ -73,20 +64,14 @@ namespace Dicom.IO
                     }
                 }
 
-                this.isTempFile = value;
+                _isTempFile = value;
             }
         }
 
         /// <summary>
         /// Gets the directory reference of the file.
         /// </summary>
-        public IDirectoryReference Directory
-        {
-            get
-            {
-                return new DesktopDirectoryReference(Path.GetDirectoryName(this.Name));
-            }
-        }
+        public IDirectoryReference Directory => new DesktopDirectoryReference(Path.GetDirectoryName(Name));
 
         /// <summary>
         /// Creates a new file for reading and writing. Overwrites existing file.
@@ -94,7 +79,7 @@ namespace Dicom.IO
         /// <returns>Stream to the created file.</returns>
         public Stream Create()
         {
-            return File.Create(this.Name);
+            return File.Create(Name);
         }
 
         /// <summary>
@@ -103,7 +88,7 @@ namespace Dicom.IO
         /// <returns></returns>
         public Stream Open()
         {
-            return File.Open(this.Name, FileMode.Open, FileAccess.ReadWrite);
+            return File.Open(Name, FileMode.Open, FileAccess.ReadWrite);
         }
 
         /// <summary>
@@ -112,7 +97,7 @@ namespace Dicom.IO
         /// <returns>Stream to the opened file.</returns>
         public Stream OpenRead()
         {
-            return File.OpenRead(this.Name);
+            return File.OpenRead(Name);
         }
 
         /// <summary>
@@ -121,7 +106,7 @@ namespace Dicom.IO
         /// <returns>Stream to the opened file.</returns>
         public Stream OpenWrite()
         {
-            return File.OpenWrite(this.Name);
+            return File.OpenWrite(Name);
         }
 
         /// <summary>
@@ -129,7 +114,7 @@ namespace Dicom.IO
         /// </summary>
         public void Delete()
         {
-            File.Delete(this.Name);
+            File.Delete(Name);
         }
 
         /// <summary>
@@ -144,9 +129,9 @@ namespace Dicom.IO
             // delete if overwriting; let File.Move thow IOException if not
             if (File.Exists(dstFileName) && overwrite) File.Delete(dstFileName);
 
-            File.Move(this.Name, dstFileName);
-            this.Name = Path.GetFullPath(dstFileName);
-            this.IsTempFile = false;
+            File.Move(Name, dstFileName);
+            Name = Path.GetFullPath(dstFileName);
+            IsTempFile = false;
         }
 
         /// <summary>
@@ -155,11 +140,11 @@ namespace Dicom.IO
         /// <param name="offset">Offset from the start position of the file.</param>
         /// <param name="count">Number of bytes to select.</param>
         /// <returns>The specified sub-range of bytes in the file.</returns>
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
             byte[] buffer = new byte[count];
 
-            using (var fs = this.OpenRead())
+            using (var fs = OpenRead())
             {
                 fs.Seek(offset, SeekOrigin.Begin);
                 fs.Read(buffer, 0, count);
@@ -176,7 +161,7 @@ namespace Dicom.IO
         /// </returns>
         public override string ToString()
         {
-            return this.IsTempFile ? string.Format("{0} [TEMP]", this.Name) : this.Name;
+            return IsTempFile ? $"{Name} [TEMP]" : Name;
         }
     }
 }

--- a/DICOM/IO/IFileReference.cs
+++ b/DICOM/IO/IFileReference.cs
@@ -77,7 +77,7 @@ namespace Dicom.IO
         /// <param name="offset">Offset from the start position of the file.</param>
         /// <param name="count">Number of bytes to select.</param>
         /// <returns>The specified sub-range of bytes in the file.</returns>
-        byte[] GetByteRange(int offset, int count);
+        byte[] GetByteRange(long offset, int count);
 
         #endregion
     }

--- a/DICOM/IO/WindowsFileReference.cs
+++ b/DICOM/IO/WindowsFileReference.cs
@@ -24,8 +24,8 @@ namespace Dicom.IO
         /// <param name="fileName">File name.</param>
         public WindowsFileReference(string fileName)
         {
-            this.Name = Path.GetFullPath(fileName);
-            this.IsTempFile = false;
+            Name = Path.GetFullPath(fileName);
+            IsTempFile = false;
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Dicom.IO
         /// </summary>
         ~WindowsFileReference()
         {
-            if (this.IsTempFile)
+            if (IsTempFile)
             {
                 TemporaryFileRemover.Delete(this);
             }
@@ -51,13 +51,7 @@ namespace Dicom.IO
         /// <summary>
         /// Gets whether the file exist or not.
         /// </summary>
-        public bool Exists
-        {
-            get
-            {
-                return IsFileExistingAsync(this.Name).Result;
-            }
-        }
+        public bool Exists => IsFileExistingAsync(Name).Result;
 
         /// <summary>Gets and sets whether the file is temporary or not.</summary>
         /// <remarks>Temporary file will be deleted when object is <c>Disposed</c>.</remarks>
@@ -66,13 +60,7 @@ namespace Dicom.IO
         /// <summary>
         /// Gets the directory reference of the file.
         /// </summary>
-        public IDirectoryReference Directory
-        {
-            get
-            {
-                return new DesktopDirectoryReference(Path.GetDirectoryName(this.Name));
-            }
-        }
+        public IDirectoryReference Directory => new DesktopDirectoryReference(Path.GetDirectoryName(Name));
 
         #endregion
 
@@ -84,7 +72,7 @@ namespace Dicom.IO
         /// <returns>Stream to the created file.</returns>
         public Stream Create()
         {
-            return CreateAsync(this.Name).Result;
+            return CreateAsync(Name).Result;
         }
 
         /// <summary>
@@ -93,7 +81,7 @@ namespace Dicom.IO
         /// <returns>Read/write stream to the opened file.</returns>
         public Stream Open()
         {
-            return OpenExistingAsync(this.Name, true, true).Result;
+            return OpenExistingAsync(Name, true, true).Result;
         }
 
         /// <summary>
@@ -102,7 +90,7 @@ namespace Dicom.IO
         /// <returns>Readable stream to the opened file.</returns>
         public Stream OpenRead()
         {
-            return OpenExistingAsync(this.Name, true, false).Result;
+            return OpenExistingAsync(Name, true, false).Result;
         }
 
         /// <summary>
@@ -111,7 +99,7 @@ namespace Dicom.IO
         /// <returns>Writeable stream to the opened file.</returns>
         public Stream OpenWrite()
         {
-            return OpenOrCreateAsync(this.Name).Result;
+            return OpenOrCreateAsync(Name).Result;
         }
 
         /// <summary>
@@ -119,7 +107,7 @@ namespace Dicom.IO
         /// </summary>
         public void Delete()
         {
-            DeleteAsync(this.Name).Wait();
+            DeleteAsync(Name).Wait();
         }
 
         /// <summary>
@@ -131,10 +119,10 @@ namespace Dicom.IO
         /// <param name="overwrite">True if <paramref name="dstFileName"/> should be overwritten if it already exists, false otherwise.</param>
         public void Move(string dstFileName, bool overwrite = false)
         {
-            MoveAsync(this.Name, dstFileName, overwrite).Wait();
+            MoveAsync(Name, dstFileName, overwrite).Wait();
 
-            this.Name = Path.GetFullPath(dstFileName);
-            this.IsTempFile = false;
+            Name = Path.GetFullPath(dstFileName);
+            IsTempFile = false;
         }
 
         /// <summary>
@@ -143,9 +131,9 @@ namespace Dicom.IO
         /// <param name="offset">Offset from the start position of the file.</param>
         /// <param name="count">Number of bytes to select.</param>
         /// <returns>The specified sub-range of bytes in the file.</returns>
-        public byte[] GetByteRange(int offset, int count)
+        public byte[] GetByteRange(long offset, int count)
         {
-            return GetByteRangeAsync(this.Name, offset, count).Result;
+            return GetByteRangeAsync(Name, offset, count).Result;
         }
 
         /// <summary>
@@ -156,7 +144,7 @@ namespace Dicom.IO
         /// </returns>
         public override string ToString()
         {
-            return this.IsTempFile ? string.Format("{0} [TEMP]", this.Name) : this.Name;
+            return IsTempFile ? $"{Name} [TEMP]" : Name;
         }
 
         private static async Task<bool> IsFileExistingAsync(string path)
@@ -258,7 +246,7 @@ namespace Dicom.IO
                     overwrite ? NameCollisionOption.ReplaceExisting : NameCollisionOption.FailIfExists);
         }
 
-        private static async Task<byte[]> GetByteRangeAsync(string path, int offset, int count)
+        private static async Task<byte[]> GetByteRangeAsync(string path, long offset, int count)
         {
             var buffer = new Windows.Storage.Streams.Buffer((uint)count);
 

--- a/DICOM/IO/Writer/DicomWriteLengthCalculator.cs
+++ b/DICOM/IO/Writer/DicomWriteLengthCalculator.cs
@@ -69,7 +69,7 @@ namespace Dicom.IO.Writer
                     // fragment item
                     length += 4; // tag
                     length += 4; // length
-                    length += fragment.Size;
+                    length += (uint)fragment.Size;
                 }
 
                 // sequence delimitation item

--- a/DICOM/IO/Writer/DicomWriter.cs
+++ b/DICOM/IO/Writer/DicomWriter.cs
@@ -211,13 +211,15 @@ namespace Dicom.IO.Writer
         /// <remarks>On false return value, the method will invoke the callback method passed in <see cref="IDicomDatasetWalker.OnBeginWalk"/> before returning.</remarks>
         public bool OnFragmentItem(IByteBuffer item)
         {
-            WriteTagHeader(DicomTag.Item, DicomVR.NONE, item.Size);
+            WriteTagHeader(DicomTag.Item, DicomVR.NONE, (uint)item.Size);
 
             var buffer = item;
-            if (buffer is EndianByteBuffer)
+            if (buffer is EndianByteBuffer ebb)
             {
-                var ebb = (EndianByteBuffer)buffer;
-                if (ebb.Endian != Endian.LocalMachine && ebb.Endian == _target.Endian) buffer = ebb.Internal;
+                if (ebb.Endian != Endian.LocalMachine && ebb.Endian == _target.Endian)
+                {
+                    buffer = ebb.Internal;
+                }
             }
 
             WriteBuffer(_target, buffer, _options.LargeObjectSize);
@@ -233,13 +235,15 @@ namespace Dicom.IO.Writer
         /// <returns>true if traversing completed without issues, false otherwise.</returns>
         public async Task<bool> OnFragmentItemAsync(IByteBuffer item)
         {
-            WriteTagHeader(DicomTag.Item, DicomVR.NONE, item.Size);
+            WriteTagHeader(DicomTag.Item, DicomVR.NONE, (uint)item.Size);
 
             var buffer = item;
-            if (buffer is EndianByteBuffer)
+            if (buffer is EndianByteBuffer ebb)
             {
-                var ebb = (EndianByteBuffer)buffer;
-                if (ebb.Endian != Endian.LocalMachine && ebb.Endian == _target.Endian) buffer = ebb.Internal;
+                if (ebb.Endian != Endian.LocalMachine && ebb.Endian == _target.Endian)
+                {
+                    buffer = ebb.Internal;
+                }
             }
 
             await WriteBufferAsync(_target, buffer, _options.LargeObjectSize).ConfigureAwait(false);
@@ -319,7 +323,7 @@ namespace Dicom.IO.Writer
                 remainingSize -= largeObjectSize;
             }
 
-            target.Write(buffer.GetByteRange(offset, (int)remainingSize), 0, remainingSize);
+            target.Write(buffer.GetByteRange(offset, (int)remainingSize), 0, (uint)remainingSize);
         }
 
 #if !NET35
@@ -337,7 +341,7 @@ namespace Dicom.IO.Writer
                 remainingSize -= largeObjectSize;
             }
 
-            target.Write(buffer.GetByteRange(offset, (int)remainingSize), 0, remainingSize);
+            target.Write(buffer.GetByteRange(offset, (int)remainingSize), 0, (uint)remainingSize);
         }
 #endif
     }

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -353,10 +353,9 @@ namespace Dicom.Imaging
             /// <inheritdoc />
             public override void AddFrame(IByteBuffer data)
             {
-                if (!(_element.Buffer is CompositeByteBuffer))
+                var buffer = _element.Buffer as CompositeByteBuffer ??
                     throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer");
 
-                var buffer = (CompositeByteBuffer)_element.Buffer;
                 buffer.Buffers.Add(data);
 
                 NumberOfFrames++;
@@ -408,13 +407,14 @@ namespace Dicom.Imaging
             /// <inheritdoc />
             public override IByteBuffer GetFrame(int frame)
             {
-                if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
+                if (frame < 0 || frame >= NumberOfFrames)
+                    throw new IndexOutOfRangeException("Requested frame out of range!");
 
-                var offset = UncompressedFrameSize * frame;
+                var offset = (long)UncompressedFrameSize * frame;
                 IByteBuffer buffer = new RangeByteBuffer(_element.Buffer, offset, UncompressedFrameSize);
 
                 // mainly for GE Private Implicit VR Big Endian
-                if (Syntax.SwapPixelData) buffer = new SwapByteBuffer(buffer, 2);
+                if (Syntax.SwapPixelData) { buffer = new SwapByteBuffer(buffer, 2); }
 
                 return buffer;
             }
@@ -422,9 +422,8 @@ namespace Dicom.Imaging
             /// <inheritdoc />
             public override void AddFrame(IByteBuffer data)
             {
-                if (!(_element.Buffer is CompositeByteBuffer)) throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer.");
-
-                var buffer = (CompositeByteBuffer)_element.Buffer;
+                var buffer = (_element.Buffer as CompositeByteBuffer)
+                    ?? throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer.");
 
                 if (Syntax.SwapPixelData) data = new SwapByteBuffer(data, 2);
 
@@ -486,7 +485,8 @@ namespace Dicom.Imaging
             /// <inheritdoc />
             public override IByteBuffer GetFrame(int frame)
             {
-                if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
+                if (frame < 0 || frame >= NumberOfFrames)
+                    throw new IndexOutOfRangeException("Requested frame out of range!");
 
                 IByteBuffer buffer;
 
@@ -496,7 +496,10 @@ namespace Dicom.Imaging
                         ? _element.Fragments[0]
                         : new CompositeByteBuffer(_element.Fragments);
                 }
-                else if (_element.Fragments.Count == NumberOfFrames) buffer = _element.Fragments[frame];
+                else if (_element.Fragments.Count == NumberOfFrames)
+                {
+                    buffer = _element.Fragments[frame];
+                }
                 else if (_element.OffsetTable.Count == NumberOfFrames)
                 {
                     var start = _element.OffsetTable[frame];

--- a/DICOM/Imaging/DicomPixelData.cs
+++ b/DICOM/Imaging/DicomPixelData.cs
@@ -346,8 +346,8 @@ namespace Dicom.Imaging
                 if (frame < 0 || frame >= NumberOfFrames)
                     throw new IndexOutOfRangeException("Requested frame out of range!");
 
-                var offset = UncompressedFrameSize * frame;
-                return new RangeByteBuffer(_element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
+                var offset = (long)UncompressedFrameSize * frame;
+                return new RangeByteBuffer(_element.Buffer, offset, UncompressedFrameSize);
             }
 
             /// <inheritdoc />
@@ -411,7 +411,7 @@ namespace Dicom.Imaging
                 if (frame < 0 || frame >= NumberOfFrames) throw new IndexOutOfRangeException("Requested frame out of range!");
 
                 var offset = UncompressedFrameSize * frame;
-                IByteBuffer buffer = new RangeByteBuffer(_element.Buffer, (uint)offset, (uint)UncompressedFrameSize);
+                IByteBuffer buffer = new RangeByteBuffer(_element.Buffer, offset, UncompressedFrameSize);
 
                 // mainly for GE Private Implicit VR Big Endian
                 if (Syntax.SwapPixelData) buffer = new SwapByteBuffer(buffer, 2);
@@ -506,7 +506,7 @@ namespace Dicom.Imaging
 
                     var composite = new CompositeByteBuffer();
 
-                    uint pos = 0;
+                    long pos = 0;
                     var frag = 0;
 
                     while (pos < start && frag < _element.Fragments.Count)
@@ -548,7 +548,7 @@ namespace Dicom.Imaging
             {
                 NumberOfFrames++;
 
-                var pos = _element.Fragments.Sum(x => (long)x.Size + 8);
+                var pos = _element.Fragments.Sum(x => x.Size + 8);
                 if (pos < uint.MaxValue)
                 {
                     _element.OffsetTable.Add((uint)pos);


### PR DESCRIPTION
Fixes #743 and #402  .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- use long instead of int where possible
