### PR TITLE
Validate host, calling AE and called AE when constructing a DicomClient

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -10,6 +10,7 @@
 * Fixed bug where disposal of DicomService could throw an exception if the buffered write stream still had content (#1319)
 * Improve handling of dropped connections (#1332)
 * Ignore empty VOI LUT and Modality LUT Sequence (#1369)
+* Validate calling AE and called AE length when creating a DicomClient (#1323)
 * Improve handling of WSI creation: faster offset table calucation and a naming of temp files to allow more than 64.000.
 
 #### 5.0.2 (2022-01-11)

--- a/FO-DICOM.Core/Network/Client/DicomClientFactory.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientFactory.cs
@@ -73,13 +73,13 @@ namespace FellowOakDicom.Network.Client
             if (callingAe != null && callingAe.Length > DicomVR.AE.MaximumLength)
             {
                 throw new ArgumentException($"Calling AE '{callingAe}' is {callingAe.Length} characters long, " +
-                                            $"which is longer than maximum allowed length ({DicomVR.AE.MaximumLength} characters)");
+                                            $"which is longer than the maximum allowed length ({DicomVR.AE.MaximumLength} characters)");
             }
 
             if (calledAe != null && calledAe.Length > DicomVR.AE.MaximumLength)
             {
                 throw new ArgumentException($"Called AE '{calledAe}' is {calledAe.Length} characters long, " +
-                                            $"which is longer than maximum allowed length ({DicomVR.AE.MaximumLength} characters)");
+                                            $"which is longer than the maximum allowed length ({DicomVR.AE.MaximumLength} characters)");
             }
 
             var clientOptions = _defaultClientOptions.Value.Clone();

--- a/FO-DICOM.Core/Network/Client/DicomClientFactory.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientFactory.cs
@@ -65,6 +65,23 @@ namespace FellowOakDicom.Network.Client
 
         public virtual IDicomClient Create(string host, int port, bool useTls, string callingAe, string calledAe)
         {
+            if (host == null)
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+
+            if (callingAe != null && callingAe.Length > DicomVR.AE.MaximumLength)
+            {
+                throw new ArgumentException($"Calling AE '{callingAe}' is {callingAe.Length} characters long, " +
+                                            $"which is longer than maximum allowed length ({DicomVR.AE.MaximumLength} characters)");
+            }
+
+            if (calledAe != null && calledAe.Length > DicomVR.AE.MaximumLength)
+            {
+                throw new ArgumentException($"Called AE '{calledAe}' is {calledAe.Length} characters long, " +
+                                            $"which is longer than maximum allowed length ({DicomVR.AE.MaximumLength} characters)");
+            }
+
             var clientOptions = _defaultClientOptions.Value.Clone();
             var serviceOptions = _defaultServiceOptions.Value.Clone();
 

--- a/FO-DICOM.Core/Network/PDU.cs
+++ b/FO-DICOM.Core/Network/PDU.cs
@@ -381,7 +381,7 @@ namespace FellowOakDicom.Network
         /// <param name="pad">Padding character</param>
         public void Write(string name, string value, int count, char pad)
         {
-            Write(name, value.PadRight(count, pad));
+            Write(name, value.Substring(0, Math.Min(value.Length, count)).PadRight(count, pad));
         }
 
         /// <summary>

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientFactoryTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientFactoryTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using FellowOakDicom.Network.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Network.Client
+{
+    public class DicomClientFactoryTests
+    {
+        private readonly IDicomClientFactory _factory;
+        private readonly string _host;
+        private readonly int _port;
+        private readonly bool _useTls;
+        private readonly string _callingAe;
+        private readonly string _calledAe;
+
+        public DicomClientFactoryTests()
+        {
+            _factory = Setup.ServiceProvider.GetRequiredService<IDicomClientFactory>();
+            _host = "127.0.0.1";
+            _port = 104;
+            _useTls = false;
+            _callingAe = "ANY-SCU";
+            _calledAe = "ANY-SCP";
+        }
+
+        [Fact]
+        public void ShouldThrowWhenHostIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => _factory.Create(null, _port, _useTls, _callingAe, _calledAe));
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCallingAeTitleIsTooLong()
+        {
+            Assert.Throws<ArgumentException>(() => _factory.Create(_host, _port, _useTls, "SuperDuperLongAeTitle", _calledAe));
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCalledAeTitleIsTooLong()
+        {
+            Assert.Throws<ArgumentException>(() => _factory.Create(_host, _port, _useTls, _callingAe, "SuperDuperLongAeTitle"));
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
@@ -16,6 +16,7 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Network.Client.States;
 using FellowOakDicom.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -141,6 +142,34 @@ namespace FellowOakDicom.Tests.Network.Client
                 Assert.Equal(1, counter);
             }
         }
+
+
+        [Fact]
+        public async Task AutomaticallyFixTooLongAETitles()
+        {
+            int port = Ports.GetNext();
+            using (CreateServer<DicomCEchoProvider>(port))
+            {
+                var counter = 0;
+                var request = new DicomCEchoRequest { OnResponseReceived = (req, res) => Interlocked.Increment(ref counter) };
+
+                // DicomClientFactory cares about the length of AETitles,
+                // but in case some developer registeres a custom Factory or creates DicomClient directly for some other reason.
+                var client = new DicomClient("localhost", port, false, "STORAGECOMMITTEST", "DE__257a276f6d47",
+                    new DicomClientOptions { }, new DicomServiceOptions { }, Setup.ServiceProvider.GetRequiredService<INetworkManager>(), Setup.ServiceProvider.GetRequiredService<ILogManager>(), Setup.ServiceProvider.GetRequiredService<ITranscoderManager>(), Setup.ServiceProvider.GetRequiredService<IMemoryProvider>());
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+
+                var task = client.SendAsync();
+                var winning = await Task.WhenAny(task, Task.Delay(10000));
+                if (winning != task)
+                {
+                    task.Wait(100);
+                }
+
+                Assert.Equal(1, counter);
+            }
+        }
+
 
         [Theory]
         [InlineData(2)]


### PR DESCRIPTION
Fixes #1323

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Throw ArgumentException when trying to instantiate a DicomClient with invalid AE titles
