### PR TITLE
fix encoding assertion in anonymizer tests

### DIFF
--- a/Tests/Desktop/DicomAnonymizerTest.cs
+++ b/Tests/Desktop/DicomAnonymizerTest.cs
@@ -235,7 +235,7 @@ namespace Dicom
             Assert.NotEqual(DicomEncoding.GetEncoding(originalDicom.Dataset.GetString(DicomTag.SpecificCharacterSet)), DicomEncoding.Default);
 
             // Ensure DICOM encoding same as original.
-            Assert.Equal(originalDicom.Dataset.GetString(DicomTag.SpecificCharacterSet), originalDicom.Dataset.GetString(DicomTag.SpecificCharacterSet));
+            Assert.Equal(originalDicom.Dataset.GetString(DicomTag.SpecificCharacterSet), anonymizedDicom.Dataset.GetString(DicomTag.SpecificCharacterSet));
             Assert.Equal("kökö", anonymizedDicom.Dataset.GetString(DicomTag.PatientName));
         }
 


### PR DESCRIPTION
Fixes DICOM encoding assertion in test case Anonymize_PatientName_ShouldUseOriginalDicomEncoding.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-
-
-
