### PR TITLE
Add 'NumberSerializationMode' option to DICOM to JSON serialization

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,5 +1,5 @@
 #### 5.0.3 (TBD)
-* JsonDicomConverter allows serializing DS/IS dicom item with invalid values when autoValidate is False. (#1354)
+* JsonDicomConverter allows option 'numberSerializationMode' for serializing DS/IS/UV/SV dicom items with (invalid) values. (#1354 & #1362)
 * Breaking change: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)
 * Breaking change: subclasses of DicomServer will have to pass an instance of DicomServerDependencies along to the DicomServer base constructor. This replaces the old NetworkManager / LogManager dependencies. (Implemented in the context of #1291)
 * Added an extension to get a DateTimeOffset respecting the timezone info in the dataset (#1310)

--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,5 +1,5 @@
 #### 5.0.3 (TBD)
-* JsonDicomConverter allows option 'numberSerializationMode' for serializing DS/IS/UV/SV dicom items with (invalid) values. (#1354 & #1362)
+* Added option `numberSerializationMode` to `JsonDicomConverter` that allows different modes for serializing DS/IS/UV/SV DICOM items, including handling of invalid values (#1354 & #1362)
 * Breaking change: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)
 * Breaking change: subclasses of DicomServer will have to pass an instance of DicomServerDependencies along to the DicomServer base constructor. This replaces the old NetworkManager / LogManager dependencies. (Implemented in the context of #1291)
 * Added an extension to get a DateTimeOffset respecting the timezone info in the dataset (#1310)

--- a/Contributors.md
+++ b/Contributors.md
@@ -48,7 +48,7 @@
 * [gustavosaita](https://github.com/gustavosaita)
 * [MikaelBertze](https://github.com/mikaelbertze)
 * [PalminX](https://github.com/PalminX)
-* [Pieter-Jan Van Robays](https://github.com/PieterJanVR)
+* [Pieter-Jan Van Robays](https://github.com/pvrobays)
 * [Alexander Moerman](https://github.com/amoerie)
 * [Harald Köstinger](https://github.com/hkoestin)
 * [Dave Stelpstra](https://github.com/davidsybren)

--- a/FO-DICOM.Core/Serialization/DicomJson.cs
+++ b/FO-DICOM.Core/Serialization/DicomJson.cs
@@ -5,17 +5,20 @@ namespace FellowOakDicom.Serialization
 {
     public static class DicomJson
     {
-
         /// <summary>
         /// Converts a <see cref="DicomDataset"/> to a Json-String.
         /// </summary>
         /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
         /// <param name="formatIndented">Gets or sets a value that defines whether JSON should use pretty printing. By default, JSON is serialized without any extra white space.</param>
-        /// <param name="autoValidate">Whether the content of DicomItems shall be validated when serializing or deserializing. </param>
-        public static string ConvertDicomToJson(DicomDataset dataset, bool writeTagsAsKeywords = false, bool formatIndented = false, bool autoValidate = true)
+        /// <param name="numberSerializationMode">Defines how numbers should be serialized. Default 'AsNumber', will throw errors when a number is not parsable.</param>
+        public static string ConvertDicomToJson(DicomDataset dataset, bool writeTagsAsKeywords = false, bool formatIndented = false,
+            NumberSerializationMode numberSerializationMode = NumberSerializationMode.AsNumber)
         {
             var options = new JsonSerializerOptions();
-            options.Converters.Add(new DicomJsonConverter(writeTagsAsKeywords: writeTagsAsKeywords, autoValidate: autoValidate));
+            options.Converters.Add(new DicomJsonConverter(
+                writeTagsAsKeywords: writeTagsAsKeywords,
+                numberSerializationMode: numberSerializationMode
+            ));
             options.WriteIndented = formatIndented;
             var conv = JsonSerializer.Serialize(dataset, options);
             return conv;

--- a/FO-DICOM.Core/Serialization/DicomJson.cs
+++ b/FO-DICOM.Core/Serialization/DicomJson.cs
@@ -10,7 +10,7 @@ namespace FellowOakDicom.Serialization
         /// </summary>
         /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
         /// <param name="formatIndented">Gets or sets a value that defines whether JSON should use pretty printing. By default, JSON is serialized without any extra white space.</param>
-        /// <param name="numberSerializationMode">Defines how numbers should be serialized. Default 'AsNumber', will throw errors when a number is not parsable.</param>
+        /// <param name="numberSerializationMode">Defines how numbers should be serialized. Defaults to 'AsNumber', which will throw FormatException when a number is not parsable.</param>
         public static string ConvertDicomToJson(DicomDataset dataset, bool writeTagsAsKeywords = false, bool formatIndented = false,
             NumberSerializationMode numberSerializationMode = NumberSerializationMode.AsNumber)
         {

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -90,7 +90,7 @@ namespace FellowOakDicom.Serialization
     {
         /// <summary>
         /// Always serialize DICOM numbers (tags with VR: IS, DS, SV and UV) as JSON numbers.
-        /// ⚠️ This will throw errors when a number can't be parsed!
+        /// ⚠️ This will throw FormatException when a number can't be parsed!
         /// i.e.: "00081160":{"vr":"IS","Value":[76]}
         /// </summary>
         AsNumber,

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -22,6 +22,7 @@ namespace FellowOakDicom.Serialization
     {
         private readonly bool _writeTagsAsKeywords;
         private readonly bool _autoValidate;
+        private readonly NumberSerializationMode _numberSerializationMode;
         private readonly static Encoding[] _jsonTextEncodings = { Encoding.UTF8 };
         private readonly static char _personNameComponentGroupDelimiter = '=';
         private readonly static string[] _personNameComponentGroupNames = { "Alphabetic", "Ideographic", "Phonetic" };
@@ -30,11 +31,13 @@ namespace FellowOakDicom.Serialization
         /// Initialize the JsonDicomConverter.
         /// </summary>
         /// <param name="writeTagsAsKeywords">Whether to write the json keys as DICOM keywords instead of tags. This makes the json non-compliant to DICOM JSON.</param>
-        /// <param name="autoValidate">Whether the content of DicomItems shall be validated as soon as they are added to the DicomDataset.</param>
-        public JsonDicomConverter(bool writeTagsAsKeywords = false, bool autoValidate = true)
+        /// <param name="autoValidate">Whether the content of DicomItems shall be validated when deserializing.</param>
+        /// <param name="numberSerializationMode">Defines how numbers should be serialized. Default 'AsNumber', will throw errors when a number is not parsable.</param>
+        public JsonDicomConverter(bool writeTagsAsKeywords = false, bool autoValidate = true, NumberSerializationMode numberSerializationMode = NumberSerializationMode.AsNumber)
         {
             _writeTagsAsKeywords = writeTagsAsKeywords;
             _autoValidate = autoValidate;
+            _numberSerializationMode = numberSerializationMode;
         }
 
         #region JsonConverter overrides
@@ -435,7 +438,8 @@ namespace FellowOakDicom.Serialization
                     WriteJsonElement<double>(writer, (DicomElement)item);
                     break;
                 case "IS":
-                    WriteJsonIntegerString(writer, (DicomElement)item);
+                    WriteJsonAsNumberOrString(writer, (DicomElement)item, () =>
+                        WriteJsonElement<int>(writer, (DicomElement)item));
                     break;
                 case "SL":
                     WriteJsonElement<int>(writer, (DicomElement)item);
@@ -444,7 +448,8 @@ namespace FellowOakDicom.Serialization
                     WriteJsonElement<short>(writer, (DicomElement)item);
                     break;
                 case "SV":
-                    WriteJsonElement<long>(writer, (DicomElement)item);
+                    WriteJsonAsNumberOrString(writer, (DicomElement)item, () =>
+                        WriteJsonElement<long>(writer, (DicomElement)item));
                     break;
                 case "UL":
                     WriteJsonElement<uint>(writer, (DicomElement)item);
@@ -453,10 +458,12 @@ namespace FellowOakDicom.Serialization
                     WriteJsonElement<ushort>(writer, (DicomElement)item);
                     break;
                 case "UV":
-                    WriteJsonElement<ulong>(writer, (DicomElement)item);
+                    WriteJsonAsNumberOrString(writer, (DicomElement)item, () =>
+                        WriteJsonElement<ulong>(writer, (DicomElement)item));
                     break;
                 case "DS":
-                    WriteJsonDecimalString(writer, (DicomElement)item);
+                    WriteJsonAsNumberOrString(writer, (DicomElement)item, () =>
+                        WriteJsonDecimalString(writer, (DicomElement)item));
                     break;
                 case "AT":
                     WriteJsonAttributeTag(writer, (DicomElement)item);
@@ -469,63 +476,78 @@ namespace FellowOakDicom.Serialization
             writer.WriteEndObject();
         }
 
-        private void WriteJsonIntegerString(JsonWriter writer, DicomElement elem)
+        private void WriteJsonAsNumberOrString(JsonWriter writer, DicomElement elem, Action numberWriterAction)
         {
-            if (!_autoValidate)
+            if (_numberSerializationMode == NumberSerializationMode.AsString)
             {
-                // Always serialize IS as string for best compatibility while autoValidate is False.
                 WriteJsonElement<string>(writer, elem);
             }
             else
             {
-                WriteJsonElement<int>(writer, elem);
+                try
+                {
+                    numberWriterAction();
+                }
+                catch (FormatException)
+                {
+                    if (_numberSerializationMode == NumberSerializationMode.PreferablyAsNumber)
+                    {
+                        WriteJsonElement<string>(writer, elem);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
             }
         }
 
         private void WriteJsonDecimalString(JsonWriter writer, DicomElement elem)
         {
-            if (!_autoValidate)
+            if (elem.Count == 0) return;
+
+            var writerActions = new List<Action>
             {
-                // Always serialize IS as string for best compatibility while autoValidate is False.
-                WriteJsonElement<string>(writer, elem);
-                return;
-            }
-            if (elem.Count != 0)
+                () => writer.WritePropertyName("Value"),
+                writer.WriteStartArray
+            };
+
+            foreach (var val in elem.Get<string[]>())
             {
-                writer.WritePropertyName("Value");
-                writer.WriteStartArray();
-                foreach (var val in elem.Get<string[]>())
+                if (string.IsNullOrEmpty(val))
                 {
-                    if (string.IsNullOrEmpty(val))
+                    writerActions.Add(writer.WriteNull);
+                }
+                else
+                {
+                    var fix = FixDecimalString(val);
+                    if (ulong.TryParse(fix, NumberStyles.Integer, CultureInfo.InvariantCulture, out ulong xulong))
                     {
-                        writer.WriteNull();
+                        writerActions.Add(() => writer.WriteValue(xulong));
+                    }
+                    else if (long.TryParse(fix, NumberStyles.Integer, CultureInfo.InvariantCulture, out long xlong))
+                    {
+                        writerActions.Add(() => writer.WriteValue(xlong));
+                    }
+                    else if (decimal.TryParse(fix, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal xdecimal))
+                    {
+                        writerActions.Add(() => writer.WriteValue(xdecimal));
+                    }
+                    else if (double.TryParse(fix, NumberStyles.Float, CultureInfo.InvariantCulture, out double xdouble))
+                    {
+                        writerActions.Add(() => writer.WriteValue(xdouble));
                     }
                     else
                     {
-                        var fix = FixDecimalString(val);
-                        if (ulong.TryParse(fix, NumberStyles.Integer, CultureInfo.InvariantCulture, out ulong xulong))
-                        {
-                            writer.WriteValue(xulong);
-                        }
-                        else if (long.TryParse(fix, NumberStyles.Integer, CultureInfo.InvariantCulture, out long xlong))
-                        {
-                            writer.WriteValue(xlong);
-                        }
-                        else if (decimal.TryParse(fix, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal xdecimal))
-                        {
-                            writer.WriteValue(xdecimal);
-                        }
-                        else if (double.TryParse(fix, NumberStyles.Float, CultureInfo.InvariantCulture, out double xdouble))
-                        {
-                            writer.WriteValue(xdouble);
-                        }
-                        else
-                        {
-                            throw new FormatException($"Cannot write dicom number {val} to json");
-                        }
+                        throw new FormatException($"Cannot write dicom number {val} to json");
                     }
                 }
-                writer.WriteEndArray();
+            }
+            writerActions.Add(writer.WriteEndArray);
+
+            foreach (var action in writerActions)
+            {
+                action();
             }
         }
 
@@ -596,16 +618,17 @@ namespace FellowOakDicom.Serialization
                 return val;
             }
 
-            throw new ArgumentException("Failed converting DS value to json");
+            throw new FormatException("Failed converting DS value to json");
         }
 
         private static void WriteJsonElement<T>(JsonWriter writer, DicomElement elem)
         {
             if (elem.Count != 0)
             {
+                var values = elem.Get<T[]>();
                 writer.WritePropertyName("Value");
                 writer.WriteStartArray();
-                foreach (var val in elem.Get<T[]>())
+                foreach (var val in values)
                 {
                     if (val == null || (typeof(T) == typeof(string) && val.Equals("")))
                     {

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -1133,23 +1133,121 @@ namespace FellowOakDicom.Tests.Serialization
             Assert.True(ds.Contains(DicomTag.PatientAge));
         }
 
-
         [Fact]
-        public static void GivenInvalidValue_WhenAutoValidateIsFalse_ThenDeserializationShouldSucceed()
+        public static void GivenInvalidValue_WhenNumberSerializationModeAsString_ThenDeserializationShouldSucceed()
         {
             var dataset = new DicomDataset().NotValidated();
-            string invalidDS = "InvalidDS";
-            string invalidIS = "InvalidIS";            
+            const string invalidDS = "InvalidDS";
+            const string invalidIS = "InvalidIS";
             dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidDS))));
-            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));            
-            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(autoValidate: false));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));
+            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsString));
             Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]}}", json);
+        }
+
+        [Fact]
+        public static void GivenInvalidValue_WhenNumberSerializationModePreferablyAsNumber_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string invalidDS = "InvalidDS";
+            const string invalidIS = "InvalidIS";
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidDS))));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));
+            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.PreferablyAsNumber));
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]}}", json);
+        }
+
+        [Fact]
+        public static void GivenInvalidValueForDS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidNumber))));
+            Assert.Throws<FormatException>(() => JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsNumber)));
+        }
+
+        [Fact]
+        public static void GivenInvalidValueForIS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidNumber))));
+            Assert.Throws<FormatException>(() => JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsNumber)));
+        }
+
+        [Fact]
+        public static void GivenValidValue_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset();
+            const decimal validDS = 3.1415926535m;
+            const int validIS = 299792458;
+            const long validSV = 9223372036854775800;
+            const ulong validUV = 18446744073709551600;
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, validDS));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validIS));
+            dataset.Add(new DicomSignedVeryLong(DicomTag.SelectorSVValue, validSV));
+            dataset.Add(new DicomUnsignedVeryLong(DicomTag.SelectorUVValue, validUV));
+            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsNumber));
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[299792458]},\"00101020\":{\"vr\":\"DS\",\"Value\":[3.1415926535]},\"00720082\":{\"vr\":\"SV\",\"Value\":[9223372036854775800]},\"00720083\":{\"vr\":\"UV\",\"Value\":[18446744073709551600]}}", json);
+        }
+
+        [Fact]
+        public static void GivenValidValue_WhenNumberSerializationModePreferablyAsNumber_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset();
+            const decimal validDS = 3.1415926535m;
+            const int validIS = 299792458;
+            const long validSV = 9223372036854775800;
+            const ulong validUV = 18446744073709551600;
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, validDS));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validIS));
+            dataset.Add(new DicomSignedVeryLong(DicomTag.SelectorSVValue, validSV));
+            dataset.Add(new DicomUnsignedVeryLong(DicomTag.SelectorUVValue, validUV));
+            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.PreferablyAsNumber));
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[299792458]},\"00101020\":{\"vr\":\"DS\",\"Value\":[3.1415926535]},\"00720082\":{\"vr\":\"SV\",\"Value\":[9223372036854775800]},\"00720083\":{\"vr\":\"UV\",\"Value\":[18446744073709551600]}}", json);
+        }
+
+        [Fact]
+        public static void GivenValidValue_WhenNumberSerializationModeAsString_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset();
+            const decimal validDS = 3.1415926535m;
+            const int validIS = 299792458;
+            const long validSV = 9223372036854775800;
+            const ulong validUV = 18446744073709551600;
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, validDS));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validIS));
+            dataset.Add(new DicomSignedVeryLong(DicomTag.SelectorSVValue, validSV));
+            dataset.Add(new DicomUnsignedVeryLong(DicomTag.SelectorUVValue, validUV));
+            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsString));
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"299792458\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"3.1415926535\"]},\"00720082\":{\"vr\":\"SV\",\"Value\":[\"9223372036854775800\"]},\"00720083\":{\"vr\":\"UV\",\"Value\":[\"18446744073709551600\"]}}", json);
+        }
+
+        [Fact]
+        public static void GivenArrayWithValidAndInvalidValuesForIS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string validNumber = "299792458";
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validNumber, invalidNumber));
+            Assert.Throws<FormatException>(() => JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsNumber)));
+        }
+
+        [Fact]
+        public static void GivenArrayWithValidAndInvalidValuesForIS_WhenNumberSerializationModePreferablyAsNumber_ThenDeserializationShouldSucceedAndAllValuesShouldBeStrings()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string validNumber = "299792458";
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validNumber, invalidNumber));
+            var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.PreferablyAsNumber));
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"299792458\",\"InvalidNumber\"]}}", json);
         }
 
         #region Sample Data
 
         private string _jsonExampleFromDicomNemaOrg = @"
