### PR TITLE
When a timeout occurs while sending the P-DATA-TF chunks of C-STORE requests, the DICOM association should no longer be used for further sending

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,5 +1,7 @@
 #### 5.0.4 (TBD)
 * Fix reading of DICOM files with extra tags in File Meta Information (#1376)
+* Fix sending more DICOM requests over an existing association where a request previously timed out (#1396)
+* Improve throughput of DicomClient when more requests are added mid-flight (#1396)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociation.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociation.cs
@@ -16,18 +16,18 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
     /// <summary>
     /// Represents an open DICOM association.
     /// </summary>
-    public interface IAdvancedDicomClientAssociation: IDisposable
+    public interface IAdvancedDicomClientAssociation : IDisposable
     {
         /// <summary>
         /// Contains information about the DICOM association that was opened
         /// </summary>
         DicomAssociation Association { get; }
-        
+
         /// <summary>
         /// Whether or not this association is already disposed.
         /// </summary>
         bool IsDisposed { get; }
-        
+
         /// <summary>
         /// Sends a request over this association and returns the received responses from the other AE
         /// There is no guarantee that the message will be sent immediately.
@@ -81,12 +81,12 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
         private readonly ConcurrentDictionary<int, Channel<IAdvancedDicomClientConnectionEvent>> _requestChannels;
         private readonly Channel<IAdvancedDicomClientConnectionEvent> _associationChannel;
         private readonly IAdvancedDicomClientConnection _connection;
-        
+
         private long _isDisposed;
         private ConnectionClosedEvent _connectionClosedEvent;
-        
+
         public bool IsDisposed => Interlocked.Read(ref _isDisposed) > 0;
-        
+
         /// <inheritdoc cref="IAdvancedDicomClientAssociation.Association"/>
         public DicomAssociation Association { get; }
 
@@ -109,7 +109,7 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
 
             Association = association ?? throw new ArgumentNullException(nameof(association));
         }
-        
+
         /// <summary>
         /// The finalizer will be called when this instance is not disposed properly.
         /// </summary>
@@ -270,21 +270,21 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
                         break;
                     }
                 }
-            }        
+            }
         }
-        
+
         /// <inheritdoc cref="IAdvancedDicomClientAssociation.SendRequestAsync"/>
-        public async IAsyncEnumerable<DicomResponse> SendRequestAsync(DicomRequest dicomRequest, [EnumeratorCancellation] CancellationToken cancellationToken) 
+        public async IAsyncEnumerable<DicomResponse> SendRequestAsync(DicomRequest dicomRequest, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             if (dicomRequest == null)
             {
                 throw new ArgumentNullException(nameof(dicomRequest));
             }
-            
+
             ThrowIfAlreadyDisposed();
 
             cancellationToken.ThrowIfCancellationRequested();
-            
+
             var requestChannel = Channel.CreateUnbounded<IAdvancedDicomClientConnectionEvent>(new UnboundedChannelOptions
             {
                 SingleReader = true,
@@ -293,11 +293,12 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
             });
 
             var messageId = dicomRequest.MessageID;
-            
+
             if (!_requestChannels.TryAdd(messageId, requestChannel))
             {
                 throw new DicomNetworkException($"This DICOM request is already being sent: [{messageId}] {dicomRequest.GetType()}");
             }
+
             try
             {
                 ThrowIfAlreadyDisconnected();
@@ -354,12 +355,12 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
             }
             finally
             {
-                if(!_requestChannels.TryRemove(messageId, out _))
+                if (!_requestChannels.TryRemove(messageId, out _))
                 {
                     throw new DicomNetworkException($"The response channel {dicomRequest} has already been cleaned up, this should never happen");
                 }
             }
-            
+
             ThrowIfAlreadyDisposed();
         }
 
