### PR TITLE
Do not Consume Extra Token in DicomJsonConverter

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -8,6 +8,7 @@
 * Change: `DicomFile.Open` now throws a `DicomFileException` if the file size is less than 132 bytes (#641)
 * Add XML documentation to nuget package
 * Change: Trying to add a DICOM element with invalid group ID to DICOM meta information now throws `DicomDataException` (#750)
+* Bug fix: Prevent DicomJsonConverter from consuming root end object token (#1251)
 
 #### 5.0.0 (2021-09-13)
 

--- a/Contributors.md
+++ b/Contributors.md
@@ -74,3 +74,4 @@
 * [Michael Möring](https://github.com/MichaelM223)
 * [Smitha Saligrama](https://github.com/smithago)
 * [Fredrik Carlbom](https://github.com/fredrikcarlbom)
+* [Will Sugarman](https://github.com/wsugarman)

--- a/FO-DICOM.Core/Serialization/DicomJson.cs
+++ b/FO-DICOM.Core/Serialization/DicomJson.cs
@@ -15,7 +15,7 @@ namespace FellowOakDicom.Serialization
             var options = new JsonSerializerOptions();
             options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: writeTagsAsKeywords));
             options.WriteIndented = formatIndented;
-            var conv = JsonSerializer.Serialize<DicomDataset>(dataset, options);
+            var conv = JsonSerializer.Serialize(dataset, options);
             return conv;
         }
 
@@ -35,7 +35,7 @@ namespace FellowOakDicom.Serialization
         public static DicomDataset[] ConvertJsonToDicomArray(string json)
         {
             var options = new JsonSerializerOptions();
-            options.Converters.Add(new DicomArrayJsonConverter());
+            options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: false, autoValidate: true));
             options.ReadCommentHandling = JsonCommentHandling.Skip;
             var ds = JsonSerializer.Deserialize<DicomDataset[]>(json, options);
             return ds;

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -155,12 +155,12 @@ namespace FellowOakDicom.Serialization
         /// </returns>
         public override DicomDataset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var dataset = ReadJsonDataset(ref reader, readEndObject: false);
+            var dataset = ReadJsonDataset(ref reader);
             return dataset;
         }
 
 
-        private DicomDataset ReadJsonDataset(ref Utf8JsonReader reader, bool readEndObject)
+        private DicomDataset ReadJsonDataset(ref Utf8JsonReader reader)
         {
             var dataset = _autoValidate
                 ? new DicomDataset()
@@ -179,11 +179,6 @@ namespace FellowOakDicom.Serialization
                 reader.Read(); // move to value
                 var item = ReadJsonDicomItem(tag, ref reader);
                 dataset.Add(item);
-            }
-
-            if (readEndObject)
-            {
-                AssumeAndSkip(ref reader, JsonTokenType.EndObject);
             }
 
             foreach (var item in dataset)
@@ -983,7 +978,8 @@ namespace FellowOakDicom.Serialization
                     }
                     else if (reader.TokenType == JsonTokenType.StartObject)
                     {
-                        childItems.Add(ReadJsonDataset(ref reader, readEndObject: true));
+                        childItems.Add(ReadJsonDataset(ref reader));
+                        AssumeAndSkip(ref reader, JsonTokenType.EndObject);
                     }
                     else
                     {

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -49,7 +49,21 @@ namespace FellowOakDicom.Serialization
             var conv = new DicomJsonConverter(writeTagsAsKeywords: _writeTagsAsKeywords);
             while (reader.TokenType != JsonTokenType.EndArray)
             {
-                var ds = conv.Read(ref reader, typeToConvert, options);
+                DicomDataset ds;
+                switch (reader.TokenType)
+                {
+                    case JsonTokenType.StartObject:
+                        ds = conv.Read(ref reader, typeToConvert, options);
+                        reader.AssumeAndSkip(JsonTokenType.EndObject);
+                        break;
+                    case JsonTokenType.Null:
+                        ds = null;
+                        reader.Read();
+                        break;
+                    default:
+                        throw new JsonException($"Expected either the start of an object or null but found {reader.TokenType}");
+                }
+
                 datasetList.Add(ds);
             }
             reader.Read();
@@ -173,7 +187,7 @@ namespace FellowOakDicom.Serialization
 
             while (reader.TokenType != JsonTokenType.EndObject)
             {
-                Assume(ref reader, JsonTokenType.PropertyName);
+                reader.Assume(JsonTokenType.PropertyName);
                 var tagstr = reader.GetString();
                 DicomTag tag = ParseTag(tagstr);
                 reader.Read(); // move to value
@@ -599,10 +613,10 @@ namespace FellowOakDicom.Serialization
 
         private DicomItem ReadJsonDicomItem(DicomTag tag, ref Utf8JsonReader reader)
         {
-            AssumeAndSkip(ref reader, JsonTokenType.StartObject);
+            reader.AssumeAndSkip(JsonTokenType.StartObject);
             var currentDepth = reader.CurrentDepth;
 
-            Assume(ref reader, JsonTokenType.PropertyName);
+            reader.Assume(JsonTokenType.PropertyName);
 
             string vr;
             var property = reader.GetString();
@@ -678,7 +692,7 @@ namespace FellowOakDicom.Serialization
             {
                 // skip this data
             }
-            AssumeAndSkip(ref reader, JsonTokenType.EndObject);
+            reader.AssumeAndSkip(JsonTokenType.EndObject);
 
             DicomItem item = CreateDicomItem(tag, vr, data);
             return item;
@@ -711,7 +725,7 @@ namespace FellowOakDicom.Serialization
 
         private static string ReadPropertyName(ref Utf8JsonReader reader)
         {
-            Assume(ref reader, JsonTokenType.PropertyName);
+            reader.Assume(JsonTokenType.PropertyName);
             var propertyname = reader.GetString();
             reader.Read();
             return propertyname;
@@ -725,7 +739,7 @@ namespace FellowOakDicom.Serialization
                 reader.Read();
                 return Array.Empty<string>();
             }
-            AssumeAndSkip(ref reader, JsonTokenType.StartArray);
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
             var childStrings = new List<string>();
 
             while (reader.TokenType != JsonTokenType.EndArray)
@@ -744,7 +758,7 @@ namespace FellowOakDicom.Serialization
                 }
                 reader.Read();
             }
-            AssumeAndSkip(ref reader, JsonTokenType.EndArray);
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
             var data = childStrings.ToArray();
             return data;
         }
@@ -779,7 +793,7 @@ namespace FellowOakDicom.Serialization
                 reader.Read();
                 return Array.Empty<T>();
             }
