### PR TITLE
DicomWriter.WriteBufferAsync may not copy source buffer fully.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@
 * Bug Fix : DicomPixelData.Create throws Exception if BitsAllocated >= 32 (#716)
 * Bug Fix: GetValues<object> on empty element may throw ArgumentOutOfRangeException (#720)
 * Serilog for .NET Standard 1.3/.NET Core (#772)
+* Bug Fix: C-STORE request may hang. (#792)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/Contributors.md
+++ b/Contributors.md
@@ -39,3 +39,4 @@
 * [Pressacco](https://github.com/pressacco)
 * [Victor Derks](https://github.com/vbaderks)
 * [Victor Chang](https://github.com/mocsharp)
+* [gustavosaita](https://github.com/gustavosaita)

--- a/DICOM/IO/Writer/DicomWriter.cs
+++ b/DICOM/IO/Writer/DicomWriter.cs
@@ -341,7 +341,7 @@ namespace Dicom.IO.Writer
                 remainingSize -= largeObjectSize;
             }
 
-            target.Write(buffer.GetByteRange(offset, (int)remainingSize), 0, (uint)remainingSize);
+            await target.WriteAsync(buffer.GetByteRange(offset, (int)remainingSize), 0, (uint)remainingSize).ConfigureAwait(false);
         }
 #endif
     }


### PR DESCRIPTION
Fixes #792.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- reported, investigated and fix proposed by @gustavosaita via gitter.
- DicomWriter.WriteBufferAsync may not copy source buffer fully as last write operation is not async.
- the symptom was reported as DCM4CHEE server does not return C-STORE response.

