### PR TITLE
DicomClient should use StrongBox to reduce memory consumption

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@
 * Bug Fix : DicomPixelData.Create throws Exception if BitsAllocated >= 32 (#716)
 * Bug Fix: GetValues<object> on empty element may throw ArgumentOutOfRangeException (#720)
 * Serilog for .NET Standard 1.3/.NET Core (#772)
+* DicomClient uses StrongBox to reduce memory consumption (#794)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/Contributors.md
+++ b/Contributors.md
@@ -39,3 +39,4 @@
 * [Pressacco](https://github.com/pressacco)
 * [Victor Derks](https://github.com/vbaderks)
 * [Victor Chang](https://github.com/mocsharp)
+* [vzdesic] (https://github.com/vzdesic)


### PR DESCRIPTION
Fixes #794.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- DicomClient should use StrongBox to reduce memory consumption.
- fix kindly proposed by @vzdesic
