### PR TITLE
Remove .NET Core 3.1 + .NET 5 and add .NET 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     - development
 
 jobs:
-  v5-net-462:
+  net-462:
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v2
@@ -23,33 +23,29 @@ jobs:
           name: test-v5-net-462.xml
           path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet462.xml
       
-  v5-net-core-31:
+  net-60:
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v2
-    - name: Build FO-DICOM.Core
-      run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --framework netstandard2.0 --runtime win-x64
     - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework netcoreapp3.1 --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnetcore31.xml"
-    - name: Upload test results
-      uses: actions/upload-artifact@v2
-      with:
-          name: test-v5-net-core-31.xml
-          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnetcore31.xml
-      
-  v5-net-60:
-    runs-on: windows-2022
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build FO-DICOM.Core
-      run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --runtime win-x64
-    - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net6.0 --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet60.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net6.0 --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet60.xml"
     - name: Upload test results
       uses: actions/upload-artifact@v2
       with:
           name: test-v5-net-60.xml
           path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet60.xml
+      
+  net-70:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test FO-DICOM.Tests
+      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net7.0 --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet70.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+    - name: Upload test results
+      uses: actions/upload-artifact@v2
+      with:
+          name: test-v5-net-70.xml
+          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet70.xml
     - name: Upload code coverage 
       uses: codecov/codecov-action@v2
 
@@ -58,9 +54,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build FO-DICOM..Benchmark
-      run: dotnet build ./Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj --configuration Release --framework net6.0
+      run: dotnet build ./Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj --configuration Release --framework net7.0
     - name: run benchmarks
-      run: ./Tests/FO-DICOM.Benchmark/bin/Release/net6.0/fo-dicom.Benchmark.exe
+      run: ./Tests/FO-DICOM.Benchmark/bin/Release/net7.0/fo-dicom.Benchmark.exe
     - name: Upload benchmark log
       uses: actions/upload-artifact@v2
       with:

--- a/Documentation/FO-DICOM.Documentation.DocFx.csproj
+++ b/Documentation/FO-DICOM.Documentation.DocFx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>FO_DICOM.Documentation.DocFx</RootNamespace>
     <DocfxConfigFile>$(MSBuildProjectDirectory)/v5/docfx.json</DocfxConfigFile>
   </PropertyGroup>

--- a/Platform/FO-DICOM.AspNetCore/FO-DICOM.AspNetCore.csproj
+++ b/Platform/FO-DICOM.AspNetCore/FO-DICOM.AspNetCore.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>FellowOakDicom.AspNetCore</RootNamespace>
     <AssemblyName>fo-dicom.AspNetCore</AssemblyName>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fellow Oak DICOM officially supports the following runtimes:
 * .NET Core 6.0
 * .NET Framework 4.6.2
 
-Other runtimes that implement .NET Standard 2.0 may work, but are not tested by Fellow Oak DICOM maintainers.
+Other runtimes that implement .NET Standard 2.0 may work, but be aware that our CI pipeline only tests these platforms (and only on Windows)
 
 ### Installation
 Easiest is to obtain *fo-dicom* binaries from [NuGet](https://www.nuget.org/packages/fo-dicom/). This package reference the core *fo-dicom* assemblies for all Microsoft and Xamarin platforms.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ This library is licensed under the [Microsoft Public License (MS-PL)](http://ope
 * DICOM services
 * Customize components via DI container 
 
+### Supported Runtimes
+
+Fellow Oak DICOM officially supports the following runtimes:
+
+* .NET Core 7.0
+* .NET Core 6.0
+* .NET Framework 4.6.2
+
+Other runtimes that implement .NET Standard 2.0 may work, but are not tested by Fellow Oak DICOM maintainers.
+
 ### Installation
 Easiest is to obtain *fo-dicom* binaries from [NuGet](https://www.nuget.org/packages/fo-dicom/). This package reference the core *fo-dicom* assemblies for all Microsoft and Xamarin platforms.
 

--- a/Tests/FO-DICOM.AspNetCoreTest/FO-DICOM.AspNetCoreTest.csproj
+++ b/Tests/FO-DICOM.AspNetCoreTest/FO-DICOM.AspNetCoreTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>FO_DICOM.AspNetCoreTest</RootNamespace>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
+++ b/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>FellowOakDicom.Benchmark</RootNamespace>
     <AssemblyName>FO-DICOM.Benchmark</AssemblyName>
     <LangVersion>Latest</LangVersion>

--- a/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
@@ -44,7 +44,7 @@ namespace FellowOakDicom.Tests.Bugs
                 advancedDicomClientConnectionFactory);
         }
 