@@ -436,7 +437,7 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
         }
 
         private bool IsDisconnected => Interlocked.CompareExchange(ref _connectionClosedEvent, null, null) != null;
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ThrowIfAlreadyDisconnected()
         {
@@ -472,7 +473,7 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
             {
                 return;
             }
-            
+
             // Ensure the association event collector stops running
             _eventCollectorCts.Cancel();
             _eventCollectorCts.Dispose();

--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -325,15 +325,18 @@ namespace FellowOakDicom.Network.Client
 
                         SetState(DicomClientRequestAssociationState.Instance);
 
-                        var requests = new List<DicomRequest>();
-                        requests.AddRange(requestsToRetry);
+                        var requestsToSend = new Queue<DicomRequest>();
+                        foreach (var request in requestsToRetry)
+                        {
+                            requestsToSend.Enqueue(request);
+                        }
                         requestsToRetry.Clear();
-                        var numberOfRequests = requests.Count;
+                        var numberOfRequests = requestsToSend.Count;
 
                         while (numberOfRequests < maximumNumberOfRequestsPerAssociation
                                && QueuedRequests.TryDequeue(out var request))
                         {
-                            requests.Add(request.Value);
+                            requestsToSend.Enqueue(request.Value);
                             numberOfRequests++;
                         }
                         
@@ -347,7 +350,7 @@ namespace FellowOakDicom.Network.Client
                             MaxAsyncOpsPerformed = AsyncPerformed,
                         };
 
-                        foreach (var request in requests)
+                        foreach (var request in requestsToSend)
                         {
                             associationRequest.PresentationContexts.AddFromRequest(request);
                             associationRequest.ExtendedNegotiations.AddFromRequest(request);
@@ -407,7 +410,7 @@ namespace FellowOakDicom.Network.Client
                                 }
 
                                 // Save the requests to retry, otherwise they are lost because we already extracted them from QueuedRequests
-                                requestsToRetry.AddRange(requests);
+                                requestsToRetry.AddRange(requestsToSend);
 
                                 // try again
                                 continue;
@@ -416,43 +419,88 @@ namespace FellowOakDicom.Network.Client
 
                         AssociationAccepted?.Invoke(this, new AssociationAcceptedEventArgs(association.Association));
 
