### PR TITLE
Fix JsonDicomConverter number serialization mode 'PeferablyAsNumber' for big integers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,7 @@
 * Fix GetDateTimeOffset with default offset from date/time (#1511)
 * Fix even length in pixel data by adding payload (#1019)
 * Use CommunityToolkit.HighPerformance (#1473)
-* Fix JsonDicomConverter number serialization mode 'PreferablyAsNumber' to handle integers greater or lesser than int.MaxValue (#xxxx)
+* Fix JsonDicomConverter number serialization mode 'PreferablyAsNumber' to handle integers greater than int.MaxValue or lesser than int.MinValue (#xxxx)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@
 * Fix GetDateTimeOffset with default offset from date/time (#1511)
 * Fix even length in pixel data by adding payload (#1019)
 * Use CommunityToolkit.HighPerformance (#1473)
+* Fix JsonDicomConverter number serialization mode 'PreferablyAsNumber' to handle integers greater or lesser than int.MaxValue (#xxxx)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,7 @@
 * Fix GetDateTimeOffset with default offset from date/time (#1511)
 * Fix even length in pixel data by adding payload (#1019)
 * Use CommunityToolkit.HighPerformance (#1473)
-* Fix JsonDicomConverter number serialization mode 'PreferablyAsNumber' to handle integers greater than int.MaxValue or lesser than int.MinValue (#xxxx)
+* Fix JsonDicomConverter number serialization mode 'PreferablyAsNumber' to handle integers greater than int.MaxValue or lesser than int.MinValue (#1521)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/Contributors.md
+++ b/Contributors.md
@@ -87,3 +87,4 @@
 * [Hyojae Eum](https://github.com/Amdhj22)
 * [Atte Kojo](https://github.com/akojo)
 * [Olivier Revelat](https://github.com/olivier-med)
+* [Tars De Jaeger](https://github.com/tarsdejaeger)

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -435,7 +435,7 @@ namespace FellowOakDicom.Serialization
                 {
                     numberWriterAction();
                 }
-                catch (FormatException)
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException)
                 {
                     if (_numberSerializationMode == NumberSerializationMode.PreferablyAsNumber)
                     {

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -489,7 +489,7 @@ namespace FellowOakDicom.Serialization
                 {
                     numberWriterAction();
                 }
-                catch (FormatException)
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException)
                 {
                     if (_numberSerializationMode == NumberSerializationMode.PreferablyAsNumber)
                     {

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -1151,14 +1151,16 @@ namespace FellowOakDicom.Tests.Serialization
             var dataset = new DicomDataset().NotValidated();
             const string invalidDS = "InvalidDS";
             const string invalidIS = "InvalidIS";
+            const string invalidISThatThrowsOverflowException = "73.8";
             dataset.Add(new DicomDecimalString(DicomTag.PatientSize, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidDS))));
             dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidIS))));
+            dataset.Add(new DicomIntegerString(DicomTag.Exposure, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidISThatThrowsOverflowException))));
             var json = JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.PreferablyAsNumber));
-            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]}}", json);
+            Assert.Equal("{\"00081160\":{\"vr\":\"IS\",\"Value\":[\"InvalidIS\"]},\"00101020\":{\"vr\":\"DS\",\"Value\":[\"InvalidDS\"]},\"00181152\":{\"vr\":\"IS\",\"Value\":[\"73.8\"]}}", json);
         }
 
         [Fact]
-        public static void GivenInvalidValueForDS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        public static void GivenInvalidValueForDS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowFormatException()
         {
             var dataset = new DicomDataset().NotValidated();
             const string invalidNumber = "InvalidNumber";
@@ -1167,12 +1169,21 @@ namespace FellowOakDicom.Tests.Serialization
         }
 
         [Fact]
-        public static void GivenInvalidValueForIS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowError()
+        public static void GivenInvalidValueForIS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowFormatException()
         {
             var dataset = new DicomDataset().NotValidated();
             const string invalidNumber = "InvalidNumber";
             dataset.Add(new DicomIntegerString(DicomTag.ReferencedFrameNumber, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidNumber))));
             Assert.Throws<FormatException>(() => JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsNumber)));
+        }
+
+        [Fact]
+        public static void GivenInvalidValueForIS_WhenNumberSerializationModeAsNumber_ThenDeserializationShouldThrowOverflowException()
+        {
+            var dataset = new DicomDataset().NotValidated();
+            const string invalidNumber = "2147483647500";
+            dataset.Add(new DicomIntegerString(DicomTag.Exposure, new MemoryByteBuffer(Encoding.ASCII.GetBytes(invalidNumber))));
+            Assert.Throws<OverflowException>(() => JsonConvert.SerializeObject(dataset, new JsonDicomConverter(numberSerializationMode: NumberSerializationMode.AsNumber)));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1521.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
Catch OverflowException when converting an VR IS to an integer. 
