### PR TITLE
Proposal: Add json serialize option to include tag keyword and name

### DIFF
--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -141,6 +141,20 @@ namespace FellowOakDicom.Serialization
             _numberSerializationMode = numberSerializationMode;
         }
 
+        /// <summary>
+        /// With his option enabled, Dicom tag keyword will be written as a
+        /// distinct Json attribute. 
+        /// Note! This is non-standard and may break parsers!
+        /// </summary>
+        public bool WriteKeyword { get; set; } = false;
+
+        /// <summary>
+        /// With his option enabled, Dicom tag name will be written as a
+        /// distinct Json attribute. 
+        /// Note! This is non-standard and may break parsers!
+        /// </summary>
+        public bool WriteName { get; set; } = false;
+
         #region JsonConverter overrides
 
 
@@ -415,6 +429,21 @@ namespace FellowOakDicom.Serialization
                 default:
                     WriteJsonElement<string>(writer, (DicomElement)item, (w, v) => writer.WriteStringValue(v));
                     break;
+            }
+
+            if (WriteKeyword || WriteName)
+            {
+                var unknown = item.Tag.DictionaryEntry == null
+                              || string.IsNullOrWhiteSpace(item.Tag.DictionaryEntry.Keyword)
+                              || (item.Tag.DictionaryEntry.MaskTag != null && item.Tag.DictionaryEntry.MaskTag.Mask != 0xffffffff);
+
+                if (!unknown)
+                {
+                    if (WriteKeyword)
+                        writer.WriteString("keyword", item.Tag.DictionaryEntry.Keyword);
+                    if (WriteName)
+                        writer.WriteString("name", item.Tag.DictionaryEntry.Name);
+                }
             }
 
             writer.WriteEndObject();

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -732,6 +732,8 @@ namespace FellowOakDicom.Serialization
             }
             else
             {
+                // Find the value of the VR property on a copy of the reader.
+                // This preserves the current location of the reader
                 vr = FindValue(reader, "vr", "none");
             }
 
@@ -809,23 +811,17 @@ namespace FellowOakDicom.Serialization
             {
                 return Array.Empty<string>();
             }
-            string propertyname = ReadPropertyName(ref reader);
 
-            if (propertyname == "Value")
+            switch (MoveToProperty(ref reader, "Value", "BulkDataURI"))
             {
-                return ReadJsonMultiStringValue(ref reader);
-            }
-            else if (propertyname == "BulkDataURI")
-            {
-                // JToken bulk
-                return ReadJsonBulkDataUri(ref reader);
-            }
-            else
-            {
-                return Array.Empty<string>();
+                case "Value":
+                    return ReadJsonMultiStringValue(ref reader);
+                case "BulkDataURI":
+                    return ReadJsonBulkDataUri(ref reader);
+                default:
+                    return Array.Empty<string>();
             }
         }
-
 
         private static string ReadPropertyName(ref Utf8JsonReader reader)
         {
@@ -874,19 +870,15 @@ namespace FellowOakDicom.Serialization
             {
                 return Array.Empty<T>();
             }
-            string propertyname = ReadPropertyName(ref reader);
 
-            if (propertyname == "Value")
+            switch (MoveToProperty(ref reader, "Value", "BulkDataURI"))
             {
-                return ReadJsonMultiNumberOrStringValue<T>(ref reader, getValue, tryParse);
-            }
-            else if (propertyname == "BulkDataURI")
-            {
-                return ReadJsonBulkDataUri(ref reader);
-            }
-            else
-            {
-                return Array.Empty<T>();
+                case "Value":
+                    return ReadJsonMultiNumberOrStringValue<T>(ref reader, getValue, tryParse);
+                case "BulkDataURI":
+                    return ReadJsonBulkDataUri(ref reader);
+                default:
+                    return Array.Empty<T>();
             }
         }
 
@@ -932,19 +924,15 @@ namespace FellowOakDicom.Serialization
             {
                 return Array.Empty<T>();
             }
-            string propertyname = ReadPropertyName(ref reader);
 
