### PR TITLE
Fix overwriting of Lossy Compression ratio tag (#1400)

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -1,5 +1,6 @@
 #### 5.0.4 (TBD)
 * Fix reading of DICOM files with extra tags in File Meta Information (#1376)
+* Fix overwriting of Lossy Compression ratio tag (#1400)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
@@ -283,8 +283,15 @@ namespace FellowOakDicom.Imaging.Codec
 
                 double oldSize = oldPixelData.GetFrame(0).Size;
                 double newSize = newPixelData.GetFrame(0).Size;
-                var ratio = string.Format(CultureInfo.InvariantCulture, "{0:0.000}", oldSize / newSize);
-                newDataset.AddOrUpdate(new DicomDecimalString(DicomTag.LossyImageCompressionRatio, ratio));
+
+                List<string> ratios = new List<string>();
+                if (newDataset.Contains(DicomTag.LossyImageCompressionRatio))
+                {
+                    ratios.AddRange(newDataset.GetValues<string>(DicomTag.LossyImageCompressionRatio));
+                }
+                
+                ratios.Add(string.Format(CultureInfo.InvariantCulture, "{0:0.000}", oldSize / newSize));
+                newDataset.AddOrUpdate(new DicomDecimalString(DicomTag.LossyImageCompressionRatio, ratios.ToArray()));
             }
 
             ProcessOverlays(oldDataset, newDataset);

--- a/Tests/FO-DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -19,6 +19,25 @@ namespace FellowOakDicom.Tests.Imaging.Codec
         #region Unit tests
 
         [FactForNetCore]
+        public void CheckLossyCompressionRatio_HasAddedMultiValueAfterCompression()
+        {
+            var file = DicomFile.Open(TestData.Resolve("GH538-JPEG1.dcm"));
+            var oldRatios = file.Dataset.GetValues<string>(DicomTag.LossyImageCompressionRatio);
+            var ds = file.Clone(DicomTransferSyntax.JPEGProcess1).Dataset;
+            var newRatios = ds.GetValues<string>(DicomTag.LossyImageCompressionRatio);
+            Assert.Equal(oldRatios.Length+1, newRatios.Length);
+        }
+
+        [FactForNetCore]
+        public void CheckLossyCompressionRatio_HasSingleValueAfterCompression()
+        {
+            var file = DicomFile.Open(TestData.Resolve("GH538-JPEG14SV1.dcm"));
+            var ds = file.Clone(DicomTransferSyntax.JPEGProcess1).Dataset;
+            var ratios = ds.GetValues<string>(DicomTag.LossyImageCompressionRatio);
+            Assert.Single(ratios);
+        }
+
+        [FactForNetCore]
         public void ChangeTransferSyntax_FileFromRLELosslessToJPEGProcess2_4()
         {
             var file = DicomFile.Open(TestData.Resolve("10200904.dcm"));


### PR DESCRIPTION
Fixes #1400.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Update DicomTransCoder.cs so the lossy compression ratio tag is not overwritten and the new value is added to the mult-value tag.
- Added Unit Tests
