### PR TITLE
DicomServer does not close TcpClient/socket after client closed connection.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@
 * Bug Fix : DicomPixelData.Create throws Exception if BitsAllocated >= 32 (#716)
 * Bug Fix: GetValues<object> on empty element may throw ArgumentOutOfRangeException (#720)
 * Serilog for .NET Standard 1.3/.NET Core (#772)
+* Bug Fix : DicomServer does not close TcpClient/socket after client closed connection (#795)
 
 #### v.4.0.0 (9/24/2018)
 * Demonstrate and fix error in RLELossless Transfer Syntax Codec

--- a/Contributors.md
+++ b/Contributors.md
@@ -39,3 +39,4 @@
 * [Pressacco](https://github.com/pressacco)
 * [Victor Derks](https://github.com/vbaderks)
 * [Victor Chang](https://github.com/mocsharp)
+* [cjcaldwell](https://github.com/cjcaldwell)

--- a/DICOM/Network/DesktopNetworkListener.cs
+++ b/DICOM/Network/DesktopNetworkListener.cs
@@ -79,7 +79,8 @@ namespace Dicom.Network
                         _certificate = GetX509Certificate(certificateName);
                     }
 
-                    return new DesktopNetworkStream(tcpClient, _certificate);
+                    //  let DesktopNetworkStream to dispose tcpClient
+                    return new DesktopNetworkStream(tcpClient, _certificate, true);
                 }
 
                 return null;

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -77,10 +77,16 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="tcpClient">TCP client.</param>
         /// <param name="certificate">Certificate for authenticated connection.</param>
-        /// <remarks>Ownership of <paramref name="tcpClient"/> remains with the caller, including responsibility for
-        /// disposal. Therefore, a handle to <paramref name="tcpClient"/> is <em>not</em> stored when <see cref="DesktopNetworkStream"/>
-        /// is initialized with this server-side constructor.</remarks>
-        internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate)
+        /// <param name="ownsTcpClient">dispose tcpClient on Dispose</param>
+        /// <remarks>
+        /// Ownership of <paramref name="tcpClient"/> is controlled by <paramref name="ownsTcpClient"/>.
+        /// 
+        /// if <paramref name="ownsTcpClient"/> is false, <paramref name="tcpClient"/> must be disposed by caller.
+        /// this is default so that compatible with older versions.
+        /// 
+        /// if <paramref name="ownsTcpClient"/> is true, <paramref name="tcpClient"/> will be disposed altogether on DesktopNetworkStream's disposal.
+        /// </remarks>
+        internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate, bool ownsTcpClient = false)
         {
             this.LocalHost = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Address.ToString();
             this.LocalPort = ((IPEndPoint)tcpClient.Client.LocalEndPoint).Port;
@@ -97,6 +103,11 @@ namespace Dicom.Network
                 ssl.AuthenticateAsServer(certificate, false, SslProtocols.Tls, false);
 #endif
                 stream = ssl;
+            }
+
+            if (ownsTcpClient)
+            {
+                this.tcpClient = tcpClient;
             }
 
             this.networkStream = stream;

--- a/DICOM/Network/DicomServer.cs
+++ b/DICOM/Network/DicomServer.cs
@@ -251,7 +251,7 @@ namespace Dicom.Network
                             scp.Options = Options;
                         }
 
-                        _services.Add(scp.RunAsync());
+                        _services.Add(scp.RunAsync().ContinueWith(_ => scp.Dispose()));
 
                         _hasServicesFlag.Set();
                         if (IsServicesAtMax) _hasNonMaxServicesFlag.Reset();

--- a/DICOM/Network/WindowsNetworkListener.cs
+++ b/DICOM/Network/WindowsNetworkListener.cs
@@ -28,8 +28,6 @@ namespace Dicom.Network
 
         private StreamSocketListener _listener;
 
-        private StreamSocket _socket;
-
         #endregion
 
         #region CONSTRUCTORS
@@ -76,8 +74,6 @@ namespace Dicom.Network
             _tokenRegistration.Dispose();
             _listener.ConnectionReceived -= OnConnectionReceived;
             _listener.Dispose();
-            _socket?.Dispose();
-            _socket = null;
         }
 
         /// <inheritdoc />
@@ -109,10 +105,8 @@ namespace Dicom.Network
         /// <see cref="StreamSocketListenerConnectionReceivedEventArgs.Socket">Socket</see>/> property is saved for later use.</param>
         private void OnConnectionReceived(StreamSocketListener sender, StreamSocketListenerConnectionReceivedEventArgs args)
         {
-            _socket?.Dispose();
-            _socket = args.Socket;
             _tokenRegistration.Dispose();
-            _streamTcs?.TrySetResult(new WindowsNetworkStream(_socket));
+            _streamTcs?.TrySetResult(new WindowsNetworkStream(args.Socket, true));
         }
 
         #endregion

--- a/DICOM/Network/WindowsNetworkStream.cs
+++ b/DICOM/Network/WindowsNetworkStream.cs
@@ -71,10 +71,16 @@ namespace Dicom.Network
         /// Initializes a server instance of <see cref="WindowsNetworkStream"/>.
         /// </summary>
         /// <param name="socket">TCP socket.</param>
-        /// <remarks>Ownership of <paramref name="socket"/> remains with the caller, including responsibility for
-        /// disposal. Therefore, a handle to <paramref name="socket"/> is <em>not</em> stored when <see cref="WindowsNetworkStream"/>
-        /// is initialized with this server-side constructor.</remarks>
-        internal WindowsNetworkStream(StreamSocket socket)
+        /// <param name="ownsSocket">dispose <paramref name="socket"/> on Dispose</param>
+        /// <remarks>
+        /// Ownership of <paramref name="socket"/> is controlled by <paramref name="ownsSocket"/>.
+        /// 
+        /// if <paramref name="ownsSocket"/> is false, <paramref name="socket"/> must be disposed by caller.
+        /// this is default so that compatible with older versions.
+        /// 
+        /// if <paramref name="ownsSocket"/> is true, <paramref name="socket"/> will be disposed altogether on WindowsNetworkStream's disposal.
+        /// </remarks>
+        internal WindowsNetworkStream(StreamSocket socket, bool ownsSocket = false)
         {
             this.LocalHost = socket.Information.LocalAddress.DisplayName;
             this.LocalPort = int.Parse(socket.Information.LocalPort, CultureInfo.InvariantCulture);
@@ -82,7 +88,7 @@ namespace Dicom.Network
             this.RemotePort = int.Parse(socket.Information.RemotePort, CultureInfo.InvariantCulture);
 
             this.socket = socket;
-            this.canDisposeSocket = false;
+            this.canDisposeSocket = ownsSocket;
             this.isConnected = true;
         }
 


### PR DESCRIPTION
Fixes #795.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [X] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- DicomServer should close TcpClient or socket after client closed connection, as @cjcaldwell investigated via gitter.