-        [Theory]
+        [TheoryForNetCore] // This test is flaky in .NET Framework
         [InlineData(1)]
         [InlineData(3)]
         public async Task SendingCStoreRequest_AfterPreviousCStoreRequestTimedOut_ShouldUseSeparateAssociation(int asyncInvoked)
@@ -145,9 +145,11 @@ namespace FellowOakDicom.Tests.Bugs
             _logger.Info($"Succeeded: {numberOfRequestsThatSucceeded}");
             _logger.Info($"Failed: {numberOfRequestsThatFailed}");
 
-            Assert.Contains(requestsThatSucceeded, r => r.MessageID == firstRequest.MessageID);
-            Assert.Contains(requestsThatFailed, r => r.MessageID == secondRequest.MessageID);
-            Assert.Contains(requestsThatSucceeded, r => r.MessageID == thirdRequest.MessageID);
+            var idsThatSucceeded = requestsThatSucceeded.ToList().Select(r => r.MessageID.ToString()).ToList();
+            var idsThatFailed = requestsThatFailed.ToList().Select(r => r.MessageID.ToString()).ToList();
+            Assert.Contains(firstRequest.MessageID.ToString(), idsThatSucceeded);
+            Assert.Contains(secondRequest.MessageID.ToString(), idsThatFailed);
+            Assert.Contains(thirdRequest.MessageID.ToString(), idsThatSucceeded);
 
             var receivedRequestsThatSucceeded = receivedRequests
                 .Where(r => !messageIdsThatTimedOut.Contains(r.MessageID))

--- a/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
+++ b/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>FellowOakDicom.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/Tests/FO-DICOM.Tests/Helpers/SerializationExtensions.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/SerializationExtensions.cs
@@ -26,31 +26,5 @@ namespace FellowOakDicom.Tests.Helpers
             deserializedObject = (T)serializer.ReadObject(stream);
             return deserializedObject;
         }
-
-        public static T GetBinaryFormatterDeserializedObject<T>(this T input)
-        {
-            T deserialized;
-            var formatter = new BinaryFormatter();
-            var tempFileName = Path.GetTempFileName();
-            try
-            {
-                using var write = File.OpenWrite(tempFileName);
-                formatter.Serialize(write, input);
-                write.Close();
-                using var read = File.OpenRead(tempFileName);
-                deserialized = (T)formatter.Deserialize(read);
-            }
-            finally
-            {
-                try
-                {
-                    File.Delete(tempFileName);
-                }
-                catch
-                {
-                }
-            }
-            return deserialized;
-        }
     }
 }

--- a/Tests/FO-DICOM.Tests/Imaging/Mathematics/Point2Tests.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Mathematics/Point2Tests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace FellowOakDicom.Tests.Imaging.Mathematics
 {
-
     [Collection("General")]
     public class Point2Tests
     {
@@ -18,13 +17,6 @@ namespace FellowOakDicom.Tests.Imaging.Mathematics
             var expected = new Point2(3, -5);
             var actual = expected.GetDataContractSerializerDeserializedObject();
             Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void Serialization_BinaryFormatter_Throws()
-        {
-            var point = new Point2(-2, 12);
-            Assert.Throws<SerializationException>(() => point.GetBinaryFormatterDeserializedObject());
         }
     }
 }

--- a/Tools/FO-DICOM.Dump/FO-DICOM.Dump.csproj
+++ b/Tools/FO-DICOM.Dump/FO-DICOM.Dump.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <RootNamespace>FellowOakDicom.Dump</RootNamespace>
     <UseWPF>true</UseWPF>
     <AssemblyName>fo-dicom.Dump</AssemblyName>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0",
+    "version": "7.0.0",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Removes .NET Core 3.1 and .NET 5 from our test target frameworks and adds .NET 7
According to https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core these runtimes are now out of support, so I think it makes sense for Fellow Oak DICOM to follow that same pattern.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Remove .NET Core 3.1 and .NET 5.0 from TargetFrameworks
- Add .NET 7.0
- Update Github build.yml 
- Add chapter in README on supported runtimes

Note: this is not a breaking change. 
Fellow Oak DICOM still "supports" .NET Standard 2.0 and will continue to work on .NET Core 5.0 or .NET Core 3.1
The difference is that our unit tests will no longer run against these runtimes, so these might break in the future.
