### PR TITLE
Throw on adding invalid tag to meta information

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -7,6 +7,7 @@
 * Vulnerability fix: Use secure version of `System.Text.Encodings.Web` package (#1223) 
 * Change: `DicomFile.Open` now throws a `DicomFileException` if the file size is less than 132 bytes (#641)
 * Add XML documentation to nuget package
+* Change: Trying to add a DICOM element with invalid group ID to DICOM meta information now throws `DicomDataException` (#750)
 
 #### 5.0.0 (2021-09-13)
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -990,6 +990,13 @@ namespace FellowOakDicom
         }
 
         /// <summary>
+        /// Does nothing. Can be overwritten in derived classes to check if the tag is allowed.
+        /// </summary>
+        protected virtual void ValidateTag(DicomTag tag)
+        {
+        }
+        
+        /// <summary>
         /// Add a collection of DICOM items to the dataset.
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
@@ -1004,6 +1011,7 @@ namespace FellowOakDicom
                     foreach (var item in items.Where(i => i != null))
                     {
                         var tag = item.Tag;
+                        ValidateTag(tag);
                         if (tag.IsPrivate)
                         {
                             tag = GetPrivateTag(tag);
@@ -1019,6 +1027,7 @@ namespace FellowOakDicom
                     foreach (var item in items.Where(i => i != null))
                     {
                         var tag = item.Tag;
+                        ValidateTag(tag);
                         if (tag.IsPrivate)
                         {
                             tag = GetPrivateTag(tag);
@@ -1044,6 +1053,7 @@ namespace FellowOakDicom
             if (item != null)
             {
                 var tag = item.Tag;
+                ValidateTag(tag);
                 if (tag.IsPrivate)
                 {
                     tag = GetPrivateTag(tag);

--- a/FO-DICOM.Core/DicomFileMetaInformation.cs
+++ b/FO-DICOM.Core/DicomFileMetaInformation.cs
@@ -233,6 +233,14 @@ namespace FellowOakDicom
             return machine;
         }
 
+        protected override void ValidateTag(DicomTag tag)
+        {
+            if (tag.Group != 2)
+            {
+                throw new DicomDataException($"Tag with group ID {tag.Group} is not allowed in meta information.");
+            }
+        }
+
         #endregion
     }
 }

--- a/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
@@ -76,6 +76,14 @@ namespace FellowOakDicom.Tests
             Assert.Null(exception);
         }
 
+        [Fact]
+        public void AddingRegularTag_ToMetaInformation_ShouldThrow()
+        {
+            var metaInfo = new DicomFileMetaInformation();
+            var exception = Record.Exception(() => metaInfo.AddOrUpdate(DicomTag.PatientName, "Doe^John"));
+            Assert.IsType<DicomDataException>(exception);
+        }
+
         [Theory]
         [MemberData(nameof(NewOptionalAttributes))]
         public void Save_NewOptionalAttributes_SavedWhenExisting(DicomItem item)


### PR DESCRIPTION
- closes #750

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation n/a
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- minor change to throw if trying to add non-group 2 elements to meta data