-                        while (requests.Count > 0 && exception == null)
+                        while (requestsToSend.Count > 0 && exception == null)
                         {
                             cancellationToken.ThrowIfCancellationRequested();
 
-                            SetState(DicomClientSendingRequestsState.Instance);
-
-                            _logger.Debug("Queueing {NumberOfRequests} requests", requests.Count);
-                            var sendTasks = new List<Task>(requests.Count);
-                            
-                            // Try to send all tasks immediately, this could work depending on the nr of requests and the async ops invoked setting
-                            foreach(var request in requests)
+                            if (!connection.CanStillProcessPDataTF)
                             {
-                                sendTasks.Add(SendRequestAsync(association, request, cancellationToken));
+                                _logger.Debug($"The current association can no longer accept P-DATA-TF messages, a new association will have to be created for the remaining requests");
+                                requestsToRetry.AddRange(requestsToSend);
+                                break;
                             }
 
-                            // Now wait for the requests to complete
-                            await Task.WhenAll(sendTasks).ConfigureAwait(false);
-                            
-                            requests.Clear();
+                            SetState(DicomClientSendingRequestsState.Instance);
 
-                            // If more requests were queued since we started, try to send those too over the same association
-                            while (numberOfRequests < maximumNumberOfRequestsPerAssociation
-                                   && QueuedRequests.TryDequeue(out var request))
+                            /*
+                             * Now we will send the DICOM requests
+                             * Depending on the agreed upon AsyncInvoked setting, we can have x outstanding DICOM requests
+                             * This means we can immediately send x DICOM requests in parallel
+                             * Then, whenever one of the parallel DICOM requests complete, we can send another DICOM request
+                             * Furthermore, after each DICOM request completes, we also check if more requests were queued into this DICOM client
+                             * This should result in a maximum throughput of DICOM requests, always utilizing the maximum of async invoked requests
+                             */
+                            _logger.Debug("Sending {NumberOfRequests} requests", requestsToSend.Count);
+                            var maximumNumberOfParallelRequests = association.Association.MaxAsyncOpsInvoked;
+                            var parallelRequests = new List<Task>(maximumNumberOfParallelRequests);
+                            while (parallelRequests.Count < maximumNumberOfParallelRequests
+                                   && requestsToSend.Count > 0
+                                   && connection.CanStillProcessPDataTF)
+                            {
+                                var nextRequest = requestsToSend.Dequeue();
+                                parallelRequests.Add(SendRequestAsync(association, nextRequest, cancellationToken));
+                                // Wait until the request is fully sent
+                                try
+                                {
+                                    await nextRequest.AllPDUsSent.ConfigureAwait(false);
+                                }
+                                catch (Exception)
+                                {
+                                    // Ignored
+                                }
+                            }
+                            
+                            while (parallelRequests.Count > 0)
                             {
                                 cancellationToken.ThrowIfCancellationRequested();
 
-                                requests.Add(request.Value);
+                                var finishedRequest = await Task.WhenAny(parallelRequests).ConfigureAwait(false);
+                                await finishedRequest.ConfigureAwait(false);
+                                parallelRequests.Remove(finishedRequest);
+                                
+                                // Check if more requests were queued in the meantime that we could possibly also send over the current association
+                                while (numberOfRequests < maximumNumberOfRequestsPerAssociation
+                                       && connection.CanStillProcessPDataTF
+                                       && QueuedRequests.TryDequeue(out var request))
+                                {
+                                    requestsToSend.Enqueue(request.Value);
 
-                                numberOfRequests++;
+                                    numberOfRequests++;
+                                }
+
+                                if (requestsToSend.Count > 0 && connection.CanStillProcessPDataTF)
+                                {
+                                    var nextRequest = requestsToSend.Dequeue();
+                                    parallelRequests.Add(SendRequestAsync(association, nextRequest, cancellationToken));
+                                    // Wait until the request is fully sent
+                                    try
+                                    {
+                                        await nextRequest.AllPDUsSent.ConfigureAwait(false);
+                                    }
+                                    catch (Exception)
+                                    {
+                                        // Ignored
+                                    }
+                                }
                             }
-
+                            
                             _hasMoreRequests.Reset();
                             
                             // Linger behavior: if the queue is empty, wait for a bit before closing the association
-                            if (requests.Count == 0
+                            if (requestsToSend.Count == 0
                                 && numberOfRequests < maximumNumberOfRequestsPerAssociation
-                                && ClientOptions.AssociationLingerTimeoutInMs > 0)
+                                && ClientOptions.AssociationLingerTimeoutInMs > 0
+                                && connection.CanStillProcessPDataTF)
                             {
                                 _logger.Debug($"Lingering on open association for {ClientOptions.AssociationLingerTimeoutInMs}ms");
 
@@ -469,7 +517,7 @@ namespace FellowOakDicom.Network.Client
                                 {
                                     cancellationToken.ThrowIfCancellationRequested();
 
-                                    requests.Add(request.Value);
+                                    requestsToSend.Enqueue(request.Value);
 
                                     numberOfRequests++;
                                 }
@@ -561,7 +609,7 @@ namespace FellowOakDicom.Network.Client
                 throw new ArgumentNullException(nameof(request));
             }
             
-            _logger.Debug("{Request} is being enqueued for sending", request.ToString());
+            _logger.Debug("{Request} is being sent", request.ToString());
 
             try
             {

--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -448,16 +448,10 @@ namespace FellowOakDicom.Network.Client
                                    && connection.CanStillProcessPDataTF)
                             {
                                 var nextRequest = requestsToSend.Dequeue();
-                                parallelRequests.Add(SendRequestAsync(association, nextRequest, cancellationToken));
-                                // Wait until the request is fully sent
-                                try
-                                {
-                                    await nextRequest.AllPDUsSent.ConfigureAwait(false);
-                                }
-                                catch (Exception)
-                                {
-                                    // Ignored
-                                }
+                                var sendTask = SendRequestAsync(association, nextRequest, cancellationToken);
+                                parallelRequests.Add(sendTask);
+                                // Wait until the request is fully sent or until the request completes with an error or cancellation
+                                await Task.WhenAny(nextRequest.AllPDUsSent, sendTask).ConfigureAwait(false);
                             }
                             
                             while (parallelRequests.Count > 0)
@@ -481,16 +475,10 @@ namespace FellowOakDicom.Network.Client
                                 if (requestsToSend.Count > 0 && connection.CanStillProcessPDataTF)
                                 {
                                     var nextRequest = requestsToSend.Dequeue();
-                                    parallelRequests.Add(SendRequestAsync(association, nextRequest, cancellationToken));
-                                    // Wait until the request is fully sent
-                                    try
-                                    {
-                                        await nextRequest.AllPDUsSent.ConfigureAwait(false);
-                                    }
-                                    catch (Exception)
-                                    {
-                                        // Ignored
-                                    }
+                                    var sendTask = SendRequestAsync(association, nextRequest, cancellationToken);
+                                    parallelRequests.Add(sendTask);
+                                    // Wait until the request is fully sent or until the request completes with an error or cancellation
+                                    await Task.WhenAny(nextRequest.AllPDUsSent, sendTask).ConfigureAwait(false);
                                 }
                             }
                             

