### PR TITLE
#1511 Fixed GetDateTimeOffset extension with daylight savings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@
 * Fix blanking of ValueElements in the anonymizer (#1491)
 * Throw error when adding private dicom tag without explicit VR (#1462)
 * Fix incorrect JSON conversion of inline binaries (#1487)
+* Fix GetDateTimeOffset with default offset from date/time (#1511)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
@@ -132,7 +132,7 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
-        public void Test()
+        public void GetDateTimeOffset_TopLevelDataset_With_TimeZone_Is_Applied()
         {
             var expected = new DateTimeOffset(2016, 5, 25, 14, 30, 0, new TimeSpan(-09, 00, 00));
 

--- a/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
@@ -130,6 +130,27 @@ namespace FellowOakDicom.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void Test()
+        {
+            var expected = new DateTimeOffset(2016, 5, 25, 14, 30, 0, new TimeSpan(-09, 00, 00));
+
+            var scheduledProcedure = new DicomDataset()
+            {
+                { DicomTag.ScheduledProcedureStepStartDate, "20160525" },
+                { DicomTag.ScheduledProcedureStepStartTime, "143000" }
+            };
+
+            var dataset = new DicomDataset(
+                new DicomDate(DicomTag.CreationDate, "20160524"),
+                new DicomShortString(DicomTag.TimezoneOffsetFromUTC, "-0900"),
+                new DicomSequence(DicomTag.ScheduledProcedureStepSequence, scheduledProcedure));
+ 
+            var actual = scheduledProcedure.GetDateTimeOffset(DicomTag.ScheduledProcedureStepStartDate, DicomTag.ScheduledProcedureStepStartTime, dataset);
+            Assert.Equal(expected, actual);
+        }
+
         #endregion
     }
 }

--- a/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
@@ -93,8 +93,7 @@ namespace FellowOakDicom.Tests
         [Fact]
         public void GetDateTimeOffset_DateAndTimeAndNoTimezoneAvailable_ReturnsSpecifiedDateTimeInLocalTimezone()
         {
-            var local = DateTimeOffset.Now.Offset;
-            var expected = new DateTimeOffset(2016, 5, 25, 15, 54, 31, local);
+            var expected = new DateTimeOffset(new DateTime(2016, 5, 25, 15, 54, 31));
 
             var dataset = new DicomDataset(
                 new DicomDate(DicomTag.CreationDate, "20160525"),
@@ -115,6 +114,19 @@ namespace FellowOakDicom.Tests
                 new DicomShortString(DicomTag.TimezoneOffsetFromUTC, "-0900"));
 
             var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetDateTimeOffset_NeitherDateNorTime_ReturnsMinValue()
+        {
+            var expected = DateTimeOffset.MinValue;
+
+            var dataset = new DicomDataset(
+                new DicomShortString(DicomTag.TimezoneOffsetFromUTC, "-0900"));
+
+            var actual = dataset.GetDateTimeOffset(DicomTag.StudyDate, DicomTag.StudyTime);
 
             Assert.Equal(expected, actual);
         }


### PR DESCRIPTION
Fixes #1511.

The timezone offset from DateTimeOffset.Now depends on the current daylight savings mode, and may therefore return invalid time info when querying a date in a different daylight savings mode.

#### Checklist
- [ X ] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ X ] I have included unit tests
- [ X ] I have updated the change log
- [ X ] I am listed in the CONTRIBUTORS file

