### PR TITLE
Use existing implementation class uid and version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,7 @@
 * Fix JsonDicomConverter number serialization mode 'PreferablyAsNumber' to handle integers greater than int.MaxValue or lesser than int.MinValue (#1521)
 * Fixed missing logging of RemoteHost and RemoteIP in SCU (#1518)
 * Added null check for EscapeXml in DicomXML (#1392)
+* Use existing implementation class uid and version (#1545)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/Contributors.md
+++ b/Contributors.md
@@ -89,3 +89,4 @@
 * [Olivier Revelat](https://github.com/olivier-med)
 * [Tars De Jaeger](https://github.com/tarsdejaeger)
 * [Ryan Rozario](https://github.com/ryan-rozario)
+* [Karthik Balasubramanian](https://github.com/bcarthic)

--- a/FO-DICOM.Core/DicomFile.cs
+++ b/FO-DICOM.Core/DicomFile.cs
@@ -127,7 +127,7 @@ namespace FellowOakDicom
         /// <param name="options">Options to apply during writing.</param>
         public void Save(string fileName, DicomWriteOptions options = null)
         {
-            PreprocessFileMetaInformation();
+            PreprocessFileMetaInformation(options.KeepExistingImplementionClassIdAndVersionValue);
 
             File = Setup.ServiceProvider.GetService<IFileReferenceFactory>().Create(fileName);
             File.Delete();
@@ -146,7 +146,7 @@ namespace FellowOakDicom
         /// <param name="options">Options to apply during writing.</param>
         public void Save(Stream stream, DicomWriteOptions options = null)
         {
-            PreprocessFileMetaInformation();
+            PreprocessFileMetaInformation(options.KeepExistingImplementionClassIdAndVersionValue);
             OnSave();
 
             var target = new StreamByteTarget(stream);
@@ -162,7 +162,7 @@ namespace FellowOakDicom
         /// <returns>Awaitable <see cref="Task"/>.</returns>
         public async Task SaveAsync(string fileName, DicomWriteOptions options = null)
         {
-            PreprocessFileMetaInformation();
+            PreprocessFileMetaInformation(options.KeepExistingImplementionClassIdAndVersionValue);
 
             File = Setup.ServiceProvider.GetService<IFileReferenceFactory>().Create(fileName);
             File.Delete();
@@ -182,7 +182,7 @@ namespace FellowOakDicom
         /// <returns>Awaitable task.</returns>
         public async Task SaveAsync(Stream stream, DicomWriteOptions options = null)
         {
-            PreprocessFileMetaInformation();
+            PreprocessFileMetaInformation(options.KeepExistingImplementionClassIdAndVersionValue);
             OnSave();
 
             var target = new StreamByteTarget(stream);
@@ -514,7 +514,7 @@ namespace FellowOakDicom
         /// Preprocess file meta information before save.
         /// </summary>
         /// <exception cref="DicomFileException">If file format is ACR-NEMA version 2 or 3.</exception>
-        private void PreprocessFileMetaInformation()
+        private void PreprocessFileMetaInformation(bool useExistingImplementionClassIdAnVersion = false)
         {
             if (Format == DicomFileFormat.ACRNEMA1 || Format == DicomFileFormat.ACRNEMA2)
             {
@@ -524,7 +524,7 @@ namespace FellowOakDicom
             // create file meta information from dataset or update existing file meta information.
             FileMetaInfo = Format == DicomFileFormat.DICOM3NoFileMetaInfo
                                     ? new DicomFileMetaInformation(Dataset)
-                                    : new DicomFileMetaInformation(FileMetaInfo);
+                                    : new DicomFileMetaInformation(FileMetaInfo, useExistingImplementionClassIdAnVersion);
         }
 
         #endregion

--- a/FO-DICOM.Core/DicomFileMetaInformation.cs
+++ b/FO-DICOM.Core/DicomFileMetaInformation.cs
@@ -70,7 +70,7 @@ namespace FellowOakDicom
         /// Initializes a new instance of the <see cref="DicomFileMetaInformation"/> class.
         /// </summary>
         /// <param name="metaInfo">DICOM file meta information to be updated.</param>
-        public DicomFileMetaInformation(DicomFileMetaInformation metaInfo)
+        public DicomFileMetaInformation(DicomFileMetaInformation metaInfo, bool useExistingImplementionClassIdAnVersion = false)
         {
             ValidateItems = metaInfo.ValidateItems;
             Version = new byte[] { 0x00, 0x01 };
@@ -79,8 +79,10 @@ namespace FellowOakDicom
             if (metaInfo.Contains(DicomTag.MediaStorageSOPInstanceUID)) MediaStorageSOPInstanceUID = metaInfo.MediaStorageSOPInstanceUID;
             if (metaInfo.Contains(DicomTag.TransferSyntaxUID)) TransferSyntax = metaInfo.TransferSyntax;
 
-            ImplementationClassUID = DicomImplementation.ClassUID;
-            ImplementationVersionName = DicomImplementation.Version;
+            ImplementationClassUID = useExistingImplementionClassIdAnVersion 
+                ? metaInfo.GetSingleValueOrDefault(DicomTag.ImplementationClassUID, DicomImplementation.ClassUID) : DicomImplementation.ClassUID;
+            ImplementationVersionName = useExistingImplementionClassIdAnVersion
+                ? metaInfo.GetSingleValueOrDefault(DicomTag.ImplementationVersionName, DicomImplementation.Version) : DicomImplementation.Version;
 
             var aet = metaInfo.Contains(DicomTag.SourceApplicationEntityTitle) ?
                 metaInfo.SourceApplicationEntityTitle : null;

--- a/FO-DICOM.Core/IO/Writer/DicomWriteOptions.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomWriteOptions.cs
@@ -21,6 +21,7 @@ namespace FellowOakDicom.IO.Writer
             ExplicitLengthSequenceItems = options.ExplicitLengthSequenceItems;
             KeepGroupLengths = options.KeepGroupLengths;
             LargeObjectSize = options.LargeObjectSize;
+            KeepExistingImplementionClassIdAndVersionValue = options.KeepExistingImplementionClassIdAndVersionValue;
         }
 
         private static DicomWriteOptions _default;
@@ -44,5 +45,7 @@ namespace FellowOakDicom.IO.Writer
         public bool KeepGroupLengths { get; set; }
 
         public uint LargeObjectSize { get; set; }
+
+        public bool KeepExistingImplementionClassIdAndVersionValue { get; set; }
     }
 }

--- a/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
@@ -41,6 +41,78 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void ImplementationVersionName_GetterWhenAttributeIncludedAndUseExisting_ReturnsValue()
+        {
+            var inFile = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var metaInfo =
+                new DicomFileMetaInformation(
+                    inFile.FileMetaInfo,
+                    useExistingImplementionClassIdAnVersion: true);
+
+            var exception = Record.Exception(() =>
+            {
+                Assert.NotNull(metaInfo.ImplementationVersionName);
+                Assert.Equal(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationVersionName);
+            });
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ImplementationVersionName_GetterWhenAttributeIncludedAndUseExistingIsFalse_ReturnsValue()
+        {
+            var inFile = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var metaInfo =
+                new DicomFileMetaInformation(
+                    inFile.FileMetaInfo,
+                    useExistingImplementionClassIdAnVersion: true);
+
+            var exception = Record.Exception(() =>
+            {
+                Assert.NotNull(metaInfo.ImplementationVersionName);
+                Assert.NotEqual(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationVersionName);
+            });
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ImplementationClassUID_GetterWhenAttributeIncludedAndUseExisting_ReturnsValue()
+        {
+            var inFile = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var metaInfo =
+                new DicomFileMetaInformation(
+                    inFile.FileMetaInfo,
+                    useExistingImplementionClassIdAnVersion: true);
+
+            var exception = Record.Exception(() =>
+            {
+                Assert.NotNull(metaInfo.ImplementationVersionName);
+                Assert.Equal(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationClassUID);
+            });
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ImplementationClassUID_GetterWhenAttributeIncludedAndUseExistingIsFalse_ReturnsValue()
+        {
+            var inFile = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var metaInfo =
+                new DicomFileMetaInformation(
+                    inFile.FileMetaInfo,
+                    useExistingImplementionClassIdAnVersion: true);
+
+            var exception = Record.Exception(() =>
+            {
+                Assert.NotNull(metaInfo.ImplementationVersionName);
+                Assert.NotEqual(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationClassUID);
+            });
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void SourceApplicationEntityTitle_GetterWhenAttributeMissing_ReturnsNull()
         {
             var metaInfo =

--- a/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
@@ -52,7 +52,7 @@ namespace FellowOakDicom.Tests
             var exception = Record.Exception(() =>
             {
                 Assert.NotNull(metaInfo.ImplementationVersionName);
-                Assert.Equal(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationVersionName);
+                Assert.Equal(inFile.FileMetaInfo.GetSingleValue<string>(DicomTag.ImplementationVersionName), metaInfo.ImplementationVersionName);
             });
 
             Assert.Null(exception);
@@ -70,7 +70,7 @@ namespace FellowOakDicom.Tests
             var exception = Record.Exception(() =>
             {
                 Assert.NotNull(metaInfo.ImplementationVersionName);
-                Assert.NotEqual(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationVersionName);
+                Assert.NotEqual(inFile.FileMetaInfo.GetSingleValue<string>(DicomTag.ImplementationVersionName), metaInfo.ImplementationVersionName);
             });
 
             Assert.Null(exception);
@@ -88,7 +88,7 @@ namespace FellowOakDicom.Tests
             var exception = Record.Exception(() =>
             {
                 Assert.NotNull(metaInfo.ImplementationVersionName);
-                Assert.Equal(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationClassUID);
+                Assert.Equal(inFile.FileMetaInfo.GetSingleValue<DicomUID>(DicomTag.ImplementationClassUID), metaInfo.ImplementationClassUID);
             });
 
             Assert.Null(exception);
@@ -106,7 +106,7 @@ namespace FellowOakDicom.Tests
             var exception = Record.Exception(() =>
             {
                 Assert.NotNull(metaInfo.ImplementationVersionName);
-                Assert.NotEqual(inFile.FileMetaInfo.GetSingleValue(DicomTag.ImplementationClassUID), metaInfo.ImplementationClassUID);
+                Assert.NotEqual(inFile.FileMetaInfo.GetSingleValue<DicomUID>(DicomTag.ImplementationClassUID), metaInfo.ImplementationClassUID);
             });
 
             Assert.Null(exception);

--- a/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
@@ -65,7 +65,7 @@ namespace FellowOakDicom.Tests
             var metaInfo =
                 new DicomFileMetaInformation(
                     inFile.FileMetaInfo,
-                    useExistingImplementionClassIdAnVersion: true);
+                    useExistingImplementionClassIdAnVersion: false);
 
             var exception = Record.Exception(() =>
             {
@@ -101,7 +101,7 @@ namespace FellowOakDicom.Tests
             var metaInfo =
                 new DicomFileMetaInformation(
                     inFile.FileMetaInfo,
-                    useExistingImplementionClassIdAnVersion: true);
+                    useExistingImplementionClassIdAnVersion: false);
 
             var exception = Record.Exception(() =>
             {


### PR DESCRIPTION
#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
This PR include changes to use existing implementation Class UID and implementation Version name on DicomFile.Save and DicomFile.SaveAsync

Currenly fo-dicom updates the uid and version name to different value compared to the original file values. To keep the original values, this change is proposed