### PR TITLE
No validation in CFind-, CGet- and CMove-Requests (#842) 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@
 * Bug Fix: Fix DicomClient getting stuck when sending one request fails completely (#848)
 * Added Modality LUT Sequence and VOI LUT Sequence functionality when generating a DICOM Image.
 * Bug Fix: Logging requests with very long private tags throws exception (#846)
+* Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there.
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@
 * Bug Fix: Fix DicomClient getting stuck when sending one request fails completely (#848)
 * Added Modality LUT Sequence and VOI LUT Sequence functionality when generating a DICOM Image.
 * Bug Fix: Logging requests with very long private tags throws exception (#846)
-* Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there.
+* Bug Fix: turn off validation when creating CFind-, CGet- or CMove-Requests, since there are no newly generated data included, but already existing UIDs have to be added there. (#860, #842)
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/DICOM/Network/DicomCFindRequest.cs
+++ b/DICOM/Network/DicomCFindRequest.cs
@@ -29,7 +29,8 @@ namespace Dicom.Network
         public DicomCFindRequest(DicomQueryRetrieveLevel level, DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CFindRequest, GetAffectedSOPClassUID(level), priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = level;
         }
 
@@ -46,7 +47,8 @@ namespace Dicom.Network
                 throw new DicomNetworkException("Overloaded constructor does not support Affected SOP Class UID: {0}", affectedSopClassUid.Name);
             }
 
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
         }
 
         /// <summary>
@@ -161,6 +163,8 @@ namespace Dicom.Network
             string studyInstanceUid = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Study);
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            dimse.Dataset.ValidateItems = false;
             dimse.Dataset.Add(DicomTag.PatientID, patientId);
             dimse.Dataset.Add(DicomTag.PatientName, patientName);
             dimse.Dataset.Add(DicomTag.IssuerOfPatientID, string.Empty);
@@ -187,6 +191,8 @@ namespace Dicom.Network
         public static DicomCFindRequest CreateSeriesQuery(string studyInstanceUid, string modality = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            dimse.Dataset.ValidateItems = false;
             dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             dimse.Dataset.Add(DicomTag.SeriesInstanceUID, string.Empty);
             dimse.Dataset.Add(DicomTag.SeriesNumber, string.Empty);
@@ -211,6 +217,8 @@ namespace Dicom.Network
             string modality = null)
         {
             var dimse = new DicomCFindRequest(DicomQueryRetrieveLevel.Image);
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            dimse.Dataset.ValidateItems = false;
             dimse.Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             dimse.Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
             dimse.Dataset.Add(DicomTag.SOPInstanceUID, string.Empty);
@@ -272,20 +280,22 @@ namespace Dicom.Network
 
             dimse.Dataset.Add(new DicomSequence(DicomTag.ProcedureCodeSequence));
 
-            var sps = new DicomDataset();
-            sps.Add(DicomTag.ScheduledStationAETitle, stationAE);
-            sps.Add(DicomTag.ScheduledStationName, stationName);
-            sps.Add(DicomTag.ScheduledProcedureStepStartDate, scheduledDateTime);
-            sps.Add(DicomTag.ScheduledProcedureStepStartTime, scheduledDateTime);
-            sps.Add(DicomTag.Modality, modality);
-            sps.Add(DicomTag.ScheduledPerformingPhysicianName, string.Empty);
-            sps.Add(DicomTag.ScheduledProcedureStepDescription, string.Empty);
-            sps.Add(new DicomSequence(DicomTag.ScheduledProtocolCodeSequence));
-            sps.Add(DicomTag.ScheduledProcedureStepLocation, string.Empty);
-            sps.Add(DicomTag.ScheduledProcedureStepID, string.Empty);
-            sps.Add(DicomTag.RequestedContrastAgent, string.Empty);
-            sps.Add(DicomTag.PreMedication, string.Empty);
-            sps.Add(DicomTag.AnatomicalOrientationType, string.Empty);
+            var sps = new DicomDataset
+            {
+                { DicomTag.ScheduledStationAETitle, stationAE },
+                { DicomTag.ScheduledStationName, stationName },
+                { DicomTag.ScheduledProcedureStepStartDate, scheduledDateTime },
+                { DicomTag.ScheduledProcedureStepStartTime, scheduledDateTime },
+                { DicomTag.Modality, modality },
+                { DicomTag.ScheduledPerformingPhysicianName, string.Empty },
+                { DicomTag.ScheduledProcedureStepDescription, string.Empty },
+                new DicomSequence(DicomTag.ScheduledProtocolCodeSequence),
+                { DicomTag.ScheduledProcedureStepLocation, string.Empty },
+                { DicomTag.ScheduledProcedureStepID, string.Empty },
+                { DicomTag.RequestedContrastAgent, string.Empty },
+                { DicomTag.PreMedication, string.Empty },
+                { DicomTag.AnatomicalOrientationType, string.Empty }
+            };
             dimse.Dataset.Add(new DicomSequence(DicomTag.ScheduledProcedureStepSequence, sps));
 
             return dimse;

--- a/DICOM/Network/DicomCFindResponse.cs
+++ b/DICOM/Network/DicomCFindResponse.cs
@@ -77,11 +77,13 @@ namespace Dicom.Network
             if (Remaining != 0) sb.AppendFormat("\n\t\tRemaining:	{0}", Remaining);
             if (Warnings != 0) sb.AppendFormat("\n\t\tWarnings:	{0}", Warnings);
             if (Failures != 0) sb.AppendFormat("\n\t\tFailures:	{0}", Failures);
-            if (Status.State != DicomState.Pending && Status.State != DicomState.Success)
+            if (Status.State != DicomState.Pending && Status.State != DicomState.Success
+                && !string.IsNullOrEmpty(Status.ErrorComment))
             {
-                if (!string.IsNullOrEmpty(Status.ErrorComment)) sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
+                sb.AppendFormat("\n\t\tError:		{0}", Status.ErrorComment);
             }
             return sb.ToString();
         }
+
     }
 }

--- a/DICOM/Network/DicomCGetRequest.cs
+++ b/DICOM/Network/DicomCGetRequest.cs
@@ -35,7 +35,8 @@ namespace Dicom.Network
             DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Study;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
         }
