### PR TITLE
fix private tag conversion for elements == 0xff

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 #### v.4.0.6 (TBD)
 * Update to DICOM Standard 2020b.
 * Handle N-Event requests in DicomClient (required for synchronous storage commitment) (#1001)
+* Bug fix: Fix DICOM Tag conversion for private tags for element numbers xxff (#1059)
 
 #### v.4.0.5 (5/18/2020)
 * Bug fix: DicomTags of ValueRepresentation LT have not been validated.

--- a/Contributors.md
+++ b/Contributors.md
@@ -57,3 +57,4 @@
 * [Denny Spiegelberg](https://github.com/nutzlastfan)
 * [Amos Onn](https://github.com/amosonn)
 * [Sudheesh Subramannian](https://github.com/sudheeshps)
+* [Johannes Hirschmann](https://github.com/Johannes-sg)

--- a/DICOM/DicomDataset.cs
+++ b/DICOM/DicomDataset.cs
@@ -766,7 +766,7 @@ namespace Dicom
             if (tag.PrivateCreator == null) return tag;
 
             // already a valid private tag
-            if (tag.Element >= 0xff) return tag;
+            if (tag.Element > 0xff) return tag;
 
             ushort group = 0x0010;
             for (; group <= 0x00ff; group++)

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -463,6 +463,40 @@ namespace Dicom
             Assert.Equal(loCreator, firstCreator);
         }
 
+        /// <summary>
+        /// Associated with Github issue #1059
+        /// </summary>
+        [Fact]
+        public void Add_PrivateTags_LowestAndHighestPossibleElementsShouldBeAdded()
+        {
+            var tag1Private = new DicomTag(0x0019, 0x1000, "PRIVATE"); // lowest possible element (not used for group length encoding)
+            var tag2Private = new DicomTag(0x0019, 0xff, "PRIVATE"); // Should result in (0019, 10ff)
+            var tag3Private = new DicomTag(0x0019, 0xff, "ALSOPRIVATE"); // Should result in (0019, 11ff)
+            var tag4Private = new DicomTag(0x0019, 0xffff, "PRIVATE"); // highest possible element
+
+            var dataset = new DicomDataset();
+            dataset.Add(tag1Private, 1);
+            dataset.Add(tag2Private, 2);
+            dataset.Add(tag3Private, 3);
+            dataset.Add(tag4Private, 4);
+
+            var item1 = dataset.SingleOrDefault(item => item.Tag.Group == tag1Private.Group &&
+                                            item.Tag.Element == 0x1000);
+            Assert.NotNull(item1);
+
+            var item2 = dataset.SingleOrDefault(item => item.Tag.Group == tag2Private.Group &&
+                                item.Tag.Element == 0x10ff);
+            Assert.NotNull(item2);
+
+            var item3 = dataset.SingleOrDefault(item => item.Tag.Group == tag3Private.Group &&
+                    item.Tag.Element == 0x11ff);
+            Assert.NotNull(item3);
+
+            var item4 = dataset.SingleOrDefault(item => item.Tag.Group == tag3Private.Group &&
+                item.Tag.Element == 0xffff);
+            Assert.NotNull(item4);
+        }
+
         [Fact]
         public void Add_DicomItemOnNonExistingPrivateTag_PrivateGroupShouldCorrespondToPrivateCreator()
         {

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -466,35 +466,20 @@ namespace Dicom
         /// <summary>
         /// Associated with Github issue #1059
         /// </summary>
-        [Fact]
-        public void Add_PrivateTags_LowestAndHighestPossibleElementsShouldBeAdded()
+        [Theory]
+        [InlineData(0x0019, 0x1000, "PRIVATE", 0x1000)] // lowest possible element (not used for group length encoding)
+        [InlineData(0x0019, 0xff, "PRIVATE", 0x10ff)]
+        [InlineData(0x0019, 0xffff, "PRIVATE", 0xffff)] // highest possible element
+        public void Add_PrivateTags_LowestAndHighestPossibleElementsShouldBeAdded(ushort group, ushort element, string creator, ushort expectedElement)
         {
-            var tag1Private = new DicomTag(0x0019, 0x1000, "PRIVATE"); // lowest possible element (not used for group length encoding)
-            var tag2Private = new DicomTag(0x0019, 0xff, "PRIVATE"); // Should result in (0019, 10ff)
-            var tag3Private = new DicomTag(0x0019, 0xff, "ALSOPRIVATE"); // Should result in (0019, 11ff)
-            var tag4Private = new DicomTag(0x0019, 0xffff, "PRIVATE"); // highest possible element
+            var tag1Private = new DicomTag(group, element, creator); 
 
             var dataset = new DicomDataset();
             dataset.Add(tag1Private, 1);
-            dataset.Add(tag2Private, 2);
-            dataset.Add(tag3Private, 3);
-            dataset.Add(tag4Private, 4);
 
             var item1 = dataset.SingleOrDefault(item => item.Tag.Group == tag1Private.Group &&
-                                            item.Tag.Element == 0x1000);
+                                            item.Tag.Element == expectedElement);
             Assert.NotNull(item1);
-
-            var item2 = dataset.SingleOrDefault(item => item.Tag.Group == tag2Private.Group &&
-                                item.Tag.Element == 0x10ff);
-            Assert.NotNull(item2);
-
-            var item3 = dataset.SingleOrDefault(item => item.Tag.Group == tag3Private.Group &&
-                    item.Tag.Element == 0x11ff);
-            Assert.NotNull(item3);
-
-            var item4 = dataset.SingleOrDefault(item => item.Tag.Group == tag3Private.Group &&
-                item.Tag.Element == 0xffff);
-            Assert.NotNull(item4);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1059  .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Fixing private tag conversion for case that element equals 0xff
