### PR TITLE
Adding support for synchronous storage commitment in commitment server

### DIFF
--- a/DICOM/DICOM.Shared.projitems
+++ b/DICOM/DICOM.Shared.projitems
@@ -275,6 +275,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomCMoveProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomCStoreProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomNServiceProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IAsyncDicomNEventReportRequestProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCEchoProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCFindProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomCGetProvider.cs" />
@@ -288,6 +289,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomServiceUser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\INetworkListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\INetworkStream.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Network\IDicomNEventReportRequestProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\NetworkManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\PDU.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Network\ScopedNetworkManager.cs" />

--- a/DICOM/Network/DicomService.cs
+++ b/DICOM/Network/DicomService.cs
@@ -996,7 +996,9 @@ namespace Dicom.Network
                     {
                         case DicomCommandField.NActionRequest:
                             response = thisAsNServiceProvider.OnNActionRequest(dimse as DicomNActionRequest);
-                            break;
+                            await SendResponseAsync(response).ConfigureAwait(false);
+                            thisAsNServiceProvider.OnSendNEventReportRequest(dimse as DicomNActionRequest);
+                            return;
                         case DicomCommandField.NCreateRequest:
                             response = thisAsNServiceProvider.OnNCreateRequest(dimse as DicomNCreateRequest);
                             break;
@@ -1025,7 +1027,9 @@ namespace Dicom.Network
                     {
                         case DicomCommandField.NActionRequest:
                             response = await thisAsAsyncNServiceProvider.OnNActionRequestAsync(dimse as DicomNActionRequest).ConfigureAwait(false);
-                            break;
+                            await SendResponseAsync(response).ConfigureAwait(false);
+                            await thisAsAsyncNServiceProvider.OnSendNEventReportRequestAsync(dimse as DicomNActionRequest);
+                            return;
                         case DicomCommandField.NCreateRequest:
                             response = await thisAsAsyncNServiceProvider.OnNCreateRequestAsync(dimse as DicomNCreateRequest).ConfigureAwait(false);
                             break;

--- a/DICOM/Network/IAsyncDicomNEventReportRequestProvider.cs
+++ b/DICOM/Network/IAsyncDicomNEventReportRequestProvider.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2012-2020 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Threading.Tasks;
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface representing event handler for synchronous storage commitment handling
+    /// </summary>
+    public interface IAsyncDicomDicomNEventReportRequestProvider
+    {
+        /// <summary>
+        /// Provide the server implementer a facility to send synchronous N-EVENT-REPORT.
+        /// It requires N-ACTION as the context
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        Task OnSendNEventReportRequestAsync(DicomNActionRequest request);
+    }
+}

--- a/DICOM/Network/IAsyncDicomNServiceProvider.cs
+++ b/DICOM/Network/IAsyncDicomNServiceProvider.cs
@@ -51,5 +51,13 @@ namespace Dicom.Network
         /// <param name="request">N-SET request subject to handling.</param>
         /// <returns>N-SET response based on <paramref name="request"/>.</returns>
         Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request);
+
+        /// <summary>
+        /// Provide the server implementer to send synchronous N-EVENT-REPORT.
+        /// It requires N-ACTION as the context
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        Task OnSendNEventReportRequestAsync(DicomNActionRequest request);
     }
 }

--- a/DICOM/Network/IAsyncDicomNServiceProvider.cs
+++ b/DICOM/Network/IAsyncDicomNServiceProvider.cs
@@ -50,14 +50,6 @@ namespace Dicom.Network
         /// </summary>
         /// <param name="request">N-SET request subject to handling.</param>
         /// <returns>N-SET response based on <paramref name="request"/>.</returns>
-        Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request);
-
-        /// <summary>
-        /// Provide the server implementer to send synchronous N-EVENT-REPORT.
-        /// It requires N-ACTION as the context
-        /// </summary>
-        /// <param name="request"></param>
-        /// <returns></returns>
-        Task OnSendNEventReportRequestAsync(DicomNActionRequest request);
+        Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request);      
     }
 }

--- a/DICOM/Network/IDicomNEventReportRequestProvider.cs
+++ b/DICOM/Network/IDicomNEventReportRequestProvider.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) 2012-2020 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace Dicom.Network
+{
+    /// <summary>
+    /// Interface representing event handler for synchronous storage commitment handling
+    /// </summary>
+    public interface IDicomNEventReportRequestProvider
+    {
+        /// <summary>
+        /// Provide the server implementer a facility to send synchronous N-EVENT-REPORT.
+        /// It requires N-ACTION as the context
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        void OnSendNEventReportRequest(DicomNActionRequest request);
+    }
+}

--- a/DICOM/Network/IDicomNServiceProvider.cs
+++ b/DICOM/Network/IDicomNServiceProvider.cs
@@ -49,12 +49,5 @@ namespace Dicom.Network
         /// <param name="request">N-SET request subject to handling.</param>
         /// <returns>N-SET response based on <paramref name="request"/>.</returns>
         DicomNSetResponse OnNSetRequest(DicomNSetRequest request);
-
-        /// <summary>
-        /// Provide the server implementer to send synchronous N-EVENT-REPORT.
-        /// It requires N-ACTION as the context
-        /// </summary>
-        /// <param name="request"></param>
-        void OnSendNEventReportRequest(DicomNActionRequest request);
     }
 }