-            if (propertyname == "Value")
+            switch (MoveToProperty(ref reader, "Value", "BulkDataURI"))
             {
-                return ReadJsonMultiNumberValue<T>(ref reader, getValue);
-            }
-            else if (propertyname == "BulkDataURI")
-            {
-                return ReadJsonBulkDataUri(ref reader);
-            }
-            else
-            {
-                return Array.Empty<T>();
+                case "Value":
+                    return ReadJsonMultiNumberValue<T>(ref reader, getValue);
+                case "BulkDataURI":
+                    return ReadJsonBulkDataUri(ref reader);
+                default:
+                    return Array.Empty<T>();
             }
         }
 
@@ -988,92 +976,90 @@ namespace FellowOakDicom.Serialization
             {
                 return Array.Empty<string>();
             }
-            var propertyName = ReadPropertyName(ref reader);
 
-            if (propertyName == "Value")
+            switch (MoveToProperty(ref reader, "Value"))
             {
-                if (reader.TokenType == JsonTokenType.Null)
-                {
-                    reader.Read();
-                    return Array.Empty<string>();
-                }
-                else
-                {
-                    reader.AssumeAndSkip(JsonTokenType.StartArray);
-
-                    var childStrings = new List<string>();
-                    while (reader.TokenType != JsonTokenType.EndArray)
+                case "Value":
+                    if (reader.TokenType == JsonTokenType.Null)
                     {
-                        if (reader.TokenType == JsonTokenType.Null)
-                        {
-                            reader.Read();
-                            childStrings.Add(null);
-                        }
-                        else if (reader.TokenType == JsonTokenType.StartObject)
-                        {
-                            // parse
-                            reader.Read(); // read into object
-                            var componentGroupCount = 3;
-                            var componentGroupValues = new string[componentGroupCount];
-                            while (reader.TokenType != JsonTokenType.EndObject)
-                            {
-                                if (reader.TokenType == JsonTokenType.PropertyName
-                                    && reader.GetString() == "Alphabetic")
-                                {
-                                    reader.Read(); // skip propertyname
-                                    componentGroupValues[0] = reader.GetString(); // read value
-                                }
-                                else if (reader.TokenType == JsonTokenType.PropertyName
-                                    && reader.GetString() == "Ideographic")
-                                {
-                                    reader.Read(); // skip propertyname
-                                    componentGroupValues[1] = reader.GetString(); // read value
-                                }
-                                else if (reader.TokenType == JsonTokenType.PropertyName
-                                    && reader.GetString() == "Phonetic")
-                                {
-                                    reader.Read(); // skip propertyname
-                                    componentGroupValues[2] = reader.GetString(); // read value
-                                }
-                                reader.Read();
-                            }
-
-                            //build
-                            StringBuilder stringBuilder = new StringBuilder();
-                            for (int i = 0; i < componentGroupCount; i++)
-                            {
-                                var val = componentGroupValues[i];
-
-                                if (!string.IsNullOrWhiteSpace(val))
-                                {
-                                    stringBuilder.Append(val);
-
-                                }
-                                stringBuilder.Append(_personNameComponentGroupDelimiter);
-                            }
-
-                            //remove optional trailing delimiters
-                            string pnVal = stringBuilder.ToString().TrimEnd(_personNameComponentGroupDelimiter);
-
-                            childStrings.Add(pnVal); // add value
-                            reader.AssumeAndSkip(JsonTokenType.EndObject);
-                        }
-                        else
-                        {
-                            // TODO: invalid. handle this?
-                        }
+                        reader.Read();
+                        return Array.Empty<string>();
                     }
-                    reader.AssumeAndSkip(JsonTokenType.EndArray);
-                    var data = childStrings.ToArray();
-                    return data;
-                }
-            }
-            else
-            {
-                throw new JsonException("Malformed DICOM json, property 'Value' expected");
+                    else
+                    {
+                        reader.AssumeAndSkip(JsonTokenType.StartArray);
+
+                        var childStrings = new List<string>();
+                        while (reader.TokenType != JsonTokenType.EndArray)
+                        {
+                            if (reader.TokenType == JsonTokenType.Null)
+                            {
+                                reader.Read();
+                                childStrings.Add(null);
+                            }
+                            else if (reader.TokenType == JsonTokenType.StartObject)
+                            {
+                                // parse
+                                reader.Read(); // read into object
+                                var componentGroupCount = 3;
+                                var componentGroupValues = new string[componentGroupCount];
+                                while (reader.TokenType != JsonTokenType.EndObject)
+                                {
+                                    if (reader.TokenType == JsonTokenType.PropertyName
+                                        && reader.GetString() == "Alphabetic")
+                                    {
+                                        reader.Read(); // skip propertyname
+                                        componentGroupValues[0] = reader.GetString(); // read value
+                                    }
+                                    else if (reader.TokenType == JsonTokenType.PropertyName
+                                        && reader.GetString() == "Ideographic")
+                                    {
+                                        reader.Read(); // skip propertyname
+                                        componentGroupValues[1] = reader.GetString(); // read value
+                                    }
+                                    else if (reader.TokenType == JsonTokenType.PropertyName
+                                        && reader.GetString() == "Phonetic")
+                                    {
+                                        reader.Read(); // skip propertyname
+                                        componentGroupValues[2] = reader.GetString(); // read value
+                                    }
+                                    reader.Read();
+                                }
+
+                                //build
+                                StringBuilder stringBuilder = new StringBuilder();
+                                for (int i = 0; i < componentGroupCount; i++)
+                                {
+                                    var val = componentGroupValues[i];
+
+                                    if (!string.IsNullOrWhiteSpace(val))
+                                    {
+                                        stringBuilder.Append(val);
+
+                                    }
+                                    stringBuilder.Append(_personNameComponentGroupDelimiter);
+                                }
+
+                                //remove optional trailing delimiters
+                                string pnVal = stringBuilder.ToString().TrimEnd(_personNameComponentGroupDelimiter);
+
+                                childStrings.Add(pnVal); // add value
+                                reader.AssumeAndSkip(JsonTokenType.EndObject);
+                            }
+                            else
+                            {
+                                // TODO: invalid. handle this?
+                            }
+                        }
+                        reader.AssumeAndSkip(JsonTokenType.EndArray);
+                        var data = childStrings.ToArray();
+                        return data;
+                    }
+
+                default:
+                    return Array.Empty<string>();
             }
         }
