### PR TITLE
Fix Null Reference Exception on cloning to Jpeg Process2_4

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 * Bug fix: Exception when anonymizing private tags, where the value representation is not known.
 * Implementation of IImage with ImageSharp, which is pure managed and can be used on any operation system. (#693)
 * Add link to wiki entry in DicomCodecException (#948)
+* Bug fix: Exception when cloning to Jpeg Process2_4 when parameters are set to null.
 
 #### v.4.0.3 (9/21/2019)
 * Bug fix: Exception when adding an element of VR UR/UT/LT/ST with empty value (#915)

--- a/Contributors.md
+++ b/Contributors.md
@@ -50,3 +50,4 @@
 * [Alexander Moerman](https://github.com/amoerie)
 * [Harald Köstinger](https://github.com/hkoestin)
 * [Dave Stelpstra](https://github.com/davidsybren)
+* [Paul Watt](https://github.com/paul81)

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -1624,7 +1624,7 @@ namespace Dicom
 
         #region IDisposable Support
 
-        private bool disposedValue = false; // for detecting renundant calling of Dispose
+        private bool disposedValue = false; // for detecting redundant calling of Dispose
 
         protected virtual void Dispose(bool disposing)
         {

--- a/DICOM/Imaging/Codec/DicomJpegCodecImpl.cs
+++ b/DICOM/Imaging/Codec/DicomJpegCodecImpl.cs
@@ -167,7 +167,7 @@ namespace Dicom.Imaging.Codec
                         }
                         newPixelData.AddFrame(new MemoryByteBuffer(stream.ToArray()));
                         newPixelData.PhotometricInterpretation =
-                           parameters.SampleFactor == DicomJpegSampleFactor.SF422
+                           (parameters != null && parameters.SampleFactor == DicomJpegSampleFactor.SF422)
                            ? PhotometricInterpretation.YbrFull422 : PhotometricInterpretation.YbrFull;
                     }
                 }

--- a/Tests/Desktop/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/Tests/Desktop/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -15,6 +15,28 @@ namespace Dicom.Imaging.Codec
         #region Unit tests
 
         [Fact]
+        public void ChangeTransferSyntax_FileFromRLELosslessToJPEGProcess2_4()
+        {
+            var file = DicomFile.Open(@".\Test Data\10200904.dcm");
+            var exception =
+                Record.Exception(
+                    () =>
+                    file.Clone(DicomTransferSyntax.JPEGProcess2_4));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ChangeTransferSyntax_FileFromRLELosslessToJPEGProcess2_4_WithParameters()
+        {
+            var file = DicomFile.Open(@".\Test Data\10200904.dcm");
+            var exception =
+                Record.Exception(
+                    () =>
+                    file.Clone(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { Quality = 50 }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void ChangeTransferSyntax_FileFromJ2KToJPEGWithParameters_DoesNotThrow()
         {
             var file = DicomFile.Open(@".\Test Data\CT1_J2KI");


### PR DESCRIPTION
Fixes # .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Experienced a Null Reference Exception when cloning a DICOM file to Jpeg Process2_4 when parameters were not being defined although the method defaulted to null.
- Changed handling of parameters when setting photometric interpretation to set to YBR_Full when the parameters are null.

