### PR TITLE
Use Color32 instead of System.Drawing.Color

### DIFF
--- a/FO-DICOM.Core/Imaging/DicomOverlayDataFactory.cs
+++ b/FO-DICOM.Core/Imaging/DicomOverlayDataFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2012-2020 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System.Drawing;
 using FellowOakDicom.Imaging.Mathematics;
 using FellowOakDicom.IO.Buffer;
 
@@ -22,7 +21,7 @@ namespace FellowOakDicom.Imaging
         /// <param name="bitmap">Bitmap</param>
         /// <param name="mask">Color mask for overlay</param>
         /// <returns>DICOM overlay</returns>
-        public static DicomOverlayData FromBitmap(DicomDataset ds, IImage bitmap, Color mask)
+        public static DicomOverlayData FromBitmap(DicomDataset ds, IImage bitmap, Color32 mask)
         {
             ushort group = 0x6000;
             while (ds.Contains(new DicomTag(group, DicomTag.OverlayBitPosition.Element))) group += 2;
@@ -45,7 +44,7 @@ namespace FellowOakDicom.Imaging
             {
                 for (var x = 0; x < bitmap.Width; x++, p++)
                 {
-                    if (bitmap.GetPixel(x, y).ToArgb() == mask.ToArgb()) array[p] = true;
+                    if (bitmap.GetPixel(x, y).Value == mask.Value) array[p] = true;
                 }
             }
 

--- a/FO-DICOM.Core/Imaging/IImage.cs
+++ b/FO-DICOM.Core/Imaging/IImage.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using FellowOakDicom.Imaging.Render;
 using FellowOakDicom.IO;
 
@@ -58,7 +57,7 @@ namespace FellowOakDicom.Imaging
         /// <returns>Deep copy of this image.</returns>
         IImage Clone();
 
-        Color GetPixel(int x, int y);
+        Color32 GetPixel(int x, int y);
 
         #endregion
     }

--- a/FO-DICOM.Core/Imaging/ImageBase.cs
+++ b/FO-DICOM.Core/Imaging/ImageBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Reflection;
 using FellowOakDicom.Imaging.Render;
 using FellowOakDicom.IO;
@@ -170,13 +169,13 @@ namespace FellowOakDicom.Imaging
             return bytes;
         }
 
-        public Color GetPixel(int x, int y)
+        public Color32 GetPixel(int x, int y)
         {
             if (x >= 0 && x < width && y >= 0 && y < height)
             {
-                return Color.FromArgb(pixels.Data[x + y * width]);
+                return new Color32(pixels.Data[x + y * width]);
             }
-            return Color.Black;
+            return Color32.Black;
         }
 
         private static int[] Rotate(ref int width, ref int height, int angle, int[] data)


### PR DESCRIPTION
I think the FO-DICOM.Core project should remove reference to `System.Drawing`. Because `System.Drawing` is not cross-platform. [System.Drawing Namespace](https://docs.microsoft.com/en-us/dotnet/api/system.drawing?redirectedfrom=MSDN&view=net-5.0)

I found [`Color32`](https://github.com/fo-dicom/fo-dicom/blob/development/FO-DICOM.Core/Imaging/Color32.cs). Maybe I should use it instead of `Color`.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Remove the reference to `System.Drawing`
