### PR TITLE
Feature/add support sync storage commitment

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 #### v.4.0.6 (TBD)
 * Update to DICOM Standard 2020b.
+* Handle N-Event requests in DicomClient (required for synchronous storage commitment) (#1001)
 
 #### v.4.0.5 (5/18/2020)
 * Bug fix: DicomTags of ValueRepresentation LT have not been validated.

--- a/Contributors.md
+++ b/Contributors.md
@@ -55,3 +55,4 @@
 * [sfb13](https://github.com/sfb13)
 * [Zhenghan Yang](https://github.com/kira-96)
 * [Denny Spiegelberg](https://github.com/nutzlastfan)
+* [Sudheesh Subramannian](https://github.com/sudheeshps)

--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -193,6 +193,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\DicomClientCStoreRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\DicomClientDefaults.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\DicomClientExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\Client\DicomClientNEventReportRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\EventArguments\AssociationAcceptedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\EventArguments\AssociationRejectedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\Client\EventArguments\RequestTimedOutEventArgs.cs" />

--- a/DICOM/Network/Client/DicomClient.cs
+++ b/DICOM/Network/Client/DicomClient.cs
@@ -71,6 +71,11 @@ namespace Dicom.Network.Client
         DicomClientCStoreRequestHandler OnCStoreRequest { get; set; }
 
         /// <summary>
+        /// Gets or sets the handler of  client N-EVENT-REPORT-RQ
+        /// </summary>
+        DicomClientNEventReportRequestHandler OnNEventReportRequest { get; set; }
+
+        /// <summary>
         /// Gets or sets the network manager that will be used to open connections.
         /// </summary>
         NetworkManager NetworkManager { get; set; }
@@ -155,6 +160,7 @@ namespace Dicom.Network.Client
         public List<DicomExtendedNegotiation> AdditionalExtendedNegotiations { get; set; }
         public Encoding FallbackEncoding { get; set; }
         public DicomClientCStoreRequestHandler OnCStoreRequest { get; set; }
+        public DicomClientNEventReportRequestHandler OnNEventReportRequest { get; set; }
         public NetworkManager NetworkManager { get; set; }
 
         public event EventHandler<EventArguments.AssociationAcceptedEventArgs> AssociationAccepted;
@@ -275,6 +281,14 @@ namespace Dicom.Network.Client
                 return new DicomCStoreResponse(request, DicomStatus.StorageStorageOutOfResources);
 
             return await OnCStoreRequest(request).ConfigureAwait(false);
+        }
+
+        internal async Task<DicomResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request)
+        {
+            if (OnNEventReportRequest == null)
+                return new DicomNEventReportResponse(request, DicomStatus.AttributeListError);
+
+            return await OnNEventReportRequest(request).ConfigureAwait(false);
         }
 
         public void NegotiateAsyncOps(int invoked = 0, int performed = 0)

--- a/DICOM/Network/Client/DicomClientConnection.cs
+++ b/DICOM/Network/Client/DicomClientConnection.cs
@@ -120,6 +120,17 @@ namespace Dicom.Network.Client
         /// The <see cref="DicomCStoreResponse"/> related to the C-STORE <paramref name="request"/>.
         /// </returns>
         Task<DicomResponse> OnCStoreRequestAsync(DicomCStoreRequest request);
+
+        /// <summary>
+        /// Callback for handling a client related N-EVENT-REPORT-RQ request, typically emanating from the client's N-ACTION request.
+        /// </summary>
+        /// <param name="request">
+        /// N-EVENT-REPORT-RQ request.
+        /// </param>
+        /// <returns>
+        /// The <see cref="DicomNEventReportResponse"/> related to the N-EVENT-REPORT-RQ <paramref name="request"/>.
+        /// </returns>
+        Task<DicomResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request);
     }
 
     public class DicomClientConnection : DicomService, IDicomClientConnection
@@ -212,6 +223,11 @@ namespace Dicom.Network.Client
         public Task<DicomResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
         {
             return DicomClient.OnCStoreRequestAsync(request);
+        }
+
+        public Task<DicomResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request)
+        {
+            return DicomClient.OnNEventReportRequestAsync(request);
         }
     }
 }

--- a/DICOM/Network/Client/DicomClientNEventReportRequestHandler.cs
+++ b/DICOM/Network/Client/DicomClientNEventReportRequestHandler.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace Dicom.Network.Client
+{
+    /// <summary>
+    /// Delegate for client handling the N-EVENT-REPORT-RQ request immediately.
+    /// </summary>
+    /// <param name="request">N-EVENT-REPORT-RQ request subject to handling.</param>
+    /// <returns>Response from handling the N-EVENT-REPORT-RQ <paramref name="request"/>.</returns>
+    public delegate Task<DicomNEventReportResponse> DicomClientNEventReportRequestHandler(DicomNEventReportRequest request);
+}

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -59,6 +59,7 @@ using Dicom.IO.Reader;
 using Dicom.IO.Writer;
 using Dicom.Log;
 using Dicom.Network.Client;
