### PR TITLE
fo-dicom.ImageSharp nuspec depedency change

### DIFF
--- a/Setup/fo-dicom.ImageSharp.nuspec
+++ b/Setup/fo-dicom.ImageSharp.nuspec
@@ -13,7 +13,7 @@
         <language>en-US</language>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="fo-dicom.NetCore" version="$version$" />
+        <dependency id="Dicom.Core" version="$version$" />
         <dependency id="SixLabors.ImageSharp" version="1.0.0-beta0007" exclude="Build,Analyzers" />
         <dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta0007" exclude="Build,Analyzers" />
       </group>

--- a/Setup/fo-dicom.ImageSharp.nuspec
+++ b/Setup/fo-dicom.ImageSharp.nuspec
@@ -13,7 +13,7 @@
         <language>en-US</language>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Dicom.Core" version="1.0.0" exclude="Build,Analyzers" />
+        <dependency id="fo-dicom.NetCore" version="$version$" />
         <dependency id="SixLabors.ImageSharp" version="1.0.0-beta0007" exclude="Build,Analyzers" />
         <dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta0007" exclude="Build,Analyzers" />
       </group>

--- a/Setup/fo-dicom.ImageSharp.nuspec
+++ b/Setup/fo-dicom.ImageSharp.nuspec
@@ -13,7 +13,7 @@
         <language>en-US</language>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Dicom.Core" version="$version$" />
+        <dependency id="Dicom.Core" version="$version$" exclude="Build,Analyzers" />
         <dependency id="SixLabors.ImageSharp" version="1.0.0-beta0007" exclude="Build,Analyzers" />
         <dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta0007" exclude="Build,Analyzers" />
       </group>


### PR DESCRIPTION
Change reference to old Dicom.Core nuget package to newer fo-dicom.Netcore

Fixes # .

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-
-
-
