### PR TITLE
Write small files to memory when receiving C-STORE

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -4,6 +4,7 @@
 * Improve throughput of DicomClient when more requests are added mid-flight (#1396)
 * Fix race-condition where Dicom clients could be accepted for connection before the server was fully configured (#1398)
 * Fix overwriting of Lossy Compression ratio tag (#1400)
+* Buffer small DICOM files in memory instead of using temporary files when a DicomService receives them via C-STORE (#1412)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/Network/DicomServiceOptions.cs
+++ b/FO-DICOM.Core/Network/DicomServiceOptions.cs
@@ -60,6 +60,11 @@ namespace FellowOakDicom.Network
         /// Gets the maximum PDU length, increasing this may speed up the sending of C-Store requests, but beware too high values in spotty networks.
         /// </summary>
         public uint MaxPDULength { get; set; } = 262144; // 256 Kb
+        
+        /// <summary>
+        /// Gets or sets maximum size a C-Store memory stream can have before using a temp file
+        /// </summary>
+        public int MaxCStoreMemoryStreamSize { get; set; } = 1024 * 1024; //1MB
 
         public DicomServiceOptions Clone() =>
             new DicomServiceOptions
@@ -75,7 +80,8 @@ namespace FellowOakDicom.Network
                 MaxClientsAllowed = MaxClientsAllowed,
                 IgnoreUnsupportedTransferSyntaxChange = IgnoreUnsupportedTransferSyntaxChange,
                 MaxPDULength = MaxPDULength,
-                MaxPDVsPerPDU = MaxPDVsPerPDU
+                MaxPDVsPerPDU = MaxPDVsPerPDU,
+                MaxCStoreMemoryStreamSize = MaxCStoreMemoryStreamSize
             };
     }
 }

--- a/FO-DICOM.Core/Network/DicomServiceOptions.cs
+++ b/FO-DICOM.Core/Network/DicomServiceOptions.cs
@@ -62,7 +62,7 @@ namespace FellowOakDicom.Network
         public uint MaxPDULength { get; set; } = 262144; // 256 Kb
         
         /// <summary>
-        /// Gets or sets maximum size a C-Store memory stream can have before using a temp file
+        /// Gets or sets maximum size a C-Store memory stream can have before automatically switching to a temp file
         /// </summary>
         public int MaxCStoreMemoryStreamSize { get; set; } = 1024 * 1024; //1MB
 


### PR DESCRIPTION
Fixes #1412.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When receiving a C-STORE request, don't immediately create a temporary file to buffer the incoming DICOM file. Instead, buffer it in memory (using a MemoryStream) and automatically create a temporary file if the memory stream grows beyond a configurable threshold.
- The aforementioned threshold is configurable via `DicomServiceOptions.MaxCStoreMemoryStreamSize`
- The default threshold is set to 1 megabyte
- Setting the threshold to 0 disables this new behavior, causing a temporary file to always be created again even for small files
- Custom implementations of `DicomService.CreateCStoreReceiveStream` might be broken now if you assign a `MemoryStream` to `DicomService._dimseStream`. You can ensure `DicomService.PrepareCStoreReceiveStreamForNextBytes` won't modify your custom `_dimseStream` by setting the `MaxCStoreMemoryStreamSize` option to 0 or by also overriding the implementation of `DicomService.PrepareCStoreReceiveStreamForNextBytes`  and ensuring the base method is never called there.