### PR TITLE
padding payload to an even number of bytes in pixeldata

### DIFF
--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -359,6 +359,7 @@ namespace FellowOakDicom.Imaging
             /// The pixel data other byte (OB) element
             /// </summary>
             private readonly DicomOtherByte _element;
+            private readonly IByteBuffer _padingByteBuffer = new MemoryByteBuffer(new byte[1] { DicomVR.OB.PaddingValue });
 
             #endregion
 
@@ -403,10 +404,17 @@ namespace FellowOakDicom.Imaging
             /// <inheritdoc />
             public override void AddFrame(IByteBuffer data)
             {
+
+
                 var buffer = _element.Buffer as CompositeByteBuffer ??
                     throw new DicomImagingException("Expected pixel data element to have a CompositeByteBuffer");
 
+                buffer.Buffers.Remove(this._padingByteBuffer);
                 buffer.Buffers.Add(data);
+                if (buffer.Buffers.Count % 2 == 1)
+                {
+                    buffer.Buffers.Add(this._padingByteBuffer);
+                }
 
                 NumberOfFrames++;
             }

--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -411,7 +411,7 @@ namespace FellowOakDicom.Imaging
 
                 buffer.Buffers.Remove(this._padingByteBuffer);
                 buffer.Buffers.Add(data);
-                if (buffer.Buffers.Count % 2 == 1)
+                if (buffer.Size % 2 == 1)
                 {
                     buffer.Buffers.Add(this._padingByteBuffer);
                 }

--- a/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
+++ b/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
@@ -2,6 +2,9 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using FellowOakDicom.Imaging;
+using FellowOakDicom.IO.Buffer;
+using FellowOakDicom.Tests.Helpers;
+using Microsoft.Toolkit.HighPerformance.Helpers;
 using System.IO;
 using Xunit;
 
@@ -60,6 +63,40 @@ namespace FellowOakDicom.Tests.Imaging
             var pixelData = DicomPixelData.Create(dataset, true);
 
             Assert.Equal("OtherBytePixelData", pixelData.GetType().Name);
+        }
+
+
+
+        [Fact]
+        public void CheckEvenBytesInOtherBytePixelData()
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
+            dataset.Add(DicomTag.BitsAllocated, (ushort)1);
+            var pixelData = DicomPixelData.Create(dataset, true);
+
+            Assert.Equal("OtherBytePixelData", pixelData.GetType().Name);
+
+            pixelData.AddFrame(new TempFileBuffer(new byte[1]));
+            pixelData.AddFrame(new TempFileBuffer(new byte[2]));
+            pixelData.AddFrame(new TempFileBuffer(new byte[1]));
+
+            Assert.True(3 == pixelData.NumberOfFrames);
+            //var pixels = pixelData.Dataset.GetDicomItem<DicomItem>(DicomTag.PixelData);
+
+
+            dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
+            dataset.Add(DicomTag.BitsAllocated, (ushort)1);
+            pixelData = DicomPixelData.Create(dataset, true);
+
+            Assert.Equal("OtherBytePixelData", pixelData.GetType().Name);
+
+            pixelData.AddFrame(new TempFileBuffer(new byte[1]));
+            pixelData.AddFrame(new TempFileBuffer(new byte[2]));
+
+            Assert.True(2 == pixelData.NumberOfFrames);
+            
+            //pixels = pixelData.Dataset.GetDicomItem<DicomItem>(DicomTag.PixelData);
+
         }
 
         [Theory]


### PR DESCRIPTION
-fixed: padding payload to an even number of bytes

fixes #1019 

#### Checklist
- [ ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the class DicomPixelData pads uneven payload with an extra byte in case the payload is odd
- Unit test added
- bug fixed in getting the buffer size

