### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: bug, new
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ If applicable, add screenshots or test DICOM files to help explain your problem.
 
 **Environment**
 Fellow Oak DICOM version: (e.g. 4.0.6)
-OS: (e.g. Windows 8.1)
+OS: (e.g. 64-bit Windows 8.1)
 Platform: (e.g. .NET Framework 4.6.2)
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior (code snippet or clear description)
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots or test DICOM files**
+If applicable, add screenshots or test DICOM files to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ If applicable, add screenshots or test DICOM files to help explain your problem.
 
 **Environment**
 Fellow Oak DICOM version: (e.g. 4.0.6)
-OS: (e.g. 64-bit Windows 8.1)
+OS: (e.g. Windows 8.1 x64)
 Platform: (e.g. .NET Framework 4.6.2)
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,3 +18,10 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots or test DICOM files**
 If applicable, add screenshots or test DICOM files to help explain your problem.
+
+**Environment**
+Fellow Oak DICOM version: (e.g. 4.0.6)
+OS: (e.g. Windows 8.1)
+Platform: (e.g. .NET Framework 4.6.2)
+
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug, new
+labels: new
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: evaluating
+assignees: ''
+
+---
+
+**What is, according to you, missing from fo-dicom? Please describe.**
+A clear and concise description of the use case that this new feature would solve. 
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe possible alternatives or existing workarounds you've considered**
+A clear and concise description of any alternative solutions or existing workarounds you've considered.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement, new
+labels: new
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: evaluating
+labels: enhancement, new
 assignees: ''
 
 ---


### PR DESCRIPTION
Hey @gofal , I found out about this Github feature via other open source projects, and it's quite nice: when people create a new issue, they can choose between any of the existing templates, or make an empty one. The benefit is that it "guides" the user into filling in the correct details, and it requires a little less typing of people.

Let me know what you think, I think it's neat. :-) 