-// The following example is a QIDO-RS SearchForStudies response consisting 
+// The following example is a QIDO-RS SearchForStudies response consisting
 // of two matching studies, corresponding to the example QIDO-RS request:
 // GET http://qido.nema.org/studies?PatientID=12345&includefield=all&limit=2
 [
@@ -1300,7 +1398,7 @@ namespace FellowOakDicom.Tests.Serialization
             ""vr"": ""PN"",
             ""Value"": [
               {
-                ""Alphabetic"": ""^Bob^^Dr."" 
+                ""Alphabetic"": ""^Bob^^Dr.""
               }
             ]
         },
@@ -1321,7 +1419,7 @@ namespace FellowOakDicom.Tests.Serialization
             ""Value"": [
               {
                 ""Alphabetic"": ""Wang^XiaoDong"",
-                ""Ideographic"": ""王^小東"" 
+                ""Ideographic"": ""王^小東""
               }
             ]
         },

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -1217,20 +1217,120 @@ namespace FellowOakDicom.Tests.Serialization
         }
 
         [Fact]
-        public static void GivenInvalidValue_WhenAutoValidateIsFalse_ThenDeserializationShouldSucceed()
+        public static void GivenInvalidValue_WhenNumberSerializationModeAsString_ThenDeserializationShouldSucceed()
         {
             var dataset = new DicomDataset().NotValidated();
-            string invalidDS = "InvalidDS";
-            string invalidIS = "InvalidIS";
+            const string invalidDS = "InvalidDS";
+            const string invalidIS = "InvalidIS";
             dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidDS))));
             dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));
