### PR TITLE
updated VR=UI validation to reject empty component

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@
 * Fix blanking of ValueElements in the anonymizer (#1491)
 * Throw error when adding private dicom tag without explicit VR (#1462)
 * Fix incorrect JSON conversion of inline binaries (#1487)
+* Update VR=UI validation to reject empty component (#1509)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/Contributors.md
+++ b/Contributors.md
@@ -86,3 +86,4 @@
 * [Taehyun Hwang](https://github.com/HwangTaehyun)
 * [Hyojae Eum](https://github.com/Amdhj22)
 * [Atte Kojo](https://github.com/akojo)
+* [Olivier Revelat](https://github.com/olivier-med)

--- a/FO-DICOM.Core/DicomValidation.cs
+++ b/FO-DICOM.Core/DicomValidation.cs
@@ -674,7 +674,7 @@ namespace FellowOakDicom
             {
                 throw new DicomValidationException(content, DicomVR.UI, "components must not have leading zeros");
             }
-            if (Regex.IsMatch(content, @"^[.]") || Regex.IsMatch(content, @"[.][.]+") || Regex.IsMatch(content, @"[.]$"))
+            if (Regex.IsMatch(content, @"^[.]") || Regex.IsMatch(content, @"[.][.]") || Regex.IsMatch(content, @"[.]$"))
             {
                 throw new DicomValidationException(content, DicomVR.UI, "a component can not be empty");
             }

--- a/FO-DICOM.Core/DicomValidation.cs
+++ b/FO-DICOM.Core/DicomValidation.cs
@@ -674,6 +674,10 @@ namespace FellowOakDicom
             {
                 throw new DicomValidationException(content, DicomVR.UI, "components must not have leading zeros");
             }
+            if (Regex.IsMatch(content, @"^[.]") || Regex.IsMatch(content, @"[.][.]+") || Regex.IsMatch(content, @"[.]$"))
+            {
+                throw new DicomValidationException(content, DicomVR.UI, "a component can not be empty");
+            }
         }
 
 

--- a/Tests/FO-DICOM.Tests/DicomValidationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomValidationTest.cs
@@ -67,6 +67,18 @@ namespace FellowOakDicom.Tests
             var leadingZeroUid = validUid + ".03";
             var ex2 = Assert.ThrowsAny<DicomValidationException>(() => ds.AddOrUpdate(DicomTag.SeriesInstanceUID, leadingZeroUid));
             Assert.Contains("leading zero", ex2.Message);
+
+            var emptyComponentUid = validUid + ".";
+            var ex3 = Assert.ThrowsAny<DicomValidationException>(() => ds.AddOrUpdate(DicomTag.SeriesInstanceUID, emptyComponentUid));
+            Assert.Contains("not be empty", ex3.Message);
+
+            var emptyComponent2Uid = validUid + ".2..3459.123";
+            var ex4 = Assert.ThrowsAny<DicomValidationException>(() => ds.AddOrUpdate(DicomTag.SeriesInstanceUID, emptyComponent2Uid));
+            Assert.Contains("not be empty", ex4.Message);
+
+            var emptyComponent3Uid = "." + validUid;
+            var ex5 = Assert.ThrowsAny<DicomValidationException>(() => ds.AddOrUpdate(DicomTag.SeriesInstanceUID, emptyComponent3Uid));
+            Assert.Contains("not be empty", ex5.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1503 

Update VR=UI validation to reject empty component.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- reject leading dot, trailing dot and empty component (e.g. x..y.z)
