### PR TITLE
Replace deprecated licenseUrl tags with license tags.

### DIFF
--- a/Setup/fo-dicom.Android.nuspec
+++ b/Setup/fo-dicom.Android.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM Android Library</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.Desktop.nuspec
+++ b/Setup/fo-dicom.Desktop.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM .NET Framework Libraries</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.Drawing.nuspec
+++ b/Setup/fo-dicom.Drawing.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM System.Drawing support for .NET Core</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.Json.nuspec
+++ b/Setup/fo-dicom.Json.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM Json serialization</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.MetroLog.nuspec
+++ b/Setup/fo-dicom.MetroLog.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM MetroLog connector</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.Mono.nuspec
+++ b/Setup/fo-dicom.Mono.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM Mono Library</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.NLog.nuspec
+++ b/Setup/fo-dicom.NLog.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM NLog connector</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.NetCore.nuspec
+++ b/Setup/fo-dicom.NetCore.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM .NET Core Library</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.Portable.nuspec
+++ b/Setup/fo-dicom.Portable.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM Portable Class Library</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.Serilog.nuspec
+++ b/Setup/fo-dicom.Serilog.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM Serilog connector</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.Universal.nuspec
+++ b/Setup/fo-dicom.Universal.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM Universal Windows Platform Libraries</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.iOS.nuspec
+++ b/Setup/fo-dicom.iOS.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM iOS Library</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.log4net.nuspec
+++ b/Setup/fo-dicom.log4net.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM log4net connector</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Setup/fo-dicom.nuspec
+++ b/Setup/fo-dicom.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>Fellow Oak DICOM</title>
         <authors>fo-dicom contributors</authors>
-        <licenseUrl>http://opensource.org/licenses/MS-PL</licenseUrl>
+        <license type="expression">MS-PL</license>
         <projectUrl>https://github.com/fo-dicom/fo-dicom</projectUrl>
         <iconUrl>https://lh3.googleusercontent.com/-Fq3nigRUo7U/VfaIPuJMjfI/AAAAAAAAALo/7oaLrrTBhnw/s1600/Fellow%2BOak%2BSquare%2BTransp.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Use `license` tag instead of deprecated `licenseUrl` tag in .nuspec files.
