### PR TITLE
Added property to skip adding the default Implicit VR Little Endian transfer syntax for CStoreRequest

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@
 * Fix reading of Confidentiality Profile Attributes from standard (led to missing Clean Graphics option) (#1212) 
 * **Breaking change**: Updated DICOM Dictionary to 2022d. Several DicomTag constant names changed to singular name from plural form (#1469)
 * Added support for DICOM supplement 225, Multi-Fragment video transfer syntax (#1469)
-* Added property to skip adding the default Implicit VR Little Endian transfer syntax for CStoreRequest (#1475)
+* Added property to omit adding the default Implicit VR Little Endian transfer syntax for CStoreRequest (#1475)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
 * Fix reading of Confidentiality Profile Attributes from standard (led to missing Clean Graphics option) (#1212) 
 * **Breaking change**: Updated DICOM Dictionary to 2022d. Several DicomTag constant names changed to singular name from plural form (#1469)
 * Added support for DICOM supplement 225, Multi-Fragment video transfer syntax (#1469)
+* Added property to skip adding the default Implicit VR Little Endian transfer syntax for CStoreRequest (#1475)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/Network/DicomCStoreRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreRequest.cs
@@ -99,6 +99,12 @@ namespace FellowOakDicom.Network
         public DicomTransferSyntax[] AdditionalTransferSyntaxes { get; set; }
 
         /// <summary>
+        /// Automatically add the Implicit VR Little Endian transfer syntax
+        /// if not present in the request itself.
+        /// </summary>
+        public bool AddDefaultTransferSyntax { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the (optional) Common Extended Negotiation Service Class UID.
         /// </summary>
         public DicomUID CommonServiceClassUid { get; set; }

--- a/FO-DICOM.Core/Network/DicomCStoreRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreRequest.cs
@@ -99,10 +99,11 @@ namespace FellowOakDicom.Network
         public DicomTransferSyntax[] AdditionalTransferSyntaxes { get; set; }
 
         /// <summary>
-        /// Automatically add the Implicit VR Little Endian transfer syntax
-        /// if not present in the request itself.
+        /// If set, the default transfer syntax (Implicit VR Little Endian) will
+        /// not be automatically proposed when associating with remote system. 
+        /// This should only be used in exception cases (See PS3.5 section 10.1).
         /// </summary>
-        public bool AddDefaultTransferSyntax { get; set; } = true;
+        public bool OmitImplicitVrTransferSyntaxInAssociationRequest { get; set; }
 
         /// <summary>
         /// Gets or sets the (optional) Common Extended Negotiation Service Class UID.

--- a/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
+++ b/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
@@ -136,7 +136,8 @@ namespace FellowOakDicom.Network
                     {
                         tx.AddRange(cstore.AdditionalTransferSyntaxes);
                     }
-                    if (cstore.TransferSyntax != DicomTransferSyntax.ImplicitVRLittleEndian)
+                    if (cstore.TransferSyntax != DicomTransferSyntax.ImplicitVRLittleEndian
+                        && cstore.AddDefaultTransferSyntax)
                     {
                         tx.Add(DicomTransferSyntax.ImplicitVRLittleEndian);
                     }

--- a/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
+++ b/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
@@ -136,10 +136,20 @@ namespace FellowOakDicom.Network
                     {
                         tx.AddRange(cstore.AdditionalTransferSyntaxes);
                     }
-                    if (cstore.TransferSyntax != DicomTransferSyntax.ImplicitVRLittleEndian
-                        && cstore.AddDefaultTransferSyntax)
+
+                    if (cstore.TransferSyntax != DicomTransferSyntax.ImplicitVRLittleEndian)
                     {
-                        tx.Add(DicomTransferSyntax.ImplicitVRLittleEndian);
+                        if (cstore.OmitImplicitVrTransferSyntaxInAssociationRequest)
+                        {
+                            // This should only be allowed when the original
+                            // data is using a lossy compression
+                            if (!cstore.TransferSyntax.IsLossy)
+                                throw new InvalidOperationException("It is only permissable to omit default transfer syntax with lossy encapsulated data");
+                        }
+                        else
+                        {
+                            tx.Add(DicomTransferSyntax.ImplicitVRLittleEndian);
+                        }
                     }
 
                     if (tx.Any())


### PR DESCRIPTION
Fixes #1475.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add option to DicomCStoreRequest to omit suggesting Implicit VR Transfer Syntax in association request, if and only if the transfer syntax of the file is lossy
