### PR TITLE
Fix for anonymizer Sequence parsing (#1202)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
 * Update to DICOM Standard 2021b (#1189)
 * Do not validate VM for VRs OF, OL and OV (#1186)
 * Add possibility to add values for the VRs UV, SV and OV
+* Bug fix: Anonymizer not parsing items in sequences (#1202)
 
 #### v.4.0.7 (11/1/2020)
 * Bug fix: Not able to open deflated dicom file which contains squence (#1097)

--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -7,6 +7,7 @@
 * Add possibility to register additional encodings via `DicomEncoding.RegisterEncoding()` 
 * Do not validate VM for VRs OF, OL and OV (#1186)
 * Add possibility to add values for the VRs UV, SV and OV
+* Bug fix: Anonymizer not parsing items in sequences (#1202)
 
 #### 5.0.0-alpha5 (2021-05-25)
 

--- a/Contributors.md
+++ b/Contributors.md
@@ -71,3 +71,4 @@
 * [James Allsopp](https://github.com/EthicsGradient)
 * [Gabriel Schafflützel](https://github.com/gasupidupi)
 * [mrbean-bremen](https://github.com/mrbean-bremen)
+* [Michael Möring](https://github.com/MichaelM223)

--- a/DICOM/DicomAnonymizer.cs
+++ b/DICOM/DicomAnonymizer.cs
@@ -179,57 +179,70 @@ namespace Dicom
         /// <param name="dataset">The dataset to be altered</param>
         public void AnonymizeInPlace(DicomDataset dataset)
         {
-            var toRemove = new List<DicomItem>();
-            var itemList = dataset.ToArray();
-
             var encoding = DicomEncoding.Default;
             if (dataset.TryGetSingleValue<string>(DicomTag.SpecificCharacterSet, out var characterSet))
             {
                 encoding = DicomEncoding.GetEncoding(characterSet);
             }
 
-            foreach (var item in itemList)
+            Action<DicomDataset> parseDataset = null;
+            parseDataset = (ds) =>
             {
-                var parenthesis = new[] { '(', ')' };
-                var tag = item.Tag.ToString().Trim(parenthesis);
-                var action = Profile.FirstOrDefault(pair => pair.Key.IsMatch(tag));
-                if (action.Key != null)
+                var toRemove = new List<DicomItem>();
+                var itemList = ds.ToArray();
+                foreach (var item in itemList)
                 {
+                    var parenthesis = new[] { '(', ')' };
+                    var tag = item.Tag.ToString().Trim(parenthesis);
+                    var action = Profile.FirstOrDefault(pair => pair.Key.IsMatch(tag));
                     var vr = item.ValueRepresentation;
 
-                    switch (action.Value)
+                    if (vr == DicomVR.SQ && (action.Key == null || action.Value == SecurityProfileActions.K))
                     {
-                        case SecurityProfileActions.U: // UID
-                        case SecurityProfileActions.C: // Clean
-                        case SecurityProfileActions.D: // Dummy
-                            if (vr == DicomVR.UI) ReplaceUID(dataset, item);
-                            else if (vr.ValueType == typeof(string)) ReplaceString(dataset, encoding, item, "ANONYMOUS");
-                            else BlankItem(dataset, item, true);
-                            break;
-                        case SecurityProfileActions.K: // Keep
-                            break;
-                        case SecurityProfileActions.X: // Remove
-                            toRemove.Add(item);
-                            break;
-                        case SecurityProfileActions.Z: // Zero-length
-                            BlankItem(dataset, item, false);
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException(nameof(action));
+                        foreach (DicomDataset sqDataset in item as DicomSequence)
+                        {
+                            parseDataset(sqDataset);
+                        };
+                    }
+
+                    if (action.Key != null)
+                    {
+                        switch (action.Value)
+                        {
+                            case SecurityProfileActions.U: // UID
+                            case SecurityProfileActions.C: // Clean
+                            case SecurityProfileActions.D: // Dummy
+                                if (vr == DicomVR.UI) ReplaceUID(ds, item);
+                                else if (vr.ValueType == typeof(string)) ReplaceString(ds, encoding, item, "ANONYMOUS");
+                                else BlankItem(ds, item, true);
+                                break;
+                            case SecurityProfileActions.K: // Keep
+                                break;
+                            case SecurityProfileActions.X: // Remove
+                                toRemove.Add(item);
+                                break;
+                            case SecurityProfileActions.Z: // Zero-length
+                                BlankItem(ds, item, false);
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException(nameof(action));
+                        }
+                    }
+
+                    if (item.Tag.Equals(DicomTag.PatientName) && Profile.PatientName != null)
+                    {
+                        ReplaceString(ds, encoding, item, Profile.PatientName);
+                    }
+                    else if (item.Tag.Equals(DicomTag.PatientID) && Profile.PatientID != null)
+                    {
+                        ReplaceString(ds, encoding, item, Profile.PatientID);
                     }
                 }
 
-                if (item.Tag.Equals(DicomTag.PatientName) && Profile.PatientName != null)
-                {
-                    ReplaceString(dataset, encoding, item, Profile.PatientName);
-                }
-                else if (item.Tag.Equals(DicomTag.PatientID) && Profile.PatientID != null)
-                {
-                    ReplaceString(dataset, encoding, item, Profile.PatientID);
-                }
-            }
+                ds.Remove(item => toRemove.Contains(item));
+            };
 
-            dataset.Remove(item => toRemove.Contains(item));
+            parseDataset(dataset);
         }
 
         /// <summary>Clones and anonymizes a dataset</summary>

--- a/Tests/FO-DICOM.Tests/DicomAnonymizerTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomAnonymizerTest.cs
@@ -158,6 +158,48 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void AnonymizeInPlace_SequenceToKeep_NestedDatasetsShouldBeParsed()
+        {
+            const string fileName = "GH610.dcm";
+            var tagRoiContourSeq = DicomTag.ROIContourSequence;
+            var tagContourSeq = DicomTag.ContourSequence;
+            var tagContourImgSeq = DicomTag.ContourImageSequence;
+            var generatedUid1 = DicomUIDGenerator.GenerateDerivedFromUUID();
+            var generatedUid2 = DicomUIDGenerator.GenerateDerivedFromUUID();
+
+            var dataset = DicomFile.Open($"./Test Data/{fileName}").Dataset;
+
+            dataset.Add(new DicomSequence(tagRoiContourSeq, new DicomDataset(
+                new DicomSequence(tagContourSeq, new DicomDataset(
+                    new DicomSequence(tagContourImgSeq,
+                    new DicomDataset(
+                        new DicomUniqueIdentifier(DicomTag.ReferencedSOPInstanceUID, generatedUid1.UID),
+                        new DicomIntegerString(DicomTag.ReferencedFrameNumber, 1)
+                        ),
+                    new DicomDataset(
+                        new DicomUniqueIdentifier(DicomTag.ReferencedSOPInstanceUID, generatedUid2.UID),
+                        new DicomIntegerString(DicomTag.ReferencedFrameNumber, 2)
+                        )
+                    ))
+                ))
+            ));
+
+            var anonymizer = new DicomAnonymizer();
+            anonymizer.AnonymizeInPlace(dataset);
+
+            Assert.True(dataset.Contains(tagRoiContourSeq));
+
+            var sequence1 = dataset.GetSequence(tagRoiContourSeq);
+            var sequence2 = sequence1.Items[0].GetSequence(tagContourSeq);
+            var sequence3 = sequence2.Items[0].GetSequence(tagContourImgSeq);
+            Assert.NotEqual(sequence3.Items[0].GetSingleValue<DicomUID>(DicomTag.ReferencedSOPInstanceUID), sequence3.Items[1].GetSingleValue<DicomUID>(DicomTag.ReferencedSOPInstanceUID));
+            Assert.NotEqual(generatedUid1, sequence3.Items[0].GetSingleValue<DicomUID>(DicomTag.ReferencedSOPInstanceUID));
+            Assert.NotEqual(generatedUid2, sequence3.Items[1].GetSingleValue<DicomUID>(DicomTag.ReferencedSOPInstanceUID));
+            Assert.Equal(1, sequence3.Items[0].GetSingleValue<int>(DicomTag.ReferencedFrameNumber));
+            Assert.Equal(2, sequence3.Items[1].GetSingleValue<int>(DicomTag.ReferencedFrameNumber));
+        }
+
+        [Fact]
         public void AnonymizeInPlace_BasicProfile()
         {
             const string fileName = "CT1_J2KI";


### PR DESCRIPTION
Fixes #1202 and adds anonymizer unit test for nested items.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] ~~I have updated API documentation~~ <- not applicable
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
Changes the behavior of the Anonymizer class; now correctly parses datasets in Sequences when a Sequence is being kept.
