### PR TITLE
Add support for asynchronous server providers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
 * Bug fix: Send only PrintManagementMetaSopClassUid on AssociationRequest instead of all the various SopClassUids of the NCreate and NSet requests (#667)
 * Global static property DicomValidation.PerformValidation to turn off validation for every DicomDataset. 
 * Bug fix: Prevent DICOM client from freezing when too many DICOM requests time out and async operations invoked is a low number
+* New feature: asynchronous counterparts to IDicomCEchoProvider, IDicomCFindProvider, IDicomCStoreProvider, IDicomCMoveProvider, IDicomCGetProvider and IDicomNServiceProvider
 
 #### v.4.0.2 (7/30/2019)
 * Bug fix: prevent resource leak when DesktopNetworkListener waits for new TCP clients

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 #### v.4.0.4 (TBD)
-
+* New feature: asynchronous counterparts to IDicomCEchoProvider, IDicomCFindProvider, IDicomCStoreProvider, IDicomCMoveProvider, IDicomCGetProvider and IDicomNServiceProvider
 
 #### v.4.0.3 (9/21/2019)
 * Bug fix: Exception when adding an element of VR UR/UT/LT/ST with empty value (#915)
@@ -15,7 +15,6 @@
 * Bug fix: Send only PrintManagementMetaSopClassUid on AssociationRequest instead of all the various SopClassUids of the NCreate and NSet requests (#667)
 * Global static property DicomValidation.PerformValidation to turn off validation for every DicomDataset. 
 * Bug fix: Prevent DICOM client from freezing when too many DICOM requests time out and async operations invoked is a low number
-* New feature: asynchronous counterparts to IDicomCEchoProvider, IDicomCFindProvider, IDicomCStoreProvider, IDicomCMoveProvider, IDicomCGetProvider and IDicomNServiceProvider
 
 #### v.4.0.2 (7/30/2019)
 * Bug fix: prevent resource leak when DesktopNetworkListener waits for new TCP clients

--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -267,6 +267,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomServiceOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\DicomTimeout.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomCEchoProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomCFindProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomCGetProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomCMoveProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomCStoreProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomNServiceProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCEchoProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCFindProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCGetProvider.cs" />

--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -184,6 +184,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Media\DicomDirectoryRecordCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Media\DicomDirectoryRecordType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Media\DicomFileScanner.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\AsyncDicomCEchoProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\AsyncManualResetEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\DicomClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\DicomClientCancellation.cs" />

--- a/DICOM/Network/AsyncDicomCEchoProvider.cs
+++ b/DICOM/Network/AsyncDicomCEchoProvider.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+using Dicom.Log;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Implementation of an asynchronous C-ECHO Service Class Provider.
+    /// </summary>
+    public class AsyncDicomCEchoProvider : DicomService, IDicomServiceProvider, IAsyncDicomCEchoProvider
+    {
+        /// <summary>
+        /// Initializes an instance of the <see cref="DicomCEchoProvider"/> class.
+        /// </summary>
+        /// <param name="stream">Network stream on which DICOM communication is establshed.</param>
+        /// <param name="fallbackEncoding">Text encoding if not specified within messaging.</param>
+        /// <param name="log">DICOM logger.</param>
+        public AsyncDicomCEchoProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        /// <inheritdoc />
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(pc.AbstractSyntax == DicomUID.Verification
+                    ? DicomPresentationContextResult.Accept
+                    : DicomPresentationContextResult.RejectAbstractSyntaxNotSupported);
+            }
+
+            return SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            return SendAssociationReleaseResponseAsync();
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        /// <summary>
+        /// Event handler for C-ECHO request.
+        /// </summary>
+        /// <param name="request">C-ECHO request.</param>
+        /// <returns>C-ECHO response with Success status.</returns>
+        public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        {
+            return Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success));
+        }
+    }
+}

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Text;
-
-#if !NET35
 using System.Threading.Tasks;
-#endif
 
 using Dicom.Log;
 
@@ -28,7 +25,6 @@ namespace Dicom.Network
         {
         }
 
-#if !NET35
         /// <inheritdoc />
         public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
         {
@@ -47,7 +43,6 @@ namespace Dicom.Network
         {
             return SendAssociationReleaseResponseAsync();
         }
-#endif
 
         /// <inheritdoc />
         public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)

--- a/DICOM/Network/DicomCEchoProvider.cs
+++ b/DICOM/Network/DicomCEchoProvider.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Text;
+
+#if !NET35
 using System.Threading.Tasks;
+#endif
 
 using Dicom.Log;
 
@@ -25,6 +28,7 @@ namespace Dicom.Network
         {
         }
 
+#if !NET35
         /// <inheritdoc />
         public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
         {
@@ -43,6 +47,7 @@ namespace Dicom.Network
         {
             return SendAssociationReleaseResponseAsync();
         }
+#endif
 
         /// <inheritdoc />
         public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -793,7 +793,7 @@ namespace Dicom.Network
                                     }
                                     else if (this is IAsyncDicomCStoreProvider thisAsAsyncCStoreProvider)
                                     {
-                                        await thisAsAsyncCStoreProvider.OnCStoreRequestExceptionAsync(_dimseStreamFile?.Name, e);
+                                        await thisAsAsyncCStoreProvider.OnCStoreRequestExceptionAsync(_dimseStreamFile?.Name, e).ConfigureAwait(false);
                                     }
 
                                     return;

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -787,7 +787,15 @@ namespace Dicom.Network
                                         .ConfigureAwait(false);
 
                                     Logger.Error("Error parsing C-Store dataset: {@error}", e);
