### PR TITLE
Add handling of SV, UV and OV in DicomDatasetReaderObserver.OnElement

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -9,6 +9,7 @@
 * Add XML documentation to nuget package
 * Change: Trying to add a DICOM element with invalid group ID to DICOM meta information now throws `DicomDataException` (#750)
 * Bug fix: Prevent DicomJsonConverter from consuming root end object token (#1251)
+* Add missing handling of UV, SV and OV in DicomDatasetReaderObserver.OnElement
 
 #### 5.0.0 (2021-09-13)
 

--- a/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
@@ -61,12 +61,14 @@ namespace FellowOakDicom.IO.Reader
                 "OD" => new DicomOtherDouble(tag, data),
                 "OF" => new DicomOtherFloat(tag, data),
                 "OL" => new DicomOtherLong(tag, data),
+                "OV" => new DicomOtherVeryLong(tag, data),
                 "OW" => new DicomOtherWord(tag, data),
                 "PN" => new DicomPersonName(tag, _encodings.Peek(), data),
                 "SH" => new DicomShortString(tag, _encodings.Peek(), data),
                 "SL" => new DicomSignedLong(tag, data),
                 "SS" => new DicomSignedShort(tag, data),
                 "ST" => new DicomShortText(tag, _encodings.Peek(), data),
+                "SV" => new DicomSignedVeryLong(tag, data),
                 "TM" => new DicomTime(tag, data),
                 "UC" => new DicomUnlimitedCharacters(tag, _encodings.Peek(), data),
                 "UI" => new DicomUniqueIdentifier(tag, data),
@@ -75,6 +77,7 @@ namespace FellowOakDicom.IO.Reader
                 "UR" => new DicomUniversalResource(tag, _encodings.Peek(), data),
                 "US" => new DicomUnsignedShort(tag, data),
                 "UT" => new DicomUnlimitedText(tag, _encodings.Peek(), data),
+                "UV" => new DicomUnsignedVeryLong(tag, data),
                 _ => throw new DicomDataException($"Unhandled VR in DICOM parser observer: {vr.Code}"),
             };
             if (element.Tag == DicomTag.SpecificCharacterSet)

--- a/Tests/FO-DICOM.Tests/DicomFileTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileTest.cs
@@ -148,6 +148,54 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void Open_File_FromStream()
+        {
+            var dataset = new DicomDataset(_minimumDatatset)
+            {
+                // random tags with all VRs except SQ
+                new DicomApplicationEntity(DicomTag.StationAETitle, "MYPACS"),
+                new DicomAgeString(DicomTag.PatientAge, "050Y"),
+                new DicomAttributeTag(DicomTag.DimensionIndexPointer, new DicomTag(0x0054, 0x0080)),
+                new DicomCodeString(DicomTag.ImageType, "DERIVED\\SECONDARY"),
+                new DicomDate(DicomTag.InstanceCreationDate, "20200101"),
+                new DicomDecimalString(DicomTag.EventElapsedTimes, "1234.5678"),
+                new DicomDateTime(DicomTag.AcquisitionDateTime, "20111101082000"),
+                new DicomFloatingPointSingle(DicomTag.ExaminedBodyThickness, 123.456f),
+                new DicomFloatingPointDouble(DicomTag.OutlineRightVerticalEdge, 123.456789),
+                new DicomIntegerString(DicomTag.ReferencedFrameNumber, "25"),
+                new DicomLongString(DicomTag.ManufacturerModelName, "ACME Vision"),
+                new DicomLongText(DicomTag.AdditionalPatientHistory, "У пациента насморк"),
+                new DicomOtherByte(DicomTag.DarkCurrentCounts, new byte[] { 12, 13, 14, 15, 16, 17 }),
+                new DicomOtherDouble(DicomTag.DoubleFloatPixelData, new double[] { 12.3, 13.4, 14.5 }),
+                new DicomOtherFloat(DicomTag.FloatPixelData, new float[] { 1.2f, 2.3f, 3.4f, 4.5f }),
+                new DicomOtherLong(DicomTag.SelectorOLValue, new uint[] { 123456, 789012 }),
+                new DicomOtherVeryLong(DicomTag.SelectorOVValue,  new ulong[] { 12, 13, 14, 15 }),
+                new DicomOtherWord(DicomTag.SelectorOWValue, new ushort[] { 1234, 5678 }),
+                new DicomPersonName(DicomTag.PatientName, "Doe^John"),
+                new DicomShortString(DicomTag.AccessionNumber, "ACC-123"),
+                new DicomSignedLong(DicomTag.ReferencePixelX0, -12345),
+                new DicomSignedShort(DicomTag.TIDOffset, -2030),
+                new DicomShortText(DicomTag.SelectorSTValue, "Some short text"),
+                new DicomSignedVeryLong(DicomTag.SelectorSVValue, -1234567890),
+                new DicomTime(DicomTag.SeriesTime, "113022.45"),
+                new DicomUnlimitedCharacters(DicomTag.SelectorUCValue, "Some very long text"),
+                new DicomUniqueIdentifier(DicomTag.SelectorUIValue, "123.4.5.89"),
+                new DicomUnsignedLong(DicomTag.SimpleFrameList, 12345),
+                new DicomUnknown(DicomTag.SelectorUNValue, new byte[] { 1, 2 }),
+                new DicomUniversalResource(DicomTag.SelectorURValue, "https://example.com"),
+                new DicomUnsignedShort(DicomTag.BitsAllocated, 8),
+                new DicomUnlimitedText(DicomTag.SelectorUTValue, "More text..."),
+                new DicomUnsignedVeryLong(DicomTag.SelectorUVValue, 1234567890),
+            };
+            var saveFile = new DicomFile(dataset);
+            var stream = new MemoryStream();
+            saveFile.Save(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var exception = Record.Exception(() => DicomFile.Open(stream));
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void Open_FromFile_YieldsValidDicomFile()
         {
             var saveFile = new DicomFile(_minimumDatatset);


### PR DESCRIPTION
#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation n/a
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

I found this accidentally while writing a test (the one that is added) for another purpose.
As these are still rare VRs, it is probably not a real problem yet.