@@ -58,7 +59,8 @@ namespace Dicom.Network
             DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Series;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
@@ -86,7 +88,8 @@ namespace Dicom.Network
             DicomPriority priority = DicomPriority.Medium)
             : base(DicomCommandField.CGetRequest, DicomUID.StudyRootQueryRetrieveInformationModelGET, priority)
         {
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Image;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);

--- a/DICOM/Network/DicomCMoveRequest.cs
+++ b/DICOM/Network/DicomCMoveRequest.cs
@@ -32,7 +32,8 @@ namespace Dicom.Network
             : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
         {
             DestinationAE = destinationAe;
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
             Level = DicomQueryRetrieveLevel.Study;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
         }
@@ -52,7 +53,9 @@ namespace Dicom.Network
             : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
         {
             DestinationAE = destinationAe;
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
+
             Level = DicomQueryRetrieveLevel.Series;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);
@@ -75,7 +78,9 @@ namespace Dicom.Network
             : base(DicomCommandField.CMoveRequest, DicomUID.StudyRootQueryRetrieveInformationModelMOVE, priority)
         {
             DestinationAE = destinationAe;
-            Dataset = new DicomDataset();
+            // when creating requests, one may be forced to use invalid UIDs. So turn off validation
+            Dataset = new DicomDataset { ValidateItems = false };
+
             Level = DicomQueryRetrieveLevel.Image;
             Dataset.Add(DicomTag.StudyInstanceUID, studyInstanceUid);
             Dataset.Add(DicomTag.SeriesInstanceUID, seriesInstanceUid);

--- a/Tests/Desktop/DicomValidationTest.cs
+++ b/Tests/Desktop/DicomValidationTest.cs
@@ -77,6 +77,30 @@ namespace Dicom
             Assert.Throws<DicomValidationException>(() => ds.AddOrUpdate(DicomTag.ReferencedFileID, "HUGOHUGOHUGOHUGO1"));
         }
 
+
+        [Fact]
+        public void AddInvalidUIDMultiplicity()
+        {
+            Assert.Throws<DicomValidationException>(() =>
+            {
+                var ds = new DicomDataset();
+                ds.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+            });
+
+            Assert.Throws<DicomValidationException>(() =>
+            {
+                var ds = new DicomDataset();
+                ds.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+            });
+
+            Assert.Throws<DicomValidationException>(() =>
+            {
+                var ds = new DicomDataset();
+                ds.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+            });
+        }
+
+
         #endregion
 
     }

--- a/Tests/Desktop/Network/DicomCFindRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCFindRequestTest.cs
@@ -84,6 +84,34 @@ namespace Dicom.Network
             Assert.Null(e);
         }
 
+        [Fact]
+        public void AddSeveralUIDsToQuery()
+        {
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Series);
+                request.Dataset.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data

