### PR TITLE
Improve handling of dropped connections in DicomService

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -6,6 +6,7 @@
 * Catch exception in logmessage, to avoid making the application crash because of logging (#1288)
 * Fixed StreamByteBuffer to read an internally buffered stream completely (#1313)
 * Optimize performance and reduce memory allocations in network layer (#1291)
+* Improve handling of dropped connections (#1332)
 
 #### 5.0.2 (2022-01-11)
 * Update to DICOM Standard 2021e

--- a/FO-DICOM.Core/DicomDatasetWalker.cs
+++ b/FO-DICOM.Core/DicomDatasetWalker.cs
@@ -358,20 +358,10 @@ namespace FellowOakDicom
                         walker.OnEndSequence();
                     }
                 }
-
-                walker.OnEndWalk();
             }
-            catch (Exception e)
+            finally
             {
-                try
-                {
-                    walker.OnEndWalk();
-                    throw;
-                }
-                catch
-                {
-                    throw e;
-                }
+                walker.OnEndWalk();
             }
         }
 

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -430,7 +430,7 @@ namespace FellowOakDicom.Network
                         if (count == 0)
                         {
                             // disconnected
-                            await TryCloseConnectionAsync().ConfigureAwait(false);
+                            await TryCloseConnectionAsync(force: true).ConfigureAwait(false);
                             return;
                         }
 
@@ -465,7 +465,7 @@ namespace FellowOakDicom.Network
                         if (count == 0)
                         {
                             // disconnected
-                            await TryCloseConnectionAsync().ConfigureAwait(false);
+                            await TryCloseConnectionAsync(force: true).ConfigureAwait(false);
                             return;
                         }
 

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1884,10 +1884,7 @@ namespace FellowOakDicom.Network
             protected override void Dispose(bool disposing)
             {
                 var bytes = Interlocked.Exchange(ref _memory, null);
-                if (bytes != null)
-                {
-                    _memory.Dispose();
-                }
+                bytes?.Dispose();
 
                 var pdu = Interlocked.Exchange(ref _pdu, null);
                 pdu?.Dispose();

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1304,10 +1304,11 @@ namespace FellowOakDicom.Network
                         {
                             await deflateStream.FlushAsync(CancellationToken.None);
                         }                    
-                        await pDataStream.FlushAsync(CancellationToken.None);
-                        
-                        msg.LastPDUSent = DateTime.Now;
                     }
+                    
+                    await pDataStream.FlushAsync(CancellationToken.None);
+                    
+                    msg.LastPDUSent = DateTime.Now;
                 }
                 catch (Exception e)
                 {

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1303,6 +1303,9 @@ namespace FellowOakDicom.Network
                         if (deflateStream != null)
                         {
                             await deflateStream.FlushAsync(CancellationToken.None);
+                            
+                            // Deflate stream in .NET Framework only fully flushes when disposed...
+                            deflateStream.Dispose();
                         }                    
                     }
                     

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
@@ -1339,8 +1339,14 @@ namespace FellowOakDicom.Tests.Network.Client
                 {
                     await client.SendAsync(cancellation.Token, DicomClientCancellationMode.ImmediatelyAbortAssociation).ConfigureAwait(false);
                 }
-                catch(IOException)
-                { /* Ignore */ }
+                catch (DicomNetworkException)
+                {
+                    /* Ignore */
+                }
+                catch (IOException)
+                {
+                     /* Ignore */
+                }
 
                 Assert.False(cancellation.IsCancellationRequested);
             }


### PR DESCRIPTION
Fixes #1325

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- This PR is an attempt to improve the handling of lost connections. In some cases, a race condition can occur and DicomService is stuck forever waiting to send the next PDU even though the connection is already gone. 