+using Dicom.Network.Client.Tasks;
 
 namespace Dicom.Network
 {
@@ -1066,6 +1067,11 @@ namespace Dicom.Network
 
         private Task SendMessageAsync(DicomMessage message)
         {
+            if (message == null)
+            {
+                return CompletedTaskProvider.CompletedTask;
+            }
+
             lock (_lock)
             {
                 _msgQueue.Enqueue(message);
@@ -1095,7 +1101,7 @@ namespace Dicom.Network
                     }
 
                     if (Association.MaxAsyncOpsInvoked > 0
-                        && _pending.Count(req => req.Type != DicomCommandField.CGetRequest)
+                        && _pending.Count(req => req.Type != DicomCommandField.CGetRequest && req.Type != DicomCommandField.NActionRequest)
                         >= Association.MaxAsyncOpsInvoked)
                     {
                         break;

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -1012,7 +1012,7 @@ namespace Dicom.Network
                             response = thisAsNServiceProvider.OnNSetRequest(dimse as DicomNSetRequest);
                             break;
                     }
-
+                    
                     await SendResponseAsync(response).ConfigureAwait(false);
                     return;
                 }
@@ -1043,6 +1043,18 @@ namespace Dicom.Network
                     }
 
                     await SendResponseAsync(response).ConfigureAwait(false);