-                                    (this as IDicomCStoreProvider).OnCStoreRequestException(_dimseStreamFile?.Name, e);
+                                    if (this is IDicomCStoreProvider thisAsCStoreProvider)
+                                    {
+                                        thisAsCStoreProvider.OnCStoreRequestException(_dimseStreamFile?.Name, e);
+                                    }
+                                    else if (this is IAsyncDicomCStoreProvider thisAsAsyncCStoreProvider)
+                                    {
+                                        await thisAsAsyncCStoreProvider.OnCStoreRequestExceptionAsync(_dimseStreamFile?.Name, e);
+                                    }
+
                                     return;
                                 }
                             }
@@ -861,6 +869,13 @@ namespace Dicom.Network
                     return;
                 }
 
+                if (this is IAsyncDicomCStoreProvider thisAsyncDicomCStoreProvider)
+                {
+                    var response = await thisAsyncDicomCStoreProvider.OnCStoreRequestAsync(dimse as DicomCStoreRequest).ConfigureAwait(false);
+                    await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
+
                 if (this is IDicomServiceUser thisDicomServiceUser)
                 {
                     var response = thisDicomServiceUser.OnCStoreRequest(dimse as DicomCStoreRequest);
@@ -880,72 +895,158 @@ namespace Dicom.Network
 
             if (dimse.Type == DicomCommandField.CFindRequest)
             {
-                var thisAsCFindProvider = this as IDicomCFindProvider ?? throw new DicomNetworkException("C-Find SCP not implemented");
+                if (this is IDicomCFindProvider thisAsCFindProvider)
+                {
+                    var responses = thisAsCFindProvider.OnCFindRequest(dimse as DicomCFindRequest);
+                    foreach (var response in responses) await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
 
-                var responses = thisAsCFindProvider.OnCFindRequest(dimse as DicomCFindRequest);
-                foreach (var response in responses) await SendResponseAsync(response).ConfigureAwait(false);
-                return;
+                if (this is IAsyncDicomCFindProvider thisAsAsyncCFindProvider)
+                {
+                    var asyncResponses = await thisAsAsyncCFindProvider.OnCFindRequestAsync(dimse as DicomCFindRequest).ConfigureAwait(false);
+                    foreach (var asyncResponse in asyncResponses)
+                    {
+                        var response = await asyncResponse.ConfigureAwait(false);
+                        await SendResponseAsync(response).ConfigureAwait(false);
+                    }
+                    return;
+                }
+
+                throw new DicomNetworkException("C-Find SCP not implemented");
             }
 
             if (dimse.Type == DicomCommandField.CGetRequest)
             {
-                var thisAsCGetProvider = this as IDicomCGetProvider ?? throw new DicomNetworkException("C-GET SCP not implemented");
+                if(this is IDicomCGetProvider thisAsCGetProvider)
+                {
+                    var responses = thisAsCGetProvider.OnCGetRequest(dimse as DicomCGetRequest);
+                    foreach (var response in responses) await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
 
-                var responses = thisAsCGetProvider.OnCGetRequest(dimse as DicomCGetRequest);
-                foreach (var response in responses) await SendResponseAsync(response).ConfigureAwait(false);
-                return;
+                if(this is IAsyncDicomCGetProvider thisAsAsyncCGetProvider)
+                {
+                    var asyncResponses = await thisAsAsyncCGetProvider.OnCGetRequestAsync(dimse as DicomCGetRequest).ConfigureAwait(false);
+                    foreach (var asyncResponse in asyncResponses)
+                    {
+                        var response = await asyncResponse.ConfigureAwait(false);
+                        await SendResponseAsync(response).ConfigureAwait(false);
+                    }
+                    return;
+                }
+
+                throw new DicomNetworkException("C-GET SCP not implemented");
             }
 
             if (dimse.Type == DicomCommandField.CMoveRequest)
             {
-                var thisAsCMoveProvider = this as IDicomCMoveProvider ?? throw new DicomNetworkException("C-Move SCP not implemented");
+                if (this is IDicomCMoveProvider thisAsCMoveProvider)
+                {
+                    var responses = thisAsCMoveProvider.OnCMoveRequest(dimse as DicomCMoveRequest);
+                    foreach (var response in responses) await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
 
-                var responses = thisAsCMoveProvider.OnCMoveRequest(dimse as DicomCMoveRequest);
-                foreach (var response in responses) await SendResponseAsync(response).ConfigureAwait(false);
-                return;
+                if (this is IAsyncDicomCMoveProvider thisAsAsyncCMoveProvider)
+                {
+                    var asyncResponses = await thisAsAsyncCMoveProvider.OnCMoveRequestAsync(dimse as DicomCMoveRequest).ConfigureAwait(false);
+                    foreach (var asyncResponse in asyncResponses)
+                    {
+                        var response = await asyncResponse.ConfigureAwait(false);
+                        await SendResponseAsync(response).ConfigureAwait(false);
+                    }
+                    return;
+                }
+
+                throw new DicomNetworkException("C-Move SCP not implemented");
             }
 
             if (dimse.Type == DicomCommandField.CEchoRequest)
             {
-                var thisAsCEchoProvider = this as IDicomCEchoProvider ?? throw new DicomNetworkException("C-Echo SCP not implemented");
-
-                var response = thisAsCEchoProvider.OnCEchoRequest(dimse as DicomCEchoRequest);
-                await SendResponseAsync(response).ConfigureAwait(false);
-                return;
-            }
-
-            if (dimse.Type == DicomCommandField.NActionRequest || dimse.Type == DicomCommandField.NCreateRequest
-                || dimse.Type == DicomCommandField.NDeleteRequest
-                || dimse.Type == DicomCommandField.NEventReportRequest
-                || dimse.Type == DicomCommandField.NGetRequest || dimse.Type == DicomCommandField.NSetRequest)
-            {
-                var thisAsNServiceProvider = this as IDicomNServiceProvider ?? throw new DicomNetworkException("N-Service SCP not implemented");
-
-                DicomResponse response = null;
-                switch (dimse.Type)
+                if (this is IDicomCEchoProvider thisAsCEchoProvider)
                 {
-                    case DicomCommandField.NActionRequest:
-                        response = thisAsNServiceProvider.OnNActionRequest(dimse as DicomNActionRequest);
-                        break;
-                    case DicomCommandField.NCreateRequest:
-                        response = thisAsNServiceProvider.OnNCreateRequest(dimse as DicomNCreateRequest);
-                        break;
-                    case DicomCommandField.NDeleteRequest:
-                        response = thisAsNServiceProvider.OnNDeleteRequest(dimse as DicomNDeleteRequest);
-                        break;
-                    case DicomCommandField.NEventReportRequest:
-                        response = thisAsNServiceProvider.OnNEventReportRequest(dimse as DicomNEventReportRequest);
-                        break;
-                    case DicomCommandField.NGetRequest:
-                        response = thisAsNServiceProvider.OnNGetRequest(dimse as DicomNGetRequest);
-                        break;
-                    case DicomCommandField.NSetRequest:
-                        response = thisAsNServiceProvider.OnNSetRequest(dimse as DicomNSetRequest);
-                        break;
+                    var response = thisAsCEchoProvider.OnCEchoRequest(dimse as DicomCEchoRequest);
+                    await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
                 }
 
-                await SendResponseAsync(response).ConfigureAwait(false);
-                return;
+                if (this is IAsyncDicomCEchoProvider thisAsAsyncCEchoProvider)
+                {
+                    var response = await thisAsAsyncCEchoProvider.OnCEchoRequestAsync(dimse as DicomCEchoRequest).ConfigureAwait(false);
+                    await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
+
+                throw new DicomNetworkException("C-Echo SCP not implemented");
+            }
+
+            if (dimse.Type == DicomCommandField.NActionRequest
+                || dimse.Type == DicomCommandField.NCreateRequest
+                || dimse.Type == DicomCommandField.NDeleteRequest
+                || dimse.Type == DicomCommandField.NEventReportRequest
+                || dimse.Type == DicomCommandField.NGetRequest
+                || dimse.Type == DicomCommandField.NSetRequest)
+            {
+                if (this is IDicomNServiceProvider thisAsNServiceProvider)
+                {
+                    DicomResponse response = null;
+                    switch (dimse.Type)
+                    {
+                        case DicomCommandField.NActionRequest:
+                            response = thisAsNServiceProvider.OnNActionRequest(dimse as DicomNActionRequest);
+                            break;
+                        case DicomCommandField.NCreateRequest:
+                            response = thisAsNServiceProvider.OnNCreateRequest(dimse as DicomNCreateRequest);
+                            break;
+                        case DicomCommandField.NDeleteRequest:
+                            response = thisAsNServiceProvider.OnNDeleteRequest(dimse as DicomNDeleteRequest);
+                            break;
+                        case DicomCommandField.NEventReportRequest:
+                            response = thisAsNServiceProvider.OnNEventReportRequest(dimse as DicomNEventReportRequest);
+                            break;
+                        case DicomCommandField.NGetRequest:
+                            response = thisAsNServiceProvider.OnNGetRequest(dimse as DicomNGetRequest);
+                            break;
+                        case DicomCommandField.NSetRequest:
+                            response = thisAsNServiceProvider.OnNSetRequest(dimse as DicomNSetRequest);
+                            break;
+                    }
+
+                    await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
+
+                if (this is IAsyncDicomNServiceProvider thisAsAsyncNServiceProvider)
+                {
+                    DicomResponse response = null;
+                    switch (dimse.Type)
+                    {
+                        case DicomCommandField.NActionRequest:
+                            response = await thisAsAsyncNServiceProvider.OnNActionRequestAsync(dimse as DicomNActionRequest).ConfigureAwait(false);
+                            break;
+                        case DicomCommandField.NCreateRequest:
+                            response = await thisAsAsyncNServiceProvider.OnNCreateRequestAsync(dimse as DicomNCreateRequest).ConfigureAwait(false);
+                            break;
+                        case DicomCommandField.NDeleteRequest:
+                            response = await thisAsAsyncNServiceProvider.OnNDeleteRequestAsync(dimse as DicomNDeleteRequest).ConfigureAwait(false);
+                            break;
+                        case DicomCommandField.NEventReportRequest:
+                            response = await thisAsAsyncNServiceProvider.OnNEventReportRequestAsync(dimse as DicomNEventReportRequest).ConfigureAwait(false);
+                            break;
+                        case DicomCommandField.NGetRequest:
+                            response = await thisAsAsyncNServiceProvider.OnNGetRequestAsync(dimse as DicomNGetRequest).ConfigureAwait(false);
+                            break;
+                        case DicomCommandField.NSetRequest:
+                            response = await thisAsAsyncNServiceProvider.OnNSetRequestAsync(dimse as DicomNSetRequest).ConfigureAwait(false);
+                            break;
+                    }
+
+                    await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
+
+                throw new DicomNetworkException("N-Service SCP not implemented");
             }
 
             throw new DicomNetworkException("Operation not implemented");

--- a/DICOM/Network/IAsyncDicomCEchoProvider.cs
+++ b/DICOM/Network/IAsyncDicomCEchoProvider.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface for asynchronous C-ECHO service class providers.
+    /// </summary>
+    public interface IAsyncDicomCEchoProvider
+    {
+        /// <summary>
+        /// Event handler for C-ECHO request.
+        /// </summary>
+        /// <param name="request">C-ECHO request.</param>
+        /// <returns>C-ECHO response.</returns>
+        Task<DicomCEchoResponse> OnCEchoRequest(DicomCEchoRequest request);
+    }
+}

--- a/DICOM/Network/IAsyncDicomCEchoProvider.cs
+++ b/DICOM/Network/IAsyncDicomCEchoProvider.cs
@@ -15,6 +15,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-ECHO request.</param>
         /// <returns>C-ECHO response.</returns>
-        Task<DicomCEchoResponse> OnCEchoRequest(DicomCEchoRequest request);
+        Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomCFindProvider.cs
+++ b/DICOM/Network/IAsyncDicomCFindProvider.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface representing asynchronous event handlers for DIMSE services applicable to C-FIND SOP instances.
+    /// </summary>
+    public interface IAsyncDicomCFindProvider
+    {
+        /// <summary>
+        /// Handler of C-FIND request.
+        /// </summary>
+        /// <param name="request">C-FIND request subject to handling.</param>
+        /// <returns>Collection of C-FIND responses based on <paramref name="request"/>.</returns>
+        IEnumerable<Task<DicomCFindResponse>> OnCFindRequest(DicomCFindRequest request);
+    }
+}

--- a/DICOM/Network/IAsyncDicomCFindProvider.cs
+++ b/DICOM/Network/IAsyncDicomCFindProvider.cs
@@ -16,6 +16,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-FIND request subject to handling.</param>
         /// <returns>Collection of C-FIND responses based on <paramref name="request"/>.</returns>
-        IEnumerable<Task<DicomCFindResponse>> OnCFindRequestAsync(DicomCFindRequest request);
+        Task<IEnumerable<Task<DicomCFindResponse>>> OnCFindRequestAsync(DicomCFindRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomCFindProvider.cs
+++ b/DICOM/Network/IAsyncDicomCFindProvider.cs
@@ -16,6 +16,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-FIND request subject to handling.</param>
         /// <returns>Collection of C-FIND responses based on <paramref name="request"/>.</returns>
-        IEnumerable<Task<DicomCFindResponse>> OnCFindRequest(DicomCFindRequest request);
+        IEnumerable<Task<DicomCFindResponse>> OnCFindRequestAsync(DicomCFindRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomCGetProvider.cs
+++ b/DICOM/Network/IAsyncDicomCGetProvider.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface for methods related to a C-GET SCP.
+    /// </summary>
+    public interface IAsyncDicomCGetProvider
+    {
+        /// <summary>
+        /// Generate collection of <see cref="DicomCGetResponse">C-GET responses</see> from a <see cref="DicomCGetRequest">C-GET request</see>.
+        /// </summary>
+        /// <param name="request">C-GET request.</param>
+        /// <returns>Collection of C-GET responses resulting from the <paramref name="request"/>.</returns>
+        IEnumerable<Task<DicomCGetResponse>> OnCGetRequest(DicomCGetRequest request);
+    }
+}

--- a/DICOM/Network/IAsyncDicomCGetProvider.cs
+++ b/DICOM/Network/IAsyncDicomCGetProvider.cs
@@ -16,6 +16,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-GET request.</param>
         /// <returns>Collection of C-GET responses resulting from the <paramref name="request"/>.</returns>
-        IEnumerable<Task<DicomCGetResponse>> OnCGetRequest(DicomCGetRequest request);
+        IEnumerable<Task<DicomCGetResponse>> OnCGetRequestAsync(DicomCGetRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomCGetProvider.cs
+++ b/DICOM/Network/IAsyncDicomCGetProvider.cs
@@ -16,6 +16,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-GET request.</param>
         /// <returns>Collection of C-GET responses resulting from the <paramref name="request"/>.</returns>
-        IEnumerable<Task<DicomCGetResponse>> OnCGetRequestAsync(DicomCGetRequest request);
+        Task<IEnumerable<Task<DicomCGetResponse>>> OnCGetRequestAsync(DicomCGetRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomCMoveProvider.cs
+++ b/DICOM/Network/IAsyncDicomCMoveProvider.cs
@@ -16,6 +16,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-MOVE request subject to handling.</param>
         /// <returns>Collection of C-MOVE responses based on <paramref name="request"/>.</returns>
-        IEnumerable<Task<DicomCMoveResponse>> OnCMoveRequestAsync(DicomCMoveRequest request);
+        Task<IEnumerable<Task<DicomCMoveResponse>>> OnCMoveRequestAsync(DicomCMoveRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomCMoveProvider.cs
+++ b/DICOM/Network/IAsyncDicomCMoveProvider.cs
@@ -16,6 +16,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-MOVE request subject to handling.</param>
         /// <returns>Collection of C-MOVE responses based on <paramref name="request"/>.</returns>
-        IEnumerable<Task<DicomCMoveResponse>> OnCMoveRequest(DicomCMoveRequest request);
+        IEnumerable<Task<DicomCMoveResponse>> OnCMoveRequestAsync(DicomCMoveRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomCMoveProvider.cs
+++ b/DICOM/Network/IAsyncDicomCMoveProvider.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface representing asynchronous event handlers for DIMSE services applicable to C-MOVE SOP instances.
+    /// </summary>
+    public interface IAsyncDicomCMoveProvider
+    {
+        /// <summary>
+        /// Handler of C-MOVE request.
+        /// </summary>
+        /// <param name="request">C-MOVE request subject to handling.</param>
+        /// <returns>Collection of C-MOVE responses based on <paramref name="request"/>.</returns>
+        IEnumerable<Task<DicomCMoveResponse>> OnCMoveRequest(DicomCMoveRequest request);
+    }
+}

--- a/DICOM/Network/IAsyncDicomCStoreProvider.cs
+++ b/DICOM/Network/IAsyncDicomCStoreProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface for an asynchronous DICOM C-STORE Service Class Provider.
+    /// </summary>
+    public interface IAsyncDicomCStoreProvider
+    {
+        /// <summary>
+        /// Callback for each Sop Instance received.  The default implementation of
+        /// DicomService is to write a temporary file that is automatically deleted
+        /// for each SopInstance received.  See the documentation for DicomService.CreateCStoreReceiveStream()
+        /// and DicomService.GetCStoreDicomFile() for information about changing this
+        /// behavior (e.g. writing to your own custom stream and avoiding the temporary file)
+        /// </summary>
+        /// <param name="request">C-STORE request.</param>
+        /// <returns>C-STORE response.</returns>
+        Task<DicomCStoreResponse> OnCStoreRequest(DicomCStoreRequest request);
+
+        /// <summary>
+        /// Callback for exceptions raised during the parsing of the received SopInstance.  Note that
+        /// it is possible to avoid parsing the file by overriding DicomService.GetCStoreDicomFile() if
+        /// desired.
+        /// </summary>
+        /// <param name="tempFileName">Name of the temporary file, may be null.</param>
+        /// <param name="e">Thrown exception.</param>
+        void OnCStoreRequestException(string tempFileName, Exception e);
+    }
+}

--- a/DICOM/Network/IAsyncDicomCStoreProvider.cs
+++ b/DICOM/Network/IAsyncDicomCStoreProvider.cs
@@ -20,7 +20,7 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">C-STORE request.</param>
         /// <returns>C-STORE response.</returns>
-        Task<DicomCStoreResponse> OnCStoreRequest(DicomCStoreRequest request);
+        Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request);
 
         /// <summary>
         /// Callback for exceptions raised during the parsing of the received SopInstance.  Note that
@@ -29,6 +29,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="tempFileName">Name of the temporary file, may be null.</param>
         /// <param name="e">Thrown exception.</param>
-        void OnCStoreRequestException(string tempFileName, Exception e);
+        Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e);
     }
 }

--- a/DICOM/Network/IAsyncDicomNServiceProvider.cs
+++ b/DICOM/Network/IAsyncDicomNServiceProvider.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface representing event handlers for DIMSE services applicable to Normalized SOP instances.
+    /// </summary>
+    public interface IAsyncDicomNServiceProvider
+    {
+        /// <summary>
+        /// Handler of N-ACTION request.
+        /// </summary>
+        /// <param name="request">N-ACTION request subject to handling.</param>
+        /// <returns>N-ACTION response based on <paramref name="request"/>.</returns>
+        Task<DicomNActionResponse> OnNActionRequest(DicomNActionRequest request);
+
+        /// <summary>
+        /// Handler of N-CREATE request.
+        /// </summary>
+        /// <param name="request">N-CREATE request subject to handling.</param>
+        /// <returns>N-CREATE response based on <paramref name="request"/>.</returns>
+        Task<DicomNCreateResponse> OnNCreateRequest(DicomNCreateRequest request);
+
+        /// <summary>
+        /// Handler of N-DELETE request.
+        /// </summary>
+        /// <param name="request">N-DELETE request subject to handling.</param>
+        /// <returns>N-DELETE response based on <paramref name="request"/>.</returns>
+        Task<DicomNDeleteResponse> OnNDeleteRequest(DicomNDeleteRequest request);
+
+        /// <summary>
+        /// Handler of N-EVENT-REPORT request.
+        /// </summary>
+        /// <param name="request">N-EVENT-REPORT request subject to handling.</param>
+        /// <returns>N-EVENT-REPORT response based on <paramref name="request"/>.</returns>
+        Task<DicomNEventReportResponse> OnNEventReportRequest(DicomNEventReportRequest request);
+
+        /// <summary>
+        /// Handler of N-GET request.
+        /// </summary>
+        /// <param name="request">N-GET request subject to handling.</param>
+        /// <returns>N-GET response based on <paramref name="request"/>.</returns>
+        Task<DicomNGetResponse> OnNGetRequest(DicomNGetRequest request);
+
+        /// <summary>
+        /// Handler of N-SET request.
+        /// </summary>
+        /// <param name="request">N-SET request subject to handling.</param>
+        /// <returns>N-SET response based on <paramref name="request"/>.</returns>
+        Task<DicomNSetResponse> OnNSetRequest(DicomNSetRequest request);
+    }
+}

--- a/DICOM/Network/IAsyncDicomNServiceProvider.cs
+++ b/DICOM/Network/IAsyncDicomNServiceProvider.cs
@@ -15,41 +15,41 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">N-ACTION request subject to handling.</param>
         /// <returns>N-ACTION response based on <paramref name="request"/>.</returns>
-        Task<DicomNActionResponse> OnNActionRequest(DicomNActionRequest request);
+        Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request);
 
         /// <summary>
         /// Handler of N-CREATE request.
         /// </summary>
         /// <param name="request">N-CREATE request subject to handling.</param>
         /// <returns>N-CREATE response based on <paramref name="request"/>.</returns>
-        Task<DicomNCreateResponse> OnNCreateRequest(DicomNCreateRequest request);
+        Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request);
 
         /// <summary>
         /// Handler of N-DELETE request.
         /// </summary>
         /// <param name="request">N-DELETE request subject to handling.</param>
         /// <returns>N-DELETE response based on <paramref name="request"/>.</returns>
-        Task<DicomNDeleteResponse> OnNDeleteRequest(DicomNDeleteRequest request);
+        Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request);
 
         /// <summary>
         /// Handler of N-EVENT-REPORT request.
         /// </summary>
         /// <param name="request">N-EVENT-REPORT request subject to handling.</param>
         /// <returns>N-EVENT-REPORT response based on <paramref name="request"/>.</returns>
-        Task<DicomNEventReportResponse> OnNEventReportRequest(DicomNEventReportRequest request);
+        Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request);
 
         /// <summary>
         /// Handler of N-GET request.
         /// </summary>
         /// <param name="request">N-GET request subject to handling.</param>
         /// <returns>N-GET response based on <paramref name="request"/>.</returns>