--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -325,11 +325,7 @@ namespace FellowOakDicom.Network.Client
 
                         SetState(DicomClientRequestAssociationState.Instance);
 
-                        var requestsToSend = new Queue<DicomRequest>();
-                        foreach (var request in requestsToRetry)
-                        {
-                            requestsToSend.Enqueue(request);
-                        }
+                        var requestsToSend = new Queue<DicomRequest>(requestsToRetry);
                         requestsToRetry.Clear();
                         var numberOfRequests = requestsToSend.Count;
 

--- a/FO-DICOM.Core/Network/Client/DicomClientConnection.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientConnection.cs
@@ -22,6 +22,13 @@ namespace FellowOakDicom.Network.Client
         /// Gets whether or not SendNextMessage is required, i.e. if any requests still have to be sent and there is no send loop currently running.
         /// </summary>
         bool IsSendNextMessageRequired { get; }
+        
+        /// <summary>
+        /// Gets whether or not the connection can still process P-DATA-TF
+        /// This can be false when a previous P-DATA-TF timed out before it was sent completely
+        /// In this scenario, the connection can only be used for control PDUs anymore
+        /// </summary>
+        bool CanStillProcessPDataTF { get; }
 
         /// <summary>
         /// Gets whether or not the send queue is empty, i.e. if all requests are sent *and* handled

--- a/FO-DICOM.Core/Network/DicomAssociation.cs
+++ b/FO-DICOM.Core/Network/DicomAssociation.cs
@@ -170,5 +170,47 @@ namespace FellowOakDicom.Network
             sb.Length -= 1;
             return sb.ToString();
         }
+        
+        /// <summary>
+        /// Creates a snapshot clone of this DICOM association.
+        /// This can be helpful when trying to diagnose association issues, because DicomAssociations are typically modified during the DICOM handshake
+        /// </summary>
+        /// <returns></returns>
+        internal DicomAssociation Clone()
+        {
+            var clone = new DicomAssociation(CallingAE, CalledAE)
+            {
+                Options = Options,
+                RemoteHost = RemoteHost,
+                RemotePort = RemotePort,
+                MaxAsyncOpsInvoked = MaxAsyncOpsInvoked,
+                MaxAsyncOpsPerformed = MaxAsyncOpsPerformed,
+                RemoteImplementationVersion = RemoteImplementationVersion,
+                RemoteImplementationClassUID = RemoteImplementationClassUID,
+                MaximumPDULength = MaximumPDULength
+            };
+
+            foreach (var presentationContext in PresentationContexts)
+            {
+                clone.PresentationContexts.Add(
+                    presentationContext.AbstractSyntax,
+                    presentationContext.UserRole,
+                    presentationContext.ProviderRole,
+                    presentationContext.GetTransferSyntaxes().ToArray()
+                );
+            }
+
+            foreach (var extendedNegotiation in ExtendedNegotiations)
+            {
+                clone.ExtendedNegotiations.Add(
+                    extendedNegotiation.SopClassUid,
+                    extendedNegotiation.RequestedApplicationInfo,
+                    extendedNegotiation.ServiceClassUid,
+                    extendedNegotiation.RelatedGeneralSopClasses.ToArray()
+                );
+            }
+
+            return clone;
+        }
     }
 }

--- a/FO-DICOM.Core/Network/DicomMessage.cs
+++ b/FO-DICOM.Core/Network/DicomMessage.cs
@@ -141,12 +141,12 @@ namespace FellowOakDicom.Network
         /// <summary>
         /// Gets or sets the timestamp of when the last PDU was sent
         /// </summary>
-        public DateTime? LastPDUSent { get; set; }
+        internal DateTime? LastPDUSent { get; set; }
 
         /// <summary>
         /// Gets or sets a task that will complete when all the PDUs of this DICOM message have been sent
         /// </summary>
-        public Task AllPDUsSent => _allPDUsSentTCS.Task;
+        internal Task AllPDUsSent => _allPDUsSentTCS.Task;
 
         /// <summary>
         /// Gets or sets the timestamp of when the last response with status 'Pending' was received
@@ -179,8 +179,7 @@ namespace FellowOakDicom.Network
         }
 
         internal void AllPDUsWereSentSuccessfully() => _allPDUsSentTCS.TrySetResult(true);
