### PR TITLE
JsonDicomConverter allows serializing DS/IS dicom item with invalid values

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,5 +1,5 @@
 #### 5.0.3 (TBD)
-* JsonDicomConverter allows serializing DS/IS dicom item with invalid values when autoValidate is False(#1354)
+* JsonDicomConverter allows serializing DS/IS dicom item with invalid values when autoValidate is False. (#1354)
 * Breaking change: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)
 * Breaking change: subclasses of DicomServer will have to pass an instance of DicomServerDependencies along to the DicomServer base constructor. This replaces the old NetworkManager / LogManager dependencies. (Implemented in the context of #1291)
 * Added an extension to get a DateTimeOffset respecting the timezone info in the dataset (#1310)

--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,4 +1,5 @@
 #### 5.0.3 (TBD)
+* JsonDicomConverter allows serializing DS/IS dicom item with invalid values when autoValidate is False(#1354)
 * Breaking change: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)
 * Breaking change: subclasses of DicomServer will have to pass an instance of DicomServerDependencies along to the DicomServer base constructor. This replaces the old NetworkManager / LogManager dependencies. (Implemented in the context of #1291)
 * Added an extension to get a DateTimeOffset respecting the timezone info in the dataset (#1310)

--- a/FO-DICOM.Core/Serialization/DicomJson.cs
+++ b/FO-DICOM.Core/Serialization/DicomJson.cs
@@ -11,10 +11,11 @@ namespace FellowOakDicom.Serialization
         /// </summary>
         /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
         /// <param name="formatIndented">Gets or sets a value that defines whether JSON should use pretty printing. By default, JSON is serialized without any extra white space.</param>
-        public static string ConvertDicomToJson(DicomDataset dataset, bool writeTagsAsKeywords = false, bool formatIndented = false)
+        /// <param name="autoValidate">Whether the content of DicomItems shall be validated when serializing or deserializing. </param>
+        public static string ConvertDicomToJson(DicomDataset dataset, bool writeTagsAsKeywords = false, bool formatIndented = false, bool autoValidate = true)
         {
             var options = new JsonSerializerOptions();
-            options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: writeTagsAsKeywords));
+            options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: writeTagsAsKeywords, autoValidate: autoValidate));
             options.WriteIndented = formatIndented;
             var conv = JsonSerializer.Serialize(dataset, options);
             return conv;

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -326,72 +326,86 @@ namespace FellowOakDicom.Serialization
             writer.WriteStartObject();
             writer.WriteString("vr", item.ValueRepresentation.Code);
 
-            if (!_autoValidate && (item.ValueRepresentation.Code == DicomVRCode.IS || item.ValueRepresentation.Code == DicomVRCode.DS))
+            switch (item.ValueRepresentation.Code)
             {
-                // Always serialize DS, IS as string for best compatibility while autoValidate is False.
-                WriteJsonElement<string>(writer, (DicomElement)item, (w, v) => writer.WriteStringValue(v));
+                case "PN":
+                    WriteJsonPersonName(writer, (DicomPersonName)item);
+                    break;
+                case "SQ":
+                    WriteJsonSequence(writer, (DicomSequence)item, options);
+                    break;
+                case "OB":
+                case "OD":
+                case "OF":
+                case "OL":
+                case "OV":
+                case "OW":
+                case "UN":
+                    WriteJsonOther(writer, (DicomElement)item);
+                    break;
+                case "FL":
+                    WriteJsonElement<float>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "FD":
+                    WriteJsonElement<double>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "IS":
+                    WriteJsonIntegerString(writer, (DicomElement)item);
+                    break;
+                case "SL":
+                    WriteJsonElement<int>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "SS":
+                    WriteJsonElement<short>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "SV":
+                    WriteJsonElement<long>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "UL":
+                    WriteJsonElement<uint>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "US":
+                    WriteJsonElement<ushort>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "UV":
+                    WriteJsonElement<ulong>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
+                    break;
+                case "DS":
+                    WriteJsonDecimalString(writer, (DicomElement)item);
+                    break;
+                case "AT":
+                    WriteJsonAttributeTag(writer, (DicomElement)item);
+                    break;
+                default:
+                    WriteJsonElement<string>(writer, (DicomElement)item, (w, v) => writer.WriteStringValue(v));
+                    break;
             }
-            else
-            {
 
-                switch (item.ValueRepresentation.Code)
-                {
-                    case "PN":
-                        WriteJsonPersonName(writer, (DicomPersonName)item);
-                        break;
-                    case "SQ":
-                        WriteJsonSequence(writer, (DicomSequence)item, options);
-                        break;
-                    case "OB":
-                    case "OD":
-                    case "OF":
-                    case "OL":
-                    case "OV":
-                    case "OW":
-                    case "UN":
-                        WriteJsonOther(writer, (DicomElement)item);
-                        break;
-                    case "FL":
-                        WriteJsonElement<float>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "FD":
-                        WriteJsonElement<double>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "IS":
-                    case "SL":
-                        WriteJsonElement<int>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "SS":
-                        WriteJsonElement<short>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "SV":
-                        WriteJsonElement<long>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "UL":
-                        WriteJsonElement<uint>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "US":
-                        WriteJsonElement<ushort>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "UV":
-                        WriteJsonElement<ulong>(writer, (DicomElement)item, (w, v) => writer.WriteNumberValue(v));
-                        break;
-                    case "DS":
-                        WriteJsonDecimalString(writer, (DicomElement)item);
-                        break;
-                    case "AT":
-                        WriteJsonAttributeTag(writer, (DicomElement)item);
-                        break;
-                    default:
-                        WriteJsonElement<string>(writer, (DicomElement)item, (w, v) => writer.WriteStringValue(v));
-                        break;
-                }
-            }
             writer.WriteEndObject();
         }
 
-        private static void WriteJsonDecimalString(Utf8JsonWriter writer, DicomElement elem)
+        private void WriteJsonIntegerString(Utf8JsonWriter writer, DicomElement elem)
         {
+            if (!_autoValidate)
+            {
+                // Always serialize IS as string for best compatibility while autoValidate is False.
+                WriteJsonElement<string>(writer, elem, (w, v) => writer.WriteStringValue(v));
+            }
+            else
+            {
+                WriteJsonElement<int>(writer, elem, (w, v) => writer.WriteNumberValue(v));
+            }
+        }
+
+        private void WriteJsonDecimalString(Utf8JsonWriter writer, DicomElement elem)
+        {
+            if (!_autoValidate)
+            {
+                // Always serialize DS as string for best compatibility while autoValidate is False.
+                WriteJsonElement<string>(writer, elem, (w, v) => writer.WriteStringValue(v));
+                return;
+            }
+
             if (elem.Count != 0)
             {
                 writer.WritePropertyName("Value");

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -410,58 +410,65 @@ namespace FellowOakDicom.Serialization
             writer.WriteStartObject();
             writer.WritePropertyName("vr");
             writer.WriteValue(item.ValueRepresentation.Code);
-
-            switch (item.ValueRepresentation.Code)
+            if (!_autoValidate && (item.ValueRepresentation.Code == DicomVRCode.IS || item.ValueRepresentation.Code == DicomVRCode.DS))
             {
-                case "PN":
-                    WriteJsonPersonName(writer, (DicomPersonName)item);
-                    break;
-                case "SQ":
-                    WriteJsonSequence(writer, (DicomSequence)item);
-                    break;
-                case "OB":
-                case "OD":
-                case "OF":
-                case "OL":
-                case "OV":
-                case "OW":
-                case "UN":
-                    WriteJsonOther(writer, (DicomElement)item);
-                    break;
-                case "FL":
-                    WriteJsonElement<float>(writer, (DicomElement)item);
-                    break;
-                case "FD":
-                    WriteJsonElement<double>(writer, (DicomElement)item);
-                    break;
-                case "IS":
-                case "SL":
-                    WriteJsonElement<int>(writer, (DicomElement)item);
-                    break;
-                case "SS":
-                    WriteJsonElement<short>(writer, (DicomElement)item);
-                    break;
-                case "SV":
-                    WriteJsonElement<long>(writer, (DicomElement)item);
-                    break;
-                case "UL":
-                    WriteJsonElement<uint>(writer, (DicomElement)item);
-                    break;
-                case "US":
-                    WriteJsonElement<ushort>(writer, (DicomElement)item);
-                    break;
-                case "UV":
-                    WriteJsonElement<ulong>(writer, (DicomElement)item);
-                    break;
-                case "DS":
-                    WriteJsonDecimalString(writer, (DicomElement)item);
-                    break;
-                case "AT":
-                    WriteJsonAttributeTag(writer, (DicomElement)item);
-                    break;
-                default:
-                    WriteJsonElement<string>(writer, (DicomElement)item);
-                    break;
+                // Always serialize DS, IS as string for best compatibility while autoValidate is False.
+                WriteJsonElement<string>(writer, (DicomElement)item);
+            }
+            else
+            {
+                switch (item.ValueRepresentation.Code)
+                {
+                    case "PN":
+                        WriteJsonPersonName(writer, (DicomPersonName)item);
+                        break;
+                    case "SQ":
+                        WriteJsonSequence(writer, (DicomSequence)item);
+                        break;
+                    case "OB":
+                    case "OD":
+                    case "OF":
+                    case "OL":
+                    case "OV":
+                    case "OW":
+                    case "UN":
+                        WriteJsonOther(writer, (DicomElement)item);
+                        break;
+                    case "FL":
+                        WriteJsonElement<float>(writer, (DicomElement)item);
+                        break;
+                    case "FD":
+                        WriteJsonElement<double>(writer, (DicomElement)item);
+                        break;
+                    case "IS":
+                    case "SL":
+                        WriteJsonElement<int>(writer, (DicomElement)item);
+                        break;
+                    case "SS":
+                        WriteJsonElement<short>(writer, (DicomElement)item);
+                        break;
+                    case "SV":
+                        WriteJsonElement<long>(writer, (DicomElement)item);
+                        break;
+                    case "UL":
+                        WriteJsonElement<uint>(writer, (DicomElement)item);
+                        break;
+                    case "US":
+                        WriteJsonElement<ushort>(writer, (DicomElement)item);
+                        break;
+                    case "UV":
+                        WriteJsonElement<ulong>(writer, (DicomElement)item);
+                        break;
+                    case "DS":
+                        WriteJsonDecimalString(writer, (DicomElement)item);
+                        break;
+                    case "AT":
+                        WriteJsonAttributeTag(writer, (DicomElement)item);
+                        break;
+                    default:
+                        WriteJsonElement<string>(writer, (DicomElement)item);
+                        break;
+                }
             }
             writer.WriteEndObject();
         }
@@ -655,7 +662,7 @@ namespace FellowOakDicom.Serialization
                     }
                     else
                     {
-                        var componentGroupValues = val.Split(_personNameComponentGroupDelimiter); 
+                        var componentGroupValues = val.Split(_personNameComponentGroupDelimiter);
                         int i = 0;
 
                         writer.WriteStartObject();
@@ -872,10 +879,10 @@ namespace FellowOakDicom.Serialization
                         {
                             var val = componentGroupValues[i];
 
-                            if(!string.IsNullOrWhiteSpace(val))
+                            if (!string.IsNullOrWhiteSpace(val))
                             {
                                 stringBuilder.Append(val);
-                                
+
                             }
                             stringBuilder.Append(_personNameComponentGroupDelimiter);
                         }

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -410,71 +410,86 @@ namespace FellowOakDicom.Serialization
             writer.WriteStartObject();
             writer.WritePropertyName("vr");
             writer.WriteValue(item.ValueRepresentation.Code);
-            if (!_autoValidate && (item.ValueRepresentation.Code == DicomVRCode.IS || item.ValueRepresentation.Code == DicomVRCode.DS))
+
+            switch (item.ValueRepresentation.Code)
             {
-                // Always serialize DS, IS as string for best compatibility while autoValidate is False.
-                WriteJsonElement<string>(writer, (DicomElement)item);
+                case "PN":
+                    WriteJsonPersonName(writer, (DicomPersonName)item);
+                    break;
+                case "SQ":
+                    WriteJsonSequence(writer, (DicomSequence)item);
+                    break;
+                case "OB":
+                case "OD":
+                case "OF":
+                case "OL":
+                case "OV":
+                case "OW":
+                case "UN":
+                    WriteJsonOther(writer, (DicomElement)item);
+                    break;
+                case "FL":
+                    WriteJsonElement<float>(writer, (DicomElement)item);
+                    break;
+                case "FD":
+                    WriteJsonElement<double>(writer, (DicomElement)item);
+                    break;
+                case "IS":
+                    WriteJsonIntegerString(writer, (DicomElement)item);
+                    break;
+                case "SL":
+                    WriteJsonElement<int>(writer, (DicomElement)item);
+                    break;
+                case "SS":
+                    WriteJsonElement<short>(writer, (DicomElement)item);
+                    break;
+                case "SV":
+                    WriteJsonElement<long>(writer, (DicomElement)item);
+                    break;
+                case "UL":
+                    WriteJsonElement<uint>(writer, (DicomElement)item);
+                    break;
+                case "US":
+                    WriteJsonElement<ushort>(writer, (DicomElement)item);
+                    break;
+                case "UV":
+                    WriteJsonElement<ulong>(writer, (DicomElement)item);
+                    break;
+                case "DS":
+                    WriteJsonDecimalString(writer, (DicomElement)item);
+                    break;
+                case "AT":
+                    WriteJsonAttributeTag(writer, (DicomElement)item);
+                    break;
+                default:
+                    WriteJsonElement<string>(writer, (DicomElement)item);
+                    break;
             }
-            else
-            {
-                switch (item.ValueRepresentation.Code)
-                {
-                    case "PN":
-                        WriteJsonPersonName(writer, (DicomPersonName)item);
-                        break;
-                    case "SQ":
-                        WriteJsonSequence(writer, (DicomSequence)item);
-                        break;
-                    case "OB":
-                    case "OD":
-                    case "OF":
-                    case "OL":
-                    case "OV":
-                    case "OW":
-                    case "UN":
-                        WriteJsonOther(writer, (DicomElement)item);
-                        break;
-                    case "FL":
-                        WriteJsonElement<float>(writer, (DicomElement)item);
-                        break;
-                    case "FD":
-                        WriteJsonElement<double>(writer, (DicomElement)item);
-                        break;
-                    case "IS":
-                    case "SL":
-                        WriteJsonElement<int>(writer, (DicomElement)item);
-                        break;
-                    case "SS":
-                        WriteJsonElement<short>(writer, (DicomElement)item);
-                        break;
-                    case "SV":
-                        WriteJsonElement<long>(writer, (DicomElement)item);
-                        break;
-                    case "UL":
-                        WriteJsonElement<uint>(writer, (DicomElement)item);
-                        break;
-                    case "US":
-                        WriteJsonElement<ushort>(writer, (DicomElement)item);
-                        break;
-                    case "UV":
-                        WriteJsonElement<ulong>(writer, (DicomElement)item);
-                        break;
-                    case "DS":
-                        WriteJsonDecimalString(writer, (DicomElement)item);
-                        break;
-                    case "AT":
-                        WriteJsonAttributeTag(writer, (DicomElement)item);
-                        break;
-                    default:
-                        WriteJsonElement<string>(writer, (DicomElement)item);
-                        break;
-                }
-            }
+
             writer.WriteEndObject();
         }
 
-        private static void WriteJsonDecimalString(JsonWriter writer, DicomElement elem)
+        private void WriteJsonIntegerString(JsonWriter writer, DicomElement elem)
         {
+            if (!_autoValidate)
+            {
+                // Always serialize IS as string for best compatibility while autoValidate is False.
+                WriteJsonElement<string>(writer, elem);
+            }
+            else
+            {
+                WriteJsonElement<int>(writer, elem);
+            }
+        }
+
+        private void WriteJsonDecimalString(JsonWriter writer, DicomElement elem)
+        {
+            if (!_autoValidate)
+            {
+                // Always serialize IS as string for best compatibility while autoValidate is False.
+                WriteJsonElement<string>(writer, elem);
+                return;
+            }
             if (elem.Count != 0)
             {
                 writer.WritePropertyName("Value");

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -1100,8 +1100,6 @@ namespace FellowOakDicom.Tests.Serialization
         }
 
 
-
-
         [Fact]
         public static void GivenJsonIsInvalid_WhenDeserialization_ThenThrowsDicomValidationException()
         {
@@ -1135,6 +1133,18 @@ namespace FellowOakDicom.Tests.Serialization
             Assert.True(ds.Contains(DicomTag.PatientAge));
         }
 
+
+        [Fact]
+        public static void GivenInvalidValue_WhenAutoValidateIsFalse_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            string invalidDS = "InvalidDS";
+            string invalidIS = "InvalidIS";            
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidDS))));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));            
+            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(autoValidate: false));
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]}}", json);
+        }
 
         #region Sample Data
 

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -53,7 +53,7 @@ namespace FellowOakDicom.Tests.Serialization
             stopWatch.Stop();
 
             var totalElapsedMilliseconds = stopWatch.ElapsedMilliseconds;
