### PR TITLE
Fix #915 - Add an element of VR UR/LT/ST/UT with empty value throws an exception 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.3 (TBD)
+* Bug fix: Exception when adding an element of VR UR/UT/LT/ST with empty value (#915)
 * Bug fix: Exception when opening a file with FileReadOption.SkipLargeTags (#893)
 * Bug fix: Do not open new associations on the existing TCP connection (#896)
 * New feature: Add the ability to enforce a maximum number of DICOM requests per association to the new DICOM client (#898)

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -1383,7 +1383,7 @@ namespace Dicom
             if (vr == DicomVR.LT)
             {
                 if (values == null) return DoAdd(new DicomLongText(tag, encoding, EmptyBuffer.Value), allowUpdate);
-                if (typeof(T) == typeof(string)) return DoAdd(new DicomLongText(tag, encoding, values.Cast<string>().First()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomLongText(tag, encoding, values.Cast<string>().FirstOrDefault()), allowUpdate);
             }
 
             if (vr == DicomVR.OB)
@@ -1486,7 +1486,7 @@ namespace Dicom
             if (vr == DicomVR.ST)
             {
                 if (values == null) return DoAdd(new DicomShortText(tag, encoding, EmptyBuffer.Value), allowUpdate);
-                if (typeof(T) == typeof(string)) return DoAdd(new DicomShortText(tag, encoding, values.Cast<string>().First()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomShortText(tag, encoding, values.Cast<string>().FirstOrDefault()), allowUpdate);
             }
 
             if (vr == DicomVR.TM)
@@ -1538,7 +1538,7 @@ namespace Dicom
             if (vr == DicomVR.UR)
             {
                 if (values == null) return DoAdd(new DicomUniversalResource(tag, encoding, EmptyBuffer.Value), allowUpdate);
-                if (typeof(T) == typeof(string)) return DoAdd(new DicomUniversalResource(tag, encoding, values.Cast<string>().First()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomUniversalResource(tag, encoding, values.Cast<string>().FirstOrDefault()), allowUpdate);
             }
 
             if (vr == DicomVR.US)
@@ -1555,7 +1555,7 @@ namespace Dicom
             if (vr == DicomVR.UT)
             {
                 if (values == null) return DoAdd(new DicomUnlimitedText(tag, encoding, EmptyBuffer.Value), allowUpdate);
-                if (typeof(T) == typeof(string)) return DoAdd(new DicomUnlimitedText(tag, encoding, values.Cast<string>().First()), allowUpdate);
+                if (typeof(T) == typeof(string)) return DoAdd(new DicomUnlimitedText(tag, encoding, values.Cast<string>().FirstOrDefault()), allowUpdate);
             }
 
             throw new InvalidOperationException(

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -58,6 +58,67 @@ namespace Dicom
         }
 
         [Fact]
+        public void Add_UnlimitedTextElementWithEmptyValues_Succeeds()
+        {
+            var tag = DicomTag.SelectorUTValue;
+            var dataset = new DicomDataset();
+            dataset.Add<string>(tag);
+            Assert.IsType<DicomUnlimitedText>(dataset.First(item => item.Tag.Equals(tag)));
+
+            var data = dataset.GetValues<string>(tag);
+            Assert.Single(data, (item) => item == string.Empty);
+        }
+
+        [Fact]
+        public void Add_ShortTextElementWithEmptyValues_Succeeds()
+        {
+            var tag = DicomTag.SelectorSTValue;
+            var dataset = new DicomDataset();
+            dataset.Add<string>(tag);
+            Assert.IsType<DicomShortText>(dataset.First(item => item.Tag.Equals(tag)));
+
+            var data = dataset.GetValues<string>(tag);
+            Assert.Single(data, (item) => item == string.Empty);
+        }
+
+        [Fact]
+        public void Add_LongTextElementWithEmptyValues_Succeeds()
+        {
+            var tag = DicomTag.SelectorLTValue;
+            var dataset = new DicomDataset();
+            dataset.Add<string>(tag);
+            Assert.IsType<DicomLongText>(dataset.First(item => item.Tag.Equals(tag)));
+
+            var data = dataset.GetValues<string>(tag);
+            Assert.Single(data, (item) => item == string.Empty);
+        }
+
+        [Fact]
+        public void Add_UniversalResourceElementWithEmptyValues_Succeeds()
+        {
+            var tag = DicomTag.URNCodeValue;
+            var dataset = new DicomDataset();
+            dataset.Add<string>(tag);
+            Assert.IsType<DicomUniversalResource>(dataset.First(item => item.Tag.Equals(tag)));
+
+            var data = dataset.GetValues<string>(tag);
+            Assert.Single(data, (item) => item == string.Empty);
+        }
+
+        [Fact]
+        public void Add_UnsignedShortElementWithEmptyValues_Succeeds()
+        {
+            var tag = DicomTag.SamplesPerPixel;
+            var dataset = new DicomDataset();
+            dataset.Add<ushort>(tag);
+            Assert.IsType<DicomUnsignedShort>(dataset.First(item => item.Tag.Equals(tag)));
+
+            var data = dataset.GetValues<ushort>(tag);
+
+            Assert.Empty(data);
+        }
+
+        [Fact]
         public void Add_UniversalResourceElement_Succeeds()
         {
             var tag = DicomTag.URNCodeValue;


### PR DESCRIPTION
Fixes #915  .

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Support adding elements with empty values for VR UR/LT/ST/UT
-
-