-        internal void NotAllPDUsWereSentSuccessfully(Exception exception) => _allPDUsSentTCS.TrySetException(exception);
-        internal void NotAllPDUsWereSentBecauseTheyWereCancelled(CancellationToken cancellationToken) => _allPDUsSentTCS.TrySetCanceled(cancellationToken);
+        internal void NotAllPDUsWereSentSuccessfully() => _allPDUsSentTCS.TrySetResult(false);
 
         /// <summary>
         /// Formatted output of the DICOM message.

--- a/FO-DICOM.Core/Network/DicomMessage.cs
+++ b/FO-DICOM.Core/Network/DicomMessage.cs
@@ -5,7 +5,6 @@ using FellowOakDicom.Log;
 using FellowOakDicom.Network.Client.Tasks;
 using System;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
@@ -144,7 +143,8 @@ namespace FellowOakDicom.Network
         internal DateTime? LastPDUSent { get; set; }
 
         /// <summary>
-        /// Gets or sets a task that will complete when all the PDUs of this DICOM message have been sent
+        /// Gets a task that will complete when all the PDUs of this DICOM message have been sent
+        /// Important caveat: if this DICOM message is never picked up to be sent (e.g. because of connection issues) then this task never completes
         /// </summary>
         internal Task AllPDUsSent => _allPDUsSentTCS.Task;
 

--- a/FO-DICOM.Core/Network/DicomMessage.cs
+++ b/FO-DICOM.Core/Network/DicomMessage.cs
@@ -38,7 +38,7 @@ namespace FellowOakDicom.Network
         /// <param name="command">
         /// The DICOM dataset representing the message command.
         /// </param>
-        public DicomMessage(DicomDataset command): this()
+        public DicomMessage(DicomDataset command)
         {
             Command = command;
         }

--- a/FO-DICOM.Core/Network/DicomRequest.cs
+++ b/FO-DICOM.Core/Network/DicomRequest.cs
@@ -67,6 +67,12 @@ namespace FellowOakDicom.Network
         /// </summary>
         public EventHandler<OnTimeoutEventArgs> OnTimeout;
 
+        /// <summary>
+        /// Event handler for when DICOM requests are sent
+        /// This will be triggered when the request is fully sent over the wire to the SCP
+        /// </summary>
+        public EventHandler<OnRequestSentEventArgs> OnRequestSent;
+
         #endregion
 
         #region EVENTARGS
@@ -82,6 +88,10 @@ namespace FellowOakDicom.Network
             {
                 Timeout = timeout;
             }
+        }
+
+        public class OnRequestSentEventArgs
+        {
         }
 
         #endregion

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1366,6 +1366,11 @@ namespace FellowOakDicom.Network
                     await pDataStream.FlushAsync(CancellationToken.None);
                     
                     msg.LastPDUSent = DateTime.Now;
