### PR TITLE
Add unittests for the interpolation Algorithms

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -2,6 +2,7 @@
 * Fix issue where opening a DICOM file from a stream writes too much data when saving it again (#1264)
 * Add possibility to read from streams without `Seek` like `BrowserFileStream` (#1218)
 * Add method to convert an array of DicomDatasets into a json string (#1271)
+* Improved bilinear interpolation
 
 #### 5.0.1 (2021-11-11)
 

--- a/Contributors.md
+++ b/Contributors.md
@@ -75,3 +75,5 @@
 * [Smitha Saligrama](https://github.com/smithago)
 * [Fredrik Carlbom](https://github.com/fredrikcarlbom)
 * [Will Sugarman](https://github.com/wsugarman)
+* [Don Ch](https://github.com/lydonchandra)
+ 

--- a/FO-DICOM.Core/Imaging/Algorithms/BilinearInterpolation.cs
+++ b/FO-DICOM.Core/Imaging/Algorithms/BilinearInterpolation.cs
@@ -6,8 +6,22 @@ using System.Threading.Tasks;
 namespace FellowOakDicom.Imaging.Algorithms
 {
 
+    /// <summary>
+    /// 2D interpolation methods using the bilinear algorithm.
+    /// </summary>
     public static class BilinearInterpolation
     {
+
+        /// <summary>
+        /// Rescale 2D 8-bit "grayscale" image using bilinear interpolation.
+        /// </summary>
+        /// <param name="input">Input 8-bit 2D "grayscale" image grid.</param>
+        /// <param name="inputWidth">Width of input grid.</param>
+        /// <param name="inputHeight">Height of input grid.</param>
+        /// <param name="outputWidth">Requested width of output grid.</param>
+        /// <param name="outputHeight">Requested height of output grid.</param>
+        /// <returns>Bilinear interpolated grid with output <paramref name="outputWidth">width</paramref>
+        /// and <paramref name="outputHeight">height</paramref>.</returns>
         public static byte[] RescaleGrayscale(
             byte[] input,
             int inputWidth,
@@ -17,8 +31,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             byte[] output = new byte[outputWidth * outputHeight];
 
-            double xF = (double)inputWidth / (double)outputWidth;
-            double yF = (double)inputHeight / (double)outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             int xMax = inputWidth - 1;
             int yMax = inputHeight - 1;
@@ -62,6 +76,7 @@ namespace FellowOakDicom.Imaging.Algorithms
             return output;
         }
 
+
         public static short[] RescaleGrayscale(
             short[] input,
             int inputWidth,
@@ -71,8 +86,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             short[] output = new short[outputWidth * outputHeight];
 
-            double xF = (double)inputWidth / (double)outputWidth;
-            double yF = (double)inputHeight / (double)outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             int xMax = inputWidth - 1;
             int yMax = inputHeight - 1;
@@ -116,6 +131,7 @@ namespace FellowOakDicom.Imaging.Algorithms
             return output;
         }
 
+
         public static ushort[] RescaleGrayscale(
             ushort[] input,
             int inputWidth,
@@ -125,8 +141,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             ushort[] output = new ushort[outputWidth * outputHeight];
 
-            double xF = (double)inputWidth / (double)outputWidth;
-            double yF = (double)inputHeight / (double)outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             int xMax = inputWidth - 1;
             int yMax = inputHeight - 1;
@@ -170,6 +186,7 @@ namespace FellowOakDicom.Imaging.Algorithms
             return output;
         }
 
+
         public static int[] RescaleGrayscale(
             int[] input,
             int inputWidth,
@@ -179,8 +196,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             int[] output = new int[outputWidth * outputHeight];
 
-            double xF = (double)inputWidth / (double)outputWidth;
-            double yF = (double)inputHeight / (double)outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             int xMax = inputWidth - 1;
             int yMax = inputHeight - 1;
@@ -224,6 +241,7 @@ namespace FellowOakDicom.Imaging.Algorithms
             return output;
         }
 
+
         public static uint[] RescaleGrayscale(
             uint[] input,
             int inputWidth,
@@ -233,8 +251,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             uint[] output = new uint[outputWidth * outputHeight];
 
-            double xF = (double)inputWidth / (double)outputWidth;
-            double yF = (double)inputHeight / (double)outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             int xMax = inputWidth - 1;
             int yMax = inputHeight - 1;
@@ -278,6 +296,7 @@ namespace FellowOakDicom.Imaging.Algorithms
             return output;
         }
 
+
         public static byte[] RescaleColor24(
             byte[] input,
             int inputWidth,
@@ -287,8 +306,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             byte[] output = new byte[outputWidth * outputHeight * 3];
 
-            double xF = (double)inputWidth / (double)outputWidth;
-            double yF = (double)inputHeight / (double)outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             int xMax = inputWidth - 1;
             int yMax = inputHeight - 1;
@@ -320,8 +339,8 @@ namespace FellowOakDicom.Imaging.Algorithms
                         dx1 = ox0 - ox1;
                         dx2 = 1.0 - dx1;
 
-                        int x1 = ox1 * 3; //first byte of first pixel
-                        int x2 = ox2 * 3; //first byte of second pixel
+                        int x1 = ox1 * 3; // first byte of first pixel
+                        int x2 = ox2 * 3; // first byte of second pixel
 
                         output[yo0 + px] =
                             (byte)
@@ -344,8 +363,6 @@ namespace FellowOakDicom.Imaging.Algorithms
                             ((dy2 * ((dx2 * input[yo1 + x1]) + (dx1 * input[yo1 + x2])))
                                 + (dy1 * ((dx2 * input[yo2 + x1]) + (dx1 * input[yo2 + x2]))));
                         px++;
-                        x1++;
-                        x2++;
                     }
                 }
                 );
@@ -353,6 +370,7 @@ namespace FellowOakDicom.Imaging.Algorithms
 
             return output;
         }
+
 
         public static byte[] RescaleColor32(
             byte[] input,
@@ -363,8 +381,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             byte[] output = new byte[outputWidth * outputHeight * 4];
 
-            double xF = (double)inputWidth / (double)outputWidth;
-            double yF = (double)inputHeight / (double)outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             int xMax = inputWidth - 1;
             int yMax = inputHeight - 1;
@@ -425,8 +443,6 @@ namespace FellowOakDicom.Imaging.Algorithms
                             ((dy2 * ((dx2 * input[yo1 + ox1]) + (dx1 * input[yo1 + ox2])))
                                 + (dy1 * ((dx2 * input[yo2 + ox1]) + (dx1 * input[yo2 + ox2]))));
                         px++;
-                        ox1++;
-                        ox2++;
                     }
                 }
                 );
@@ -434,5 +450,7 @@ namespace FellowOakDicom.Imaging.Algorithms
 
             return output;
         }
+
+
     }
 }

--- a/FO-DICOM.Core/Imaging/Algorithms/NearestNeighborInterpolation.cs
+++ b/FO-DICOM.Core/Imaging/Algorithms/NearestNeighborInterpolation.cs
@@ -15,7 +15,7 @@ namespace FellowOakDicom.Imaging.Algorithms
         /// Rescale 2D 8-bit "grayscale" image using nearest neighbor interpolation.
         /// </summary>
         /// <param name="input">Input 8-bit 2D "grayscale" image grid.</param>
-        /// <param name="inputWidth">Width of ipnut grid.</param>
+        /// <param name="inputWidth">Width of input grid.</param>
         /// <param name="inputHeight">Height of input grid.</param>
         /// <param name="outputWidth">Requested width of output grid.</param>
         /// <param name="outputHeight">Requested height of output grid.</param>
@@ -30,8 +30,8 @@ namespace FellowOakDicom.Imaging.Algorithms
         {
             var output = new byte[outputWidth * outputHeight];
 
-            var xF = inputWidth / (double) outputWidth;
-            var yF = inputHeight / (double) outputHeight;
+            double xF = ((double)inputWidth - 1) / (outputWidth - 1);
+            double yF = ((double)inputHeight - 1) / (outputHeight - 1);
 
             var xMax = inputWidth - 1;
             var yMax = inputHeight - 1;
@@ -39,14 +39,14 @@ namespace FellowOakDicom.Imaging.Algorithms
             Parallel.For(0, outputHeight, y =>
                 {
                     var iy0 = y * yF;
-                    var iy1 = (int) iy0; // rounds down
+                    var iy1 = (int)iy0; // rounds down
                     var iy2 = iy1 == yMax ? iy1 : iy1 + 1;
                     var iyx0 = inputWidth * (iy0 - iy1 < 0.5 ? iy1 : iy2);
 
                     for (int yx = outputWidth * y, x = 0; x < outputWidth; x++, yx++)
                     {
                         var ix0 = x * xF;
-                        var ix1 = (int) ix0;
+                        var ix1 = (int)ix0;
                         var ix2 = ix1 == xMax ? ix1 : ix1 + 1;
                         var ix = ix0 - ix1 < 0.5 ? ix1 : ix2;
 

--- a/FO-DICOM.Core/Imaging/LUT/ILUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/ILUT.cs
@@ -25,7 +25,7 @@ namespace FellowOakDicom.Imaging.LUT
         double MaximumOutputValue { get; }
 
         /// <summary>
-        /// Indexer to taransform input value into output value
+        /// Indexer to transform input value into output value
         /// </summary>
         /// <param name="input">Input value</param>
         /// <returns>Output value</returns>

--- a/FO-DICOM.Full.sln
+++ b/FO-DICOM.Full.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		ChangeLog.md = ChangeLog.md
 		ChangeLog5.md = ChangeLog5.md
 		codecov.yml = codecov.yml
+		Contributors.md = Contributors.md
 		coverlet.runsettings = coverlet.runsettings
 		Directory.Build.props = Directory.Build.props
 		README.md = README.md

--- a/Tests/FO-DICOM.Tests/Imaging/InterpolationTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/InterpolationTest.cs
@@ -1,0 +1,277 @@
+﻿// Copyright (c) 2012-2021 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging.Algorithms;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Imaging
+{
+
+    [Collection("General")]
+    public class InterpolationTest
+    {
+
+
+        [Fact]
+        public void BilinearRescaleGrayscale2x2_to_4x4()
+        {
+            byte[] input = { 0, 0, 10, 10 };
+
+            const int inputWidth = 2,
+                inputHeight = inputWidth;
+
+            const int outputWidth = 4, outputHeight = 4;
+
+            byte[] output = BilinearInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0, 0, 0, 0,
+                    3, 3, 3, 3,
+                    6, 6, 6, 6,
+                    10, 10, 10, 10
+                },
+                output);
+        }
+
+        [Fact]
+        public void BilinearRescaleGrayscale3x3_to_5x5()
+        {
+            byte[] input =
+            {
+                0, 0, 0,
+                5, 5, 5,
+                10, 10, 10
+            };
+
+            const int inputWidth = 3,
+                inputHeight = inputWidth;
+
+            const int outputWidth = 5, outputHeight = 5;
+
+            byte[] output = BilinearInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0, 0, 0, 0, 0,
+                    2, 2, 2, 2, 2,
+                    5, 5, 5, 5, 5,
+                    7, 7, 7, 7, 7,
+                    10, 10, 10, 10, 10
+                },
+                output);
+
+            // non uniform input array
+
+            input = new byte[] {
+                0, 1, 2,
+                3, 4, 5,
+                6, 7, 8
+            };
+
+            output = BilinearInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0, 0, 1, 1, 2,
+                    1, 2, 2, 3, 3,
+                    3, 3, 4, 4, 5,
+                    4, 5, 5, 6, 6,
+                    6, 6, 7, 7, 8
+                },
+                output);
+        }
+
+
+        [Fact]
+        public void BilinearRescaleGrayscale4x4_to_8x8()
+        {
+            byte[] input =
+            {
+                0, 0, 0, 0,
+                5, 5, 5, 5,
+                10, 10, 10, 10,
+                15, 15, 15, 15
+            };
+
+            const int inputWidth = 4,
+                inputHeight = inputWidth;
+
+            const int outputWidth = 8, outputHeight = 8;
+
+            byte[] output = BilinearInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0,  0,  0,  0,  0,  0,  0,  0,
+                    2,  2,  2,  2,  2,  2,  2,  2,
+                    4,  4,  4,  4,  4,  4,  4,  4,
+                    6,  6,  6,  6,  6,  6,  6,  6,
+                    8,  8,  8,  8,  8,  8,  8,  8,
+                    10, 10, 10, 10, 10, 10, 10, 10,
+                    12, 12, 12, 12, 12, 12, 12, 12,
+                    15, 15, 15, 15, 15, 15, 15, 15
+                },
+                output);
+
+            // non uniform input array
+
+            input = new byte[]
+            {
+                0,  1,  2,  3,
+                4,  5,  6,  7,
+                8,  9,  10, 11,
+                12, 13, 14, 15
+            };
+
+            output = BilinearInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0,  0,  0,  1,  1,  2,  2,  3,
+                    1,  2,  2,  2,  3,  3,  4,  4,
+                    3,  3,  4,  4,  5,  5,  5,  6,
+                    5,  5,  6,  6,  6,  7,  7,  8,
+                    6,  7,  7,  8,  8,  9,  9,  9,
+                    8,  8,  9,  9,  10, 10, 11, 11,
+                    10, 10, 11, 11, 12, 12, 12, 13,
+                    12, 12, 12, 13, 13, 14, 14, 15
+                },
+                output);
+        }
+
+
+        [Fact]
+        public void NearestNeighbourRescaleGrayscale2x2_to_4x4()
+        {
+            byte[] input = { 0, 0, 10, 10 };
+
+            const int inputWidth = 2, inputHeight = inputWidth;
+            const int outputWidth = 4, outputHeight = 4;
+
+            byte[] output = NearestNeighborInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    10, 10, 10, 10,
+                    10, 10, 10, 10
+                },
+                output);
+        }
+
+        [Fact]
+        public void NearestNeighbourRescaleGrayscale3x3_to_5x5()
+        {
+            byte[] input =
+            {
+                0, 0, 0,
+                5, 5, 5,
+                10, 10, 10
+            };
+
+            const int inputWidth = 3, inputHeight = inputWidth;
+            const int outputWidth = 5, outputHeight = 5;
+
+            byte[] output = NearestNeighborInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0, 0, 0, 0, 0,
+                    5, 5, 5, 5, 5,
+                    5, 5, 5, 5, 5,
+                    10, 10, 10, 10, 10,
+                    10, 10, 10, 10, 10
+                },
+                output);
+
+            // non uniform input array
+
+            input = new byte[] {
+                0, 1, 2,
+                3, 4, 5,
+                6, 7, 8
+            };
+
+            output = NearestNeighborInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0, 1, 1, 2, 2,
+                    3, 4, 4, 5, 5,
+                    3, 4, 4, 5, 5,
+                    6, 7, 7, 8, 8,
+                    6, 7, 7, 8, 8
+                },
+                output);
+        }
+
+
+        [Fact]
+        public void NearestNeighbourRescaleGrayscale4x4_to_8x8()
+        {
+            byte[] input =
+            {
+                0, 0, 0, 0,
+                5, 5, 5, 5,
+                10, 10, 10, 10,
+                15, 15, 15, 15
+            };
+
+            const int inputWidth = 4, inputHeight = inputWidth;
+            const int outputWidth = 8, outputHeight = 8;
+
+            byte[] output = NearestNeighborInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0,  0,  0,  0,  0,  0,  0,  0,
+                    0,  0,  0,  0,  0,  0,  0,  0,
+                    5,  5,  5,  5,  5,  5,  5,  5,
+                    5,  5,  5,  5,  5,  5,  5,  5,
+                    10, 10, 10, 10, 10, 10, 10, 10,
+                    10, 10, 10, 10, 10, 10, 10, 10,
+                    15, 15, 15, 15, 15, 15, 15, 15,
+                    15, 15, 15, 15, 15, 15, 15, 15
+                },
+                output);
+
+            // non uniform input array
+
+            input = new byte[]
+            {
+                0,  1,  2,  3,
+                4,  5,  6,  7,
+                8,  9,  10, 11,
+                12, 13, 14, 15
+            };
+
+            output = NearestNeighborInterpolation.RescaleGrayscale(input, inputWidth, inputHeight, outputWidth, outputHeight);
+
+            Assert.Equal(
+                new byte[]
+                {
+                    0,  0,  1,  1,  2,  2,  3,  3,
+                    0,  0,  1,  1,  2,  2,  3,  3,
+                    4,  4,  5,  5,  6,  6,  7,  7,
+                    4,  4,  5,  5,  6,  6,  7,  7,
+                    8,  8,  9,  9,  10, 10, 11, 11,
+                    8,  8,  9,  9,  10, 10, 11, 11,
+                    12, 12, 13, 13, 14, 14, 15, 15,
+                    12, 12, 13, 13, 14, 14, 15, 15
+                },
+                output);
+        }
+
+    }
+}


### PR DESCRIPTION
This PR updates the PR #1114, which is still drafted and was done on fo-dicom version 4.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- additional unittests covering Interpolation algorithms, that are used when rendering with sizing is called
- improved behavior when interpolating small grids (fix off-by-one bug)