--- a/DICOM/Network/IDicomNServiceProvider.cs
+++ b/DICOM/Network/IDicomNServiceProvider.cs
@@ -49,5 +49,12 @@ namespace Dicom.Network
         /// <param name="request">N-SET request subject to handling.</param>
         /// <returns>N-SET response based on <paramref name="request"/>.</returns>
         DicomNSetResponse OnNSetRequest(DicomNSetRequest request);
+
+        /// <summary>
+        /// Provide the server implementer to send synchronous N-EVENT-REPORT.
+        /// It requires N-ACTION as the context
+        /// </summary>
+        /// <param name="request"></param>
+        void OnSendNEventReportRequest(DicomNActionRequest request);
     }
 }

--- a/Tests/Desktop/Network/AsyncDicomNServiceProviderTests.cs
+++ b/Tests/Desktop/Network/AsyncDicomNServiceProviderTests.cs
@@ -277,6 +277,13 @@ namespace Dicom.Network
         {
             return Task.FromResult(new DicomNSetResponse(request, DicomStatus.Success));
         }
+        public Task OnSendNEventReportRequestAsync(DicomNActionRequest request)
+        {
+            return SendRequestAsync(new DicomNEventReportRequest(DicomUID.StorageCommitmentPushModelSOPClass, DicomUID.StorageCommitmentPushModelSOPInstance, 2)
+            {
+                Dataset = request.Dataset
+            });
+        }
     }
     #endregion
 }

--- a/Tests/Desktop/Network/DicomAcceptedPresentationContextTest.cs
+++ b/Tests/Desktop/Network/DicomAcceptedPresentationContextTest.cs
@@ -193,10 +193,7 @@ namespace Dicom.Network
 
         public DicomNActionResponse OnNActionRequest(DicomNActionRequest request)
         {
-            return new DicomNActionResponse(request, DicomStatus.Success)
-            {
-                Dataset = request.Dataset
-            };
+            return new DicomNActionResponse(request, DicomStatus.Success);
         }
 
         public DicomNCreateResponse OnNCreateRequest(DicomNCreateRequest request)
@@ -245,6 +242,9 @@ namespace Dicom.Network
             {
                 Dataset = request.Dataset
             };
+        }
+        public void OnSendNEventReportRequest(DicomNActionRequest request)
+        {
         }
     }
 

--- a/Tests/Desktop/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/Desktop/Network/DicomNEventReportResponseTest.cs
@@ -147,36 +147,7 @@ namespace Dicom.Network
 
         public async Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request)
         {
-            // first return the success-response
-            await SendResponseAsync(new DicomNActionResponse(request, DicomStatus.Success));
-
-            // then synchronously send NEvents
-            if (request.Dataset.Contains(DicomTag.ReferencedSOPSequence))
-            {
-                var referencedSequence = request.Dataset.GetSequence(DicomTag.ReferencedSOPSequence);
-                foreach (var referencedDataset in referencedSequence)
-                {
-                    // This can also be done within a thread later
-                    //_ = Task.Run(async () =>
-                    //  {
-                    //      await Task.Delay(TimeSpan.FromSeconds(1));
-                          var resultDs = new DicomDataset
-                          {
-                            {
-                                DicomTag.ReferencedSOPSequence,
-                                new DicomDataset
-                                {
-                                    { DicomTag.ReferencedSOPClassUID, referencedDataset.GetString(DicomTag.ReferencedSOPClassUID) },
-                                    { DicomTag.ReferencedSOPInstanceUID, referencedDataset.GetString(DicomTag.ReferencedSOPInstanceUID) }
-                                }
-                            }
-                          };
-                          await SendRequestAsync(new DicomNEventReportRequest(DicomUID.StorageCommitmentPushModelSOPClass, DicomUID.Generate(), 1) { Dataset = resultDs });
-                      //});
-                }
-            }
-
-            return null;
+            return new DicomNActionResponse(request, DicomStatus.Success);
         }
 
         public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request) => throw new NotImplementedException();
@@ -184,6 +155,13 @@ namespace Dicom.Network
         public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request) => throw new NotImplementedException();
         public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request) => throw new NotImplementedException();
         public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request) => throw new NotImplementedException();
+        public Task OnSendNEventReportRequestAsync(DicomNActionRequest request)
+        {
+            return SendRequestAsync(new DicomNEventReportRequest(DicomUID.StorageCommitmentPushModelSOPClass, DicomUID.StorageCommitmentPushModelSOPInstance, 2)
+            {
+                Dataset = request.Dataset
+            });
+        }
     }
 
 

--- a/Tests/Desktop/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/Desktop/Network/DicomNEventReportResponseTest.cs
@@ -110,7 +110,8 @@ namespace Dicom.Network
     }
 
 
-    internal class SimpleStorageComitmentProvider : DicomService, IDicomServiceProvider, IAsyncDicomNServiceProvider
+    internal class SimpleStorageComitmentProvider : DicomService, IDicomServiceProvider, IAsyncDicomNServiceProvider,
+        IAsyncDicomDicomNEventReportRequestProvider
     {
         private static readonly DicomTransferSyntax[] _acceptedTransferSyntaxes =
         {


### PR DESCRIPTION
Adding the interface support for enabling the handling of synchronous storage commitment in a storage commitment DICOM service

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- The interface support for handling synchronous storage commitment at server side
- The necessary wiring to invoke the overridden method after N-ACTION request is processed
- The existing tests updated to use new interface