### PR TITLE
Dispose ImageSharp image when disposing the Fellow Oak DICOM image

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -24,6 +24,7 @@
 * Text encoding is now handled when a string is written into a network- or file-stream.
 * Switch to IAsyncEnumerator on netstandard2.1, netcoreapp3.X
 * internal: SCU now sends two presentation context per CStoreRequest: one with the original TS and one with the additional and the mandatory ImplicitLittleEndian. So the chance is higher to send the file without conversion. (#1048)
+* Fix memory leak in ImageSharp image manager (#1081)
 
 ##### Breaking changes:
 

--- a/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ImageSharpImage.cs
+++ b/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ImageSharpImage.cs
@@ -128,12 +128,22 @@ namespace FellowOakDicom.Imaging
                     .DrawImage(layer, new Point(graphic.ScaledOffsetX, graphic.ScaledOffsetY), 1));
             }
         }
- 
+
 
         /// <inheritdoc />
         public override IImage Clone()
         {
             return new ImageSharpImage(width, height, new PinnedIntArray(pixels.Data), image?.Clone());
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.image?.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         #endregion


### PR DESCRIPTION
Fixes #1081 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] ~~I have updated API documentation~~
- [ ] ~~I have included unit tests~~
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Dispose the ImageSharp image when disposing the Fellow Oak DICOM image.
