### PR TITLE
Use CommunityToolkit.HighPerformance (#1473)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,7 @@
 * Update VR=UI validation to reject empty component (#1509)
 * Fix GetDateTimeOffset with default offset from date/time (#1511)
 * Fix even length in pixel data by adding payload (#1019)
+* Use CommunityToolkit.HighPerformance (#1473)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/FO-DICOM.Core.csproj
+++ b/FO-DICOM.Core/FO-DICOM.Core.csproj
@@ -74,10 +74,10 @@ Version 5 has some breaking changes to version 4. Read here for more information
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />

--- a/FO-DICOM.Core/Memory/ArrayPoolMemory.cs
+++ b/FO-DICOM.Core/Memory/ArrayPoolMemory.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2012-2021 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
-using Microsoft.Toolkit.HighPerformance.Buffers;
+using CommunityToolkit.HighPerformance.Buffers;
 using System;
 
 namespace FellowOakDicom.Memory

--- a/FO-DICOM.Core/Memory/ArrayPoolMemoryProvider.cs
+++ b/FO-DICOM.Core/Memory/ArrayPoolMemoryProvider.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2012-2021 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using Microsoft.Toolkit.HighPerformance.Buffers;
+using CommunityToolkit.HighPerformance.Buffers;
 
 namespace FellowOakDicom.Memory
 {


### PR DESCRIPTION
Microsoft.Toolkit.HighPerformance is no longer maintained. Switch to using its successor CommunityToolkit.HighPerformance.

Fixes #1473.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