-            var millisecondsPerCall = totalElapsedMilliseconds / (double) numCalls;
+            var millisecondsPerCall = totalElapsedMilliseconds / (double)numCalls;
 
             return millisecondsPerCall;
         }
@@ -294,7 +294,7 @@ namespace FellowOakDicom.Tests.Serialization
         {
             var ds = new DicomDataset { ValidateItems = false };
             // have to turn off validation, since we want to add invalid DS values
-            ds.Add( new DicomDecimalString(DicomTag.ImagePositionPatient, new[] { "   001 ", " +13 ", "+000000.0000E+00", "-000000.0000E+00" } ));
+            ds.Add(new DicomDecimalString(DicomTag.ImagePositionPatient, new[] { "   001 ", " +13 ", "+000000.0000E+00", "-000000.0000E+00" }));
             var json = DicomJson.ConvertDicomToJson(ds);
             var obj = JsonDocument.Parse(json);
             var arr = obj.RootElement.GetProperty("00200032").GetProperty("Value").EnumerateArray().ToArray();
@@ -316,7 +316,7 @@ namespace FellowOakDicom.Tests.Serialization
             var ds = new DicomDataset { ValidateItems = false };
             // have to turn off validation, since DicomTag.PatientAge has Value Multiplicity 1, so
             // this dataset cannot be constructed without validation exception
-            ds.Add( new DicomAgeString( DicomTag.PatientAge, new[] { "1Y", "", "3Y" }));
+            ds.Add(new DicomAgeString(DicomTag.PatientAge, new[] { "1Y", "", "3Y" }));
             var json = DicomJson.ConvertDicomToJson(ds);
             var obj = JsonDocument.Parse(json);
             var arr = obj.RootElement.GetProperty("00101010").GetProperty("Value").EnumerateArray().ToArray();
@@ -671,7 +671,7 @@ namespace FellowOakDicom.Tests.Serialization
             var originalDataset = new DicomDataset {
                 { DicomTag.PatientName, value }
             };
-           
+
             var json = DicomJson.ConvertDicomToJson(originalDataset);
 
             Assert.Equal(expectedJson, json);
@@ -1216,6 +1216,17 @@ namespace FellowOakDicom.Tests.Serialization
             VerifyJsonTripleTrip(ds);
         }
 
+        [Fact]
+        public static void GivenInvalidValue_WhenAutoValidateIsFalse_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            string invalidDS = "InvalidDS";
+            string invalidIS = "InvalidIS";
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidDS))));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));
+            var json = DicomJson.ConvertDicomToJson(dataset, autoValidate: false);
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]}}", json);
+        }
 
         #region Sample Data
 


### PR DESCRIPTION
Fixes #1355 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When `autoValidate` is false, write DS or IS value as `string` instead of number

