### PR TITLE
Fix incorrect set OverlayOrigin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 * Bug fix: DicomDictionary accessor thew exception on unknown keyword instead of returning null (#996)
 * Update version of ImageSharp to rc1
 * Bug fix: Comparing instance of class DicomStatus with null returned wrong value (#975)
+* Bug fix: Overlay origin cannot be set correctly. (#1028)
 
 #### v.4.0.4 (1/17/2020)
 * New feature: asynchronous counterparts to IDicomCEchoProvider, IDicomCFindProvider, IDicomCStoreProvider, IDicomCMoveProvider, IDicomCGetProvider and IDicomNServiceProvider

--- a/Contributors.md
+++ b/Contributors.md
@@ -53,3 +53,4 @@
 * [Dave Stelpstra](https://github.com/davidsybren)
 * [Paul Watt](https://github.com/paul81)
 * [sfb13](https://github.com/sfb13)
+* [Zhenghan Yang](https://github.com/kira-96)

--- a/DICOM/Imaging/DicomOverlayData.cs
+++ b/DICOM/Imaging/DicomOverlayData.cs
@@ -163,7 +163,7 @@ namespace Dicom.Imaging
         public int OriginX
         {
             get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 1, 1);
-            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginY);
+            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)OriginY, (short)value);
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace Dicom.Imaging
         public int OriginY
         {
             get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 0, 1);
-            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)OriginX, (short)value);
+            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginX);
         }
 
         /// <summary>

--- a/FO-DICOM.Core/Imaging/DicomOverlayData.cs
+++ b/FO-DICOM.Core/Imaging/DicomOverlayData.cs
@@ -160,7 +160,7 @@ namespace FellowOakDicom.Imaging
         public int OriginX
         {
             get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 1, 1);
-            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginY);
+            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)OriginY, (short)value);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace FellowOakDicom.Imaging
         public int OriginY
         {
             get => Dataset.GetValueOrDefault<short>(OverlayTag(DicomTag.OverlayOrigin), 0, 1);
-            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)OriginX, (short)value);
+            set => Dataset.AddOrUpdate(OverlayTag(DicomTag.OverlayOrigin), (short)value, (short)OriginX);
         }
 
         /// <summary>

--- a/Tests/Desktop/Imaging/DicomOverlayDataTest.cs
+++ b/Tests/Desktop/Imaging/DicomOverlayDataTest.cs
@@ -164,7 +164,7 @@ namespace Dicom.Imaging
             DicomOverlayData overlayData = new DicomOverlayData(dataset, group);
             overlayData.OriginX = expected;
 
-            int originX = dataset.GetValueOrDefault<ushort>(new DicomTag(group, 0x0050), 1, 1);
+            int originX = dataset.GetValueOrDefault<short>(new DicomTag(group, 0x0050), 1, 1);
             Assert.Equal(expected, originX);
         }
 
@@ -178,7 +178,7 @@ namespace Dicom.Imaging
             DicomOverlayData overlayData = new DicomOverlayData(dataset, group);
             overlayData.OriginY = expected;
 
-            int originY = dataset.GetValueOrDefault<ushort>(new DicomTag(group, 0x0050), 0, 1);
+            int originY = dataset.GetValueOrDefault<short>(new DicomTag(group, 0x0050), 0, 1);
             Assert.Equal(expected, originY);
         }
     }

--- a/Tests/Desktop/Imaging/DicomOverlayDataTest.cs
+++ b/Tests/Desktop/Imaging/DicomOverlayDataTest.cs
@@ -153,5 +153,33 @@ namespace Dicom.Imaging
             var actual = od.OriginY;
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void OriginXSetter_ReturnsValueAtIndex1()
+        {
+            const int expected = 96;
+            const ushort group = 0x6012;
+
+            DicomDataset dataset = new DicomDataset();
+            DicomOverlayData overlayData = new DicomOverlayData(dataset, group);
+            overlayData.OriginX = expected;
+
+            int originX = dataset.GetValueOrDefault<ushort>(new DicomTag(group, 0x0050), 1, 1);
+            Assert.Equal(expected, originX);
+        }
+
+        [Fact]
+        public void OriginYSetter_ReturnsValueAtIndex0()
+        {
+            const int expected = 96;
+            const ushort group = 0x6012;
+
+            DicomDataset dataset = new DicomDataset();
+            DicomOverlayData overlayData = new DicomOverlayData(dataset, group);
+            overlayData.OriginY = expected;
+
+            int originY = dataset.GetValueOrDefault<ushort>(new DicomTag(group, 0x0050), 0, 1);
+            Assert.Equal(expected, originY);
+        }
     }
 }


### PR DESCRIPTION
Fixes # .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When set the OriginY / OriginX of `DicomOverlayData`, the dataset will not change as expected, because the positions of OriginY and OriginX are reversed when updating the dataset.
