### PR TITLE
Add possibility to add values to an existing DICOM element

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -8,6 +8,7 @@
 * Change: `DicomFile.Open` now throws a `DicomFileException` if the file size is less than 132 bytes (#641)
 * Add XML documentation to nuget package
 * Change: Trying to add a DICOM element with invalid group ID to DICOM meta information now throws `DicomDataException` (#750)
+* Add possibility to add values to data elements (#278) 
 
 #### 5.0.0 (2021-09-13)
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -96,6 +96,7 @@ namespace FellowOakDicom
                         {
                             item.Validate();
                         }
+                        item.IsMutable = false;
                         _items[item.Tag.IsPrivate ? GetPrivateTag(item.Tag) : item.Tag] = item;
                     }
                 }
@@ -1019,6 +1020,7 @@ namespace FellowOakDicom
                         }
 
                         if (ValidateItems) item.Validate();
+                        item.IsMutable = false;
                         _items[tag] = item;
                     }
                 }
@@ -1035,6 +1037,7 @@ namespace FellowOakDicom
                         }
 
                         if (ValidateItems) item.Validate();
+                        item.IsMutable = false;
                         _items.Add(tag, item);
                     }
                 }
@@ -1060,6 +1063,7 @@ namespace FellowOakDicom
                     item.Tag = tag;
                 }
                 if (ValidateItems) item.Validate();
+                item.IsMutable = false;
 
                 if (allowUpdate)
                 {

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -47,13 +47,16 @@ namespace FellowOakDicom
             ValidateVM();
         }
 
