### PR TITLE
Use secure version of System.Text.Encodings.Web package

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -3,6 +3,7 @@
 * Add generated API documentation for versions 4 and 5
 * Fix IO Exception with >2GB images (#1148)
 * Bug fix: Correct Source PDU Field in Association Abort Request (#984)
+* Vulnerability fix: Use secure version of `System.Text.Encodings.Web` package (#1223) 
 
 #### 5.0.0 (2021-09-13)
 

--- a/FO-DICOM.Core/FO-DICOM.Core.csproj
+++ b/FO-DICOM.Core/FO-DICOM.Core.csproj
@@ -77,6 +77,7 @@ Version 5 has some breaking changes to version 4. Read here for more information
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 


### PR DESCRIPTION
- explicitly reference secure version 4.7.2 instead of implicitly installed version 4.7.1

Fixes # 1223.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation - n/a
- [ ] I have included unit tests - n/a
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the vulnerable package `System.Text.Encodings.Web 4.7.1` was implicitly including by `SystemText.Json 4.7.2`;
  to ensure that a secure version is used, we reference it explicitly 
