### PR TITLE
Bug Fix: Validation exception on valid decimal string

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 * Fix handling of MaximumPDULength. DicomServer always repeated the clients value of MaximumPDULength in AssociationAccepted-message instead of returning its own value. (#1084)
 * Bug fix: It's very slow to open deflated dicom file. (#1115)
 * Bug fix: DicomUID Storage Commitment Push Model SOP Class was mapped to wrng DicomStorageCategory (#1113)
+* Bug fix: String decimals ending in . (ex. 1.) fail validatoin even though they can be converted to decimal
 
 #### v.4.0.6 (8/6/2020)
 * Update to DICOM Standard 2020b.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@
 * Fix handling of MaximumPDULength. DicomServer always repeated the clients value of MaximumPDULength in AssociationAccepted-message instead of returning its own value. (#1084)
 * Bug fix: It's very slow to open deflated dicom file. (#1115)
 * Bug fix: DicomUID Storage Commitment Push Model SOP Class was mapped to wrng DicomStorageCategory (#1113)
-* Bug fix: String decimals ending in . (ex. 1.) fail validatoin even though they can be converted to decimal
+* Bug fix: String decimals ending in . (ex. 10.) throw DicomValidationException even though they can be converted to decimal
 
 #### v.4.0.6 (8/6/2020)
 * Update to DICOM Standard 2020b.

--- a/Contributors.md
+++ b/Contributors.md
@@ -64,3 +64,4 @@
 * [Pooja Adhikari](https://github.com/poadhika)
 * [devsko](https://github.com/devsko)
 * [jasonwurzel](https://github.com/jasonwurzel)
+* [Abdullah Islam](https://github.com/abdullah248)

--- a/DICOM/DicomValidation.cs
+++ b/DICOM/DicomValidation.cs
@@ -88,7 +88,7 @@ namespace Dicom
             // This is not very inefficient - uses .NET regex caching
             if (!Regex.IsMatch(content, "^[+-]?((0|[1-9][0-9]*)([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$"))
             {
-                throw new DicomValidationException(content, DicomVR.DS, "value is no decimal string");
+                throw new DicomValidationException(content, DicomVR.DS, "value is not decimal string");
             }
         }
 

--- a/DICOM/DicomValidation.cs
+++ b/DICOM/DicomValidation.cs
@@ -86,7 +86,7 @@ namespace Dicom
         public static void ValidateDS(string content)
         {
             // This is not very inefficient - uses .NET regex caching
-            if (!Regex.IsMatch(content, "^[+-]?((0|[1-9][0-9]*)([.][0-9]+)?|[.][0-9]+)([eE][-+]?[0-9]+)?$"))
+            if (!Regex.IsMatch(content, "^[+-]?((0|[1-9][0-9]*)([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$"))
             {
                 throw new DicomValidationException(content, DicomVR.DS, "value is no decimal string");
             }

--- a/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/Desktop/Serialization/JsonDicomConverterTest.cs
@@ -156,6 +156,7 @@ namespace Dicom.Serialization
         {
             var originalDataset = new DicomDataset {
                 { DicomTag.ImagePositionPatient, new[] { "1.0000", "0.00", "0" } },
+                { DicomTag.ImagePlanePixelSpacing, new[] { "10.0", "10."} },
                 { DicomTag.ImageOrientationPatient, new[] { "1e-3096", "1", "0.0000000", ".03", "-.03", "-0" } }
             };
 


### PR DESCRIPTION
Description: Fixes issue where decimal strings ending in . such as (10.) throw DicomValidationException even though it is a valid decimal string that can be parsed.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Update regex in ValidateDS function to allow acceptance of strings ending in a decimal point.
