### PR TITLE
JsonDicomConverter should decode elements with BulkDataURI

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@
 * Bug Fix : DicomPixelData.Create throws Exception if BitsAllocated >= 32 (#716)
 * Bug Fix: GetValues<object> on empty element may throw ArgumentOutOfRangeException (#720)
 * Serilog for .NET Standard 1.3/.NET Core (#772)
+* Bug Fix : JsonDicomConverter should decode BulkDataURI element(#796)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/Contributors.md
+++ b/Contributors.md
@@ -39,3 +39,4 @@
 * [Pressacco](https://github.com/pressacco)
 * [Victor Derks](https://github.com/vbaderks)
 * [Victor Chang](https://github.com/mocsharp)
+* [Erik Edespong](https://github.com/edespong)

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -639,7 +639,7 @@ namespace Dicom.Serialization
                     data = ReadJsonMultiNumber<double>(token);
                     break;
                 case "IS":
-                    data = ReadJsonMultiNumber<int>(reader);
+                    data = ReadJsonMultiNumber<int>(token);
                     break;
                 case "SL":
                     data = ReadJsonMultiNumber<int>(token);
@@ -699,15 +699,15 @@ namespace Dicom.Serialization
             return data;
         }
 
-        private object ReadJsonMultiNumber<T>(JsonReader reader)
+        private object ReadJsonMultiNumber<T>(JToken itemObject)
         {
-            if (reader.TokenType == JsonToken.PropertyName && (string)reader.Value == "Value")
+            if (itemObject["Value"] is JToken token)
             {
-                return ReadJsonMultiNumberValue<T>(reader);
+                return ReadJsonMultiNumberValue<T>(token);
             }
-            else if (reader.TokenType == JsonToken.PropertyName && (string)reader.Value == "BulkDataURI")
+            else if (itemObject["BulkDataURI"] is JToken bulk)
             {
-                return ReadJsonBulkDataUri(reader);
+                return ReadJsonBulkDataUri(bulk);
             }
             else
             {
@@ -715,9 +715,9 @@ namespace Dicom.Serialization
             }
         }
 
-        private static T[] ReadJsonMultiNumberValue<T>(JToken reader)
+        private static T[] ReadJsonMultiNumberValue<T>(JToken token)
         {
-            if (!(itemObject["Value"] is JArray tokens)) { return new T[0]; }
+            if (!(token is JArray tokens)) { return new T[0]; }
             var childValues = new List<T>();
             foreach (var item in tokens)
             {

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -269,7 +269,15 @@ namespace Dicom.Serialization
                     }
                     break;
                 case "ST":
-                    item = new DicomShortText(tag, ((string[])data)[0]);
+                    if (data is IByteBuffer)
+                    {
+                        //XXX   what should we use for encoding here ?
+                        item = new DicomShortText(tag,DicomEncoding.Default, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomShortText(tag, ((string[])data)[0]);
+                    }
                     break;
                 case "SQ":
                     item = new DicomSequence(tag, ((DicomDataset[])data));

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -326,7 +326,15 @@ namespace Dicom.Serialization
                     }
                     break;
                 case "UT":
-                    item = new DicomUnlimitedText(tag, ((string[])data).Single());
+                    if (data is IByteBuffer)
+                    {
+                        //XXX   what should we use for encoding here ?
+                        item = new DicomUnlimitedText(tag, DicomEncoding.Default, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomUnlimitedText(tag, ((string[])data).Single());
+                    }
                     break;
                 default:
                     throw new NotSupportedException("Unsupported value representation");

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -300,7 +300,14 @@ namespace Dicom.Serialization
                     item = new DicomUniqueIdentifier(tag, (string[])data);
                     break;
                 case "UL":
-                    item = new DicomUnsignedLong(tag, (uint[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomUnsignedLong(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomUnsignedLong(tag, (uint[])data);
+                    }
                     break;
                 case "UN":
                     item = new DicomUnknown(tag, (IByteBuffer)data);
@@ -588,7 +595,7 @@ namespace Dicom.Serialization
                     data = ReadJsonMultiNumber<short>(reader);
                     break;
                 case "UL":
-                    data = ReadJsonMultiNumberValue<uint>(reader);
+                    data = ReadJsonMultiNumber<uint>(reader);
                     break;
                 case "US":
                     data = ReadJsonMultiNumberValue<ushort>(reader);

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -316,7 +316,14 @@ namespace Dicom.Serialization
                     item = new DicomUniversalResource(tag, ((string[])data).Single());
                     break;
                 case "US":
-                    item = new DicomUnsignedShort(tag, (ushort[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomUnsignedShort(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomUnsignedShort(tag, (ushort[])data);
+                    }
                     break;
                 case "UT":
                     item = new DicomUnlimitedText(tag, ((string[])data).Single());
@@ -598,7 +605,7 @@ namespace Dicom.Serialization
                     data = ReadJsonMultiNumber<uint>(reader);
                     break;
                 case "US":
-                    data = ReadJsonMultiNumberValue<ushort>(reader);
+                    data = ReadJsonMultiNumber<ushort>(reader);
                     break;
                 case "DS":
                     data = ReadJsonMultiString(reader);

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -217,7 +217,15 @@ namespace Dicom.Serialization
                     item = new DicomLongString(tag, (string[])data);
                     break;
                 case "LT":
-                    item = new DicomLongText(tag, ((string[])data).Single());
+                    if (data is IByteBuffer)
+                    {
+                        //XXX   what should we use for encoding here ?
+                        item = new DicomLongText(tag, DicomEncoding.Default, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomLongText(tag, ((string[])data).Single());
+                    }
                     break;
                 case "OB":
                     item = new DicomOtherByte(tag, (IByteBuffer)data);

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -259,7 +259,14 @@ namespace Dicom.Serialization
                     }
                     break;
                 case "SS":
-                    item = new DicomSignedShort(tag, (short[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomSignedShort(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomSignedShort(tag, (short[])data);
+                    }
                     break;
                 case "ST":
                     item = new DicomShortText(tag, ((string[])data)[0]);
@@ -562,7 +569,7 @@ namespace Dicom.Serialization
                     data = ReadJsonMultiNumber<int>(reader);
                     break;
                 case "SS":
-                    data = ReadJsonMultiNumberValue<short>(reader);
+                    data = ReadJsonMultiNumber<short>(reader);
                     break;
                 case "UL":
                     data = ReadJsonMultiNumberValue<uint>(reader);

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -514,23 +514,23 @@ namespace Dicom.Serialization
                     data = ReadJsonPersonName(reader);
                     break;
                 case "FL":
-                    data = ReadJsonMultiNumber<float>(reader);
+                    data = ReadJsonMultiNumberValue<float>(reader);
                     break;
                 case "FD":
-                    data = ReadJsonMultiNumber<double>(reader);
+                    data = ReadJsonMultiNumberValue<double>(reader);
                     break;
                 case "IS":
                 case "SL":
-                    data = ReadJsonMultiNumber<int>(reader);
+                    data = ReadJsonMultiNumberValue<int>(reader);
                     break;
                 case "SS":
-                    data = ReadJsonMultiNumber<short>(reader);
+                    data = ReadJsonMultiNumberValue<short>(reader);
                     break;
                 case "UL":
-                    data = ReadJsonMultiNumber<uint>(reader);
+                    data = ReadJsonMultiNumberValue<uint>(reader);
                     break;
                 case "US":
-                    data = ReadJsonMultiNumber<ushort>(reader);
+                    data = ReadJsonMultiNumberValue<ushort>(reader);
                     break;
                 case "DS":
                     data = ReadJsonMultiString(reader);
@@ -583,7 +583,24 @@ namespace Dicom.Serialization
             return data;
         }
 
-        private static T[] ReadJsonMultiNumber<T>(JsonReader reader)
+        private object ReadJsonMultiNumber<T>(JsonReader reader)
+        {
+            reader.Read();
+            if (reader.TokenType == JsonToken.PropertyName && (string)reader.Value == "Value")
+            {
+                return ReadJsonMultiNumberValue<T>(reader);
+            }
+            else if (reader.TokenType == JsonToken.PropertyName && (string)reader.Value == "BulkDataURI")
+            {
+                return ReadJsonBulkDataUri(reader);
+            }
+            else
+            {
+                return new T[0];
+            }
+        }
+
+        private static T[] ReadJsonMultiNumberValue<T>(JsonReader reader)
         {
             reader.Read();
             if (reader.TokenType == JsonToken.EndObject) return new T[0];

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -171,7 +171,14 @@ namespace Dicom.Serialization
                     item = new DicomDate(tag, (string[])data);
                     break;
                 case "DS":
-                    item = new DicomDecimalString(tag, (string[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomDecimalString(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomDecimalString(tag, (string[])data);
+                    }
                     break;
                 case "DT":
                     item = new DicomDateTime(tag, (string[])data);

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -194,7 +194,14 @@ namespace Dicom.Serialization
                     }
                     break;
                 case "FL":
-                    item = new DicomFloatingPointSingle(tag, (float[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomFloatingPointSingle(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomFloatingPointSingle(tag, (float[])data);
+                    }
                     break;
                 case "IS":
                     item = new DicomIntegerString(tag, (int[])data);
@@ -521,7 +528,7 @@ namespace Dicom.Serialization
                     data = ReadJsonPersonName(reader);
                     break;
                 case "FL":
-                    data = ReadJsonMultiNumberValue<float>(reader);
+                    data = ReadJsonMultiNumber<float>(reader);
                     break;
                 case "FD":
                     data = ReadJsonMultiNumber<double>(reader);

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -184,7 +184,14 @@ namespace Dicom.Serialization
                     item = new DicomDateTime(tag, (string[])data);
                     break;
                 case "FD":
-                    item = new DicomFloatingPointDouble(tag, (double[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomFloatingPointDouble(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomFloatingPointDouble(tag, (double[])data);
+                    }
                     break;
                 case "FL":
                     item = new DicomFloatingPointSingle(tag, (float[])data);
@@ -517,7 +524,7 @@ namespace Dicom.Serialization
                     data = ReadJsonMultiNumberValue<float>(reader);
                     break;
                 case "FD":
-                    data = ReadJsonMultiNumberValue<double>(reader);
+                    data = ReadJsonMultiNumber<double>(reader);
                     break;
                 case "IS":
                 case "SL":

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -204,7 +204,14 @@ namespace Dicom.Serialization
                     }
                     break;
                 case "IS":
-                    item = new DicomIntegerString(tag, (int[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomIntegerString(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomIntegerString(tag, (int[])data);
+                    }
                     break;
                 case "LO":
                     item = new DicomLongString(tag, (string[])data);
@@ -534,6 +541,8 @@ namespace Dicom.Serialization
                     data = ReadJsonMultiNumber<double>(reader);
                     break;
                 case "IS":
+                    data = ReadJsonMultiNumber<int>(reader);
+                    break;
                 case "SL":
                     data = ReadJsonMultiNumberValue<int>(reader);
                     break;

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -286,7 +286,15 @@ namespace Dicom.Serialization
                     item = new DicomTime(tag, (string[])data);
                     break;
                 case "UC":
-                    item = new DicomUnlimitedCharacters(tag, ((string[])data).SingleOrDefault());
+                    if (data is IByteBuffer)
+                    {
+                        //XXX   what should we use for encoding here ?
+                        item = new DicomUnlimitedCharacters(tag, DicomEncoding.Default, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomUnlimitedCharacters(tag, ((string[])data).SingleOrDefault());
+                    }
                     break;
                 case "UI":
                     item = new DicomUniqueIdentifier(tag, (string[])data);

--- a/Serialization/Json/JsonDicomConverter.cs
+++ b/Serialization/Json/JsonDicomConverter.cs
@@ -249,7 +249,14 @@ namespace Dicom.Serialization
                     item = new DicomShortString(tag, (string[])data);
                     break;
                 case "SL":
-                    item = new DicomSignedLong(tag, (int[])data);
+                    if (data is IByteBuffer)
+                    {
+                        item = new DicomSignedLong(tag, (IByteBuffer)data);
+                    }
+                    else
+                    {
+                        item = new DicomSignedLong(tag, (int[])data);
+                    }
                     break;
                 case "SS":
                     item = new DicomSignedShort(tag, (short[])data);
@@ -552,7 +559,7 @@ namespace Dicom.Serialization
                     data = ReadJsonMultiNumber<int>(reader);
                     break;
                 case "SL":
-                    data = ReadJsonMultiNumberValue<int>(reader);
+                    data = ReadJsonMultiNumber<int>(reader);
                     break;
                 case "SS":
                     data = ReadJsonMultiNumberValue<short>(reader);

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -294,6 +294,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=IS.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForIS()
+        {
+            const string json = @"
+{
+  ""00720064"": {
+    ""vr"": ""IS"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorISValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -234,6 +234,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=DS.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForDS()
+        {
+            const string json = @"
+{
+  ""00720072"": {
+    ""vr"": ""DS"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorDSValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -254,6 +254,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=FD.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForFD()
+        {
+            const string json = @"
+{
+  ""00720074"": {
+    ""vr"": ""FD"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorFDValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -454,6 +454,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=UT.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForUT()
+        {
+            const string json = @"
+{
+  ""00720070"": {
+    ""vr"": ""UT"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorUTValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -314,6 +314,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=LT.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForLT()
+        {
+            const string json = @"
+{
+  ""00720068"": {
+    ""vr"": ""LT"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorLTValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -414,6 +414,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=UL.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForUL()
+        {
+            const string json = @"
+{
+  ""00720078"": {
+    ""vr"": ""UL"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorULValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -274,6 +274,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=FL.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForFL()
+        {
+            const string json = @"
+{
+  ""00720076"": {
+    ""vr"": ""FL"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorFLValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -394,6 +394,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=UC.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForUC()
+        {
+            const string json = @"
+{
+  ""0072006F"": {
+    ""vr"": ""UC"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorUCValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -354,6 +354,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=SS.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForSS()
+        {
+            const string json = @"
+{
+  ""0072007E"": {
+    ""vr"": ""SS"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorSSValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -434,6 +434,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=US.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForUS()
+        {
+            const string json = @"
+{
+  ""0072007A"": {
+    ""vr"": ""US"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorUSValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -334,6 +334,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=SL.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForSL()
+        {
+            const string json = @"
+{
+  ""0072007C"": {
+    ""vr"": ""SL"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorSLValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -374,6 +374,26 @@ namespace Dicom.Serialization
         }
 
         /// <summary>
+        /// Test deserializing a dicom dataset containing a bulk data URI with VR=ST.
+        /// </summary>
+        [Fact]
+        public void TestBulkDataUriForST()
+        {
+            const string json = @"
+{
+  ""0072006E"": {
+    ""vr"": ""ST"",
+    ""BulkDataURI"": ""http://www.example.com/testdicom.dcm""
+  }
+}
+";
+            var reconstituated = JsonConvert.DeserializeObject<DicomDataset>(json, new JsonDicomConverter());
+            var buffer = reconstituated.Get<IBulkDataUriByteBuffer>(DicomTag.SelectorSTValue);
+            Assert.NotNull(buffer);
+            Assert.Equal("http://www.example.com/testdicom.dcm", buffer.BulkDataUri);
+        }
+
+        /// <summary>
         /// Run the examples from DICOM Standard PS 3.18, section F.2.1.1.2.
         /// </summary>
         [Fact]


### PR DESCRIPTION
Fixes #796.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- P.S 3.18 6.5.6 WADO-RS - RetrieveMetadata states that
> however, a RESTful Service is permitted to replace the Value Field of an attribute with a BulkDataURI for attributes with Value Representations (VR) of DS, FL, FD, IS, LT, OB, OD, OF, OL, OW, SL, SS,
ST, UC, UL, UN, US, and UT.

JsonDicomConverter should decode those elements without throwing exception.
- btw, JsonDicomConverter may need some more improvements.