+                    
+                    if (msg is DicomRequest request)
+                    {
+                        request.OnRequestSent?.Invoke(request, new DicomRequest.OnRequestSentEventArgs());
+                    }
                 }
                 catch (Exception e)
                 {

--- a/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
@@ -1,0 +1,270 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Log;
+using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using FellowOakDicom.Network.Client.Advanced.Connection;
+using FellowOakDicom.Tests.Helpers;
+using FellowOakDicom.Tests.Network;
+using FellowOakDicom.Tests.Network.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    [Collection("Network")]
+    public class GH1359
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public GH1359(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper);
+        }
+
+        private IDicomClientFactory CreateClientFactory(INetworkManager networkManager)
+        {
+            var logManager = Setup.ServiceProvider.GetRequiredService<ILogManager>();
+            var dicomServiceDependencies = Setup.ServiceProvider.GetRequiredService<DicomServiceDependencies>();
+            var defaultClientOptions = Setup.ServiceProvider.GetRequiredService<IOptions<DicomClientOptions>>();
+            var defaultServiceOptions = Setup.ServiceProvider.GetRequiredService<IOptions<DicomServiceOptions>>();
+            var advancedDicomClientConnectionFactory = new DefaultAdvancedDicomClientConnectionFactory(networkManager, logManager, defaultServiceOptions, dicomServiceDependencies);
+            return new DefaultDicomClientFactory(
+                defaultClientOptions,
+                defaultServiceOptions,
+                logManager,
+                advancedDicomClientConnectionFactory);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        public async Task SendingCStoreRequest_AfterPreviousCStoreRequestTimedOut_ShouldUseSeparateAssociation(int asyncInvoked)
+        {
+            // Arrange
+            var port = Ports.GetNext();
+            using var server = (ConfigurableDicomCStoreServer) DicomServerFactory.Create<ConfigurableDicomCStoreProvider, ConfigurableDicomCStoreServer>("127.0.0.1", port);
+            server.Options.MaxPDULength = 1024;
+            server.Options.LogDimseDatasets = false;
+            server.Options.LogDataPDUs = false;
+            server.Logger = _logger.IncludePrefix("Server");
+
+            var originalDicomFilePath = @"./Test Data/TestPattern_Palette.dcm";
+            var originalDicomFile = await DicomFile.OpenAsync(originalDicomFilePath);
+            var responses = new ConcurrentQueue<DicomCStoreResponse>();
+            var requestsThatSucceeded = new ConcurrentQueue<DicomCStoreRequest>();
+            var requestsThatFailed = new ConcurrentQueue<DicomCStoreRequest>();
+            var shouldTimeoutNextRequest = false;
+            var requests = Enumerable.Range(0, 3)
+                .Select(i => new DicomCStoreRequest(originalDicomFilePath))
+                .ToList();
+            var firstRequest = requests[0];
+            var secondRequest = requests[1];
+            var thirdRequest = requests[2];
+            for (int i = 0; i < requests.Count; i++)
+            {
+                requests[i].OnResponseReceived = (request, response) =>
+                {
+                    if (response.Status.State == DicomState.Success)
+                    {
+                        requestsThatSucceeded.Enqueue(request);
+                    }
+                    else
+                    {
+                        requestsThatFailed.Enqueue(request);
+                    }
+
+                    responses.Enqueue(response);
+                };
+            }
+
+            firstRequest.OnRequestSent += (sender, args) =>
+            {
+                shouldTimeoutNextRequest = true;
+            };
+
+            var receivedRequests = new List<DicomCStoreRequest>();
+            var random = new Random();
+            server.OnCStoreRequest = (association, storeRequest) =>
+            {
+                receivedRequests.Add(storeRequest);
+
+                Thread.Sleep(random.Next(0, 100));
+
+                return new DicomCStoreResponse(storeRequest, DicomStatus.Success);
+            };
+
+            var clientFactory = CreateClientFactory(new DicomClientTimeoutTest.ConfigurableNetworkManager(
+                () =>
+                {
+                    // Simulate a single network error after the first request
+                    if (shouldTimeoutNextRequest)
+                    {
+                        shouldTimeoutNextRequest = false;
+                        Thread.Sleep(2000);
+                    }
+                }
+            ));
+            var client = clientFactory.Create("127.0.0.1", port, false, "AnySCU", "AnySCP");
+
+            client.ServiceOptions.RequestTimeout = TimeSpan.FromSeconds(1);
+            client.ServiceOptions.MaxPDULength = server.Options.MaxPDULength;
+            client.Logger = _logger.IncludePrefix("Client");
+            client.NegotiateAsyncOps(asyncInvoked, 1);
+
+            // Act
+            await client.AddRequestsAsync(requests).ConfigureAwait(false);
+            await client.SendAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            var messageIdsThatTimedOut = new HashSet<ushort>(requestsThatFailed.Select(r => r.MessageID));
+            var numberOfRequestsThatSucceeded = responses.Count(r => r.Status.State == DicomState.Success);
+            var numberOfRequestsThatFailed = requests.Count - numberOfRequestsThatSucceeded;
+
+            _logger.Info($"Succeeded: {numberOfRequestsThatSucceeded}");
+            _logger.Info($"Failed: {numberOfRequestsThatFailed}");
+
+            Assert.Contains(requestsThatSucceeded, r => r.MessageID == firstRequest.MessageID);
+            Assert.Contains(requestsThatFailed, r => r.MessageID == secondRequest.MessageID);
+            Assert.Contains(requestsThatSucceeded, r => r.MessageID == thirdRequest.MessageID);
+
+            var receivedRequestsThatSucceeded = receivedRequests
+                .Where(r => !messageIdsThatTimedOut.Contains(r.MessageID))
+                .ToList();
+
+            var expectedPixelData = DicomPixelData.Create(originalDicomFile.Dataset);
+            var expectedNumberOfFrames = expectedPixelData.NumberOfFrames;
+            var expectedWidth = expectedPixelData.Width;
+            var expectedHeight = expectedPixelData.Height;
+            var expectedFrames = Enumerable.Range(0, expectedPixelData.NumberOfFrames)
+                .Select(frame => expectedPixelData.GetFrame(frame))
+                .ToArray();
+
+            Parallel.For((long)0, receivedRequestsThatSucceeded.Count, i =>
+            {
+                var request = receivedRequestsThatSucceeded[(int) i];
+                _logger.Info($"Verifying pixel data of request [{request.MessageID}]");
+
+                var actualPixelData = DicomPixelData.Create(request.File.Dataset);
+
+                var expectedPhotometricInterpretation = expectedPixelData.PhotometricInterpretation.Value;
+                Assert.Equal(expectedPhotometricInterpretation, actualPixelData.PhotometricInterpretation.Value);
+                Assert.Equal(expectedNumberOfFrames, actualPixelData.NumberOfFrames);
+                Assert.Equal(expectedWidth, actualPixelData.Width);
+                Assert.Equal(expectedHeight, actualPixelData.Height);
+
+                for (var frame = 0; frame < actualPixelData.NumberOfFrames; frame++)
+                {
+                    var actualFrame = actualPixelData.GetFrame(frame);
+                    var expectedFrame = expectedFrames[frame];
+
+                    Assert.Equal(expectedFrame.Size, actualFrame.Size);
+
+                    var actualData = actualFrame.Data;
+                    var expectedData = expectedFrame.Data;
+
+                    var actualFirstByte = actualData[0];
+                    var actualMiddleByte = actualData[(int) (actualData.Length / 2.0)];
+                    var actualLastByte = actualData[actualData.Length - 1];
+                    var expectedFirstByte = expectedData[0];
+                    var expectedMiddleByte = expectedData[(int) (expectedData.Length / 2.0)];
+                    var expectedLastByte = expectedData[expectedData.Length - 1];
+                    Assert.Equal(expectedData.Length, actualData.Length);
+                    Assert.Equal(expectedFirstByte, actualFirstByte);
+                    Assert.Equal(expectedMiddleByte, actualMiddleByte);
+                    Assert.Equal(expectedLastByte, actualLastByte);
+                }
+            });
+        }
+    }
+
+    #region support utilities
+
+    public class ConfigurableDicomCStoreServer : DicomServer<ConfigurableDicomCStoreProvider>
+    {
+        private readonly DicomServiceDependencies _dicomServiceDependencies;
+        public Func<DicomAssociation, DicomCStoreRequest, DicomCStoreResponse> OnCStoreRequest { get; set; }
+        public Action<DicomAssociation> OnAssociationRequest { get; set; }
+
+        public ConfigurableDicomCStoreServer(DicomServerDependencies dependencies,
+            DicomServiceDependencies dicomServiceDependencies): base(dependencies)
+        {
+            _dicomServiceDependencies = dicomServiceDependencies ?? throw new ArgumentNullException(nameof(dicomServiceDependencies));
+        }
+
+        protected override ConfigurableDicomCStoreProvider CreateScp(INetworkStream stream)
+        {
+            if (OnCStoreRequest == null)
+                throw new InvalidOperationException($"Failed to configure {nameof(OnCStoreRequest)} before opening an association");
+
+            return new ConfigurableDicomCStoreProvider(stream, Encoding.UTF8, Logger, _dicomServiceDependencies, OnCStoreRequest, OnAssociationRequest);
+        }
+    }
+
+    public class ConfigurableDicomCStoreProvider : DicomService, IDicomServiceProvider, IDicomCStoreProvider
+    {
+        private readonly Func<DicomAssociation, DicomCStoreRequest, DicomCStoreResponse> _onCStoreRequest;
+        private readonly Action<DicomAssociation> _onAssociationRequest;
+
+        public ConfigurableDicomCStoreProvider(
+            INetworkStream stream,
+            Encoding fallbackEncoding,
+            ILogger logger,
+            DicomServiceDependencies dependencies,
+            Func<DicomAssociation, DicomCStoreRequest, DicomCStoreResponse> onCStoreRequest,
+            Action<DicomAssociation> onAssociationRequest
+        ) : base(stream, fallbackEncoding, logger, dependencies)
+        {
+            _onCStoreRequest = onCStoreRequest ?? throw new ArgumentNullException(nameof(onCStoreRequest));
+            _onAssociationRequest = onAssociationRequest;
+        }
+
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason) { }
+
+        public void OnConnectionClosed(Exception exception) { }
+
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            if (_onAssociationRequest != null)
+            {
+                _onAssociationRequest(association.Clone());
+            }
+
+            foreach (var presentationContext in association.PresentationContexts)
+            {
+                foreach (var ts in presentationContext.GetTransferSyntaxes())
+                {
+                    presentationContext.SetResult(DicomPresentationContextResult.Accept, ts);
+                    break;
+                }
+            }
+
+            return SendAssociationAcceptAsync(association);
+        }
+
+        public Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            return SendAssociationReleaseResponseAsync();
+        }
+
+        public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        {
+            return Task.FromResult(_onCStoreRequest(Association, request));
+        }
+
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    #endregion
+}

