### PR TITLE
bugfix: NLogManager constructor should be public

### DIFF
--- a/Logging/FO-DICOM.NLog/NLogManager.cs
+++ b/Logging/FO-DICOM.NLog/NLogManager.cs
@@ -5,7 +5,6 @@ using System;
 
 namespace FellowOakDicom.Log
 {
-
     /// <summary>
     /// LogManager for the NLog logging framework.
     /// </summary>
@@ -22,7 +21,7 @@ namespace FellowOakDicom.Log
         /// <summary>
         /// Initializes an instance of <see cref="NLogManager"/>.
         /// </summary>
-        private NLogManager()
+        public NLogManager()
         {
         }
 
@@ -63,9 +62,9 @@ namespace FellowOakDicom.Log
                 var ordinalFormattedMessage = NameFormatToPositionalFormat(msg);
                 var nlogLevel = GetNLogLevel(level);
 
-                if (args.Length >= 1 && args[0] is Exception)
+                if (args.Length >= 1 && args[0] is Exception exception)
                 {
-                    this.logger.Log(nlogLevel, (Exception)args[0], ordinalFormattedMessage, args);
+                    this.logger.Log(nlogLevel, exception, ordinalFormattedMessage, args);
                 }
                 else
                 {

--- a/Tests/FO-DICOM.Tests/Log/LogManagerTest.cs
+++ b/Tests/FO-DICOM.Tests/Log/LogManagerTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2012-2020 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Log;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Log
+{
+    public class LogManagerTest
+    {
+        [Fact]
+        public void GetNLogManagerInstanceTest()
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddLogManager<NLogManager>();
+
+            var provider = services.BuildServiceProvider();
+
+            ILogManager logManager = provider.GetRequiredService<ILogManager>();
+
+            Assert.IsAssignableFrom<NLogManager>(logManager);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1135 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Fixes issue #1135 .