--- a/Tests/Desktop/Network/DicomCFindRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCFindRequestTest.cs
@@ -31,9 +31,9 @@ namespace Dicom.Network
         public void Constructor_ParamatersAreSet()
         {
             var cfind = new DicomCFindRequest(DicomUID.UnifiedProcedureStepEventSOPClass, DicomQueryRetrieveLevel.NotApplicable, DicomPriority.High);
-            Assert.Equal(cfind.Priority, DicomPriority.High);
-            Assert.Equal(cfind.Level, DicomQueryRetrieveLevel.NotApplicable);
-            Assert.Equal(cfind.SOPClassUID, DicomUID.UnifiedProcedureStepEventSOPClass);
+            Assert.Equal(DicomPriority.High, cfind.Priority);
+            Assert.Equal(DicomQueryRetrieveLevel.NotApplicable, cfind.Level);
+            Assert.Equal(DicomUID.UnifiedProcedureStepEventSOPClass, cfind.SOPClassUID);
         }
 
         [Theory, MemberData(nameof(InstancesLevels))]
@@ -57,6 +57,31 @@ namespace Dicom.Network
             var query = new DicomCFindRequest(DicomUID.StudyRootQueryRetrieveInformationModelFIND, DicomQueryRetrieveLevel.Study);
             Assert.Equal(DicomQueryRetrieveLevel.Study, query.Level);
             Assert.Equal(DicomUID.StudyRootQueryRetrieveInformationModelFIND, query.SOPClassUID);
+        }
+
+        [Fact]
+        public void CreateQueryWithInvalidUID()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = DicomCFindRequest.CreateSeriesQuery(invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void AddInvalidUIDToQuery()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study);
+                request.Dataset.AddOrUpdate(DicomTag.StudyInstanceUID, invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
         }
 
         #endregion

--- a/Tests/Desktop/Network/DicomCGetRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCGetRequestTest.cs
@@ -99,6 +99,31 @@ namespace Dicom.Network
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void CreateQueryWithInvalidUID()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest(invalidStudyUID, DicomPriority.Medium);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void AddInvalidUIDToQuery()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest(invalidStudyUID, DicomPriority.Medium);
+                request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data

--- a/Tests/Desktop/Network/DicomCGetRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCGetRequestTest.cs
@@ -124,6 +124,34 @@ namespace Dicom.Network
             Assert.Null(e);
         }
 
+        [Fact]
+        public void AddSeveralUIDsToQuery()
+        {
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest("1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest("1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCGetRequest("1.2.3.456");
+                request.Dataset.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data

--- a/Tests/Desktop/Network/DicomCMoveRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCMoveRequestTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System.Collections.Generic;
-using System.Threading;
 
 using Xunit;
 
@@ -25,6 +24,31 @@ namespace Dicom.Network
         {
             var actual = request.Level;
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CreateQueryWithInvalidUID()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.StudyInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
+        [Fact]
+        public void AddInvalidUIDToQuery()
+        {
+            var invalidStudyUID = "1.2.0004";
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", invalidStudyUID);
+                request.Dataset.AddOrUpdate(DicomTag.SeriesInstanceUID, invalidStudyUID);
+                Assert.Equal(invalidStudyUID, request.Dataset.GetSingleValue<string>(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
         }
 
         #endregion

--- a/Tests/Desktop/Network/DicomCMoveRequestTest.cs
+++ b/Tests/Desktop/Network/DicomCMoveRequestTest.cs
@@ -51,6 +51,35 @@ namespace Dicom.Network
             Assert.Null(e);
         }
 
+
+        [Fact]
+        public void AddSeveralUIDsToQuery()
+        {
+            var e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", "1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3\\3.4.5");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", "1.2.3.456");
+                request.Dataset.Add(DicomTag.SeriesInstanceUID, "1.2.3", "2.3.4");
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+
+            e = Record.Exception(() =>
+            {
+                var request = new DicomCMoveRequest("DestinationAE", "1.2.3.456");
+                request.Dataset.Add(new DicomUniqueIdentifier(DicomTag.SeriesInstanceUID, "1.2.3", "3.4.5"));
+                Assert.Equal(2, request.Dataset.GetValueCount(DicomTag.SeriesInstanceUID));
+            });
+            Assert.Null(e);
+        }
+
         #endregion
 
         #region Support Data


### PR DESCRIPTION
Fixes #842 .

validation is done, whenever some DicomTags are added to a DicomDataset by the developer. This is to ensure valid DICOM when creating DataSets.
But Requests as CFind, CGet or CMove are different, because there the developer is forced to add already existing UIDs and Values to the RequestDataset, actually no new data is created here. So validation is now turned off.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