--- a/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
+++ b/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
@@ -13,17 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Bugs\GH553.cs" />
-    <Compile Remove="Network\TestDicomServices\PendingAsyncDicomCGetProvider.cs" />
-    <Compile Remove="Network\TestDicomServices\PendingAsyncDicomCFindProvider.cs" />
-    <Compile Remove="Network\TestDicomServices\ImmediateSuccessAsyncDicomCGetProvider.cs" />
-    <Compile Remove="Network\TestDicomServices\ImmediateSuccessAsyncDicomCFindProvider.cs" />
-    <Compile Remove="Network\TestDicomServices\AsyncDicomCStoreProviderPreferingUncompressedTS.cs" />
-    <Compile Remove="Network\TestDicomServices\AsyncDicomCStoreProvider.cs" />
-    <Compile Remove="Network\TestDicomServices\AsyncDicomCMoveProvider.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
@@ -112,10 +101,6 @@
     <None Update="Test Data\minimumdict.xml.gz">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Network\TestDicomServices" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
+++ b/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
@@ -14,6 +14,13 @@
 
   <ItemGroup>
     <Compile Remove="Bugs\GH553.cs" />
+    <Compile Remove="Network\TestDicomServices\PendingAsyncDicomCGetProvider.cs" />
+    <Compile Remove="Network\TestDicomServices\PendingAsyncDicomCFindProvider.cs" />
+    <Compile Remove="Network\TestDicomServices\ImmediateSuccessAsyncDicomCGetProvider.cs" />
+    <Compile Remove="Network\TestDicomServices\ImmediateSuccessAsyncDicomCFindProvider.cs" />
+    <Compile Remove="Network\TestDicomServices\AsyncDicomCStoreProviderPreferingUncompressedTS.cs" />
+    <Compile Remove="Network\TestDicomServices\AsyncDicomCStoreProvider.cs" />
+    <Compile Remove="Network\TestDicomServices\AsyncDicomCMoveProvider.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -105,6 +112,10 @@
     <None Update="Test Data\minimumdict.xml.gz">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Network\TestDicomServices" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
