### PR TITLE
Update codecs to 5.1.0 in Dump and Tests projects

### DIFF
--- a/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
+++ b/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="fo-dicom.Codecs" Version="5.0.0-beta6" />
+    <PackageReference Include="fo-dicom.Codecs" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/Tools/FO-DICOM.Dump/FO-DICOM.Dump.csproj
+++ b/Tools/FO-DICOM.Dump/FO-DICOM.Dump.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="fo-dicom.Codecs" Version="5.0.0-beta6" />
+    <PackageReference Include="fo-dicom.Codecs" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR simply updates our internal references to fo-dicom.Codecs from 5.0.0-beta6 to 5.1.0 and has no impact on consumers of fo-dicom.