### PR TITLE
Fix bug: It's very slow open deflated file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 * Bug fix: Prevent special characters in association requests from crashing Fellow Oak DICOM (#1104)
 * Fixes caching of pixel data in DicomImage when rendering the same image multithreaded. (#805)
 * Fix handling of MaximumPDULength. DicomServer always repeated the clients value of MaximumPDULength in AssociationAccepted-message instead of returning its own value. (#1084)
+* Bug fix: It's very slow to open deflated dicom file. (#1115)
 
 #### v.4.0.6 (8/6/2020)
 * Update to DICOM Standard 2020b.

--- a/DICOM/IO/Buffer/ByteBufferByteSource.cs
+++ b/DICOM/IO/Buffer/ByteBufferByteSource.cs
@@ -5,6 +5,7 @@ namespace Dicom.IO.Buffer
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
 
 #if !NET35
     using System.Threading.Tasks;
@@ -445,6 +446,20 @@ namespace Dicom.IO.Buffer
 
                 _position++;
                 return _currentData[_currentPos++];
+            }
+        }
+
+        public Stream GetStream()
+        {
+            lock (_lock)
+            {
+                Stream stream = new MemoryStream();
+                foreach (var item in _buffers)
+                {
+                    byte[] data = item.Data;
+                    stream.Write(data, 0, data.Length);
+                }
+                return stream;
             }
         }
 

--- a/DICOM/IO/FileByteSource.cs
+++ b/DICOM/IO/FileByteSource.cs
@@ -85,11 +85,11 @@ namespace Dicom.IO
         /// <inheritdoc />
         public long Position => _stream.Position;
 
-      /// <inheritdoc />
-      public long Marker { get; private set; }
+        /// <inheritdoc />
+        public long Marker { get; private set; }
 
-      /// <inheritdoc />
-      public bool IsEOF => _stream.Position >= _stream.Length;
+        /// <inheritdoc />
+        public bool IsEOF => _stream.Position >= _stream.Length;
 
         /// <inheritdoc />
         public bool CanRewind => _stream.CanSeek;
@@ -249,6 +249,11 @@ namespace Dicom.IO
             { /* ignore exception */ }
 
             _disposed = true;
+        }
+
+        public Stream GetStream()
+        {
+            return _stream;
         }
 
         #endregion

--- a/DICOM/IO/IByteSource.cs
+++ b/DICOM/IO/IByteSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 #if !NET35
+using System.IO;
 using System.Threading.Tasks;
 #endif
 
@@ -176,5 +177,11 @@ namespace Dicom.IO
         /// <param name="state">Callback state.</param>
         /// <returns>true if source contains sufficient number of remaining bytes, false otherwise.</returns>
         bool Require(uint count, ByteSourceCallback callback, object state);
+
+        /// <summary>
+        /// Get stream of this byte source.
+        /// </summary>
+        /// <returns></returns>
+        Stream GetStream();
     }
 }

--- a/DICOM/IO/IByteSource.cs
+++ b/DICOM/IO/IByteSource.cs
@@ -181,7 +181,7 @@ namespace Dicom.IO
         /// <summary>
         /// Get stream of this byte source.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The stream.</returns>
         Stream GetStream();
     }
 }

--- a/DICOM/IO/Reader/DicomReader.cs
+++ b/DICOM/IO/Reader/DicomReader.cs
@@ -296,25 +296,16 @@ namespace Dicom.IO.Reader
 
             private IByteSource Decompress(IByteSource source)
             {
-                using (var compressed = new MemoryStream())
+                var compressed = source.GetStream();
+
+                var decompressed = new MemoryStream();
+                using (var decompressor = new DeflateStream(compressed, CompressionMode.Decompress, true))
                 {
-                    // It is implicitly assumed that the rest of the byte source is compressed.
-                    while (!source.IsEOF)
-                    {
-                        compressed.WriteByte(source.GetUInt8());
-                    }
-
-                    compressed.Seek(0, SeekOrigin.Begin);
-
-                    var decompressed = new MemoryStream();
-                    using (var decompressor = new DeflateStream(compressed, CompressionMode.Decompress, true))
-                    {
-                        decompressor.CopyTo(decompressed);
-                    }
-
-                    decompressed.Seek(0, SeekOrigin.Begin);
-                    return new StreamByteSource(decompressed, FileReadOption.Default);
+                    decompressor.CopyTo(decompressed);
                 }
+
+                decompressed.Seek(0, SeekOrigin.Begin);
+                return new StreamByteSource(decompressed, FileReadOption.Default);
             }
 
             private bool ParseTag(IByteSource source)

--- a/DICOM/IO/StreamByteSource.cs
+++ b/DICOM/IO/StreamByteSource.cs
@@ -209,6 +209,11 @@ namespace Dicom.IO
             }
         }
 
+        public Stream GetStream()
+        {
+            return _stream;
+        }
+
         #endregion
     }
 }

--- a/Tests/Desktop/Media/DicomDirectoryReaderObserverTest.cs
+++ b/Tests/Desktop/Media/DicomDirectoryReaderObserverTest.cs
@@ -48,6 +48,7 @@ namespace Dicom.Media
             public bool Require(uint count, ByteSourceCallback callback, object state) => throw new NotImplementedException();
             public void Rewind() => throw new NotImplementedException();
             public void Skip(int count) => throw new NotImplementedException();
+            public Stream GetStream() => throw new NotImplementedException();
         }
 
         private class Container


### PR DESCRIPTION
Fixes #1115 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add GetStream to IByteSource
- FileByteSource expose internal stream directly for DicomReader to consume

#### Notes
- GivenDeflatedDicomFileWithSequence_WhenOpenFile_ThenShouldSucceed in [DicomReaderTests.cs](https://github.com/fo-dicom/fo-dicom/blob/15258dbe7177a09c18b70be4757d25b444bcedc2/Tests/Desktop/IO/Reader/DicomReaderTest.cs#L60) can cover the change
- Please let me know if also need to update FellowOakDicom
