### PR TITLE
Update IntegerString Parsing to Accept More Valid Inputs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 * Fix handling of MaximumPDULength. DicomServer always repeated the clients value of MaximumPDULength in AssociationAccepted-message instead of returning its own value. (#1084)
 * Bug fix: It's very slow to open deflated dicom file. (#1115)
 * Bug fix: DicomUID Storage Commitment Push Model SOP Class was mapped to wrng DicomStorageCategory (#1113)
+* Allow conversion of integerString into integer if original string had decimal with trailing zeros 
 
 #### v.4.0.6 (8/6/2020)
 * Update to DICOM Standard 2020b.

--- a/DICOM/DicomElement.cs
+++ b/DICOM/DicomElement.cs
@@ -973,7 +973,7 @@ namespace Dicom
 
             if (_values == null)
             {
-                _values = base.Get<string[]>().Select(x => int.Parse(x, CultureInfo.InvariantCulture)).ToArray();
+                _values = base.Get<string[]>().Select(x => int.Parse(x, NumberStyles.Integer | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture)).ToArray();
             }
 
             if (typeof(T) == typeof(int) || typeof(T) == typeof(object))

--- a/Tests/Desktop/DicomDatasetTest.cs
+++ b/Tests/Desktop/DicomDatasetTest.cs
@@ -579,9 +579,9 @@ namespace Dicom
                     DicomTag.SeriesNumber,
                     new MemoryByteBuffer(
 #if NETSTANDARD
-                        Encoding.GetEncoding(0).GetBytes("1.0")
+                        Encoding.GetEncoding(0).GetBytes("1.1")
 #else
-                        Encoding.Default.GetBytes("1.0")
+                        Encoding.Default.GetBytes("1.1")
 #endif
                     )
                 ) },
@@ -600,9 +600,9 @@ namespace Dicom
                     DicomTag.SeriesNumber,
                     new MemoryByteBuffer(
 #if NETSTANDARD
-                        Encoding.GetEncoding(0).GetBytes("1.0")
+                        Encoding.GetEncoding(0).GetBytes("1.1")
 #else
-                        Encoding.Default.GetBytes("1.0")
+                        Encoding.Default.GetBytes("1.1")
 #endif
                     )
                 ) },
@@ -621,9 +621,9 @@ namespace Dicom
                     DicomTag.SeriesNumber,
                     new MemoryByteBuffer(
 #if NETSTANDARD
-                        Encoding.GetEncoding(0).GetBytes("1.0")
+                        Encoding.GetEncoding(0).GetBytes("1.1")
 #else
-                        Encoding.Default.GetBytes("1.0")
+                        Encoding.Default.GetBytes("1.1")
 #endif
                     )
                 ) },

--- a/Tests/Desktop/DicomElementTest.cs
+++ b/Tests/Desktop/DicomElementTest.cs
@@ -384,6 +384,12 @@ namespace Dicom
         }
 
         [Fact]
+        public void DicomIntegerString_GetIntArrayFromString_ReturnsArray()
+        {
+            this.TestDicomIntegerStringGetArrayFromString<int>();
+        }
+
+        [Fact]
         public void DicomIntegerString_GetLongArray_ReturnsArray()
         {
             this.TestDicomIntegerStringGetArray<long>();
@@ -488,6 +494,14 @@ namespace Dicom
         {
             var expected = new[] { 35, 45, 55 };
             var element = new DicomIntegerString(DicomTag.AttachedContours, expected);
+            var actual = element.Get<T[]>();
+            Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T))), actual);
+        }
+
+        internal void TestDicomIntegerStringGetArrayFromString<T>()
+        {
+            var expected = new[] { 35, 45, 55 };
+            var element = new DicomIntegerString(DicomTag.AttachedContours, new [] { "35.0", "45.0000", "55" });
             var actual = element.Get<T[]>();
             Assert.Equal(expected.Select(i => (T)Convert.ChangeType(i, Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T))), actual);
         }


### PR DESCRIPTION
This allows for IntegerString parsing on values such as "1.000" which can easily be converted into an integer by removing the trailing zeros and thus can be treated as valid inputs.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Acceptance of IntegerStrings that have decimals in them but can easily be converted into an Integer such as "1.00". In cases such as "1.01" it will continue to throw an error.