### PR TITLE
Fix incorrect JSON conversion of InlineBinary (#1487)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@
 * Added property to omit adding the default Implicit VR Little Endian transfer syntax for CStoreRequest (#1475)
 * Fix blanking of ValueElements in the anonymizer (#1491)
 * Throw error when adding private dicom tag without explicit VR (#1462)
+* Fix incorrect JSON conversion of inline binaries (#1487)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/Contributors.md
+++ b/Contributors.md
@@ -85,3 +85,4 @@
 * [John Cupitt](https://github.com/jcupitt)
 * [Taehyun Hwang](https://github.com/HwangTaehyun)
 * [Hyojae Eum](https://github.com/Amdhj22)
+* [Atte Kojo](https://github.com/akojo)

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -620,9 +620,7 @@ namespace FellowOakDicom.Serialization
             else if (elem.Count != 0)
             {
                 writer.WritePropertyName("InlineBinary");
-                writer.WriteStartArray();
                 writer.WriteBase64StringValue(elem.Buffer.Data);
-                writer.WriteEndArray();
             }
         }
 
@@ -1108,16 +1106,29 @@ namespace FellowOakDicom.Serialization
         }
 
 
-        private static IByteBuffer ReadJsonInlineBinary(ref Utf8JsonReader reader)
+        private static IByteBuffer ReadJsonInlineBinary(ref Utf8JsonReader reader) 
+            => reader.TokenType == JsonTokenType.StartArray
+                ? ReadJsonInlineBinaryArray(ref reader)
+                : ReadJsonInlineBinaryString(ref reader);
+
+        private static IByteBuffer ReadJsonInlineBinaryArray(ref Utf8JsonReader reader)
         {
-            reader.AssumeAndSkip(JsonTokenType.StartArray);
-            if (reader.TokenType != JsonTokenType.String) { throw new JsonException("Malformed DICOM json. string expected"); }
-            var data = new MemoryByteBuffer(reader.GetBytesFromBase64());
-            reader.Read();
+            reader.Read(); // caller already checked for StartArray
+            var data = ReadJsonInlineBinaryString(ref reader);
             reader.AssumeAndSkip(JsonTokenType.EndArray);
-            return data;
+            return data;            
         }
 
+        private static IByteBuffer ReadJsonInlineBinaryString(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new JsonException("Malformed DICOM json. string expected");
+            }
+            var data = new MemoryByteBuffer(reader.GetBytesFromBase64());
+            reader.Read();
+            return data;
+        }
 
         private IBulkDataUriByteBuffer ReadJsonBulkDataUri(ref Utf8JsonReader reader)
         {

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -1039,8 +1039,45 @@ namespace FellowOakDicom.Tests.Serialization
                          new DicomDecimalString(DicomTag.GantryAngle, 36)
                      };
             var json = DicomJson.ConvertDicomToJson(ds, writeTagsAsKeywords: true);
-            Assert.Equal("{\"00030010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"00031002\":{\"vr\":\"AE\",\"Value\":[\"AETITLE\"]},\"00031003\":{\"vr\":\"UN\",\"InlineBinary\":[\"V0hBVElTVEhJUw==\"]},\"00031010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"GantryAngle\":{\"vr\":\"DS\",\"Value\":[36]}}",
-                json);
+            Assert.Equal("{\"00030010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"00031002\":{\"vr\":\"AE\",\"Value\":[\"AETITLE\"]},\"00031003\":{\"vr\":\"UN\",\"InlineBinary\":\"V0hBVElTVEhJUw==\"},\"00031010\":{\"vr\":\"LO\",\"Value\":[\"TEST\"]},\"GantryAngle\":{\"vr\":\"DS\",\"Value\":[36]}}", json);
+        }
+
+        [Fact]
+        public static void TestInlineBinarySerialization()
+        {
+            var ds = new DicomDataset
+            {
+                new DicomOtherByte(DicomTag.PixelData, Encoding.ASCII.GetBytes("OTHERBYTES"))
+            };
+            Assert.Equal(
+                "{\"7FE00010\":{\"vr\":\"OB\",\"InlineBinary\":\"T1RIRVJCWVRFUw==\"}}",
+                DicomJson.ConvertDicomToJson(ds)
+            );      
+        }
+
+        [Fact]
+        public static void TestInlineBinaryDeserialization()
+        {
+            var json = "{\"7FE00010\":{\"vr\":\"OB\",\"InlineBinary\":\"T1RIRVJCWVRFUw==\"}}";
+            Assert.True(DicomJson.ConvertJsonToDicom(json).Contains(DicomTag.PixelData));
+        }
+
+        [Fact]
+        public static void TestInlineBinaryDeserialization_WithLegacy50Format()
+        {
+            var json = "{\"7FE00010\":{\"vr\":\"OB\",\"InlineBinary\":[\"T1RIRVJCWVRFUw==\"]}}";
+            Assert.True(DicomJson.ConvertJsonToDicom(json).Contains(DicomTag.PixelData));
+        }
+
+        [Fact]
+        public static void TestInvalidInlineBinaryDeserialization()
+        {
+            Assert.Throws<JsonException>(
+                () => DicomJson.ConvertJsonToDicom("{\"7FE00010\":{\"vr\":\"OB\",\"InlineBinary\":1}}")
+            );
+            Assert.Throws<JsonException>(
+                () => DicomJson.ConvertJsonToDicom("{\"7FE00010\":{\"vr\":\"OB\",\"InlineBinary\":[1]}}")
+            );
         }
 
         [Fact]
@@ -1406,7 +1443,7 @@ namespace FellowOakDicom.Tests.Serialization
         },
         ""00091002"": {
             ""vr"": ""UN"",
-            ""InlineBinary"": [ ""z0x9c8v7"" ]
+            ""InlineBinary"": ""z0x9c8v7""
         },
         ""00100010"": {
             ""vr"": ""PN"",
@@ -1521,7 +1558,7 @@ namespace FellowOakDicom.Tests.Serialization
         },
         ""00091002"": {
             ""vr"": ""UN"",
-            ""InlineBinary"": [ ""z0x9c8v7"" ]
+            ""InlineBinary"": ""z0x9c8v7""
         },
         ""00100010"": {
             ""vr"": ""PN"",


### PR DESCRIPTION
JSON converter erroneously assumed InlineBinary values should be an array instead of a string. Fix by generating an reading plain strings instead of arrays.

To ensure backwards compatibility with JSON files generated with 5.0.x series, also accept InlineBinaries as arrays when deserializing JSON.

Fixes #1487 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Generate InlineBinary values as strings when serializing Datasets as JSON
- Accept both strings and arrays as InlineBinary values when deserializing JSON to ensure backwards compatiblity with 5.0.x versions
