### PR TITLE
Improve timeout detection stability

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 * Bug fix: Some non-retired DicomTags had a name including "RETIRED". Now fixed the generation of DicomTag names. (#1131)
 * FrameGeometry is enhanced so that it also works for DX, CR or MG images. (#1138)
 * Private Creator UN tags are converted to LO (#1146)
+* Bug fix: Ensure timeout detection can never stop prematurely
 
 #### v.4.0.7 (11/1/2020)
 * Bug fix: Not able to open deflated dicom file which contains squence (#1097)

--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -28,6 +28,7 @@
 * Bug fix: Prevent special characters in association requests from crashing Fellow Oak DICOM (#1104)
 * Make DicomService more memory efficient. Use existing streams in PDU and do not create new Memorystreams for every PDU. (#1091)
 * Bug fix: No DICOM charset found for GB18030 in .NET Core (#1125)
+* Bug fix: Ensure timeout detection can never stop prematurely
 
 ##### Breaking changes:
 

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1273,45 +1273,54 @@ namespace FellowOakDicom.Network
                     return;
                 }
 
-                List<DicomRequest> timedOutPendingRequests;
-                lock (_lock)
+                try
                 {
-                    if (!_pending.Any())
+                    List<DicomRequest> timedOutPendingRequests;
+                    lock (_lock)
                     {
-                        return;
+                        if (!_pending.Any())
+                        {
+                            return;
+                        }
+
+                        timedOutPendingRequests = _pending.Where(p => p.IsTimedOut(requestTimeout)).ToList();
                     }
 
-                    timedOutPendingRequests = _pending.Where(p => p.IsTimedOut(requestTimeout)).ToList();
-                }
-
-                if (timedOutPendingRequests.Any())
-                {
-                    for (var i = timedOutPendingRequests.Count - 1; i >= 0; i--)
+                    if (timedOutPendingRequests.Any())
                     {
-                        DicomRequest timedOutPendingRequest = timedOutPendingRequests[i];
-                        try
+                        for (var i = timedOutPendingRequests.Count - 1; i >= 0; i--)
                         {
-                            Logger.Warn($"Request [{timedOutPendingRequest.MessageID}] timed out, removing from pending queue and triggering timeout callbacks");
-                            timedOutPendingRequest.OnTimeout?.Invoke(timedOutPendingRequest, new DicomRequest.OnTimeoutEventArgs(requestTimeout));
-                        }
-                        finally
-                        {
-                            lock (_lock)
+                            DicomRequest timedOutPendingRequest = timedOutPendingRequests[i];
+                            try
                             {
-                                _pending.Remove(timedOutPendingRequest);
+                                Logger.Warn($"Request [{timedOutPendingRequest.MessageID}] timed out, removing from pending queue and triggering timeout callbacks");
+                                timedOutPendingRequest.OnTimeout?.Invoke(timedOutPendingRequest, new DicomRequest.OnTimeoutEventArgs(requestTimeout));
                             }
-
-                            if (this is IDicomClientConnection connection)
+                            finally
                             {
-                                await connection.OnRequestTimedOutAsync(timedOutPendingRequest, requestTimeout).ConfigureAwait(false);
+                                lock (_lock)
+                                {
+                                    _pending.Remove(timedOutPendingRequest);
+                                }
+
+                                if (this is IDicomClientConnection connection)
+                                {
+                                    await connection.OnRequestTimedOutAsync(timedOutPendingRequest, requestTimeout).ConfigureAwait(false);
+                                }
                             }
                         }
                     }
+
+                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
                 }
-
-                await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
-
-                _isCheckingForTimeouts = 0;
+                catch (Exception e)
+                {
+                    Logger.Error("An error occurred in the Fellow Oak DICOM timeout detection loop: {Error}", e);
+                }
+                finally
+                {
+                    _isCheckingForTimeouts = 0;
+                }
             }
         }
 


### PR DESCRIPTION
This fixes an issue we saw in production:

1. A DicomClient sends a lot of DICOM C-FIND requests over one association with async ops invoked = 1 (one pending request at a time)
2. The PACS stops sending C-FIND responses after 1 minute
3. Due to a faulty OnResponseTimeout implementation, an exception occurs in DicomService.CheckForTimeouts
4. The flag _isCheckingForTimeouts is never lowered
5. A little while later, another request times out
6. Because the timeout loop is no longer running, this request is never cleared from the DicomService.pending queue
7. Because async ops invoked is set to 1, no extra requests can be added until the pending queue is empty
8. DicomClient waits forever until the request completes or times out
9. DicomClient is stuck

The solution is very straightforward: use try { .. } finally { .. } to make sure that the flag _isCheckingForTimeouts is always set correctly.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Ensure that the flag is always lowered again when something fails in the DICOM request timeout loop
