### PR TITLE
Use a concurrent stack to stored masked DICOM tags

### DIFF
--- a/ChangeLog5.md
+++ b/ChangeLog5.md
@@ -2,6 +2,7 @@
 * Fix reading of DICOM files with extra tags in File Meta Information (#1376)
 * Fix race-condition where Dicom clients could be accepted for connection before the server was fully configured (#1398)
 * Fix overwriting of Lossy Compression ratio tag (#1400)
+* Optimize memory usage of DICOM dictionary (#1414)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/DicomDictionary.cs
+++ b/FO-DICOM.Core/DicomDictionary.cs
@@ -76,7 +76,7 @@ namespace FellowOakDicom
         private readonly ConcurrentDictionary<DicomPrivateCreator, DicomDictionary> _private;
         private readonly ConcurrentDictionary<DicomTag, DicomDictionaryEntry> _entries;
         private readonly ConcurrentDictionary<string, DicomTag> _keywords;
-        private readonly ConcurrentBag<DicomDictionaryEntry> _masked;
+        private readonly ConcurrentStack<DicomDictionaryEntry> _masked;
 
         #endregion
 
@@ -88,7 +88,7 @@ namespace FellowOakDicom
             _private = new ConcurrentDictionary<DicomPrivateCreator, DicomDictionary>();
             _entries = new ConcurrentDictionary<DicomTag, DicomDictionaryEntry>();
             _keywords = new ConcurrentDictionary<string, DicomTag>();
-            _masked = new ConcurrentBag<DicomDictionaryEntry>();
+            _masked = new ConcurrentStack<DicomDictionaryEntry>();
         }
 
         private DicomDictionary(DicomPrivateCreator creator)
@@ -96,7 +96,7 @@ namespace FellowOakDicom
             PrivateCreator = creator;
             _entries = new ConcurrentDictionary<DicomTag, DicomDictionaryEntry>();
             _keywords = new ConcurrentDictionary<string, DicomTag>();
-            _masked = new ConcurrentBag<DicomDictionaryEntry>();
+            _masked = new ConcurrentStack<DicomDictionaryEntry>();
         }
 
         #endregion
@@ -307,7 +307,7 @@ namespace FellowOakDicom
             }
             else
             {
-                _masked.Add(entry);
+                _masked.Push(entry);
                 _keywords[entry.Keyword] = entry.Tag;
             }
         }


### PR DESCRIPTION
Fixes #1414

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Replace `ConcurrentBag` with `ConcurrentStack` for the masked DICOM tags in `DicomDictionary`
- This reduces the need for a full in memory snapshot every time we fetch a DICOM tag from the dictionary that is not known and not private
- In .NET Core the memory allocation difference is small but not negligible. In .NET Framework the difference is orders of magnitude higher because `ConcurrentBag.GetEnumerator` is not optimized there yet and it makes multiple intermediate copies.