-            AssumeAndSkip(ref reader, JsonTokenType.StartArray);
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
 
             var childValues = new List<T>();
             while (reader.TokenType != JsonTokenType.EndArray)
@@ -802,7 +816,7 @@ namespace FellowOakDicom.Serialization
                 }
                 reader.Read();
             }
-            AssumeAndSkip(ref reader, JsonTokenType.EndArray);
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
 
             var data = childValues.ToArray();
             return data;
@@ -838,7 +852,7 @@ namespace FellowOakDicom.Serialization
                 reader.Read();
                 return Array.Empty<T>();
             }
-            AssumeAndSkip(ref reader, JsonTokenType.StartArray);
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
 
             var childValues = new List<T>();
             while (reader.TokenType != JsonTokenType.EndArray)
@@ -857,7 +871,7 @@ namespace FellowOakDicom.Serialization
                 }
                 reader.Read();
             }
-            AssumeAndSkip(ref reader, JsonTokenType.EndArray);
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
 
             var data = childValues.ToArray();
             return data;
@@ -881,7 +895,7 @@ namespace FellowOakDicom.Serialization
                 }
                 else
                 {
-                    AssumeAndSkip(ref reader, JsonTokenType.StartArray);
+                    reader.AssumeAndSkip(JsonTokenType.StartArray);
 
                     var childStrings = new List<string>();
                     while (reader.TokenType != JsonTokenType.EndArray)
@@ -938,14 +952,14 @@ namespace FellowOakDicom.Serialization
                             string pnVal = stringBuilder.ToString().TrimEnd(_personNameComponentGroupDelimiter);
 
                             childStrings.Add(pnVal); // add value
-                            AssumeAndSkip(ref reader, JsonTokenType.EndObject);
+                            reader.AssumeAndSkip(JsonTokenType.EndObject);
                         }
                         else
                         {
                             // TODO: invalid. handle this?
                         }
                     }
-                    AssumeAndSkip(ref reader, JsonTokenType.EndArray);
+                    reader.AssumeAndSkip(JsonTokenType.EndArray);
                     var data = childStrings.ToArray();
                     return data;
                 }
@@ -967,7 +981,7 @@ namespace FellowOakDicom.Serialization
 
             if (propertyName == "Value")
             {
-                AssumeAndSkip(ref reader, JsonTokenType.StartArray);
+                reader.AssumeAndSkip(JsonTokenType.StartArray);
                 var childItems = new List<DicomDataset>();
                 while (reader.TokenType != JsonTokenType.EndArray)
                 {
@@ -979,14 +993,14 @@ namespace FellowOakDicom.Serialization
                     else if (reader.TokenType == JsonTokenType.StartObject)
                     {
                         childItems.Add(ReadJsonDataset(ref reader));
-                        AssumeAndSkip(ref reader, JsonTokenType.EndObject);
+                        reader.AssumeAndSkip(JsonTokenType.EndObject);
                     }
                     else
                     {
                         throw new JsonException("Malformed DICOM json, object expected");
                     }
                 }
-                AssumeAndSkip(ref reader, JsonTokenType.EndArray);
+                reader.AssumeAndSkip(JsonTokenType.EndArray);
                 var data = childItems.ToArray();
                 return data;
             }