-        Task<DicomNGetResponse> OnNGetRequest(DicomNGetRequest request);
+        Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request);
 
         /// <summary>
         /// Handler of N-SET request.
         /// </summary>
         /// <param name="request">N-SET request subject to handling.</param>
         /// <returns>N-SET response based on <paramref name="request"/>.</returns>
-        Task<DicomNSetResponse> OnNSetRequest(DicomNSetRequest request);
+        Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request);
     }
 }

--- a/Tests/Desktop/DICOM.Tests.Desktop.csproj
+++ b/Tests/Desktop/DICOM.Tests.Desktop.csproj
@@ -183,6 +183,11 @@
     <Compile Include="IO\Reader\DicomReaderTest.cs" />
     <Compile Include="IO\Reader\DicomDatasetReaderObserverTest.cs" />
     <Compile Include="Media\DicomFileScannerTest.cs" />
+    <Compile Include="Network\AsyncDicomCEchoProviderTests.cs" />
+    <Compile Include="Network\AsyncDicomCFindProviderTests.cs" />
+    <Compile Include="Network\AsyncDicomCGetProviderTests.cs" />
+    <Compile Include="Network\AsyncDicomCStoreProviderTests.cs" />
+    <Compile Include="Network\AsyncDicomNServiceProviderTests.cs" />
     <Compile Include="Network\Client\DicomClientTest.cs" />
     <Compile Include="Network\Client\DicomClientTimeoutTests.cs" />
     <Compile Include="Network\DicomAcceptedPresentationContextTest.cs" />