+                    return;
+                }
+
+                if (this is IDicomClientConnection connection)
+                {
+                    switch (dimse.Type)
+                    {
+                        case DicomCommandField.NEventReportRequest:
+                            var response = await connection.OnNEventReportRequestAsync(dimse as DicomNEventReportRequest).ConfigureAwait(false);
+                            await SendResponseAsync(response).ConfigureAwait(false);
+                            break;
+                    }
                     return;
                 }
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ await client.SendAsync();
 
 #### N-Action SCU
 ```csharp
-var dicomClient = new Dicom.Network.Client.DicomClient("127.0.0.1", 12345, false, "SCU-AE", "SCP-AE");
+// It is better to increase 'associationLingerTimeoutInMs' default is 50 ms, which may not be
+// be sufficient
+var dicomClient = new Dicom.Network.Client.DicomClient("127.0.0.1", 12345, false, "SCU-AE", "SCP-AE",
+DicomClientDefaults.DefaultAssociationRequestTimeoutInMs, DicomClientDefaults.DefaultAssociationReleaseTimeoutInMs,5000);
 var txnUid = DicomUIDGenerator.GenerateDerivedFromUUID().UID;
 var nActionDicomDataSet = new DicomDataset
 {

--- a/Tests/Desktop/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/Desktop/Network/DicomNEventReportResponseTest.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) 2012-2020 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using Dicom.Log;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
 namespace Dicom.Network
 {
-    using Xunit;
-
     public class DicomNEventReportResponseTest
     {
         #region Unit tests
@@ -36,5 +40,151 @@ namespace Dicom.Network
         }
 
         #endregion
+
+
+        [Fact]
+        public async Task ClientHandleNEventReport_SynchronousEvent()
+        {
+            var port = Ports.GetNext();
+            using (DicomServer.Create<SimpleStorageComitmentProvider>(port))
+            {
+
+                DicomStatus status = null;
+                int verifiedInstances = 0;
+                DateTime stampNActionResponse = DateTime.MinValue;
+                DateTime stampNEventReportRequest = DateTime.MinValue;
+
+                var dicomClient = new Client.DicomClient("127.0.0.1", port, false, "SCU", "ANY-SCP");
+
+                var nActionDicomDataSet = new DicomDataset
+                {
+                    { DicomTag.TransactionUID,  DicomUIDGenerator.GenerateDerivedFromUUID().UID },
+                    {
+                        DicomTag.ReferencedSOPSequence,
+                        new DicomDataset()
+                        {
+                            { DicomTag.ReferencedSOPClassUID, "1.2.840.10008.5.1.4.1.1.1" },
+                            { DicomTag.ReferencedSOPInstanceUID, "1.3.46.670589.30.2273540226.4.54" }
+                        },
+                        new DicomDataset()
+                        {
+                            { DicomTag.ReferencedSOPClassUID, "1.2.840.10008.5.1.4.1.1.1" },
+                            { DicomTag.ReferencedSOPInstanceUID, "1.3.46.670589.30.2273540226.4.59" }
+                        }
+                    }
+                };
+
+                var nActionRequest = new DicomNActionRequest(DicomUID.StorageCommitmentPushModelSOPClass,
+                                DicomUID.StorageCommitmentPushModelSOPInstance, 1)
+                {
+                    Dataset = nActionDicomDataSet,
+                    OnResponseReceived = (DicomNActionRequest request, DicomNActionResponse response) =>
+                    {
+                        status = response.Status;
+                        stampNActionResponse = DateTime.Now;
+                    },
+                };
+
+                await dicomClient.AddRequestAsync(nActionRequest);
+
+                dicomClient.OnNEventReportRequest = (eventReq) =>
+                {
+                    var refSopSequence = eventReq.Dataset.GetSequence(DicomTag.ReferencedSOPSequence);
+                    foreach (var item in refSopSequence.Items)
+                    {
+                        verifiedInstances += 1;
+                    }
+                    stampNEventReportRequest = DateTime.Now;
+                    return Task.FromResult(new DicomNEventReportResponse(eventReq, DicomStatus.Success));
+                };
+
+                dicomClient.AssociationLingerTimeoutInMs = (int)TimeSpan.FromSeconds(5).TotalMilliseconds;
+                await dicomClient.SendAsync().ConfigureAwait(false);
+
+                Assert.Equal(DicomStatus.Success, status);
+                Assert.Equal(2, verifiedInstances);
+                Assert.True(stampNActionResponse < stampNEventReportRequest);
+            }
+        }
+
     }
+
+
+    internal class SimpleStorageComitmentProvider : DicomService, IDicomServiceProvider, IAsyncDicomNServiceProvider
+    {
+        private static readonly DicomTransferSyntax[] _acceptedTransferSyntaxes =
+        {
+            DicomTransferSyntax.ExplicitVRLittleEndian,
+            DicomTransferSyntax.ExplicitVRBigEndian,
+            DicomTransferSyntax.ImplicitVRLittleEndian
+        };
+
+
+        public SimpleStorageComitmentProvider(INetworkStream stream, Encoding fallbackEncoding, Logger log)
+            : base(stream, fallbackEncoding, log)
+        {
+        }
+
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.AcceptTransferSyntaxes(_acceptedTransferSyntaxes);
+            }
+
+            return SendAssociationAcceptAsync(association);
+        }
+
+        public Task OnReceiveAssociationReleaseRequestAsync() => SendAssociationReleaseResponseAsync();
+
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+
+        public async Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request)
+        {
+            // first return the success-response
+            await SendResponseAsync(new DicomNActionResponse(request, DicomStatus.Success));
+
+            // then synchronously send NEvents
+            if (request.Dataset.Contains(DicomTag.ReferencedSOPSequence))
+            {
+                var referencedSequence = request.Dataset.GetSequence(DicomTag.ReferencedSOPSequence);
+                foreach (var referencedDataset in referencedSequence)
+                {
+                    // This can also be done within a thread later
+                    //_ = Task.Run(async () =>
+                    //  {
+                    //      await Task.Delay(TimeSpan.FromSeconds(1));
+                          var resultDs = new DicomDataset
+                          {
+                            {
+                                DicomTag.ReferencedSOPSequence,
+                                new DicomDataset
+                                {
+                                    { DicomTag.ReferencedSOPClassUID, referencedDataset.GetString(DicomTag.ReferencedSOPClassUID) },
+                                    { DicomTag.ReferencedSOPInstanceUID, referencedDataset.GetString(DicomTag.ReferencedSOPInstanceUID) }
+                                }
+                            }
+                          };
+                          await SendRequestAsync(new DicomNEventReportRequest(DicomUID.StorageCommitmentPushModelSOPClass, DicomUID.Generate(), 1) { Dataset = resultDs });
+                      //});
+                }
+            }
+
+            return null;
+        }
+
+        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request) => throw new NotImplementedException();
+        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request) => throw new NotImplementedException();
+        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request) => throw new NotImplementedException();
+        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request) => throw new NotImplementedException();
+        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request) => throw new NotImplementedException();
+    }
+
+
 }


### PR DESCRIPTION
Fixes #1001 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- The synchronous handling of NEventReportRequest is supported with call back in DicomClient (this enables synchronous storage commitment handling at the client side)
- The necessary interface changes and wiring required to enable the call back is done
- This follows the same strategy as the client side C-STORE request handling

Note: The change log is not updated. Not sure about the version number. Hope it will be updated while making the release. I have tested it with our in-house DICOM interoperability testing tool as PACS simulator.