### PR TITLE
Move assignment of ServiceScope to before call to StartAsync()

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,5 +1,6 @@
 #### 5.0.4 (TBD)
 * Fix reading of DICOM files with extra tags in File Meta Information (#1376)
+* Fix race-condition where Dicom clients could be accepted for connection before the server was fully configured (#1398)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/Contributors.md
+++ b/Contributors.md
@@ -79,3 +79,4 @@
 * [Björn Lundmark](https://github.com/bjorn-malmo)
 * [Josiah Vinson](https://github.com/jovinson-ms)
 * [James A Sutherland](https://github.com/jas88)
+* [Chris Conway](https://github.com/CeeJayCee)

--- a/FO-DICOM.Core/Network/DicomServerFactory.cs
+++ b/FO-DICOM.Core/Network/DicomServerFactory.cs
@@ -179,6 +179,7 @@ namespace FellowOakDicom.Network
             {
                 server.Logger = logger;
             }
+            server.ServiceScope = dicomServerScope;
 
             var serviceOptions = _defaultServiceOptions.Value.Clone();
             
@@ -187,7 +188,6 @@ namespace FellowOakDicom.Network
             var registration = _dicomServerRegistry.Register(server, runner);
 
             server.Registration = registration;
-            server.ServiceScope = dicomServerScope;
 
             return server;
         }


### PR DESCRIPTION
Move assignment of ServiceScope to before call to StartAsync(), otherwise a client can connect between these calls and the connection will fail.

Fixes #1398 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Move assignment of ServiceScope to before call to StartAsync(), otherwise a client can connect between these calls and the connection will fail.