@@ -798,7 +798,7 @@ namespace FellowOakDicom.Tests.Network.Client
 
         #region Support classes
 
-        private class ConfigurableNetworkManager : DesktopNetworkManager
+        internal class ConfigurableNetworkManager : DesktopNetworkManager
         {
             private readonly Action _onStreamWrite;
 


### PR DESCRIPTION
Fixes #1359

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Do not send any more P-DATA-TF messages over an association/connection that previously saw an earlier P-DATA-TF message time out. This is because we cannot be certain that the SCP received the data correctly, and if we continue using the connection the SCP might stitch together data in the wrong way, causing invalid/corrupt files. The correct solution is to close the association and send the remaining requests in a new association.
- To fix the above issue, I've also had to make some improvements inside DicomClient so that it does not give any requests to the association that might be lost when this happens. More specifically, I now only send a request when the previous request has been successfully sent over the wire. On a connection level, these requests are sequential anyway, so there is no performance loss. Make no mistake, we still adhere completely to the "AsyncInvoked" setting, meaning that we will still send n requests one after another without waiting for a response if the association allows it.
- While I was in the area, I've improved a minor implementation detail: when you add new requests to a DicomClient that is already sending requests over an association, those extra requests will now be sent as soon as possible (whenever there is a slot free in the AsyncInvoked). The previous implementation would wait until all pending requests completed.
- I had to expose a DicomRequest.RequestSent event which triggers when a request is sent over the wire to implement this fix.