### PR TITLE
Update DicomImage.cs

### DIFF
--- a/DICOM/Imaging/DicomImage.cs
+++ b/DICOM/Imaging/DicomImage.cs
@@ -240,6 +240,9 @@ namespace Dicom.Imaging
                 {
                     foreach (var overlay in _overlays)
                     {
+                        if (overlay.Data is Dicom.IO.Buffer.EmptyBuffer)//fixed overlay.data is null, exception thrown
+                            continue;
+                        
                         if (frame + 1 < overlay.OriginFrame
                             || frame + 1 > overlay.OriginFrame + overlay.NumberOfFrames - 1) continue;
 


### PR DESCRIPTION
In the method renderimage, an exception is thrown when overlay.data is null.

Fixes # .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-
-
-
