### PR TITLE
Cache file length in filebytesource

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 #### 5.1.0 (TBD)
-* Cache file length in FileByteSource to improve parse speed (#????)
+* Cache file length in FileByteSource to improve parse speed (#1493)
 * Fix reading of DICOM files with extra tags in File Meta Information (#1376)
 * Allow accessing person name components for empty items (#1405)
 * Fix sending more DICOM requests over an existing association where a request previously timed out (#1396)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### 5.1.0 (TBD)
+* Cache file length in FileByteSource to improve parse speed (#????)
 * Fix reading of DICOM files with extra tags in File Meta Information (#1376)
 * Allow accessing person name components for empty items (#1405)
 * Fix sending more DICOM requests over an existing association where a request previously timed out (#1396)

--- a/Contributors.md
+++ b/Contributors.md
@@ -82,3 +82,4 @@
 * [Chris Conway](https://github.com/CeeJayCee)
 * [Michael Ovens](https://github.com/MichaelOvens)
 * [Magnus Larsson](https://github.com/magla42)
+* [John Cupitt](https://github.com/jcupitt)

--- a/FO-DICOM.Core/IO/FileByteSource.cs
+++ b/FO-DICOM.Core/IO/FileByteSource.cs
@@ -21,6 +21,7 @@ namespace FellowOakDicom.IO
         private readonly IFileReference _file;
 
         private readonly Stream _stream;
+        private readonly long _length;
 
         private Endian _endian;
 
@@ -47,6 +48,10 @@ namespace FellowOakDicom.IO
         {
             _file = file;
             _stream = _file.OpenRead();
+            // this is a read stream, so length won't change ... we need to 
+            // call Require all the time while parsing, so caching this 
+            // value is a huge win for large files
+            _length = _stream.Length;
             _endian = Endian.LocalMachine;
             _reader = EndianBinaryReader.Create(_stream, _endian, false);
             Marker = 0;
@@ -88,7 +93,7 @@ namespace FellowOakDicom.IO
         public long Marker { get; private set; }
 
         /// <inheritdoc />
-        public bool IsEOF => _stream.Position >= _stream.Length;
+        public bool IsEOF => _stream.Position >= _length;
 
         /// <inheritdoc />
         public bool CanRewind => _stream.CanSeek;
@@ -211,7 +216,7 @@ namespace FellowOakDicom.IO
         {
             lock (_lock)
             {
-                return (_stream.Length - _stream.Position) >= count;
+                return (_length - _stream.Position) >= count;
             }
         }
 


### PR DESCRIPTION
This PR caches `_stream.Length` in `FileByteSource`. We are opening the file as read only, so hopefully the length will not be changing.

The parser calls `Require` for every token, `FileByteSource.Require` in turn calls `Length`, and `Length` makes a call off into the Windows filesystem. Removing this ping off to win is a huge win for large files.

On my PC, calling `DicomFile.Open()` before this patch on an 800mb file (I used the largest level of the sample Leica DICOM file) takes 8s, and with this patch it's down to 4s.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file