### PR TITLE
Swap OriginX/OriginY in DicomOverlayData

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@
 * Bug Fix: Disabling dataset validation for file meta information objects. (#859)
 * Bug Fix: JPEG 2000 decodes wrong colors in .NET Core (#850)
 * Enable secure DICOM Tls 1.0, 1.1 and 1.2 (#872)
+* Bug Fix: DicomOverlayData OriginX and OriginY were swapped
 
 #### v.4.0.1 (3/13/2019)
 * change IFileReference and IByteBuffer to have offset of type long so that big files can be processed (#743)

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -162,7 +162,7 @@ namespace Dicom.Imaging
         /// </summary>
         public int OriginX
         {
-            get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 0, 1);
+            get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 1, 1);
             set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginY);
         }
 
@@ -171,7 +171,7 @@ namespace Dicom.Imaging
         /// </summary>
         public int OriginY
         {
-            get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 1, 1);
+            get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 0, 1);
             set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)OriginX, (short)value);
         }
 

--- a/Tests/Desktop/Imaging/DicomOverlayDataTest.cs
+++ b/Tests/Desktop/Imaging/DicomOverlayDataTest.cs
@@ -124,5 +124,34 @@ namespace Dicom.Imaging
             var exception = Record.Exception(() => od.Type);
             Assert.NotNull(exception);
         }
+
+        [Fact]
+        public void OriginXGetter_ReturnsValueAtIndex1()
+        {
+            const int expected = 42;
+            const ushort group = 0x6012;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group);
+            dataset.AddOrUpdate(new DicomTag(group, 0x0050), "0", "42");
+
+            var actual = od.OriginX;
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OriginYGetter_ReturnsValueAtIndex0()
+        {
+            const int expected = 42;
+            const ushort group = 0x6012;
+
+            var dataset = new DicomDataset();
+            var od = new DicomOverlayData(dataset, group);
+            dataset.AddOrUpdate(new DicomTag(group, 0x0050), "42", "0");
+
+            var actual = od.OriginY;
+            Assert.Equal(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
- The first element is the row, a.k.a. index 0, a.k.a. OriginY
- The second element is the column, a.k.a. index 1, a.k.a. OriginX

See https://dicom.innolitics.com/ciods/cr-image/overlay-plane/60xx0050

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Swap OriginX and OriginY when reading overlay data
