### PR TITLE
Odd payload in  OtherBytePixelData.cs

### DIFF
--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -359,6 +359,7 @@ namespace FellowOakDicom.Imaging
             /// The pixel data other byte (OB) element
             /// </summary>
             private readonly DicomOtherByte _element;
+            private readonly IByteBuffer _padingByteBuffer = new MemoryByteBuffer(new byte[1] { DicomVR.OB.PaddingValue });
 
             #endregion
 
@@ -403,10 +404,17 @@ namespace FellowOakDicom.Imaging
             /// <inheritdoc />
             public override void AddFrame(IByteBuffer data)
             {
+
+
                 var buffer = _element.Buffer as CompositeByteBuffer ??
                     throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer");
 
+                buffer.Buffers.Remove(this._padingByteBuffer);
                 buffer.Buffers.Add(data);
+                if (buffer.Buffers.Count % 2 == 1)
+                {
+                    buffer.Buffers.Add(this._padingByteBuffer);
+                }
 
                 NumberOfFrames++;
             }

--- a/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
+++ b/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
-fixed: padding payload to an even number of bytes

Fixes # .

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [n/a] I have updated API documentation
- [] I have included unit tests
- [] I have updated the change log
- [] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the class DicomPixelData pads uneven payload with an extra byte in case the payload is odd 
-
-