-
 
         private DicomDataset[] ReadJsonSequence(ref Utf8JsonReader reader)
         {
@@ -1081,36 +1067,35 @@ namespace FellowOakDicom.Serialization
             {
                 return Array.Empty<DicomDataset>();
             }
-            var propertyName = ReadPropertyName(ref reader);
 
-            if (propertyName == "Value")
+            switch (MoveToProperty(ref reader, "Value"))
             {
-                reader.AssumeAndSkip(JsonTokenType.StartArray);
-                var childItems = new List<DicomDataset>();
-                while (reader.TokenType != JsonTokenType.EndArray)
-                {
-                    if (reader.TokenType == JsonTokenType.Null)
+                case "Value":
+                    reader.AssumeAndSkip(JsonTokenType.StartArray);
+                    var childItems = new List<DicomDataset>();
+                    while (reader.TokenType != JsonTokenType.EndArray)
                     {
-                        reader.Read();
-                        childItems.Add(null);
+                        if (reader.TokenType == JsonTokenType.Null)
+                        {
+                            reader.Read();
+                            childItems.Add(null);
+                        }
+                        else if (reader.TokenType == JsonTokenType.StartObject)
+                        {
+                            childItems.Add(ReadJsonDataset(ref reader));
+                            reader.AssumeAndSkip(JsonTokenType.EndObject);
+                        }
+                        else
+                        {
+                            throw new JsonException("Malformed DICOM json, object expected");
+                        }
                     }
-                    else if (reader.TokenType == JsonTokenType.StartObject)
-                    {
-                        childItems.Add(ReadJsonDataset(ref reader));
-                        reader.AssumeAndSkip(JsonTokenType.EndObject);
-                    }
-                    else
-                    {
-                        throw new JsonException("Malformed DICOM json, object expected");
-                    }
-                }
-                reader.AssumeAndSkip(JsonTokenType.EndArray);
-                var data = childItems.ToArray();
-                return data;
-            }
-            else
-            {
-                return Array.Empty<DicomDataset>();
+                    reader.AssumeAndSkip(JsonTokenType.EndArray);
+                    var data = childItems.ToArray();
+                    return data;
+
+                default:
+                    return Array.Empty<DicomDataset>();
             }
         }
 
