### PR TITLE
Correct Source PDU Field in Association Abort Request (#984)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### v.4.0.9 (TBD)
+* Bug fix: Correct Source PDU Field in Association Abort Request (#984)
 
 
 #### v.4.0.8 (09/10/2020)

--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,6 +1,7 @@
 #### 5.0.1 (TBD)
 
 * Fix IO Exception with >2GB images (#1148)
+* Bug fix: Correct Source PDU Field in Association Abort Request (#984)
 
 #### 5.0.0 (2021-09-13)
 

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -1229,11 +1229,11 @@ namespace Dicom.Network
     /// <summary>Abort source</summary>
     public enum DicomAbortSource
     {
-        /// <summary>Unknown</summary>
-        Unknown = 0,
-
         /// <summary>Service user</summary>
-        ServiceUser = 1,
+        ServiceUser = 0,
+
+        /// <summary>Reserved</summary>
+        Reserved = 1,
 
         /// <summary>Service provider</summary>
         ServiceProvider = 2

--- a/DICOM/Network/PDU.cs
+++ b/DICOM/Network/PDU.cs
@@ -1232,8 +1232,8 @@ namespace Dicom.Network
         /// <summary>Service user</summary>
         ServiceUser = 0,
 
-        /// <summary>Reserved</summary>
-        Reserved = 1,
+        /// <summary>Unknown</summary>
+        Unknown = 1,
 
         /// <summary>Service provider</summary>
         ServiceProvider = 2

--- a/FO-DICOM.Core/Network/PDU.cs
+++ b/FO-DICOM.Core/Network/PDU.cs
@@ -1223,8 +1223,8 @@ namespace FellowOakDicom.Network
         /// <summary>Service user</summary>
         ServiceUser = 0,
 
-        /// <summary>Reserved</summary>
-        Reserved = 1,
+        /// <summary>Unknown</summary>
+        Unknown = 1,
 
         /// <summary>Service provider</summary>
         ServiceProvider = 2

--- a/FO-DICOM.Core/Network/PDU.cs
+++ b/FO-DICOM.Core/Network/PDU.cs
@@ -1220,11 +1220,11 @@ namespace FellowOakDicom.Network
     /// <summary>Abort source</summary>
     public enum DicomAbortSource
     {
-        /// <summary>Unknown</summary>
-        Unknown = 0,
-
         /// <summary>Service user</summary>
-        ServiceUser = 1,
+        ServiceUser = 0,
+
+        /// <summary>Reserved</summary>
+        Reserved = 1,
 
         /// <summary>Service provider</summary>
         ServiceProvider = 2


### PR DESCRIPTION
Fixes #984 .

#### Checklist
- [ x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ x] I have updated API documentation
- [ ] I have included unit tests
- [ x] I have updated the change log
- [ x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Updates the DicomAbortSouce enum to correct the source PDU Field in Association Abort Request 
- Fixes (#984)
-