-            var json = DicomJson.ConvertDicomToJson(dataset, autoValidate: false);
+            var json = DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.AsString);
             Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]}}", json);
         }
 
+        [Fact]
+        public static void GivenInvalidValue_WhenNumberSerializationModePreferablyAsNumber_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string invalidDS = "InvalidDS";
+            const string invalidIS = "InvalidIS";
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidDS))));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));
+            var json = DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.PreferablyAsNumber);
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]}}", json);
+        }
+
+        [Fact]
+        public static void GivenInvalidValueForDS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidNumber))));
+            Assert.Throws<FormatException>(() => DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.AsNumber));
+        }
+
+        [Fact]
+        public static void GivenInvalidValueForIS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidNumber))));
+            Assert.Throws<FormatException>(() => DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.AsNumber));
+        }
+
+        [Fact]
+        public static void GivenValidValue_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset();
+            const decimal validDS = 3.1415926535m;
+            const int validIS = 299792458;
+            const long validSV = 9223372036854775800;
+            const ulong validUV = 18446744073709551600;
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, validDS));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validIS));
+            dataset.Add(new DicomSignedVeryLong(DicomTag.SelectorSVValue, validSV));
+            dataset.Add(new DicomUnsignedVeryLong(DicomTag.SelectorUVValue, validUV));
+            var json = DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.AsNumber);
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[299792458]},\"00101020\":{\"vr\":\"DS\",\"Value\":[3.1415926535]},\"00720082\":{\"vr\":\"SV\",\"Value\":[9223372036854775800]},\"00720083\":{\"vr\":\"UV\",\"Value\":[18446744073709551600]}}", json);
+        }
+
+        [Fact]
+        public static void GivenValidValue_WhenNumberSerializationModePreferablyAsNumber_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset();
+            const decimal validDS = 3.1415926535m;
+            const int validIS = 299792458;
+            const long validSV = 9223372036854775800;
+            const ulong validUV = 18446744073709551600;
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, validDS));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validIS));
+            dataset.Add(new DicomSignedVeryLong(DicomTag.SelectorSVValue, validSV));
+            dataset.Add(new DicomUnsignedVeryLong(DicomTag.SelectorUVValue, validUV));
+            var json = DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.PreferablyAsNumber);
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[299792458]},\"00101020\":{\"vr\":\"DS\",\"Value\":[3.1415926535]},\"00720082\":{\"vr\":\"SV\",\"Value\":[9223372036854775800]},\"00720083\":{\"vr\":\"UV\",\"Value\":[18446744073709551600]}}", json);
+        }
+
+        [Fact]
+        public static void GivenValidValue_WhenNumberSerializationModeAsString_ThenDeserializationShouldSucceed()
+        {
+            var dataset = new DicomDataset();
+            const decimal validDS = 3.1415926535m;
+            const int validIS = 299792458;
+            const long validSV = 9223372036854775800;
+            const ulong validUV = 18446744073709551600;
+            dataset.Add(new DicomDecimalString(DicomTag.PatientSize, validDS));
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validIS));
+            dataset.Add(new DicomSignedVeryLong(DicomTag.SelectorSVValue, validSV));
+            dataset.Add(new DicomUnsignedVeryLong(DicomTag.SelectorUVValue, validUV));
+            var json = DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.AsString);
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"299792458\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"3.1415926535\"]},\"00720082\":{\"vr\":\"SV\",\"Value\":[\"9223372036854775800\"]},\"00720083\":{\"vr\":\"UV\",\"Value\":[\"18446744073709551600\"]}}", json);
+        }
+
+        [Fact]
+        public static void GivenArrayWithValidAndInvalidValuesForIS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string validNumber = "299792458";
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validNumber, invalidNumber));
+            Assert.Throws<FormatException>(() => DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.AsNumber));
+        }
+
+        [Fact]
+        public static void GivenArrayWithValidAndInvalidValuesForIS_WhenNumberSerializationModePreferablyAsNumber_ThenDeserializationShouldSucceedAndAllValuesShouldBeStrings()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string validNumber = "299792458";
+            const string invalidNumber = "InvalidNumber";
+            dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, validNumber, invalidNumber));
+            var json = DicomJson.ConvertDicomToJson(dataset, numberSerializationMode: NumberSerializationMode.PreferablyAsNumber);
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"299792458\",\"InvalidNumber\"]}}", json);
+        }
+
+
         #region Sample Data
 
