### PR TITLE
Fix IO Exception with >2GB images (#1148)

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,5 +1,6 @@
 #### 5.0.1 (TBD)
 
+* Fix IO Exception with >2GB images (#1148)
 
 #### 5.0.0 (2021-09-13)
 

--- a/FO-DICOM.Core/IO/Writer/DicomWriter.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomWriter.cs
@@ -300,7 +300,7 @@ namespace FellowOakDicom.IO.Writer
 
         private static void WriteBuffer(IByteTarget target, IByteBuffer buffer, uint largeObjectSize)
         {
-            var offset = 0;
+            long offset = 0;
             var remainingSize = buffer.Size;
 
             while (remainingSize > largeObjectSize)
@@ -316,7 +316,7 @@ namespace FellowOakDicom.IO.Writer
 
         private static async Task WriteBufferAsync(IByteTarget target, IByteBuffer buffer, uint largeObjectSize)
         {
-            var offset = 0;
+            long offset = 0;
             var remainingSize = buffer.Size;
 
             while (remainingSize > largeObjectSize)


### PR DESCRIPTION
Fixes #1148 

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [X] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Change offset from var to long in DicomWriter WriteBuffer and WriteBufferAsync 
-
-