--- a/Tests/Desktop/Network/AsyncDicomCEchoProviderTests.cs
+++ b/Tests/Desktop/Network/AsyncDicomCEchoProviderTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Dicom.Helpers;
+using Dicom.Log;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dicom.Network
+{
+    public class AsyncDicomCEchoProviderTests
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public AsyncDicomCEchoProviderTests(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper)
+                .IncludeTimestamps()
+                .IncludeThreadId()
+                .WithMinimumLevel(LogLevel.Debug);
+        }
+
+        [Fact]
+        public async Task OnCEchoRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomCEchoProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomCEchoResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomCEchoRequest
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+    }
+
+    #region helper classes
+
+    public class AsyncDicomCEchoProvider : DicomService, IDicomServiceProvider, IAsyncDicomCEchoProvider
+    {
+        public AsyncDicomCEchoProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        async Task WaitForALittleBit()
+        {
+            var ms = new Random().Next(10);
+            await Task.Delay(ms).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            return new DicomCEchoResponse(request, DicomStatus.Success);
+        }
+    }
+
+
+    #endregion
+}

--- a/Tests/Desktop/Network/AsyncDicomCFindProviderTests.cs
+++ b/Tests/Desktop/Network/AsyncDicomCFindProviderTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Dicom.Helpers;
+using Dicom.Log;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dicom.Network
+{
+    public class AsyncDicomCFindProviderTests
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public AsyncDicomCFindProviderTests(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper)
+                .IncludeTimestamps()
+                .IncludeThreadId()
+                .WithMinimumLevel(LogLevel.Debug);
+        }
+
+        [Fact]
+        public async Task OnCFindRequestAsync_ImmediateSuccess_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<ImmediateSuccessAsyncDicomCFindProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomCFindResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study)
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+
+        [Fact]
+        public async Task OnCFindRequestAsync_Pending_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<PendingAsyncDicomCFindProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                var responses = new ConcurrentQueue<DicomCFindResponse>();
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study)
+                {
+                    OnResponseReceived = (req, res) => responses.Enqueue(res),
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.Collection(
+                    responses,
+                    response1 => Assert.Equal(DicomStatus.Pending, response1.Status),
+                    response2 => Assert.Equal(DicomStatus.Pending, response2.Status),
+                    response3 => Assert.Equal(DicomStatus.Success, response3.Status)
+                );
+                Assert.Null(timeout);
+            }
+        }
+    }
+
+    #region helper classes
+
+    public class ImmediateSuccessAsyncDicomCFindProvider : DicomService, IDicomServiceProvider, IAsyncDicomCFindProvider
+    {
+        public ImmediateSuccessAsyncDicomCFindProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        async Task WaitForALittleBit()
+        {
+            var ms = new Random().Next(10);
+            await Task.Delay(ms).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public async Task<IEnumerable<Task<DicomCFindResponse>>> OnCFindRequestAsync(DicomCFindRequest request)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            return InnerOnCFindRequestAsync();
+
+            IEnumerable<Task<DicomCFindResponse>> InnerOnCFindRequestAsync()
+            {
+                yield return Task.FromResult(new DicomCFindResponse(request, DicomStatus.Success));
+            }
+        }
+    }
+
+    public class PendingAsyncDicomCFindProvider : DicomService, IDicomServiceProvider, IAsyncDicomCFindProvider
+    {
+        public PendingAsyncDicomCFindProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        async Task WaitForALittleBit()
+        {
+            var ms = new Random().Next(10);
+            await Task.Delay(ms).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public async Task<IEnumerable<Task<DicomCFindResponse>>> OnCFindRequestAsync(DicomCFindRequest request)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            return InnerOnCFindRequestAsync();
+
+            IEnumerable<Task<DicomCFindResponse>> InnerOnCFindRequestAsync()
+            {
+                yield return Task.FromResult(new DicomCFindResponse(request, DicomStatus.Pending));
+                yield return Task.FromResult(new DicomCFindResponse(request, DicomStatus.Pending));
+                yield return Task.FromResult(new DicomCFindResponse(request, DicomStatus.Success));
+            }
+        }
+    }
+
+
+    #endregion
+}