-        // The following example is a QIDO-RS SearchForStudies response consisting 
+        // The following example is a QIDO-RS SearchForStudies response consisting
         // of two matching studies, corresponding to the example QIDO-RS request:
         // GET http://qido.nema.org/studies?PatientID=12345&includefield=all&limit=2
         private readonly string _jsonExampleFromDicomNemaOrg = @"
@@ -1382,7 +1482,7 @@ namespace FellowOakDicom.Tests.Serialization
             ""vr"": ""PN"",
             ""Value"": [
               {
-                ""Alphabetic"": ""^Bob^^Dr."" 
+                ""Alphabetic"": ""^Bob^^Dr.""
               }
             ]
         },
@@ -1403,7 +1503,7 @@ namespace FellowOakDicom.Tests.Serialization
             ""Value"": [
               {
                 ""Alphabetic"": ""Wang^XiaoDong"",
-                ""Ideographic"": ""王^小東"" 
+                ""Ideographic"": ""王^小東""
               }
             ]
         },


### PR DESCRIPTION
Add 'NumberSerializationMode' option to DICOM to JSON serialization

Fixes #1362 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation (no API documentation found about JSON (de)serialization)
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Remove autoValidate from JSON serialization
- Add 'NumberSerializationMode' option to DICOM to JSON serialization
- Use actions in JsonDicomConverter to avoid appending to JsonWriter while future code might throw exceptions

In case you chose for 'PreferablyAsNumber' and there are multiple values within a tag (IS/DS) with at least one of them which an invalid number, then we'll serialize all of them as a string. This seemed like the best solution to me.

As `WriteJsonDecimalString` might throw an exception, I've wrapped all JSON writer calls into a list of actions which get triggered at the end (once we're sure no exception will be thrown). Not sure if I'm completely satisfied with this though. Proposals with a better solution are welcome.