+        /// <summary> Number of defined values in a DICOM element. Used internally only. </summary>
+        protected virtual int NumberOfValues => Count;
+
         /// <summary>
         /// Check if adding a value would exceed the maximum values allowed for this tag.
         /// </summary>
         /// <exception cref="DicomValidationException">A value cannot be added.</exception>
         protected void ValidateVMForAddedValue()
         {
-            if (!Tag.IsPrivate && (Count > 0))
+            if (!Tag.IsPrivate && (NumberOfValues > 0))
             {
                 var entry = Tag.DictionaryEntry;
                 if (Count + 1 > entry.ValueMultiplicity.Maximum)
@@ -66,8 +69,7 @@ namespace FellowOakDicom
 
         protected virtual void ValidateVM()
         {
-            if (!Tag.IsPrivate
-                && (Count > 0))
+            if (!Tag.IsPrivate && (Count > 0))
             {
                 var entry = Tag.DictionaryEntry;
                 if (Count < entry.ValueMultiplicity.Minimum || Count > entry.ValueMultiplicity.Maximum)
@@ -140,9 +142,13 @@ namespace FellowOakDicom
             set => _targetEncodings = new[] { value };
         }
 
-        /// <summary>Gets the number of values that the DICOM element contains.</summary>
-        /// <value>Number of value items</value>
-        public override int Count => Length > 0 ? 1 : 0;
+        /// <summary>
+        /// Always returns 1 as the number of contained values,
+        /// as no values are handled as an empty string value.
+        /// </summary>
+        public override int Count => 1;
+        
+        protected override int NumberOfValues => Length > 0 ? 1 : 0;
 
         protected string StringValue
         {

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -22,12 +22,13 @@ namespace FellowOakDicom
             : base(tag)
         {
             Buffer = data;
+            IsMutable = true;
         }
 
         /// <summary>Gets the number of values that the DICOM element contains.</summary>
         /// <value>Number of value items</value>
         public abstract int Count { get; }
-
+        
         public IByteBuffer Buffer { get; protected set; }
 
         public uint Length => (uint)(Buffer?.Size ?? 0);
@@ -53,9 +54,15 @@ namespace FellowOakDicom
         /// <summary>
         /// Check if adding a value would exceed the maximum values allowed for this tag.
         /// </summary>
-        /// <exception cref="DicomValidationException">A value cannot be added.</exception>
+        /// <exception cref="DicomDataException">The element is already added to a dataset.</exception>
+        /// <exception cref="DicomValidationException">Adding a value would exceed the tag VM.</exception>
         protected void ValidateVMForAddedValue()
         {
+            if (!IsMutable)
+            {
+                throw new DicomDataException($"Values cannot be added after the element is added to a dataset.");
+            }
+
             if (!Tag.IsPrivate && (NumberOfValues > 0))
             {
                 var entry = Tag.DictionaryEntry;

--- a/FO-DICOM.Core/DicomItem.cs
+++ b/FO-DICOM.Core/DicomItem.cs
@@ -18,6 +18,7 @@ namespace FellowOakDicom
         protected DicomItem(DicomTag tag)
         {
             Tag = tag;
+            IsMutable = false;
         }
 
         /// <summary>
@@ -82,5 +83,10 @@ namespace FellowOakDicom
         public virtual void Validate()
         { }
 
+        /// <summary>
+        /// Returns true if values can be appended to the item.
+        /// Appending items is only allowed for DICOM elements outside of a dataset. 
+        /// </summary>
+        internal bool IsMutable { get; set; }
     }
 }

--- a/FO-DICOM.Core/Imaging/Mathematics/Extensions.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Extensions.cs
@@ -17,6 +17,8 @@ namespace FellowOakDicom.Imaging.Mathematics
 
         public static bool IsOdd(this int v) => (v & 1) == 1;
 
+        public static bool IsOdd(this long v) => (v & 1) == 1;
+
         public static bool IsOdd(this uint v) => (v & 1) == 1;
 
 

--- a/Tests/FO-DICOM.Tests/DicomElementTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomElementTest.cs
@@ -451,10 +451,10 @@ namespace FellowOakDicom.Tests
         public void AddAdditionalString_ToMultiStringElement()
         {
             var tag = DicomTag.ImageType;
-            var element = new DicomCodeString(tag, "Derived", "Secondary");
+            var element = new DicomCodeString(tag, "DERIVED", "SECONDARY");
             element.Add("MIP");
             Assert.Equal(3, element.Count);
-            Assert.Equal("Derived", element.Get<string>(0));
+            Assert.Equal("DERIVED", element.Get<string>(0));
             Assert.Equal("MIP", element.Get<string>(2));
         }
 
@@ -465,6 +465,31 @@ namespace FellowOakDicom.Tests
             var exception = Record.Exception(() => element.Add("MR"));
             Assert.IsType<DicomValidationException>(exception);
             Assert.Equal(1, element.Count);
+        }
+
+        [Fact]
+        public void AddValues_ToElementInDataset_Throws()
+        {
+            var element = new DicomCodeString(DicomTag.ImageType, "DERIVED", "SECONDARY");
+            var dataset = new DicomDataset
+            {
+                element
+            };
+
+            var exception = Record.Exception(() => element.Add("MIP"));
+            Assert.IsType<DicomDataException>(exception);
+            Assert.Equal(2, element.Count);
+        }
+
+        [Fact]
+        public void AddValues_ToElementAddedToDataset_Throws()
+        {
+            var element = new DicomCodeString(DicomTag.ImageType, "DERIVED", "SECONDARY");
+            var dataset = new DicomDataset();
+            dataset.AddOrUpdate(element);
+            var exception = Record.Exception(() => element.Add("MIP"));
+            Assert.IsType<DicomDataException>(exception);
+            Assert.Equal(2, element.Count);
         }
 
         [Fact]

--- a/Tests/FO-DICOM.Tests/DicomElementTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomElementTest.cs
@@ -459,6 +459,18 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void AddAdditionalStrings_ToMultiStringElement()
+        {
+            var tag = DicomTag.ImageType;
+            var element = new DicomCodeString(tag, "DERIVED", "SECONDARY");
+            element.Add(new[] { "MIP", "RADIAL" });
+            Assert.Equal(4, element.Count);
+            Assert.Equal("DERIVED", element.Get<string>(0));
+            Assert.Equal("MIP", element.Get<string>(2));
+            Assert.Equal("RADIAL", element.Get<string>(3));
+        }
+
+        [Fact]
         public void AddTooManyValues_ToMultiStringElement_Throws()
         {
             var element = new DicomCodeString(DicomTag.Modality, "US");
@@ -502,7 +514,7 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
-        public void AddAdditionalValue_ToIntegerString()
+        public void AddValue_ToIS()
         {
             var element = new DicomIntegerString(DicomTag.SelectorISValue, String.Empty);
             element.Add("1234");
@@ -515,7 +527,20 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
-        public void AddAdditionalValue_ToDecimalString()
+        public void AddValues_ToIS()
+        {
+            var element = new DicomIntegerString(DicomTag.SelectorISValue, String.Empty);
+            element.Add(new [] {"1234", "5678"});
+            element.Add(new [] {-9101112, 42});
+            Assert.Equal(4, element.Count);
+            Assert.Equal(1234, element.Get<int>(0));
+            Assert.Equal(5678, element.Get<int>(1));
+            Assert.Equal(-9101112, element.Get<int>(2));
+            Assert.Equal(42, element.Get<int>(3));
+        }
+
+        [Fact]
+        public void AddValue_ToDS()
         {
             var element = new DicomDecimalString(DicomTag.SelectorDSValue, String.Empty);
             element.Add("-1234");
@@ -525,6 +550,20 @@ namespace FellowOakDicom.Tests
             Assert.Equal(4, element.Count);
             Assert.Equal(-1234, element.Get<double>(0));
             Assert.Equal(5678, element.Get<double>(1));
+            Assert.Equal(-10, element.Get<double>(2));
+            Assert.Equal(123.4, element.Get<double>(3));
+        }
+
+        [Fact]
+        public void AddValues_ToDS()
+        {
+            var element = new DicomDecimalString(DicomTag.SelectorDSValue, String.Empty);
+            element.Add(new[] { -1234, 5678 });
+            Assert.Equal(2, element.Count);
+            Assert.Equal(-1234, element.Get<double>(0));
+            Assert.Equal(5678, element.Get<double>(1));
+            element.Add(new[] { -10, 0.1234e3 });
+            Assert.Equal(4, element.Count);
             Assert.Equal(-10, element.Get<double>(2));
             Assert.Equal(123.4, element.Get<double>(3));
         }
@@ -563,6 +602,27 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void AddValue_ToAT()
+        {
+            var element = new DicomAttributeTag(DicomTag.DataElementsSigned);
+            element.Add(new DicomTag(0x0020, 0x0111));
+            element.Add(0x00200112);
+            Assert.Equal(2, element.Count);
+            Assert.Equal(0x00200111u, element.Get<DicomTag>(0));
+            Assert.Equal(0x00200112u, element.Get<DicomTag>(1));
+        }
+
+        [Fact]
+        public void AddValues_ToAT()
+        {
+            var element = new DicomAttributeTag(DicomTag.DataElementsSigned);
+            element.Add(new [] { new DicomTag(0x0020, 0x0111), new DicomTag(0x0020, 0x0112) });
+            Assert.Equal(2, element.Count);
+            Assert.Equal(0x00200111u, element.Get<DicomTag>(0));
+            Assert.Equal(0x00200112u, element.Get<DicomTag>(1));
+        }
+
+        [Fact]
         public void AddValue_ToFD()
         {
             var element = new DicomFloatingPointDouble(DicomTag.SpectralWidth);
@@ -571,6 +631,17 @@ namespace FellowOakDicom.Tests
             Assert.Equal(2, element.Count);
             Assert.Equal(123.4567, element.Get<double>(0), 8);
             Assert.Equal(89.2, element.Get<double>(1), 5);
+        }
+
+        [Fact]
+        public void AddValues_ToFD()
+        {
+            var element = new DicomFloatingPointDouble(DicomTag.InversionTimes);
+            element.Add(new[] { 123.4567, 76.5, 337 });
+            Assert.Equal(3, element.Count);
+            Assert.Equal(123.4567, element.Get<double>(0), 8);
+            Assert.Equal(76.5, element.Get<double>(1), 5);
+            Assert.Equal(337, element.Get<double>(2), 8);
         }
 
         [Fact]
@@ -631,6 +702,16 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void AddValues_ToUS()
+        {
+            var element = new DicomUnsignedShort(DicomTag.LUTFrameRange);
+            element.Add(new[] { 1, 37, 5, 57 });
+            Assert.Equal(4, element.Count);
+            Assert.Equal(1, element.Get<ushort>(0));
+            Assert.Equal(57, element.Get<ushort>(3));
+        }
+
+        [Fact]
         public void AddValue_ToUL()
         {
             var element = new DicomUnsignedLong(DicomTag.PrivateDataElementValueMultiplicity);
@@ -648,6 +729,17 @@ namespace FellowOakDicom.Tests
             element.Add(long.MaxValue);
             element.Add(long.MinValue);
             element.Add(0);
+            Assert.Equal(3, element.Count);
+            Assert.Equal(9223372036854775807, element.Get<long>(0));
+            Assert.Equal(-9223372036854775808, element.Get<long>(1));
+            Assert.Equal(0, element.Get<long>(2));
+        }
+
+        [Fact]
+        public void AddValues_ToSV()
+        {
+            var element = new DicomSignedVeryLong(DicomTag.SelectorSVValue);
+            element.Add(new[] { long.MaxValue, long.MinValue, 0 });
             Assert.Equal(3, element.Count);
             Assert.Equal(9223372036854775807, element.Get<long>(0));
             Assert.Equal(-9223372036854775808, element.Get<long>(1));


### PR DESCRIPTION
- see #278

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
In #278 a `Set` method was proposed, with an index as argument, but the actual proposal was to allow appending values, which does not need an index. I added an `Add` method without an index instead - I think this should be sufficient.

Took the last issue in the list (again), but I'm not trying to make a habit of this 😄 
