### PR TITLE
Add MaximumNumberOfDicomRequestsPerAssociation setting to DicomClient

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 #### v.4.0.3 (TBD)
 * Bug fix: Exception when opening a file with FileReadOption.SkipLargeTags (#893)
 * Bug fix: Do not open new associations on the existing TCP connection (#896)
+* New feature: Add the ability to enforce a maximum number of DICOM requests per association to the new DICOM client (#898)
 
 #### v.4.0.2 (7/30/2019)
 * Bug fix: prevent resource leak when DesktopNetworkListener waits for new TCP clients

--- a/DICOM/Network/Client/DicomClient.cs
+++ b/DICOM/Network/Client/DicomClient.cs
@@ -54,6 +54,13 @@ namespace Dicom.Network.Client
         int AssociationLingerTimeoutInMs { get; }
 
         /// <summary>
+        /// Gets the maximum number of DICOM requests that are allowed to be sent over one single association.
+        /// When this limit is reached, the DICOM client will wait for pending requests to complete, and then open a new association
+        /// to send the remaining requests, if any.
+        /// </summary>
+        int? MaximumNumberOfRequestsPerAssociation { get; }
+
+        /// <summary>
         /// Gets or sets the handler of a client C-STORE request.
         /// </summary>
         DicomClientCStoreRequestHandler OnCStoreRequest { get; set; }
@@ -125,6 +132,7 @@ namespace Dicom.Network.Client
         public int AssociationRequestTimeoutInMs { get; set; }
         public int AssociationReleaseTimeoutInMs { get; set; }
         public int AssociationLingerTimeoutInMs { get; set; }
+        public int? MaximumNumberOfRequestsPerAssociation { get; set; }
         public bool IsSendRequired => State is DicomClientIdleState && QueuedRequests.Any();
         public Logger Logger { get; set; } = LogManager.GetLogger("Dicom.Network");
         public DicomServiceOptions Options { get; set; }
@@ -148,10 +156,12 @@ namespace Dicom.Network.Client
         /// <param name="associationRequestTimeoutInMs">Timeout in milliseconds for establishing association.</param>
         /// <param name="associationReleaseTimeoutInMs">Timeout in milliseconds to break off association</param>
         /// <param name="associationLingerTimeoutInMs">Timeout in milliseconds to keep open association after all requests have been processed.</param>
+        /// <param name="maximumNumberOfRequestsPerAssociation">The maximum number of DICOM requests that can be sent over a single DICOM association</param>
         public DicomClient(string host, int port, bool useTls, string callingAe, string calledAe,
             int associationRequestTimeoutInMs = DicomClientDefaults.DefaultAssociationRequestTimeoutInMs,
             int associationReleaseTimeoutInMs = DicomClientDefaults.DefaultAssociationReleaseTimeoutInMs,
-            int associationLingerTimeoutInMs = DicomClientDefaults.DefaultAssociationLingerInMs)
+            int associationLingerTimeoutInMs = DicomClientDefaults.DefaultAssociationLingerInMs,
+            int? maximumNumberOfRequestsPerAssociation = null)
         {
             Host = host;
             Port = port;
@@ -161,6 +171,7 @@ namespace Dicom.Network.Client
             AssociationRequestTimeoutInMs = associationRequestTimeoutInMs;
             AssociationReleaseTimeoutInMs = associationReleaseTimeoutInMs;
             AssociationLingerTimeoutInMs = associationLingerTimeoutInMs;
+            MaximumNumberOfRequestsPerAssociation = maximumNumberOfRequestsPerAssociation;
             QueuedRequests = new ConcurrentQueue<StrongBox<DicomRequest>>();
             AdditionalPresentationContexts = new List<DicomPresentationContext>();
             AsyncInvoked = 1;

--- a/DICOM/Network/Client/States/DicomClientSendingRequestsState.cs
+++ b/DICOM/Network/Client/States/DicomClientSendingRequestsState.cs
@@ -146,13 +146,13 @@ namespace Dicom.Network.Client.States
 
                 if (dicomRequest == null) continue;
 
-                _pendingRequests[dicomRequest.MessageID] = dicomRequest;
+                queuedItem.Value = null;
 
-                await Connection.SendRequestAsync(dicomRequest).ConfigureAwait(false);
+                _pendingRequests[dicomRequest.MessageID] = dicomRequest;
 
                 _sentRequests.Add(dicomRequest);
 
-                queuedItem.Value = null;
+                await Connection.SendRequestAsync(dicomRequest).ConfigureAwait(false);
             }
         }
 

--- a/Tests/Desktop/Network/Client/DicomClientTest.cs
+++ b/Tests/Desktop/Network/Client/DicomClientTest.cs
@@ -1299,7 +1299,7 @@ namespace Dicom.Network.Client
                     var iLocal = i;
                     var dicomCEchoRequest = new DicomCEchoRequest
                     {
-                        OnResponseReceived                        = (request, response) =>
+                        OnResponseReceived = (request, response) =>
                         {
                             logger.Debug($"Request completed: {iLocal}");
                             responses.Add(response);
@@ -1310,7 +1310,7 @@ namespace Dicom.Network.Client
 
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
                 {
-                    await client.SendAsync(cts.Token);
+                    await client.SendAsync(cts.Token).ConfigureAwait(false);
                 }
 
                 AllResponsesShouldHaveSucceeded(responses);

--- a/Tests/Desktop/Network/Client/DicomClientTest.cs
+++ b/Tests/Desktop/Network/Client/DicomClientTest.cs
@@ -1308,7 +1308,7 @@ namespace Dicom.Network.Client
                     await client.AddRequestAsync(dicomCEchoRequest).ConfigureAwait(false);
                 }
 
-                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
                 {
                     await client.SendAsync(cts.Token);
                 }

--- a/Tests/Desktop/Network/Client/DicomClientTest.cs
+++ b/Tests/Desktop/Network/Client/DicomClientTest.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Dicom.Helpers;
 using Dicom.Log;
 using Dicom.Network.Client.States;
-using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
Fixes #898.

⚠️  This PR depends on #897 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add a setting MaximumNumberOfDicomRequestsPerAssociation to DICOM client
- The default value for this setting is null, to ensure backwards compatibility and to ensure that no limit exists by default.
- When this setting is provided, the DICOM client will automatically release and open a new association as necessary.
