### PR TITLE
Fixed blanking of ValueElements in the anonymizer and minor cleanup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@
 * **Breaking change**: Updated DICOM Dictionary to 2022d. Several DicomTag constant names changed to singular name from plural form (#1469)
 * Added support for DICOM supplement 225, Multi-Fragment video transfer syntax (#1469)
 * Added property to omit adding the default Implicit VR Little Endian transfer syntax for CStoreRequest (#1475)
+* Fixes blanking of ValueElements in the anonymizer and replaced usage of GetConstructor with Activator.CreateInstance (#1491)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@
 * **Breaking change**: Updated DICOM Dictionary to 2022d. Several DicomTag constant names changed to singular name from plural form (#1469)
 * Added support for DICOM supplement 225, Multi-Fragment video transfer syntax (#1469)
 * Added property to omit adding the default Implicit VR Little Endian transfer syntax for CStoreRequest (#1475)
-* Fixes blanking of ValueElements in the anonymizer and replaced usage of GetConstructor with Activator.CreateInstance (#1491)
+* Fix blanking of ValueElements in the anonymizer (#1491)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)


### PR DESCRIPTION
Fixes #1491 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- ~~[ ] I have updated API documentation~~
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Fixes issue #1491
- `GetConstuctor` function not necessary and replaced with `Activator.CreateInstance`
