### PR TITLE
Patch 1

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -80,3 +80,4 @@
 * [Josiah Vinson](https://github.com/jovinson-ms)
 * [James A Sutherland](https://github.com/jas88)
 * [Chris Conway](https://github.com/CeeJayCee)
+* [Michael Ovens](https://github.com/MichaelOvens)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Then when rendering you can cast the IImage to the type by
 or
 
     var image = new DicomImage("filename.dcm");
-    var shartimage = image.RenderImage().AsSharpImage();
+    var sharpimage = image.RenderImage().AsSharpImage();
 
 #### Logging configuration
 By default, logging defaults to the no-op `NullLogerManager`. There are several logmanagers configurable within `DicomSetupBuilder` like


### PR DESCRIPTION
Fixed a documentation typo in the 'ImageSharp' example variable name in README.md - 'shartimage' => 'sharpimage'.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Changed "shartimage" to "sharpimage" in README.md