--- a/Tests/Desktop/Network/AsyncDicomCGetProviderTests.cs
+++ b/Tests/Desktop/Network/AsyncDicomCGetProviderTests.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Dicom.Helpers;
+using Dicom.Log;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dicom.Network
+{
+    public class AsyncDicomCGetProviderTests
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public AsyncDicomCGetProviderTests(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper)
+                .IncludeTimestamps()
+                .IncludeThreadId()
+                .WithMinimumLevel(LogLevel.Debug);
+        }
+
+        [Fact]
+        public async Task OnCGetRequestAsync_ImmediateSuccess_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<ImmediateSuccessAsyncDicomCGetProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomCGetResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var studyInstanceUID = DicomUIDGenerator.GenerateDerivedFromUUID().ToString();
+                var request = new DicomCGetRequest(studyInstanceUID)
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+
+        [Fact]
+        public async Task OnCGetRequestAsync_Pending_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<PendingAsyncDicomCGetProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                var responses = new ConcurrentQueue<DicomCGetResponse>();
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var studyInstanceUID = DicomUIDGenerator.GenerateDerivedFromUUID().ToString();
+                var request = new DicomCGetRequest(studyInstanceUID)
+                {
+                    OnResponseReceived = (req, res) => responses.Enqueue(res),
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.Collection(
+                    responses,
+                    response1 => Assert.Equal(DicomStatus.Pending, response1.Status),
+                    response2 => Assert.Equal(DicomStatus.Pending, response2.Status),
+                    response3 => Assert.Equal(DicomStatus.Success, response3.Status)
+                );
+                Assert.Null(timeout);
+            }
+        }
+    }
+
+    #region helper classes
+
+    public class ImmediateSuccessAsyncDicomCGetProvider : DicomService, IDicomServiceProvider, IAsyncDicomCGetProvider
+    {
+        public ImmediateSuccessAsyncDicomCGetProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        async Task WaitForALittleBit()
+        {
+            var ms = new Random().Next(10);
+            await Task.Delay(ms).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public async Task<IEnumerable<Task<DicomCGetResponse>>> OnCGetRequestAsync(DicomCGetRequest request)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            return InnerOnCGetRequestAsync();
+
+            IEnumerable<Task<DicomCGetResponse>> InnerOnCGetRequestAsync()
+            {
+                yield return Task.FromResult(new DicomCGetResponse(request, DicomStatus.Success));
+            }
+        }
+    }
+
+    public class PendingAsyncDicomCGetProvider : DicomService, IDicomServiceProvider, IAsyncDicomCGetProvider
+    {
+        public PendingAsyncDicomCGetProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        async Task WaitForALittleBit()
+        {
+            var ms = new Random().Next(10);
+            await Task.Delay(ms).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public async Task<IEnumerable<Task<DicomCGetResponse>>> OnCGetRequestAsync(DicomCGetRequest request)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            return InnerOnCGetRequestAsync();
+
+            IEnumerable<Task<DicomCGetResponse>> InnerOnCGetRequestAsync()
+            {
+                yield return Task.FromResult(new DicomCGetResponse(request, DicomStatus.Pending));
+                yield return Task.FromResult(new DicomCGetResponse(request, DicomStatus.Pending));
+                yield return Task.FromResult(new DicomCGetResponse(request, DicomStatus.Success));
+            }
+        }
+    }
+
+
+    #endregion
+}

