### PR TITLE
Fix reading from buffered stream

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -2,6 +2,7 @@
 * Added an extension to get a DateTimeOffset respecting the timezone info in the dataset (#1310)
 * Fixed bug where anonymization threw an exception if a DicomTag of VR UI contained no value (#1308)
 * Catch exception in logmessage, to avoid making the application crash because of logging (#1288)
+* Fixed StreamByteBuffer to read an internally buffered stream completely (#1313)
 
 #### 5.0.2 (2022-01-11)
 * Update to DICOM Standard 2021e

--- a/Contributors.md
+++ b/Contributors.md
@@ -77,4 +77,4 @@
 * [Will Sugarman](https://github.com/wsugarman)
 * [Don Ch](https://github.com/lydonchandra)
 * [Björn Lundmark](https://github.com/bjorn-malmo)
- 
+* [Josiah Vinson](https://github.com/jovinson-ms)

--- a/Tests/FO-DICOM.Tests/IO/Buffer/StreamByteBufferTests.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/StreamByteBufferTests.cs
@@ -58,10 +58,102 @@ namespace FellowOakDicom.Tests.IO.Buffer
         #region Unit tests
 
         [Theory]
+        [InlineData(0, 255, 20, 150)]
+        [InlineData(0, 255, 0, 128)]
+        [InlineData(0, 255, 5, 1)]
+        [InlineData(0, 255, 30, 224)]
+        [InlineData(0, 255, 12, 0)]
+        [InlineData(50, 100, 20, 15)]
+        [InlineData(50, 100, 5, 1)]
+        [InlineData(50, 100, 12, 0)]
+        public void GetByteRange_CompareWithInitializer_ExactMatch(int ctorOffset, int ctorCount, int byteRangeOffset, int byteRangeCount)
+        {
+            // Arrange
+            var bytes = Enumerable.Range(0, 255).Select(i => (byte)i).ToArray();
+            using var ms = new MemoryStream(bytes);
+            var buffer = new StreamByteBuffer(ms, ctorOffset, ctorCount);
+            var expected = new ArraySegment<byte>(bytes, ctorOffset + byteRangeOffset, Math.Min(ctorCount, byteRangeCount));
+
+            // Act
+            var actual = new byte[Math.Min(ctorCount, byteRangeCount)];
+            buffer.GetByteRange(byteRangeOffset, byteRangeCount, actual);
+
+            // Assert
+            Assert.Equal(expected.Count, actual.Length);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetByteRange_WhenBufferIsSmallerThanRequestedCount_Throws()
+        {
+            // Arrange
+            var bytes = Enumerable.Range(0, 255).Select(i => (byte)i).ToArray();
+            using var ms = new MemoryStream(bytes);
+            var streamByteBuffer = new StreamByteBuffer(ms, 0, 255);
+
+            // Act + Assert
+            var buffer = new byte[10];
+            Assert.Throws<ArgumentException>(() => streamByteBuffer.GetByteRange(0, 20, buffer));
+        }
+
+        [Theory]
+        [InlineData(255, 20, 150)]
+        [InlineData(255, 0, 128)]
+        [InlineData(255, 5, 1)]
+        [InlineData(255, 30, 224)]
+        [InlineData(255, 12, 0)]
+        [InlineData(5 * (1024 * 1024) + 256, 0, 5 * (1024 * 1024) + 256)]
+        [InlineData(5 * (1024 * 1024) + 256, 0, 5 * (1024 * 1024))]
+        [InlineData(5 * (1024 * 1024) + 256, 256, 5 * (1024 * 1024))]
+        public void CopyToStream_ShouldWorkCorrectly(int total, int offset, int count)
+        {
+            // Arrange
+            var bytes = Enumerable.Range(0, total).Select(i => (byte)i).ToArray();
+            using var inputMs = new MemoryStream(bytes);
+            using var outputMs = new MemoryStream(bytes.Length);
+            var buffer = new StreamByteBuffer(inputMs, offset, count);
+            var expected = new ArraySegment<byte>(bytes, offset, count);
+
+            // Act
+            buffer.CopyToStream(outputMs);
+
+            // Assert
+            var actual = outputMs.ToArray();
+            Assert.Equal(expected.Count, actual.Length);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(255, 20, 150)]
+        [InlineData(255, 0, 128)]
+        [InlineData(255, 5, 1)]
+        [InlineData(255, 30, 224)]
+        [InlineData(255, 12, 0)]
+        [InlineData(5 * (1024 * 1024) + 256, 0, 5 * (1024 * 1024) + 256)]
+        [InlineData(5 * (1024 * 1024) + 256, 0, 5 * (1024 * 1024))]
+        [InlineData(5 * (1024 * 1024) + 256, 256, 5 * (1024 * 1024))]
+        public async Task CopyToStreamAsync_ShouldWorkCorrectly(int total, int offset, int count)
+        {
+            // Arrange
+            var bytes = Enumerable.Range(0, total).Select(i => (byte)i).ToArray();
+            using var inputMs = new MemoryStream(bytes);
+            using var outputMs = new MemoryStream(bytes.Length);
+            var buffer = new StreamByteBuffer(inputMs, offset, count);
+            var expected = new ArraySegment<byte>(bytes, offset, count);
+
+            // Act
+            await buffer.CopyToStreamAsync(outputMs, CancellationToken.None);
+
+            // Assert
+            var actual = outputMs.ToArray();
+            Assert.Equal(expected.Count, actual.Length);
+            Assert.Equal(expected, actual);
+        }
+        [Theory]
         [InlineData(0, 255)]
         [InlineData(0, 10)]
         [InlineData(10, 245)]
-        public void Data_CompareWithInitializer_ExactMatch(int offset, int count)
+        public void DataFromBufferedStream_CompareWithInitializer_ExactMatch(int offset, int count)
         {
             // Arrange
             var bytes = Enumerable.Range(0, 255).Select(i => (byte)i).ToArray();
@@ -86,7 +178,7 @@ namespace FellowOakDicom.Tests.IO.Buffer
         [InlineData(50, 100, 20, 15)]
         [InlineData(50, 100, 5, 1)]
         [InlineData(50, 100, 12, 0)]
-        public void GetByteRange_CompareWithInitializer_ExactMatch(int ctorOffset, int ctorCount, int byteRangeOffset, int byteRangeCount)
+        public void GetByteRangeFromBufferedStream_CompareWithInitializer_ExactMatch(int ctorOffset, int ctorCount, int byteRangeOffset, int byteRangeCount)
         {
             // Arrange
             var bytes = Enumerable.Range(0, 255).Select(i => (byte)i).ToArray();
@@ -104,7 +196,7 @@ namespace FellowOakDicom.Tests.IO.Buffer
         }
 
         [Fact]
-        public void GetByteRange_WhenBufferIsSmallerThanRequestedCount_Throws()
+        public void GetByteRangeFromBufferedStream_WhenBufferIsSmallerThanRequestedCount_Throws()
         {
             // Arrange
             var bytes = Enumerable.Range(0, 255).Select(i => (byte)i).ToArray();
@@ -125,7 +217,7 @@ namespace FellowOakDicom.Tests.IO.Buffer
         [InlineData(5 * (1024*1024) + 256, 0, 5 * (1024*1024) + 256)]
         [InlineData(5 * (1024*1024) + 256, 0, 5 * (1024*1024))]
         [InlineData(5 * (1024*1024) + 256, 256, 5 * (1024*1024))]
-        public void CopyToStream_ShouldWorkCorrectly(int total, int offset, int count)
+        public void CopyToStreamFromBufferedStream_ShouldWorkCorrectly(int total, int offset, int count)
         {
             // Arrange
             var bytes = Enumerable.Range(0, total).Select(i => (byte)i).ToArray();
@@ -152,7 +244,7 @@ namespace FellowOakDicom.Tests.IO.Buffer
         [InlineData(5 * (1024*1024) + 256, 0, 5 * (1024*1024) + 256)]
         [InlineData(5 * (1024*1024) + 256, 0, 5 * (1024*1024))]
         [InlineData(5 * (1024*1024) + 256, 256, 5 * (1024*1024))]
-        public async Task CopyToStreamAsync_ShouldWorkCorrectly(int total, int offset, int count)
+        public async Task CopyToStreamAsyncFromBufferedStream_ShouldWorkCorrectly(int total, int offset, int count)
         {
             // Arrange
             var bytes = Enumerable.Range(0, total).Select(i => (byte)i).ToArray();


### PR DESCRIPTION
Fixes #1313.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Fixes the issue described in #1313 where an internally buffered `Stream`, such as a network-based `Stream`, would not be read completely by `StreamByteBuffer`. The fix involves a simple loop that calls `Stream.Read` until the return value is 0. Callers such as `DicomFile` will be blocked until the `Stream` is read, but this in an on-demand behavior. 
- Added a `FakeBufferedStream` class to the `StreamByteBuffer` tests that mimics buffering behavior on top of a `MemoryStream`. The standard `BufferedStream` class won't work here because it does internal checks to see if buffering will provide performance benefits, and won't instantiate its internal buffer if not.
- Since all `Stream`-derived classes have the same `Read` contract, it may be worth implementing the same looping read on `FileReference`, but I'll leave that for another issue since it is a very rare occurrence and needs a separate fake.