### PR TITLE
Update index.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -78,3 +78,4 @@
 * [Don Ch](https://github.com/lydonchandra)
 * [Björn Lundmark](https://github.com/bjorn-malmo)
 * [Josiah Vinson](https://github.com/jovinson-ms)
+* [James A Sutherland](https://github.com/jas88)

--- a/Documentation/v5/index.md
+++ b/Documentation/v5/index.md
@@ -27,7 +27,7 @@ Package | Description
 ------- | -----------
 [fo-dicom](https://www.nuget.org/packages/fo-dicom/) | Core package containing parser, services and tools
 [fo-dicom.Imaging.Desktop](https://www.nuget.org/packages/fo-dicom.Imaging.Desktop/) | Library with referencte to System.Drawing, required for rendering into Bitmaps
-[fo-dicom.Imaging.ImageSharp](https://www.nuget.org/packages/fo-dicom.Desktop/) | Library with reference to ImageSharp, can be used for platform independent rendering
+[fo-dicom.Imaging.ImageSharp](https://www.nuget.org/packages/fo-dicom.Imaging.ImageSharp/) | Library with reference to ImageSharp, can be used for platform independent rendering
 [fo-dicom.NLog](https://www.nuget.org/packages/fo-dicom.NLog/) | .NET connector to enable `fo-dicom` logging with NLog
 [fo-dicom.Codecs](https://www.nuget.org/packages/fo-dicom.Codecs/) | Cross-platform DICOM codecs for `fo-dicom`, developed by [Efferent Health] (https://github.com/Efferent-Health/fo-dicom.Codecs)
 


### PR DESCRIPTION
Correct URL for fo-dicom.Imaging.ImageSharp (current link erroneously points to fo-dicom.Desktop instead)

Trivial doc fix, does it merit Contributors inclusion?

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-
-
-
