### PR TITLE
Remove unsupported .NET Core 2.1, add .NET 6 to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,20 +23,6 @@ jobs:
           name: test-v5-net-framework.xml
           path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet462.xml
       
-  v5-net-core-21:
-    runs-on: windows-2019
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build FO-DICOM.Core
-      run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --framework netstandard2.0 --runtime win-x64
-    - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework netcoreapp2.1 --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnetcore21.xml"
-    - name: Upload test results
-      uses: actions/upload-artifact@v2
-      with:
-          name: test-v5-net-core-21.xml
-          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnetcore21.xml
-      
   v5-net-core-31:
     runs-on: windows-2019
     steps:
@@ -53,6 +39,20 @@ jobs:
     - name: Upload code coverage 
       uses: codecov/codecov-action@v2
 
+  v5-net-6:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build FO-DICOM.Core
+      run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --runtime win-x64
+    - name: Test FO-DICOM.Tests
+      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net6 --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet6.xml"
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      with:
+          name: test-v5-net-6.xml
+          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet6.xml
+      
   benchmarks:
     runs-on: windows-2019
     steps:


### PR DESCRIPTION
- .NET Core 2.1 is EOL since 08/2021 and no longer available in CI
- this currently fails the builds

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation n.a.
- [ ] I have included unit tests n.a.
- [ ] I have updated the change log n.a.
- [x] I am listed in the CONTRIBUTORS file
