### PR TITLE
fill properties after constructing DicomAssociation class

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,7 @@
 * Fix even length in pixel data by adding payload (#1019)
 * Use CommunityToolkit.HighPerformance (#1473)
 * Fix JsonDicomConverter number serialization mode 'PreferablyAsNumber' to handle integers greater than int.MaxValue or lesser than int.MinValue (#1521)
+* Fixed missing logging of RemoteHost and RemoteIP in SCU (#1518)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnection.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnection.cs
@@ -169,7 +169,12 @@ namespace FellowOakDicom.Network.Client.Advanced.Connection
         {
             var dicomAssociation = new DicomAssociation(request.CallingAE, request.CalledAE)
             {
-                Options = Options, MaxAsyncOpsInvoked = request.MaxAsyncOpsInvoked, MaxAsyncOpsPerformed = request.MaxAsyncOpsPerformed, MaximumPDULength = Options.MaxPDULength,
+                RemoteHost = NetworkStream.RemoteHost,
+                RemotePort = NetworkStream.RemotePort,
+                Options = Options,
+                MaxAsyncOpsInvoked = request.MaxAsyncOpsInvoked,
+                MaxAsyncOpsPerformed = request.MaxAsyncOpsPerformed,
+                MaximumPDULength = Options.MaxPDULength,
             };
 
             foreach (var presentationContext in request.PresentationContexts)

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) 2012-2021 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using FellowOakDicom.Log;
 using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
@@ -15,6 +8,14 @@ using FellowOakDicom.Network.Client.Advanced.Connection;
 using FellowOakDicom.Network.Client.States;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -140,6 +141,30 @@ namespace FellowOakDicom.Tests.Network.Client
                 await task.ConfigureAwait(false);
                 Assert.Equal(1, counter);
             }
+        }
+
+        [Fact]
+        public async Task LogAssociationProperties()
+        {
+            var writer = new StringWriter();
+            ILogManager logManager = new TextWriterLogManager(writer);
+
+            int port = Ports.GetNext();
+            using (CreateServer<DicomCEchoProvider>(port))
+            {
+                var request = new DicomCEchoRequest { };
+                var client = CreateClient("127.0.0.1", port, false, "LOG-SCU", "ANY-SCP");
+                client.Logger = logManager.GetLogger("client");
+
+                await client.AddRequestAsync(request).ConfigureAwait(false);
+                await client.SendAsync().ConfigureAwait(false);
+            }
+
+            var logcontent = writer.ToString();
+            Assert.Contains("\nRemote host:            127.0.0.1\n", logcontent);
+            Assert.Contains($"\nRemote port:            {port}\n", logcontent);
+            Assert.Contains("\nCalling AE Title:       LOG-SCU\n", logcontent);
+            Assert.Contains("\nCalled AE Title:        ANY-SCP\n", logcontent);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1518  .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- The logging of the DicomAssociation is done before the AssociationRequest is sent via network, so the properties have to be filled earlier.
