### PR TITLE
Collect code coverage when running tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,8 @@ jobs:
       with:
           name: test-v5-net-framework.xml
           path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet462.xml
+    - name: Upload code coverage
+      uses: codecov/codecov-action@v2
       
   v5-net-core-21:
     runs-on: windows-2019

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Build FO-DICOM.Core
       run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --runtime win-x64
     - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net462 --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet462.xml"
+      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net462 --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet462.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile sdksetup.exe -UseBasicParsing
           Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1
       - name: Setup MSBuild
@@ -39,7 +39,7 @@ jobs:
   v4-net-core-21:
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1
       - name: Setup MSBuild
@@ -60,7 +60,7 @@ jobs:
   v5-net-framework:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build FO-DICOM.Core
       run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --runtime win-x64
     - name: Test FO-DICOM.Tests
@@ -74,7 +74,7 @@ jobs:
   v5-net-core-21:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build FO-DICOM.Core
       run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --framework netstandard2.0 --runtime win-x64
     - name: Test FO-DICOM.Tests
@@ -88,7 +88,7 @@ jobs:
   v5-net-core-31:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build FO-DICOM.Core
       run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --runtime win-x64
     - name: Test FO-DICOM.Tests
@@ -104,7 +104,7 @@ jobs:
   benchmarks:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build FO-DICOM..Benchmark
       run: dotnet build ./Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj --configuration Release --framework netcoreapp3.1
     - name: run benchmarks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,12 +92,14 @@ jobs:
     - name: Build FO-DICOM.Core
       run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --runtime win-x64
     - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework netcoreapp3.1 --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnetcore31.xml"
+      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework netcoreapp3.1 --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnetcore31.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:
           name: test-v5-net-core-31.xml
           path: ./Tests/FO-DICOM.Tests/TestResults/resultsnetcore31.xml
+    - name: Upload code coverage 
+      uses: codecov/codecov-action@v2
 
   benchmarks:
     runs-on: windows-2019

--- a/FO-DICOM.Full.sln
+++ b/FO-DICOM.Full.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		coverlet.runsettings = coverlet.runsettings
 		codecov.yml = codecov.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FO-DICOM.AspNetCore", "Platform\FO-DICOM.AspNetCore\FO-DICOM.AspNetCore.csproj", "{FA637A4F-A8AE-4EB3-AD02-E8F5CFBEE215}"

--- a/FO-DICOM.Full.sln
+++ b/FO-DICOM.Full.sln
@@ -33,6 +33,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		ChangeLog.md = ChangeLog.md
 		ChangeLog5.md = ChangeLog5.md
 		Directory.Build.props = Directory.Build.props
+		coverlet.runsettings = coverlet.runsettings
+		codecov.yml = codecov.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FO-DICOM.AspNetCore", "Platform\FO-DICOM.AspNetCore\FO-DICOM.AspNetCore.csproj", "{FA637A4F-A8AE-4EB3-AD02-E8F5CFBEE215}"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/fo-dicom.svg)](https://www.nuget.org/packages/fo-dicom/)
 ![build development](https://github.com/fo-dicom/fo-dicom/workflows/build/badge.svg?branch=development)
+[![codecov](https://codecov.io/gh/fo-dicom/fo-dicom/branch/development/graph/badge.svg)](https://codecov.io/gh/fo-dicom/fo-dicom)
 [![Join the chat at https://gitter.im/fo-dicom/fo-dicom](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fo-dicom/fo-dicom?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ### License

--- a/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
+++ b/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
@@ -17,6 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.1.6" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="fo-dicom.Codecs" Version="5.0.0-beta6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+# Documentation: https://docs.codecov.io/docs/codecov-yaml
+
+codecov:
+  # Avoid "Missing base report"
+  # https://github.com/codecov/support/issues/363
+  # https://docs.codecov.io/docs/comparing-commits
+  allow_coverage_offsets: true
+
+  # Avoid Report Expired
+  # https://docs.codecov.io/docs/codecov-yaml#section-expired-reports
+  max_report_age: off
+
+coverage:
+  # Use integer precision
+  # https://docs.codecov.com/docs/codecovyml-reference#coverageprecision
+  precision: 0
+
+  # Explicitly control coverage status checks
+  # https://docs.codecov.com/docs/commit-status#disabling-a-status
+  status:
+    project: on
+    patch: off

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -6,7 +6,7 @@
             <DataCollector friendlyName="XPlat code coverage">
                 <Configuration>
                     <Format>cobertura</Format>
-                    <Include>[FellowOakDicom*]*</Include>
+                    <Include>[fo-dicom*]FellowOakDicom*</Include>
                     <Exclude>[*.Tests]*</Exclude>
                     <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
                     <IncludeTestAssembly>false</IncludeTestAssembly>

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <MaxCpuCount>0</MaxCpuCount>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="XPlat code coverage">
+                <Configuration>
+                    <Format>cobertura</Format>
+                    <Include>[FellowOakDicom*]*</Include>
+                    <Exclude>[*.Tests]*</Exclude>
+                    <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+                    <IncludeTestAssembly>false</IncludeTestAssembly>
+                    <SkipAutoProps>true</SkipAutoProps>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Collect code coverage using coverlet when running unit tests
- Upload code coverage to https://about.codecov.io/

For now, only the v5 code will be configured, and only when running the .NET Core 3.1 or .NET Framework tests