### PR TITLE
OtherWordPixelData (OW) padded to even length on AddFrame 

### DIFF
--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -425,6 +425,7 @@ namespace FellowOakDicom.Imaging
             /// The pixel data other word (OW) element
             /// </summary>
             private readonly DicomOtherWord _element;
+            private readonly IByteBuffer _paddingByteBuffer = new MemoryByteBuffer(new[] { DicomVR.OW.PaddingValue });
 
             #endregion
 
@@ -482,7 +483,13 @@ namespace FellowOakDicom.Imaging
                     data = new SwapByteBuffer(data, 2);
                 }
 
+                buffer.Buffers.Remove(_paddingByteBuffer);
                 buffer.Buffers.Add(data);
+                if (buffer.Size % 2 == 1)
+                {
+                    buffer.Buffers.Add(_paddingByteBuffer);
+                }
+
                 NumberOfFrames++;
             }
 

--- a/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using FellowOakDicom.Imaging;
-using System.IO;
+using FellowOakDicom.IO.Buffer;
 using Xunit;
 
 namespace FellowOakDicom.Tests.Imaging
@@ -129,6 +129,34 @@ namespace FellowOakDicom.Tests.Imaging
             myImg.Render(3, true, true, 0);
         }
 
+        [Fact]
+        public void AddFrame_ImplicitVRLittleEndian_PixelData_Length_Always_Even()
+        {
+            var dataset = new DicomDataset(DicomTransferSyntax.ImplicitVRLittleEndian);
+            dataset.Add(DicomTag.BitsAllocated, (ushort)8);
+            var pixelData = DicomPixelData.Create(dataset, true);
 
+            Assert.Equal("OtherWordPixelData", pixelData.GetType().Name);
+
+            var oddPayload = new TempFileBuffer(new byte[13]);
+
+            pixelData.AddFrame(oddPayload);
+            var item = dataset.GetDicomItem<DicomOtherWord>(DicomTag.PixelData);
+
+            Assert.Equal(1, pixelData.NumberOfFrames);
+            Assert.Equal<uint>(0, item.Length % 2);
+
+            pixelData.AddFrame(oddPayload);
+            item = dataset.GetDicomItem<DicomOtherWord>(DicomTag.PixelData);
+
+            Assert.Equal(2, pixelData.NumberOfFrames);
+            Assert.Equal<uint>(0, item.Length % 2);
+
+            pixelData.AddFrame(oddPayload);
+            item = dataset.GetDicomItem<DicomOtherWord>(DicomTag.PixelData);
+
+            Assert.Equal(3, pixelData.NumberOfFrames);
+            Assert.Equal<uint>(0, item.Length % 2);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes issue #1403.


#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- AddFrame method of OtherWordPixelData now adds padding byte to ensure even length of dicom item.
- This fix is similar to #1410. 1410 fixes odd length issue related OtherBytePixelData. This PR fixes OtherWordPixelData.
