### PR TITLE
Do not try to open another association on the existing TCP connection

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 #### v.4.0.3 (TBD)
 * Bug fix: Exception when opening a file with FileReadOption.SkipLargeTags (#893)
+* Bug fix: Do not open new associations on the existing TCP connection (#896)
 
 #### v.4.0.2 (7/30/2019)
 * Bug fix: prevent resource leak when DesktopNetworkListener waits for new TCP clients

--- a/DICOM/Network/Client/States/DicomClientReleaseAssociationState.cs
+++ b/DICOM/Network/Client/States/DicomClientReleaseAssociationState.cs
@@ -128,15 +128,7 @@ namespace Dicom.Network.Client.States
             {
                 _dicomClient.NotifyAssociationReleased();
 
-                if (!cancellation.Token.IsCancellationRequested && _dicomClient.QueuedRequests.TryPeek(out StrongBox<DicomRequest> _))
-                {
-                    _dicomClient.Logger.Debug($"[{this}] More requests need to be sent after association release, creating new association");
-                    return await _dicomClient.TransitionToRequestAssociationState(_initialisationParameters, cancellation).ConfigureAwait(false);
-                }
-
-                _dicomClient.Logger.Debug(cancellation.Token.IsCancellationRequested
-                    ? $"[{this}] Cancellation requested, disconnecting..."
-                    : $"[{this}] No more requests to be sent, disconnecting...");
+                _dicomClient.Logger.Debug($"[{this}] Association release response received, disconnecting...");
                 return await _dicomClient.TransitionToCompletedState(_initialisationParameters, cancellation).ConfigureAwait(false);
             }
 


### PR DESCRIPTION
Fixes #896 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation (no public API changes)
- [x] I have included unit tests (covered by #899)
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Prevent the new DICOM client from creating new associations over the existing TCP connection