@@ -1019,11 +1033,11 @@ namespace FellowOakDicom.Serialization
 
         private static IByteBuffer ReadJsonInlineBinary(ref Utf8JsonReader reader)
         {
-            AssumeAndSkip(ref reader, JsonTokenType.StartArray);
+            reader.AssumeAndSkip(JsonTokenType.StartArray);
             if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
             var data = new MemoryByteBuffer(reader.GetBytesFromBase64());
             reader.Read();
-            AssumeAndSkip(ref reader, JsonTokenType.EndArray);
+            reader.AssumeAndSkip(JsonTokenType.EndArray);
             return data;
         }
 
@@ -1038,22 +1052,6 @@ namespace FellowOakDicom.Serialization
 
 
         #endregion
-
-
-        private static void Assume(ref Utf8JsonReader reader, JsonTokenType tokenType)
-        {
-            if (reader.TokenType != tokenType)
-            {
-                throw new JsonException($"invalid: {tokenType} expected at position {reader.TokenStartIndex}, instead found {reader.TokenType}");
-            }
-        }
-
-
-        private static void AssumeAndSkip(ref Utf8JsonReader reader, JsonTokenType tokenType)
-        {
-            Assume(ref reader, tokenType);
-            reader.Read();
-        }
 
 
         private string FindValue(Utf8JsonReader reader, string property, string defaultValue)

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -61,7 +61,7 @@ namespace FellowOakDicom.Serialization
                         reader.Read();
                         break;
                     default:
-                        throw new JsonException($"Expected either the start of an object or null but found {reader.TokenType}");
+                        throw new JsonException($"Expected either the start of an object or null but found '{reader.TokenType}'.");
                 }
 
                 datasetList.Add(ds);
@@ -181,7 +181,7 @@ namespace FellowOakDicom.Serialization
                 : new DicomDataset().NotValidated();
             if (reader.TokenType != JsonTokenType.StartObject)
             {
-                throw new JsonException($"Expected the start of a JSON object but found {reader.TokenType}");
+                throw new JsonException($"Expected the start of an object but found '{reader.TokenType}'.");
             }
             reader.Read();
 

--- a/FO-DICOM.Core/Serialization/Utf8JsonReaderExtensions.cs
+++ b/FO-DICOM.Core/Serialization/Utf8JsonReaderExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2012-2021 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.Text.Json;
+
+namespace FellowOakDicom.Serialization
+{
+    internal static class Utf8JsonReaderExtensions
+    {
+        public static void Assume(this ref Utf8JsonReader reader, JsonTokenType tokenType)
+        {
+            if (reader.TokenType != tokenType)
+            {
+                throw new JsonException($"invalid: {tokenType} expected at position {reader.TokenStartIndex}, instead found {reader.TokenType}");
+            }
+        }
+
+        public static void AssumeAndSkip(this ref Utf8JsonReader reader, JsonTokenType tokenType)
+        {
+            Assume(ref reader, tokenType);
+            reader.Read();
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -1076,6 +1076,13 @@ namespace FellowOakDicom.Tests.Serialization
             Assert.Equal(validAccelarationValue, recoveredString);
         }
 
+        [Fact]
+        public static void GivenInvalidJsonToken_WhenDeserialization_ThenThrowsJsonException()
+        {
+            string invalidDatasetJson = "12345";
+            Assert.Throws<JsonException>(() => DicomJson.ConvertJsonToDicom(invalidDatasetJson));
+        }
+
 
         [Fact]
         public static void GivenJsonIsInvalid_WhenDeserialization_ThenThrowsDicomValidationException()

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -1083,7 +1083,6 @@ namespace FellowOakDicom.Tests.Serialization
             Assert.Throws<JsonException>(() => DicomJson.ConvertJsonToDicom(invalidDatasetJson));
         }
 
-
         [Fact]
         public static void GivenJsonIsInvalid_WhenDeserialization_ThenThrowsDicomValidationException()
         {


### PR DESCRIPTION
Fixes #1251.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] No API documentation update needed
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Fix `DicomJsonConverter` to no longer consume the end object JSON token. With this fix, the converter may be used when deserializing arrays automatically
- Mark the `DicomArrayJsonConverter` as `Obsolete`
- Throw a `JsonException` if the token is unexpected instead of returning `null`