--- a/Tests/Desktop/Network/AsyncDicomCStoreProviderTests.cs
+++ b/Tests/Desktop/Network/AsyncDicomCStoreProviderTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Dicom.Helpers;
+using Dicom.Log;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dicom.Network
+{
+    public class AsyncDicomCStoreProviderTests
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public AsyncDicomCStoreProviderTests(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper)
+                .IncludeTimestamps()
+                .IncludeThreadId()
+                .WithMinimumLevel(LogLevel.Debug);
+        }
+
+        [Fact]
+        public async Task OnCStoreRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomCStoreProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomCStoreResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomCStoreRequest(@"./Test Data/10200904.dcm")
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+    }
+
+    #region helper classes
+
+    public class AsyncDicomCStoreProvider : DicomService, IDicomServiceProvider, IAsyncDicomCStoreProvider
+    {
+        public AsyncDicomCStoreProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        async Task WaitForALittleBit()
+        {
+            var ms = new Random().Next(10);
+            await Task.Delay(ms).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            return new DicomCStoreResponse(request, DicomStatus.Success);
+        }
+
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+
+    #endregion
+}

--- a/Tests/Desktop/Network/AsyncDicomNServiceProviderTests.cs
+++ b/Tests/Desktop/Network/AsyncDicomNServiceProviderTests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Dicom.Helpers;
+using Dicom.Log;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dicom.Network
+{
+    public class AsyncDicomNServiceProviderTests
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public AsyncDicomNServiceProviderTests(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper)
+                .IncludeTimestamps()
+                .IncludeThreadId()
+                .WithMinimumLevel(LogLevel.Debug);
+        }
+
+        [Fact]
+        public async Task OnNActionRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomNServiceProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomNActionResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomNActionRequest(
+                    DicomUID.BasicFilmSessionSOPClass,
+                    new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                    1)
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+
+        [Fact]
+        public async Task OnNCreateRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomNServiceProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomNCreateResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomNCreateRequest(
+                    DicomUID.BasicFilmSessionSOPClass,
+                    new DicomUID("1.2.3", null, DicomUidType.SOPInstance))
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+
+        [Fact]
+        public async Task OnNDeleteRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomNServiceProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomNDeleteResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomNDeleteRequest(
+                    DicomUID.BasicFilmSessionSOPClass,
+                    new DicomUID("1.2.3", null, DicomUidType.SOPInstance))
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+
+        [Fact]
+        public async Task OnNEventReportRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomNServiceProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomNEventReportResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomNEventReportRequest(
+                    DicomUID.BasicFilmSessionSOPClass,
+                    new DicomUID("1.2.3", null, DicomUidType.SOPInstance),
+                    1)
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+
+        [Fact]
+        public async Task OnNGetRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomNServiceProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomNGetResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomNGetRequest(
+                    DicomUID.BasicFilmSessionSOPClass,
+                    new DicomUID("1.2.3", null, DicomUidType.SOPInstance))
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+
+        [Fact]
+        public async Task OnNSetRequestAsync_ShouldRespond()
+        {
+            var port = Ports.GetNext();
+
+            using (DicomServer.Create<AsyncDicomNServiceProvider>(port, logger: _logger.IncludePrefix("DicomServer")))
+            {
+                var client = new Network.Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP")
+                {
+                    Logger = _logger.IncludePrefix(typeof(DicomClient).Name)
+                };
+
+                DicomNSetResponse response = null;
+                DicomRequest.OnTimeoutEventArgs timeout = null;
+                var request = new DicomNSetRequest(
+                    DicomUID.BasicFilmSessionSOPClass,
+                    new DicomUID("1.2.3", null, DicomUidType.SOPInstance))
+                {
+                    OnResponseReceived = (req, res) => response = res,
+                    OnTimeout = (sender, args) => timeout = args
+                };
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+
+                Assert.NotNull(response);
+                Assert.Equal(DicomStatus.Success, response.Status);
+                Assert.Null(timeout);
+            }
+        }
+    }
+
+    #region helper classes
+
+    public class AsyncDicomNServiceProvider : DicomService, IDicomServiceProvider, IAsyncDicomNServiceProvider
+    {
+        public AsyncDicomNServiceProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        async Task WaitForALittleBit()
+        {
+            var ms = new Random().Next(10);
+            await Task.Delay(ms).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            await WaitForALittleBit().ConfigureAwait(false);
+
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request)
+        {
+            return Task.FromResult(new DicomNActionResponse(request, DicomStatus.Success));
+        }
+
+        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request)
+        {
+            return Task.FromResult(new DicomNCreateResponse(request, DicomStatus.Success));
+        }
+
+        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request)
+        {
+            return Task.FromResult(new DicomNDeleteResponse(request, DicomStatus.Success));
+        }
+
+        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request)
+        {
+            return Task.FromResult(new DicomNEventReportResponse(request, DicomStatus.Success));
+        }
+
+        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request)
+        {
+            return Task.FromResult(new DicomNGetResponse(request, DicomStatus.Success));
+        }
+
+        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request)
+        {
+            return Task.FromResult(new DicomNSetResponse(request, DicomStatus.Success));
+        }
+    }
+    #endregion
+}