@@ -1121,17 +1106,16 @@ namespace FellowOakDicom.Serialization
             {
                 return EmptyBuffer.Value;
             }
-            var propertyName = ReadPropertyName(ref reader);
 
-            if (propertyName == "InlineBinary")
+            switch (MoveToProperty(ref reader, "InlineBinary", "BulkDataURI"))
             {
-                return ReadJsonInlineBinary(ref reader);
+                case "InlineBinary":
+                    return ReadJsonInlineBinary(ref reader);
+                case "BulkDataURI":
+                    return ReadJsonBulkDataUri(ref reader);
+                default:
+                    return EmptyBuffer.Value;
             }
-            else if (propertyName == "BulkDataURI")
-            {
-                return ReadJsonBulkDataUri(ref reader);
-            }
-            return EmptyBuffer.Value;
         }
 
 
@@ -1170,6 +1154,43 @@ namespace FellowOakDicom.Serialization
 
         #endregion
 
+        /// <summary>
+        /// Move the reader to the first occurance of any of the specified properties
+        /// in the current Json object
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="properties"></param>
+        /// <returns>
+        /// The name of the property moved to, 
+        /// or null if no such property exists
+        /// </returns>
+        private static string MoveToProperty(ref Utf8JsonReader reader, params string[] properties)
+        {
+            while (reader.TokenType != JsonTokenType.EndObject)
+            {
+                string propertyname = ReadPropertyName(ref reader);
+                if (properties.Contains(propertyname))
+                {
+                    // This property is one of the requested
+                    return propertyname;
+                }
+
+                // Move to next property
+                var currentDepth = reader.CurrentDepth;
+                while (reader.CurrentDepth >= currentDepth && reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.PropertyName
+                        && reader.CurrentDepth == currentDepth)
+                    {
+                        // We have found the next property in the same object
+                        break;
+                    }
+                }
+            }
+
+            reader.Assume(JsonTokenType.EndObject);
+            return null;
+        }
 
         private string FindValue(Utf8JsonReader reader, string property, string defaultValue)
         {
@@ -1204,7 +1225,6 @@ namespace FellowOakDicom.Serialization
             => ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
 
     }
-
 
     internal static class JsonDicomConverterExtensions
     {


### PR DESCRIPTION
When serializing to Json, if the purpose is to provide a client application with detailed information, it would help to have the Dicom name and maybe the keyword in addition to other data. 
As the Json model (https://dicom.nema.org/dicom/2013/output/chtml/part18/sect_F.2.html) is based on the XML model, in which the keyword actually is mandatory, I think it makes sense to have this non-standard option, to use in non data-exchange scenarios.

Note: Using the existing non-standard option to set keyword as property name, this removes the tag number (0000,1111) which can make it harder for a user to find correct information in the dataset. I think this is also "more" non-standard and would definitely break data exchange scenarios.

Example of serialized Json:

` 
  "00080201": {
    "vr": "SH",
    "Value": [
      "-0400"
    ],
    "keyword": "TimezoneOffsetFromUTC",
    "name": "Timezone Offset From UTC"
  },
  "00081030": {
    "vr": "LO",
    "Value": [
      "Barretts Esophagus"
    ],
    "keyword": "StudyDescription",
    "name": "Study Description"
  },
  "00100010": {
    "vr": "PN",
    "Value": [
      {
        "Alphabetic": "CompressedSamples^VL1"
      }
    ],
    "keyword": "PatientName",
    "name": "Patient's Name"
  },
`
If the proposal is accepted, I will add unit-tests as well.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-
-
-
