### PR TITLE
All decimal values are converted to valid decimal string

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 * Fix DicomJsonConverter deserialization to handle invalid private creator item (#1445)
 * Improve performance and reduce memory usage when opening DICOM files (#1414)
 * Fix rendering of XA/XRF images that include a modality LUT sequence (#1442)
+* Fix incorrect conversion of some decimal strings (#1454)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/Contributors.md
+++ b/Contributors.md
@@ -81,3 +81,4 @@
 * [James A Sutherland](https://github.com/jas88)
 * [Chris Conway](https://github.com/CeeJayCee)
 * [Michael Ovens](https://github.com/MichaelOvens)
+* [Magnus Larsson](https://github.com/magla42)

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -879,7 +879,7 @@ namespace FellowOakDicom
             var valueString = value.ToString(CultureInfo.InvariantCulture);
             if (valueString.Length > 16)
             {
-                valueString = value.ToString("G11", CultureInfo.InvariantCulture);
+                valueString = value.ToString("G10", CultureInfo.InvariantCulture);
             }
             return valueString;
         }

--- a/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
@@ -444,6 +444,27 @@ namespace FellowOakDicom.Tests
         }
 
         /// <summary>
+        /// Associated with Github issue #1454
+        /// </summary>
+        [Theory]
+        [InlineData(0.142916000000001)]
+        [InlineData(-12345678901234.1)]
+        [InlineData(123456789112345.6)]
+        [InlineData(0.12345678911234567)]
+        [InlineData(-0.12345678911234567)]
+        public void Add_AnyDecimalValue_PassesValidation(decimal value)
+        {
+            var tag = DicomTag.MaterialThickness;
+            DicomDataset dataSet = null;
+            var exception = Record.Exception(() =>
+            {
+                dataSet = new DicomDataset { { tag, value } };
+            });
+            Assert.Null(exception);
+            Assert.True(dataSet.Contains(tag));
+        }
+
+        /// <summary>
         /// Associated with Github issue #535.
         /// </summary>
         [Theory]

--- a/Tests/FO-DICOM.Tests/DicomElementTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomElementTest.cs
@@ -419,6 +419,16 @@ namespace FellowOakDicom.Tests
             Assert.IsType<DicomDataException>(exception);
         }
 
+        [Theory]
+        [MemberData(nameof(ValidDecimalToStringData))]
+        public void DicomDecimalString_ToDecimalString_ReturnsExpectedValue(decimal value, string expectedString)
+        {
+            var actual = DicomDecimalString.ToDecimalString(value);
+
+            Assert.True(actual.Length <= 16, actual);
+            Assert.Equal(expectedString, actual);
+        }
+
         #endregion
 
         #region Support methods
@@ -505,6 +515,23 @@ namespace FellowOakDicom.Tests
             new object[] { DicomUID.StorageCommitmentPushModel },
             new object[] { DicomUID.dicomTransferSyntax },
             new object[] { DicomUID.PETPalette }
+        };
+
+        public static IEnumerable<object[]> ValidDecimalToStringData = new[]
+        {
+            new object[] { 0.142916000000001m, "0.142916" },
+            new object[] { 0.142916m, "0.142916" },
+            new object[] { 0.12345678911234m, "0.12345678911234" },
+            new object[] { 0.12345678911234567m, "0.1234567891" },
+            new object[] { -0.12345678911234567m, "-0.1234567891" },
+            new object[] { -12345678911234.1m, "-1.234567891E+13" },
+            new object[] { 12345678911234.1m,  "12345678911234.1" },
+            new object[] { 123456789112345.7m, "1.234567891E+14" },
+            new object[] { 1234567891123456789m, "1.234567891E+18" },
+            new object[] { 1.1E-27m, "1.1E-27" },
+            new object[] { -1.1E-27m, "-1.1E-27" },
+            new object[] { 1.1E27m, "1.1E+27" },
+            new object[] { -1.1E27m, "-1.1E+27" }
         };
 
         #endregion


### PR DESCRIPTION
Fixes #1454

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- The `DicomElement.ToDecimalString` method uses the G10 formatter instead of G11 when the default serialization is longer than the valid 16 chars, to account for worst case decimal values.