### PR TITLE
DicomDatasetDumper truncates UID's, fixes (#1505) 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 #### 5.1.0 (TBD)
+* Fix Truncating UIDs during Dimse and PDU logging (#1505)
 * Cache file length in FileByteSource to improve parse speed (#1493)
 * Fix reading of DICOM files with extra tags in File Meta Information (#1376)
 * Allow accessing person name components for empty items (#1405)

--- a/FO-DICOM.Core/Log/DicomDatasetDumper.cs
+++ b/FO-DICOM.Core/Log/DicomDatasetDumper.cs
@@ -15,13 +15,13 @@ namespace FellowOakDicom.Log
 
         private int _width = 128;
 
-        private int _value = 64;
+        private int _value = 82;
 
         private int _depth = 0;
 
         private string _pad = string.Empty;
 
-        public DicomDatasetDumper(StringBuilder log, int width = 128, int valueLength = 64)
+        public DicomDatasetDumper(StringBuilder log, int width = 128, int valueLength = 82)
         {
             _log = log;
             _width = width;


### PR DESCRIPTION
Fixes #1505 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Increases _value from 64 to 82 to compensate for UID value lengths
-
-
