### PR TITLE
Run SSL authentication in a task with timeout

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
 * Bug fix: Send only PrintManagementMetaSopClassUid on AssociationRequest instead of all the various SopClassUids of the NCreate and NSet requests (#667)
 * Global static property DicomValidation.PerformValidation to turn off validation for every DicomDataset. 
 * Bug fix: Prevent DICOM client from freezing when too many DICOM requests time out and async operations invoked is a low number
+* Bug fix: Prevent SSL handshake freeze from blocking the TCP listener (#923)
 
 #### v.4.0.2 (7/30/2019)
 * Bug fix: prevent resource leak when DesktopNetworkListener waits for new TCP clients

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.4 (TBD)
+* Bug fix: Prevent SSL handshake freeze from blocking the TCP listener (#923)
 
 
 #### v.4.0.3 (9/21/2019)
@@ -15,7 +16,6 @@
 * Bug fix: Send only PrintManagementMetaSopClassUid on AssociationRequest instead of all the various SopClassUids of the NCreate and NSet requests (#667)
 * Global static property DicomValidation.PerformValidation to turn off validation for every DicomDataset. 
 * Bug fix: Prevent DICOM client from freezing when too many DICOM requests time out and async operations invoked is a low number
-* Bug fix: Prevent SSL handshake freeze from blocking the TCP listener (#923)
 
 #### v.4.0.2 (7/30/2019)
 * Bug fix: prevent resource leak when DesktopNetworkListener waits for new TCP clients

--- a/DICOM/Network/DesktopNetworkStream.cs
+++ b/DICOM/Network/DesktopNetworkStream.cs
@@ -10,6 +10,7 @@ namespace Dicom.Network
     using System.Net.Sockets;
     using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// .NET implementation of <see cref="INetworkStream"/>.
@@ -17,6 +18,8 @@ namespace Dicom.Network
     public sealed class DesktopNetworkStream : INetworkStream
     {
         #region FIELDS
+
+        private static readonly TimeSpan SslHandshakeTimeout = TimeSpan.FromMinutes(1);
 
         private bool disposed = false;
 
@@ -58,11 +61,19 @@ namespace Dicom.Network
                 ssl.ReadTimeout = millisecondsTimeout;
                 ssl.WriteTimeout = millisecondsTimeout;
 
-#if NETSTANDARD
-                ssl.AuthenticateAsClientAsync(host).Wait();
-#else
-                ssl.AuthenticateAsClient(host);
-#endif
+                var authenticate = Task.Run(async () =>
+                {
+                    var authenticateAsClient = ssl.AuthenticateAsClientAsync(host);
+                    var authenticateAsClientTimeout = Task.Delay(SslHandshakeTimeout);
+                    return await Task.WhenAny(authenticateAsClient, authenticateAsClientTimeout).ConfigureAwait(false) == authenticateAsClient;
+                });
+
+                var authenticationSucceeded = authenticate.GetAwaiter().GetResult();
+                if (!authenticationSucceeded)
+                {
+                    throw new DicomNetworkException($"SSL client authentication took longer than {SslHandshakeTimeout.TotalSeconds}s");
+                }
+
                 stream = ssl;
             }
 
@@ -80,10 +91,10 @@ namespace Dicom.Network
         /// <param name="ownsTcpClient">dispose tcpClient on Dispose</param>
         /// <remarks>
         /// Ownership of <paramref name="tcpClient"/> is controlled by <paramref name="ownsTcpClient"/>.
-        /// 
+        ///
         /// if <paramref name="ownsTcpClient"/> is false, <paramref name="tcpClient"/> must be disposed by caller.
         /// this is default so that compatible with older versions.
-        /// 
+        ///
         /// if <paramref name="ownsTcpClient"/> is true, <paramref name="tcpClient"/> will be disposed altogether on DesktopNetworkStream's disposal.
         /// </remarks>
         internal DesktopNetworkStream(TcpClient tcpClient, X509Certificate certificate, bool ownsTcpClient = false)
@@ -97,11 +108,20 @@ namespace Dicom.Network
             if (certificate != null)
             {
                 var ssl = new SslStream(stream, false);
-#if NETSTANDARD
-                ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false).Wait();
-#else
-                ssl.AuthenticateAsServer(certificate, false, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
-#endif
+
+                var authenticate = Task.Run(async () =>
+                {
+                    var authenticateAsServer = ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false);
+                    var authenticateAsServerTimeout = Task.Delay(SslHandshakeTimeout);
+                    return await Task.WhenAny(authenticateAsServer, authenticateAsServerTimeout).ConfigureAwait(false) == authenticateAsServer;
+                });
+
+                var authenticationSucceeded = authenticate.GetAwaiter().GetResult();
+                if (!authenticationSucceeded)
+                {
+                    throw new DicomNetworkException($"SSL server authentication took longer than {SslHandshakeTimeout.TotalSeconds}s");
+                }
+
                 stream = ssl;
             }
 


### PR DESCRIPTION
Run SSL authentication with Task.Run to offload it
Add timeout detection, hardcoded to 1 minute (should this be configurable?)

This prevents the main TCP listener from freezing. Sometimes, the SSL handshake can block completely.
Because this handshake is called from the TCP listener handler loop, no new TCP connections can be accepted while this handshake is in progress.
If this handshake then freezes, the TCP listener freezes too.

This commit prevents that problem by letting the TCP listener loop continue after, at most, 1 minute.

Fixes #923.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file