### PR TITLE
Fix possible disposal issues in DicomServer and DicomService

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -3,6 +3,7 @@
 * Fixed bug where anonymization threw an exception if a DicomTag of VR UI contained no value (#1308)
 * Catch exception in logmessage, to avoid making the application crash because of logging (#1288)
 * Fixed StreamByteBuffer to read an internally buffered stream completely (#1313)
+* Fixed bug where disposal of DicomService could throw an exception if the buffered write stream still had content (#1319)
 
 #### 5.0.2 (2022-01-11)
 * Update to DICOM Standard 2021e

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -341,8 +341,12 @@ namespace FellowOakDicom.Network
                     {
                         runningDicomServiceTasks = _services.Select(s => s.Task).ToList();
                     }
-                    await Task.WhenAny(runningDicomServiceTasks).ConfigureAwait(false);
-                    
+
+                    if (runningDicomServiceTasks.Count > 0)
+                    {
+                        await Task.WhenAny(runningDicomServiceTasks).ConfigureAwait(false);
+                    }
+
                     lock (_services)
                     {
                         for (int i = _services.Count - 1; i >= 0; i--)

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -229,7 +229,15 @@ namespace FellowOakDicom.Network
             if (disposing)
             {
                 _dimseStream?.Dispose();
-                _writeStream?.Dispose();
+                try
+                {
+                    _writeStream?.Dispose();
+                }
+                catch(IOException)
+                {
+                    // The buffered stream will try to flush its contents upon disposal, which might fail if the underlying network stream is already closed
+                    // This can be ignored here
+                }
                 _network?.Dispose();
                 _pduQueueWatcher?.Dispose();
             }


### PR DESCRIPTION
Fixes #1319

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Prevent buffered write stream from throwing an exception when disposing DicomService and the write stream still has buffered content
- Double check that there are running dicom servers when cleaning up unused services in DicomServer