--- a/Tests/Desktop/Network/DicomServerTest.cs
+++ b/Tests/Desktop/Network/DicomServerTest.cs
@@ -1,5 +1,4 @@
-﻿/*
-// Copyright (c) 2012-2019 fo-dicom contributors.
+﻿// Copyright (c) 2012-2019 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System.Linq;
@@ -408,4 +407,4 @@ namespace Dicom.Network
         #endregion
     }
 }
-*/
+


### PR DESCRIPTION
This PR introduces asynchronous variants of IDicomCEchoProvider, IDicomCFindProvider, etc.

Up until now, it was impossible to use asynchronous methods inside these providers, and in 2019 a whole lot of .NET APIs and libraries have become asynchronous.

In our code base at least, this meant calling asynchronous methods from within these synchronous interfaces, introducing a whole array of potential pitfalls and potential deadlocks.

I scoured around the DicomService to find a reason why these interfaces are not asynchronous, and to my surprise they are all called from DicomService.PerformDimseAsync, an asynchronous method itself!! 

Obviously, we cannot break backwards compatibility, so new interfaces have been added with asynchronous signatures. 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add IAsyncDicomCEchoProvider, ...
- If a class implements both the synchronous and asynchronous APIs, the synchronous APIs will be used.
- No support for AsyncEnumerable (yet)

#### Notes 

In C# 8, AsyncEnumerable will be introduced. This would have been a perfect fit for providers that return an enumerable, because then it would become possible to combine await with  yield.

Since Fellow Oak DICOM is not switching to .NET Core 3.0 (and only .NET Core 3.0!) soon, the signature for these async providers is Task<IEnumerable<Task<TResponse>>>.

This enables the most flexibility, allowing asynchronous methods to produce the enumerable, and more asynchronous methods to produce a single response object.

In the future, we could introduce support for AsyncEnumerable with ifdef pragma's where appropriate.
