### PR TITLE
Add benchmark that saves a DICOM file

### DIFF
--- a/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
+++ b/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
@@ -34,6 +34,9 @@
     <None Update="Data\mr.dcm">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Data\MG.dcm">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Tests/FO-DICOM.Benchmark/Program.cs
+++ b/Tests/FO-DICOM.Benchmark/Program.cs
@@ -3,26 +3,14 @@
 
 using BenchmarkDotNet.Running;
 
-
 namespace FellowOakDicom.Benchmark
 {
     static class Program
     {
-
-        static void Main(string[] args)
+        static void Main()
         {
-            // benchmark opening files
-            BenchmarkRunner.Run<OpenFileBenchmarks>();
-
-            // benchmark instantiating a server
-            BenchmarkRunner.Run<ServerBenchmarks>();
-
-            // benchmark json serialization and deserialization
-            BenchmarkRunner.Run<JsonBenchmarks>();
-
-            // benchmark parsing datasets
-            BenchmarkRunner.Run<ParseDatasetBenchmark>();
+            // Run all benchmarks in assembly
+            BenchmarkRunner.Run(typeof(Program).Assembly);
         }
-
     }
 }

--- a/Tests/FO-DICOM.Benchmark/SaveFileBenchmarks.cs
+++ b/Tests/FO-DICOM.Benchmark/SaveFileBenchmarks.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2012-2021 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace FellowOakDicom.Benchmark
+{
+    [MemoryDiagnoser]
+    public class SaveFileBenchmarks
+    {
+        private readonly DicomFile _dicomFile;
+        private readonly FileInfo _output;
+
+        public SaveFileBenchmarks()
+        {
+            var rootPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            _dicomFile = DicomFile.Open(Path.Combine(rootPath, "Data\\MG.dcm"));
+            _output = new FileInfo(Path.Combine(rootPath, "Data\\MG_copy.dcm"));
+            _output.Delete();
+        }
+
+        [Benchmark]
+        public void Save()
+        {
+            _dicomFile.Save(_output.FullName);
+            _output.Delete();
+        }
+
+        [Benchmark]
+        public async Task SaveAsync()
+        {
+            await _dicomFile.SaveAsync(_output.FullName);
+            _output.Delete();
+        }
+    }
+}


### PR DESCRIPTION
Creating this pull request separately so I can compare benchmarks with my other pull request #1258 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add benchmarks that deal with saving a DICOM file