### PR TITLE
XML documentation fixes

### DIFF
--- a/FO-DICOM.Core/DicomAnonymizer.cs
+++ b/FO-DICOM.Core/DicomAnonymizer.cs
@@ -106,9 +106,9 @@ namespace FellowOakDicom
             /// <param name="source">A reader for a profile file source. If null, the default profile is loaded</param>
             /// <param name="options">The optional flags for the profile</param>
             /// <returns>A dictionary containing the security profile</returns>
-            /// <exception cref="ArgumentException">A regular expression parsing error occurred</exception>
-            /// <exception cref="IOException">An I/O error occurs</exception>
-            /// <exception cref="ObjectDisposedException">The TextReader is closed</exception>
+            /// <exception cref="System.ArgumentException">A regular expression parsing error occurred</exception>
+            /// <exception cref="System.IO.IOException">An I/O error occurs</exception>
+            /// <exception cref="System.ObjectDisposedException">The TextReader is closed</exception>
             public static SecurityProfile LoadProfile(TextReader source, SecurityProfileOptions options)
             {
                 var profile = new SecurityProfile();

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -779,7 +779,7 @@ namespace FellowOakDicom
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
         /// <returns>The dataset instance.</returns>
-        /// <exception cref="ArgumentException">If tag of added item already exists in dataset.</exception>
+        /// <exception cref="System.ArgumentException">If tag of added item already exists in dataset.</exception>
         public DicomDataset Add(params DicomItem[] items)
         {
             return DoAdd(items, false);
@@ -790,7 +790,7 @@ namespace FellowOakDicom
         /// </summary>
         /// <param name="items">Collection of DICOM items to add.</param>
         /// <returns>The dataset instance.</returns>
-        /// <exception cref="ArgumentException">If tag of added item already exists in dataset.</exception>
+        /// <exception cref="System.ArgumentException">If tag of added item already exists in dataset.</exception>
         public DicomDataset Add(IEnumerable<DicomItem> items)
         {
             return DoAdd(items, false);
@@ -803,7 +803,7 @@ namespace FellowOakDicom
         /// <param name="tag">DICOM tag of the added item.</param>
         /// <param name="values">Values of the added item.</param>
         /// <returns>The dataset instance.</returns>
-        /// <exception cref="ArgumentException">If tag already exists in dataset.</exception>
+        /// <exception cref="System.ArgumentException">If tag already exists in dataset.</exception>
         public DicomDataset Add<T>(DicomTag tag, params T[] values)
         {
             return DoAdd(tag, values, false);
@@ -820,7 +820,7 @@ namespace FellowOakDicom
         /// This method is useful when adding a private tag and need to explicitly set the VR of the created element.
         /// </remarks>
         /// <returns>The dataset instance.</returns>
-        /// <exception cref="ArgumentException">If tag already exists in dataset.</exception>
+        /// <exception cref="System.ArgumentException">If tag already exists in dataset.</exception>
         public DicomDataset Add<T>(DicomVR vr, DicomTag tag, params T[] values)
         {
             return DoAdd(vr, tag, values, false);

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -26,12 +26,12 @@ namespace FellowOakDicom
             };
 
         /// <summary>
-        /// Get a composite <see cref="DateTime"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
+        /// Get a composite <see cref="System.DateTime"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
         /// </summary>
         /// <param name="dataset">Dataset from which data should be retrieved.</param>
         /// <param name="date">Tag associated with date value.</param>
         /// <param name="time">Tag associated with time value.</param>
-        /// <returns>Composite <see cref="DateTime"/>.</returns>
+        /// <returns>Composite <see cref="System.DateTime"/>.</returns>
         public static DateTime GetDateTime(this DicomDataset dataset, DicomTag date, DicomTag time)
         {
             var dd = dataset.GetDicomItem<DicomDate>(date);
@@ -44,15 +44,15 @@ namespace FellowOakDicom
         }
 
         /// <summary>
-        /// Get a composite <see cref="DateTimeOffset"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
+        /// Get a composite <see cref="System.DateTimeOffset"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
         /// This will take any time zone information specified in the dataset into account. 
-        /// If the dataset is a child sequence item, the <see cref="topLevelDataset"/> must be specified to find time zone information.
+        /// If the dataset is a child sequence item, the <paramref name="topLevelDataset"/> must be specified to find time zone information.
         /// </summary>
         /// <param name="dataset">Dataset from which data should be retrieved.</param>
         /// <param name="date">Tag associated with date value.</param>
         /// <param name="time">Tag associated with time value.</param>
         /// <param name="topLevelDataset">The top-level dataset (if different from the current dataset). This is where the time zone information will be located</param>
-        /// <returns>Composite <see cref="DateTimeOffset"/>.</returns>
+        /// <returns>Composite <see cref="System.DateTimeOffset"/>.</returns>
         public static DateTimeOffset GetDateTimeOffset(this DicomDataset dataset, DicomTag date, DicomTag time, DicomDataset topLevelDataset = null)
         {
             var datetime = GetDateTime(dataset, date, time);

--- a/FO-DICOM.Core/DicomDatasetWalker.cs
+++ b/FO-DICOM.Core/DicomDatasetWalker.cs
@@ -195,7 +195,7 @@ namespace FellowOakDicom
         /// Perform an asynchronous "walk" across the DICOM dataset provided in the <see cref="DicomDatasetWalker"/> constructor.
         /// </summary>
         /// <param name="walker">Dataset walker implementation to be used for dataset traversal.</param>
-        /// <returns>Awaitable <see cref="Task"/>.</returns>
+        /// <returns>Awaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         public Task WalkAsync(IDicomDatasetWalker walker)
         {
             _dataset.OnBeforeSerializing();

--- a/FO-DICOM.Core/DicomEncoding.cs
+++ b/FO-DICOM.Core/DicomEncoding.cs
@@ -110,7 +110,7 @@ namespace FellowOakDicom
         /// <param name="encoding">Encoding.</param>
         /// <param name="extended">If true, the extended version of the character set is returned.</param>
         /// <returns>The Specific Character Set as defined in DICOM.</returns>
-        /// <exception cref="ArgumentException">No character set found for the encoding.</exception>
+        /// <exception cref="System.ArgumentException">No character set found for the encoding.</exception>
         public static string GetCharset(Encoding encoding, bool extended = false)
         {
             var name = _knownEncodingNames.FirstOrDefault(x => x.Value == encoding.WebName &&

--- a/FO-DICOM.Core/DicomFile.cs
+++ b/FO-DICOM.Core/DicomFile.cs
@@ -159,7 +159,7 @@ namespace FellowOakDicom
         /// </summary>
         /// <param name="fileName">Name of file.</param>
         /// <param name="options">Options to apply during writing.</param>
-        /// <returns>Awaitable <see cref="Task"/>.</returns>
+        /// <returns>Awaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         public async Task SaveAsync(string fileName, DicomWriteOptions options = null)
         {
             PreprocessFileMetaInformation();

--- a/FO-DICOM.Core/DicomTransferSyntax.cs
+++ b/FO-DICOM.Core/DicomTransferSyntax.cs
@@ -77,10 +77,8 @@ namespace FellowOakDicom
 
         #region METHODS
 
-        /// <inheritdoc />
         public override string ToString() => UID.Name;
 
-        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             return obj switch
@@ -92,7 +90,6 @@ namespace FellowOakDicom
             };
         }
 
-        /// <inheritdoc />
         public override int GetHashCode() => UID.GetHashCode();
 
         #endregion

--- a/FO-DICOM.Core/IO/Buffer/IBulkDataUriByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/IBulkDataUriByteBuffer.cs
@@ -10,7 +10,7 @@ namespace FellowOakDicom.IO.Buffer
     public interface IBulkDataUriByteBuffer : IByteBuffer
     {
         /// <summary>
-        /// Gets the URI of a bulk data element as defined in <see cref="!:http://dicom.nema.org/medical/dicom/current/output/chtml/part19/chapter_A.html#table_A.1.5-2">Table A.1.5-2 in PS3.19</see>.
+        /// Gets the URI of a bulk data element as defined in <a href="http://dicom.nema.org/medical/dicom/current/output/chtml/part19/chapter_A.html#table_A.1.5-2">Table A.1.5-2 in PS3.19</a>.
         /// </summary>
         string BulkDataUri { get; }
     }

--- a/FO-DICOM.Core/IO/DirectoryReference.cs
+++ b/FO-DICOM.Core/IO/DirectoryReference.cs
@@ -23,7 +23,7 @@ namespace FellowOakDicom.IO
         #region CONSTRUCTORS
 
         /// <summary>
-        /// Initializes a <see cref="DesktopDirectoryReference"/> object.
+        /// Initializes a <see cref="DirectoryReference"/> object.
         /// </summary>
         /// <param name="directoryName">Name of the directory.</param>
         public DirectoryReference(string directoryName)

--- a/FO-DICOM.Core/IO/Endian.cs
+++ b/FO-DICOM.Core/IO/Endian.cs
@@ -27,7 +27,7 @@ namespace FellowOakDicom.IO
         public static readonly Endian Big = new Endian(true);
 
         /// <summary>
-        /// Endianness of the local machine, according to <see cref="BitConverter.IsLittleEndian"/>.
+        /// Endianness of the local machine, according to <see cref="System.BitConverter.IsLittleEndian"/>.
         /// </summary>
         public static readonly Endian LocalMachine = BitConverter.IsLittleEndian ? Little : Big;
 
@@ -47,7 +47,6 @@ namespace FellowOakDicom.IO
             _isBigEndian = isBigEndian;
         }
 
-        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             if (obj == null) return false;
@@ -55,13 +54,11 @@ namespace FellowOakDicom.IO
             return false;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return _isBigEndian.GetHashCode();
         }
 
-        /// <inheritdoc />
         public override string ToString()
         {
             return _isBigEndian ? "Big Endian" : "Little Endian";
@@ -324,7 +321,7 @@ namespace FellowOakDicom.IO
         /// </summary>
         /// <typeparam name="T">Array element type, must be one of <see cref="short"/>, <see cref="ushort"/>, <see cref="int"/> or <see cref="uint"/>.</typeparam>
         /// <param name="values">Array of values to swap.</param>
-        /// <exception cref="InvalidOperationException">if array element type is not <see cref="short"/>, <see cref="ushort"/>, <see cref="int"/> or <see cref="uint"/>.</exception>
+        /// <exception cref="System.InvalidOperationException">if array element type is not <see cref="short"/>, <see cref="ushort"/>, <see cref="int"/> or <see cref="uint"/>.</exception>
         public static void Swap<T>(T[] values)
         {
             if (typeof(T) == typeof(short)) Swap(values as short[]);

--- a/FO-DICOM.Core/IO/FileByteTarget.cs
+++ b/FO-DICOM.Core/IO/FileByteTarget.cs
@@ -164,7 +164,7 @@ namespace FellowOakDicom.IO
         /// <param name="buffer">Array of <see cref="byte"/>s to write.</param>
         /// <param name="offset">Index of first position in <paramref name="buffer"/> to write to byte target.</param>
         /// <param name="count">Number of bytes to write to byte target.</param>
-        /// <returns>Avaitable <see cref="Task"/>.</returns>
+        /// <returns>Avaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         public Task WriteAsync(byte[] buffer, uint offset, uint count)
         {
             return _stream.WriteAsync(buffer, (int)offset, (int)count);

--- a/FO-DICOM.Core/IO/FileReference.cs
+++ b/FO-DICOM.Core/IO/FileReference.cs
@@ -22,7 +22,7 @@ namespace FellowOakDicom.IO
         private bool _isTempFile;
 
         /// <summary>
-        /// Initializes a <see cref="DesktopFileReference"/> object.
+        /// Initializes a <see cref="FileReference"/> object.
         /// </summary>
         /// <param name="fileName">File name.</param>
         public FileReference(string fileName)

--- a/FO-DICOM.Core/IO/IByteTarget.cs
+++ b/FO-DICOM.Core/IO/IByteTarget.cs
@@ -96,7 +96,7 @@ namespace FellowOakDicom.IO
         /// <param name="buffer">Array of <see cref="byte"/>s to write.</param>
         /// <param name="offset">Index of first position in <paramref name="buffer"/> to write to byte target.</param>
         /// <param name="count">Number of bytes to write to byte target.</param>
-        /// <returns>Avaitable <see cref="Task"/>.</returns>
+        /// <returns>Avaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         Task WriteAsync(byte[] buffer, uint offset, uint count);
 
         /// <summary>

--- a/FO-DICOM.Core/IO/StreamByteTarget.cs
+++ b/FO-DICOM.Core/IO/StreamByteTarget.cs
@@ -155,7 +155,7 @@ namespace FellowOakDicom.IO
         /// <param name="buffer">Array of <see cref="byte"/>s to write.</param>
         /// <param name="offset">Index of first position in <paramref name="buffer"/> to write to byte target.</param>
         /// <param name="count">Number of bytes to write to byte target.</param>
-        /// <returns>Avaitable <see cref="Task"/>.</returns>
+        /// <returns>Avaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         public Task WriteAsync(byte[] buffer, uint offset, uint count)
         {
             return _stream.WriteAsync(buffer, (int)offset, (int)count);

--- a/FO-DICOM.Core/IO/Writer/DicomFileWriter.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomFileWriter.cs
@@ -53,7 +53,7 @@ namespace FellowOakDicom.IO.Writer
         /// <param name="target">Byte target subject to writing.</param>
         /// <param name="fileMetaInfo">File meta information.</param>
         /// <param name="dataset">Dataset.</param>
-        /// <returns>Awaitable <see cref="Task"/>.</returns>
+        /// <returns>Awaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         public async Task WriteAsync(IByteTarget target, DicomFileMetaInformation fileMetaInfo, DicomDataset dataset)
         {
             await WritePreambleAsync(target).ConfigureAwait(false);

--- a/FO-DICOM.Core/Imaging/BitDepth.cs
+++ b/FO-DICOM.Core/Imaging/BitDepth.cs
@@ -112,10 +112,10 @@ namespace FellowOakDicom.Imaging
         }
 
         /// <summary>
-        /// Create new instance of <seealso cref="BitDepth"/> from input <paramref name="dataset"/>
+        /// Create new instance of <see cref="BitDepth"/> from input <paramref name="dataset"/>
         /// </summary>
         /// <param name="dataset">Input dataset to extract bit depth information from</param>
-        /// <returns>New <seealso cref="BitDepth"/> instance</returns>
+        /// <returns>New <see cref="BitDepth"/> instance</returns>
         public static BitDepth FromDataset(DicomDataset dataset)
         {
             var allocated = dataset.GetSingleValue<ushort>(DicomTag.BitsAllocated);

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/DicomJpegLosslessDecoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/DicomJpegLosslessDecoder.cs
@@ -45,7 +45,7 @@ namespace FellowOakDicom.Imaging.Codec.JpegLossless
         /// </summary>
         /// <param name="data">ByteBuffer which contains a jpeg lossess</param>
         /// <returns>if successfully a MemoryStream contained the codeded data is returned</returns>
-        /// <exception cref="IOException"></exception>
+        /// <exception cref="System.IO.IOException"></exception>
         private MemoryStream ReadImage(IByteBuffer data)
         {
             using var decoder = new DicomJpegLosslessDecoderImpl(data);

--- a/FO-DICOM.Core/Imaging/DicomImagingException.cs
+++ b/FO-DICOM.Core/Imaging/DicomImagingException.cs
@@ -7,12 +7,12 @@ namespace FellowOakDicom.Imaging
 {
 
     /// <summary>
-    /// <seealso cref="DicomImage"/> operations related exceptions
+    /// <see cref="DicomImage"/> operations related exceptions
     /// </summary>
     public class DicomImagingException : DicomException
     {
         /// <summary>
-        /// Initialize new instance of <seealso cref="DicomImagingException"/> class
+        /// Initialize new instance of <see cref="DicomImagingException"/> class
         /// </summary>
         /// <param name="message">The message that describes the error</param>
         public DicomImagingException(string message)
@@ -21,7 +21,7 @@ namespace FellowOakDicom.Imaging
         }
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="DicomImagingException"/> class
+        /// Initialize new instance of <see cref="DicomImagingException"/> class
         /// </summary>
         /// <param name="message">The message that describes the error</param>
         /// <param name="innerException">The exception that is the cause of the current exception</param>

--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -62,7 +62,7 @@ namespace FellowOakDicom.Imaging
         }
 
         /// <summary>
-        /// Gets new instance of <seealso cref="BitDepth"/> using dataset information.
+        /// Gets new instance of <see cref="BitDepth"/> using dataset information.
         /// </summary>
         public BitDepth BitDepth => new BitDepth(
             BitsAllocated,
@@ -206,12 +206,12 @@ namespace FellowOakDicom.Imaging
         }
 
         /// <summary>
-        /// Gets palette color LUT, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
+        /// Gets palette color LUT, valid for PALETTE COLOR <see cref="PhotometricInterpretation"/>
         /// </summary>
         public Color32[] PaletteColorLUT => GetPaletteColorLUT();
 
         /// <summary>
-        /// Extracts the palette color LUT from DICOM dataset, valid for PALETTE COLOR <seealso cref="PhotometricInterpretation"/>
+        /// Extracts the palette color LUT from DICOM dataset, valid for PALETTE COLOR <see cref="PhotometricInterpretation"/>
         /// </summary>
         /// <returns>Palette color LUT</returns>
         /// <exception cref="DicomImagingException">Invalid photometric interpretation or plaette color lUT missing from database</exception>
@@ -286,12 +286,12 @@ namespace FellowOakDicom.Imaging
         public abstract void AddFrame(IByteBuffer data);
 
         /// <summary>
-        /// A factory method to initialize new instance of <seealso cref="DicomPixelData"/> implementation either 
-        /// <seealso cref="OtherWordPixelData"/>, <seealso cref="OtherBytePixelData"/>, or <seealso cref="EncapsulatedPixelData"/>
+        /// A factory method to initialize new instance of <see cref="DicomPixelData"/> implementation either 
+        /// <see cref="OtherWordPixelData"/>, <see cref="OtherBytePixelData"/>, or <see cref="EncapsulatedPixelData"/>
         /// </summary>
         /// <param name="dataset">Source DICOM Dataset</param>
-        /// <param name="newPixelData">true if new <seealso cref="DicomPixelData"/>will be created for current dataset,
-        /// false to read <seealso cref="DicomPixelData"/> from <paramref name="dataset"/>.
+        /// <param name="newPixelData">true if new <see cref="DicomPixelData"/>will be created for current dataset,
+        /// false to read <see cref="DicomPixelData"/> from <paramref name="dataset"/>.
         /// Default is false (read)</param>
         /// <returns>New instance of DicomPixelData</returns>
         public static DicomPixelData Create(DicomDataset dataset, bool newPixelData = false)
@@ -349,7 +349,7 @@ namespace FellowOakDicom.Imaging
         }
 
         /// <summary>
-        /// Other Byte (OB) implementation of <seealso cref="DicomPixelData"/>
+        /// Other Byte (OB) implementation of <see cref="DicomPixelData"/>
         /// </summary>
         private sealed class OtherBytePixelData : DicomPixelData
         {
@@ -421,7 +421,7 @@ namespace FellowOakDicom.Imaging
         }
 
         /// <summary>
-        /// Other Word (OW) implementation of <seealso cref="DicomPixelData"/>
+        /// Other Word (OW) implementation of <see cref="DicomPixelData"/>
         /// </summary>
         private sealed class OtherWordPixelData : DicomPixelData
         {
@@ -496,7 +496,7 @@ namespace FellowOakDicom.Imaging
         }
 
         /// <summary>
-        /// Other Byte/Word Fragment implementation of <seealso cref="DicomPixelData"/>, used for handling encapsulated (compressed)
+        /// Other Byte/Word Fragment implementation of <see cref="DicomPixelData"/>, used for handling encapsulated (compressed)
         /// pixel data
         /// </summary>
         private sealed class EncapsulatedPixelData : DicomPixelData

--- a/FO-DICOM.Core/Imaging/LUT/InvertLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/InvertLUT.cs
@@ -5,7 +5,7 @@ namespace FellowOakDicom.Imaging.LUT
 {
 
     /// <summary>
-    /// Invert LUT implementation of <seealso cref="ILUT"/> to invert grayscale images
+    /// Invert LUT implementation of <see cref="ILUT"/> to invert grayscale images
     /// </summary>
     public class InvertLUT : ILUT
     {
@@ -16,7 +16,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="InvertLUT"/> 
+        /// Initialize new instance of <see cref="InvertLUT"/> 
         /// </summary>
         /// <param name="minValue">Miniumum input value</param>
         /// <param name="maxValue">Maximum output value</param>

--- a/FO-DICOM.Core/Imaging/LUT/ModalityRescaleLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/ModalityRescaleLUT.cs
@@ -5,7 +5,7 @@ namespace FellowOakDicom.Imaging.LUT
 {
 
     /// <summary>
-    /// Modality Rescale LUT implementation of <seealso cref="IModalityLUT"/> and <seealso cref="ILUT"/>
+    /// Modality Rescale LUT implementation of <see cref="IModalityLUT"/> and <see cref="ILUT"/>
     /// </summary>
     public class ModalityRescaleLUT : IModalityLUT
     {
@@ -18,7 +18,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="ModalityRescaleLUT"/> using the specified slope and intercept parameters
+        /// Initialize new instance of <see cref="ModalityRescaleLUT"/> using the specified slope and intercept parameters
         /// </summary>
         /// <param name="options">Render options</param>
         public ModalityRescaleLUT(GrayscaleRenderOptions options)

--- a/FO-DICOM.Core/Imaging/LUT/ModalitySequenceLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/ModalitySequenceLUT.cs
@@ -8,7 +8,7 @@ namespace FellowOakDicom.Imaging.LUT
 {
 
     /// <summary>
-    /// Modality Sequence LUT implementation of <seealso cref="IModalityLUT"/> and <seealso cref="ILUT"/>
+    /// Modality Sequence LUT implementation of <see cref="IModalityLUT"/> and <see cref="ILUT"/>
     /// </summary>
     public class ModalitySequenceLUT : IModalityLUT
     {
@@ -29,7 +29,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="ModalitySequenceLUT"/> using the specified Modality LUT Descriptor and Data
+        /// Initialize new instance of <see cref="ModalitySequenceLUT"/> using the specified Modality LUT Descriptor and Data
         /// </summary>
         /// <param name="options">Render options</param>
         public ModalitySequenceLUT(GrayscaleRenderOptions options)

--- a/FO-DICOM.Core/Imaging/LUT/OutputLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/OutputLUT.cs
@@ -5,7 +5,7 @@ namespace FellowOakDicom.Imaging.LUT
 {
 
     /// <summary>
-    /// Output LUT implementation of <seealso cref="ILUT"/> used to map grayscale images to RGB grays, or colorize grayscale 
+    /// Output LUT implementation of <see cref="ILUT"/> used to map grayscale images to RGB grays, or colorize grayscale 
     /// images using custom color map
     /// </summary>
     public class OutputLUT : ILUT
@@ -19,7 +19,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="OutputLUT"/> 
+        /// Initialize new instance of <see cref="OutputLUT"/> 
         /// </summary>
         /// <param name="options">The grayscale render options containing the grayscale color map.</param>
         public OutputLUT(GrayscaleRenderOptions options)

--- a/FO-DICOM.Core/Imaging/LUT/PaletteColorLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/PaletteColorLUT.cs
@@ -5,7 +5,7 @@ namespace FellowOakDicom.Imaging.LUT
 {
 
     /// <summary>
-    /// Paletter color LUT implementation of <seealso cref="ILUT"/> maps PALETTE COLOR images
+    /// Paletter color LUT implementation of <see cref="ILUT"/> maps PALETTE COLOR images
     /// </summary>
     public class PaletteColorLUT : ILUT
     {
@@ -20,7 +20,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="PaletteColorLUT"/>
+        /// Initialize new instance of <see cref="PaletteColorLUT"/>
         /// </summary>
         /// <param name="firstEntry">The first entry (minium value)</param>
         /// <param name="lut">The palette color LUT</param>

--- a/FO-DICOM.Core/Imaging/LUT/VOILUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/VOILUT.cs
@@ -7,7 +7,7 @@ namespace FellowOakDicom.Imaging.LUT
 {
 
     /// <summary>
-    /// Abstract VOI LUT implementation of <seealso cref="ILUT"/>
+    /// Abstract VOI LUT implementation of <see cref="ILUT"/>
     /// </summary>
     public abstract class VOILUT : ILUT
     {
@@ -20,7 +20,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="VOILUT"/>
+        /// Initialize new instance of <see cref="VOILUT"/>
         /// </summary>
         /// <param name="options">Render options</param>
         protected VOILUT(GrayscaleRenderOptions options)
@@ -111,7 +111,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="VOILinearLUT"/>
+        /// Initialize new instance of <see cref="VOILinearLUT"/>
         /// </summary>
         /// <param name="options">Render options</param>
         public VOILinearLUT(GrayscaleRenderOptions options)
@@ -157,7 +157,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="VOILinearLUT"/>
+        /// Initialize new instance of <see cref="VOILinearLUT"/>
         /// </summary>
         /// <param name="options">Render options</param>
         public VOILinearExactLUT(GrayscaleRenderOptions options)
@@ -202,7 +202,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="VOISigmoidLUT"/>
+        /// Initialize new instance of <see cref="VOISigmoidLUT"/>
         /// </summary>
         /// <param name="options">Render options</param>
         public VOISigmoidLUT(GrayscaleRenderOptions options)

--- a/FO-DICOM.Core/Imaging/LUT/VOISequenceLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/VOISequenceLUT.cs
@@ -22,7 +22,7 @@ namespace FellowOakDicom.Imaging.LUT
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="VOISequenceLUT"/> using the specified VOI LUT Descriptor and Data
+        /// Initialize new instance of <see cref="VOISequenceLUT"/> using the specified VOI LUT Descriptor and Data
         /// </summary>
         /// <param name="options">Render options</param>
         public VOISequenceLUT(GrayscaleRenderOptions options)

--- a/FO-DICOM.Core/Imaging/PhotometricInterpretation.cs
+++ b/FO-DICOM.Core/Imaging/PhotometricInterpretation.cs
@@ -60,7 +60,6 @@ namespace FellowOakDicom.Imaging
 
         #region Public Methods
 
-        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(this, obj)) return true;
@@ -68,13 +67,11 @@ namespace FellowOakDicom.Imaging
             return ((PhotometricInterpretation)obj).Value == Value;
         }
 
-        /// <inheritdoc />
         public override int GetHashCode()
         {
             return Value.GetHashCode();
         }
 
-        /// <inheritdoc />
         public override string ToString()
         {
             return Description;

--- a/FO-DICOM.Core/Imaging/Render/CompositeGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/CompositeGraphic.cs
@@ -9,7 +9,7 @@ namespace FellowOakDicom.Imaging.Render
 {
 
     /// <summary>
-    /// The Composite Graphic implementation of <seealso cref="IGraphic"/> which layers graphics one over the other
+    /// The Composite Graphic implementation of <see cref="IGraphic"/> which layers graphics one over the other
     /// </summary>
     public class CompositeGraphic : IGraphic
     {
@@ -22,7 +22,7 @@ namespace FellowOakDicom.Imaging.Render
         #region Public Constructor
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="CompositeGraphic"/>
+        /// Initialize new instance of <see cref="CompositeGraphic"/>
         /// </summary>
         /// <param name="bg">background (initial) graphic layer</param>
         public CompositeGraphic(IGraphic bg)

--- a/FO-DICOM.Core/Imaging/Render/GenericGrayscalePipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/GenericGrayscalePipeline.cs
@@ -7,7 +7,7 @@ namespace FellowOakDicom.Imaging.Render
 {
 
     /// <summary>
-    /// Grayscale color pipeline implementation of <seealso cref="IPipeline"/> interface
+    /// Grayscale color pipeline implementation of <see cref="IPipeline"/> interface
     /// </summary>
     public class GenericGrayscalePipeline : IPipeline
     {
@@ -32,7 +32,7 @@ namespace FellowOakDicom.Imaging.Render
         #region Public Constructor
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="GenericGrayscalePipeline"/> which consist of the following sequence
+        /// Initialize new instance of <see cref="GenericGrayscalePipeline"/> which consist of the following sequence
         /// Rescale (Modality) LUT -> VOI LUT -> Output LUT and optionally Invert LUT if specified by grayscale options
         /// </summary>
         /// <param name="options">Grayscale options to use in the pipeline</param>
@@ -70,7 +70,7 @@ namespace FellowOakDicom.Imaging.Render
         #region Public Properties
 
         /// <summary>
-        /// Get <seealso cref="CompositeLUT"/> of LUTs available in this pipeline instance
+        /// Get <see cref="CompositeLUT"/> of LUTs available in this pipeline instance
         /// </summary>
         public ILUT LUT
         {

--- a/FO-DICOM.Core/Imaging/Render/GenericGrayscalePipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/GenericGrayscalePipeline.cs
@@ -70,7 +70,7 @@ namespace FellowOakDicom.Imaging.Render
         #region Public Properties
 
         /// <summary>
-        /// Get <see cref="CompositeLUT"/> of LUTs available in this pipeline instance
+        /// Get <see cref="FellowOakDicom.Imaging.LUT.CompositeLUT"/> of LUTs available in this pipeline instance
         /// </summary>
         public ILUT LUT
         {

--- a/FO-DICOM.Core/Imaging/Render/IGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/IGraphic.cs
@@ -105,7 +105,7 @@ namespace FellowOakDicom.Imaging.Render
         void Transform(double scale, int rotation, bool flipx, bool flipy);
 
         /// <summary>
-        /// Render the image and return the result as <seealso cref="IImage"/>
+        /// Render the image and return the result as <see cref="IImage"/>
         /// </summary>
         /// <param name="lut">The image LUT </param>
         /// <returns>Image after applying LUT and transformation</returns>

--- a/FO-DICOM.Core/Imaging/Render/ImageGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/ImageGraphic.cs
@@ -10,7 +10,7 @@ namespace FellowOakDicom.Imaging.Render
 {
 
     /// <summary>
-    /// The Image Graphic implementation of <seealso cref="IGraphic"/>
+    /// The Image Graphic implementation of <see cref="IGraphic"/>
     /// </summary>
     public class ImageGraphic : IGraphic
     {
@@ -115,7 +115,7 @@ namespace FellowOakDicom.Imaging.Render
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="ImageGraphic"/>
+        /// Initialize new instance of <see cref="ImageGraphic"/>
         /// </summary>
         /// <param name="pixelData">Pixel data</param>
         public ImageGraphic(IPixelData pixelData)

--- a/FO-DICOM.Core/Imaging/Render/OverlayGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/OverlayGraphic.cs
@@ -31,7 +31,7 @@ namespace FellowOakDicom.Imaging.Render
         #region Public Constructors
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="OverlayGraphic"/>
+        /// Initialize new instance of <see cref="OverlayGraphic"/>
         /// </summary>
         /// <param name="pixelData">Overlay pixel data</param>
         /// <param name="offsetx">X offset</param>

--- a/FO-DICOM.Core/Imaging/Render/PaletteColorPipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/PaletteColorPipeline.cs
@@ -26,7 +26,7 @@ namespace FellowOakDicom.Imaging.Render
         }
 
         /// <summary>
-        /// Get the <see cref="PaletteColorLUT"/>
+        /// Get the <see cref="FellowOakDicom.Imaging.LUT.PaletteColorLUT"/>
         /// </summary>
         public ILUT LUT { get; private set; }
     }

--- a/FO-DICOM.Core/Imaging/Render/PaletteColorPipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/PaletteColorPipeline.cs
@@ -7,13 +7,13 @@ namespace FellowOakDicom.Imaging.Render
 {
 
     /// <summary>
-    /// Palette color pipeline implementation of <seealso cref="IPipeline"/>
+    /// Palette color pipeline implementation of <see cref="IPipeline"/>
     /// </summary>
     public class PaletteColorPipeline : IPipeline
     {
 
         /// <summary>
-        /// Initialize new instance of <seealso cref="PaletteColorPipeline"/> containing palette color LUT extracted from
+        /// Initialize new instance of <see cref="PaletteColorPipeline"/> containing palette color LUT extracted from
         /// <paramref name="pixelData"/>
         /// </summary>
         /// <param name="pixelData">Dicom Pixel Data containing paletter color LUT</param>
@@ -26,7 +26,7 @@ namespace FellowOakDicom.Imaging.Render
         }
 
         /// <summary>
-        /// Get the <seealso cref="PaletteColorLUT"/>
+        /// Get the <see cref="PaletteColorLUT"/>
         /// </summary>
         public ILUT LUT { get; private set; }
     }

--- a/FO-DICOM.Core/Imaging/Render/PixelData.cs
+++ b/FO-DICOM.Core/Imaging/Render/PixelData.cs
@@ -79,18 +79,18 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Pixel data factory to create <seealso cref="IPixelData"/> and <seealso cref="SingleBitPixelData"/> from 
-    /// <seealso cref="DicomPixelData"/>
+    /// Pixel data factory to create <see cref="IPixelData"/> and <see cref="SingleBitPixelData"/> from 
+    /// <see cref="DicomPixelData"/>
     /// </summary>
     public static class PixelDataFactory
     {
         /// <summary>
         /// Create <see cref="IPixelData"/> form <see cref="DicomPixelData"/> 
-        /// according to the input <paramref name="pixelData"/> <seealso cref="PhotometricInterpretation"/>
+        /// according to the input <paramref name="pixelData"/> <see cref="PhotometricInterpretation"/>
         /// </summary>
         /// <param name="pixelData">Input pixel data</param>
         /// <param name="frame">Frame number (0 based)</param>
-        /// <returns>Implementation of <seealso cref="IPixelData"/> according to <seealso cref="PhotometricInterpretation"/></returns>
+        /// <returns>Implementation of <see cref="IPixelData"/> according to <see cref="PhotometricInterpretation"/></returns>
         public static IPixelData Create(DicomPixelData pixelData, int frame)
         {
             PhotometricInterpretation pi = pixelData.PhotometricInterpretation;
@@ -210,7 +210,7 @@ namespace FellowOakDicom.Imaging.Render
         /// according to the input <paramref name="overlayData"/>
         /// </summary>
         /// <param name="overlayData">The input overlay data</param>
-        /// <returns>The result overlay stored in <seealso cref="SingleBitPixelData"/></returns>
+        /// <returns>The result overlay stored in <see cref="SingleBitPixelData"/></returns>
         public static SingleBitPixelData Create(DicomOverlayData overlayData)
         {
             return new SingleBitPixelData(overlayData.Columns, overlayData.Rows, overlayData.Data);
@@ -218,7 +218,7 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Grayscale unsigned 8 bits <seealso cref="IPixelData"/> implementation
+    /// Grayscale unsigned 8 bits <see cref="IPixelData"/> implementation
     /// </summary>
     public class GrayscalePixelDataU8 : IPixelData
     {
@@ -366,7 +366,7 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Single bit pixel <seealso cref="IPixelData"/> implementation(for binary pixels) usually used for overlay pixel data
+    /// Single bit pixel <see cref="IPixelData"/> implementation(for binary pixels) usually used for overlay pixel data
     /// </summary>
     public class SingleBitPixelData : GrayscalePixelDataU8
     {
@@ -434,7 +434,7 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Grayscale signed 16 bits <seealso cref="IPixelData"/> implementation
+    /// Grayscale signed 16 bits <see cref="IPixelData"/> implementation
     /// </summary>
     public class GrayscalePixelDataS16 : IPixelData
     {
@@ -610,7 +610,7 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Grayscale unsigned 16 bits <seealso cref="IPixelData"/> implementation
+    /// Grayscale unsigned 16 bits <see cref="IPixelData"/> implementation
     /// </summary>
     public class GrayscalePixelDataU16 : IPixelData
     {
@@ -785,7 +785,7 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Grayscale signed 32 bits <seealso cref="IPixelData"/> implementation
+    /// Grayscale signed 32 bits <see cref="IPixelData"/> implementation
     /// </summary>
     public class GrayscalePixelDataS32 : IPixelData
     {
@@ -947,7 +947,7 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Grayscale unsigned 32 bits <seealso cref="IPixelData"/> implementation
+    /// Grayscale unsigned 32 bits <see cref="IPixelData"/> implementation
     /// </summary>
     public class GrayscalePixelDataU32 : IPixelData
     {
@@ -1111,7 +1111,7 @@ namespace FellowOakDicom.Imaging.Render
     }
 
     /// <summary>
-    /// Color 24 bits <seealso cref="IPixelData"/> implementation used for RGB
+    /// Color 24 bits <see cref="IPixelData"/> implementation used for RGB
     /// </summary>
     public class ColorPixelData24 : IPixelData
     {

--- a/FO-DICOM.Core/Imaging/Render/RgbColorPipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/RgbColorPipeline.cs
@@ -7,7 +7,7 @@ namespace FellowOakDicom.Imaging.Render
 {
 
     /// <summary>
-    /// RGB color pipeline implementation of <seealso cref="IPipeline"/> interface
+    /// RGB color pipeline implementation of <see cref="IPipeline"/> interface
     /// </summary>
     public class RgbColorPipeline : IPipeline
     {

--- a/FO-DICOM.Core/Media/DicomDirectory.cs
+++ b/FO-DICOM.Core/Media/DicomDirectory.cs
@@ -53,7 +53,7 @@ namespace FellowOakDicom.Media
         /// <summary>
         /// Gets or sets the file set ID.
         /// </summary>
-        /// <exception cref="ArgumentException">If applied file set ID is null or empty.</exception>
+        /// <exception cref="System.ArgumentException">If applied file set ID is null or empty.</exception>
         public string FileSetID
         {
             get => Dataset.GetSingleValueOrDefault(DicomTag.FileSetID, string.Empty);

--- a/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociation.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociation.cs
@@ -41,10 +41,10 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
         /// C-FIND or C-MOVE requests will typically receive back a pending response per SOP instance, and finally one last success response
         /// C-STORE and C-ECHO requests on the other hand typically only receives one response
         /// </returns>
-        /// <exception cref="OperationCanceledException">When the request is cancelled using the <paramref name="cancellationToken"/></exception>
+        /// <exception cref="System.OperationCanceledException">When the request is cancelled using the <paramref name="cancellationToken"/></exception>
         /// <exception cref="System.IO.IOException">When connection/socket issues occur</exception>
         /// <exception cref="DicomNetworkException">When DICOM protocol issues occur</exception>
-        /// <exception cref="ObjectDisposedException">When the association is already disposed</exception>
+        /// <exception cref="System.ObjectDisposedException">When the association is already disposed</exception>
         IAsyncEnumerable<DicomResponse> SendRequestAsync(DicomRequest dicomRequest, CancellationToken cancellationToken);
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
         /// </summary>
         /// <param name="cancellationToken">The token that immediately cancels the request. Note that the association will be left in an unusable state regardless.</param>
         /// <returns>A task that will complete when the association release has been acknowledged, the association is aborted or the connection is closed by the other AE.</returns>
-        /// <exception cref="ObjectDisposedException">When the association is already disposed</exception>
+        /// <exception cref="System.ObjectDisposedException">When the association is already disposed</exception>
         ValueTask ReleaseAsync(CancellationToken cancellationToken);
 
         /// <summary>
@@ -64,11 +64,13 @@ namespace FellowOakDicom.Network.Client.Advanced.Association
         /// </summary>
         /// <param name="cancellationToken">The token that immediately cancels the abort notification. Note that the association will be left in an unusable state regardless.</param>
         /// <returns>A task that will complete when the association is aborted or the connection is closed by the other AE</returns>
-        /// <exception cref="ObjectDisposedException">When the association is already disposed</exception>
+        /// <exception cref="System.ObjectDisposedException">When the association is already disposed</exception>
         ValueTask AbortAsync(CancellationToken cancellationToken);
     }
 
-    /// <inheritdoc cref="IAdvancedDicomClientAssociation"/>>
+    /// <summary>
+    /// Represents an open DICOM association.
+    /// </summary>
     public class AdvancedDicomClientAssociation : IAdvancedDicomClientAssociation
     {
         private const string _responseChannelIsGoneNote = "(Note: the response channel is gone. This can happen when the request is cancelled after it has been sent)";

--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -112,7 +112,7 @@ namespace FellowOakDicom.Network.Client
 
         /// <summary>
         /// Whenever the DICOM client changes state, an event will be emitted containing the old state and the new state.
-        /// The current DICOM client implementation is no longer state based, and has been rewritten as a wrapper around the new <see cref="IAdvancedDicomClientConnection"/>
+        /// The current DICOM client implementation is no longer state based, and has been rewritten as a wrapper around the new <see cref="FellowOakDicom.Network.Client.Advanced.Connection.IAdvancedDicomClientConnection"/>
         /// This event handler is still supported for backwards compatibility reasons, but may be removed in the future.
         /// </summary>
         [Obsolete(nameof(StateChanged) + " is an artifact of an older state-based implementation of the DicomClient and will be deleted in the future. It only exists today for backwards compatibility purposes")]

--- a/FO-DICOM.Core/Network/DesktopNetworkStream.cs
+++ b/FO-DICOM.Core/Network/DesktopNetworkStream.cs
@@ -174,9 +174,9 @@ namespace FellowOakDicom.Network
         #region METHODS
 
         /// <summary>
-        /// Get corresponding <see cref="Stream"/> object.
+        /// Get corresponding <see cref="System.IO.Stream"/> object.
         /// </summary>
-        /// <returns>Network stream as <see cref="Stream"/> object.</returns>
+        /// <returns>Network stream as <see cref="System.IO.Stream"/> object.</returns>
         public Stream AsStream()
         {
             return _networkStream;

--- a/FO-DICOM.Core/Network/DicomCStoreRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreRequest.cs
@@ -9,30 +9,6 @@ namespace FellowOakDicom.Network
     /// <summary>
     /// Represents a DICOM C-Store request to be sent to a C-Store SCP or a C-Store request that has been received from a C-Store SCU.
     /// </summary>
-    /// <example>
-    /// The following example shows how to use the <see cref="DicomClient"/> class to send DICOM C-Store requests to a DICOM C-Store SCP.
-    /// <code>
-    /// var client = new DicomClient();
-    ///
-    /// // queue C-Store request to send DICOM file
-    /// client.Add(new DicomCStoreRequest(@"test1.dcm") {
-    ///		OnResponseReceived = (DicomCStoreRequest req, DicomCStoreResponse rsp) => {
-    ///			Console.WriteLine("{0}: {1}", req.SOPInstanceUID, rsp.Status);
-    ///		}
-    /// });
-    ///
-    /// // queue C-Store request with additional proposed transfer syntaxes
-    /// client.Add(new DicomCStoreRequest(@"test2.dcm") {
-    ///		AdditionalTransferSyntaxes = new DicomTransferSyntax[] {
-    ///			DicomTransferSyntax.JPEGLSLossless,
-    ///			DicomTransferSyntax.JPEG2000Lossless
-    ///		}
-    /// });
-    ///
-    /// // connect and send queued requests
-    /// client.Send("127.0.0.1", 12345, false, "SCU", "ANY-SCP");
-    /// </code>
-    /// </example>
     public sealed class DicomCStoreRequest : DicomPriorityRequest
     {
         /// <summary>

--- a/FO-DICOM.Core/Network/DicomExtendedNegotiationCollection.cs
+++ b/FO-DICOM.Core/Network/DicomExtendedNegotiationCollection.cs
@@ -227,7 +227,7 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="array">Array of extended negotiations</param>
         /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-        /// <exception cref="NotSupportedException"></exception>
+        /// <exception cref="System.NotSupportedException"></exception>
         public void CopyTo(DicomExtendedNegotiation[] array, int arrayIndex)
         {
             throw new NotSupportedException("Not implemented");

--- a/FO-DICOM.Core/Network/DicomQueryRetrieveLevel.cs
+++ b/FO-DICOM.Core/Network/DicomQueryRetrieveLevel.cs
@@ -7,7 +7,7 @@ namespace FellowOakDicom.Network
 {
     /// <summary>
     /// Query&#47;Retrieve level of DICOM command messages, applicable to C-FIND, C-GET and C-MOVE.
-    /// <seealso cref="DicomTag.QueryRetrieveLevel"/>
+    /// <see cref="DicomTag.QueryRetrieveLevel"/>
     /// </summary>
     public enum DicomQueryRetrieveLevel
     {

--- a/FO-DICOM.Core/Network/DicomServiceApplicationInfo.cs
+++ b/FO-DICOM.Core/Network/DicomServiceApplicationInfo.cs
@@ -52,7 +52,7 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="index">Application info field index.</param>
         /// <returns>Byte value</returns>
-        /// <exception cref="ArgumentException">Invalid field index.</exception>
+        /// <exception cref="System.ArgumentException">Invalid field index.</exception>
         public byte this[byte index]
         {
             get => _fields[index];
@@ -126,7 +126,7 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="index">Application info field index.</param>
         /// <param name="value">Application info field value.</param>
-        /// <exception cref="ArgumentException">Invalid field index or a field with same index already exists.</exception>
+        /// <exception cref="System.ArgumentException">Invalid field index or a field with same index already exists.</exception>
         public void Add(byte index, byte value)
         {
             if (index == 0)
@@ -143,7 +143,7 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="index">Application info field index.</param>
         /// <param name="value">Application info field value.</param>
-        /// <exception cref="ArgumentException">Invalid field index.</exception>
+        /// <exception cref="System.ArgumentException">Invalid field index.</exception>
         public void AddOrUpdate(byte index, byte value)
         {
             this[index] = value;
@@ -154,7 +154,7 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="index">Application info field index.</param>
         /// <param name="value">Application info field value.</param>
-        /// <exception cref="ArgumentException">Invalid field index.</exception>
+        /// <exception cref="System.ArgumentException">Invalid field index.</exception>
         public void AddOrUpdate(byte index, bool value)
         {
             this[index] = value ? (byte)1 : (byte)0;
@@ -196,7 +196,7 @@ namespace FellowOakDicom.Network
         /// <param name="index">Application info field index.</param>
         /// <param name="defaultValue">Default value if Application info field index does not exist.</param>
         /// <returns>Application info field value or <paramref name="defaultValue"/> if not exists.</returns>
-        /// <exception cref="ArgumentException"><paramref name="'T"/> is not an Enum.</exception>
+        /// <exception cref="System.ArgumentException"><paramref name="'T"/> is not an Enum.</exception>
         public byte GetValueForEnum<T>(byte index, byte defaultValue)
         {
             if (Contains(index) && Enum.IsDefined(typeof(T), (int)this[index]))

--- a/FO-DICOM.Core/Network/IDicomServer.cs
+++ b/FO-DICOM.Core/Network/IDicomServer.cs
@@ -73,7 +73,7 @@ namespace FellowOakDicom.Network
         /// <param name="fallbackEncoding">Encoding to apply if no encoding is identified.</param>
         /// <param name="options">Service options.</param>
         /// <param name="userState">User state to be shared with the connected services.</param>
-        /// <returns>Awaitable <see cref="Task"/>.</returns>
+        /// <returns>Awaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         Task StartAsync(string ipAddress, int port, string certificateName, Encoding fallbackEncoding,
             DicomServiceOptions options, object userState);
 

--- a/FO-DICOM.Core/Network/INetworkListener.cs
+++ b/FO-DICOM.Core/Network/INetworkListener.cs
@@ -15,7 +15,7 @@ namespace FellowOakDicom.Network
         /// <summary>
         /// Start listening.
         /// </summary>
-        /// <returns>An await:able <see cref="Task"/>.</returns>
+        /// <returns>An awaitable <see cref="System.Threading.Tasks.Task"/>.</returns>
         Task StartAsync();
         /// <summary>
         /// Stop listening.

--- a/FO-DICOM.Core/Network/INetworkStream.cs
+++ b/FO-DICOM.Core/Network/INetworkStream.cs
@@ -38,9 +38,9 @@ namespace FellowOakDicom.Network
         #region METHODS
 
         /// <summary>
-        /// Get corresponding <see cref="Stream"/> object.
+        /// Get corresponding <see cref="System.IO.Stream"/> object.
         /// </summary>
-        /// <returns>Network stream as <see cref="Stream"/> object.</returns>
+        /// <returns>Network stream as <see cref="System.IO.Stream"/> object.</returns>
         Stream AsStream();
 
         #endregion

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -259,7 +259,7 @@ namespace FellowOakDicom.Serialization
         /// <summary>
         /// Create an instance of a IBulkDataUriByteBuffer. Override this method to use a different IBulkDataUriByteBuffer implementation in applications.
         /// </summary>
-        /// <param name="bulkDataUri">The URI of a bulk data element as defined in <see cref="!:http://dicom.nema.org/medical/dicom/current/output/chtml/part19/chapter_A.html#table_A.1.5-2">Table A.1.5-2 in PS3.19</see>.</param>
+        /// <param name="bulkDataUri">The URI of a bulk data element as defined in <a href="http://dicom.nema.org/medical/dicom/current/output/chtml/part19/chapter_A.html#table_A.1.5-2">Table A.1.5-2 in PS3.19</a>.</param>
         /// <returns>An instance of a Bulk URI Byte buffer.</returns>
         protected virtual IBulkDataUriByteBuffer CreateBulkDataUriByteBuffer(string bulkDataUri) => new BulkDataUriByteBuffer(bulkDataUri);
 


### PR DESCRIPTION
DocFx produces a whole list of warnings when it runs.
This PR fixes those warnings.
There are no actual code changes, only changes in the XML annotations of public types, properties or methods.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation (not needed)
- [ ] I have included unit tests (not needed)
- [ ] I have updated the change log (not needed)
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Fix a bunch of incorrect XML documentation annotations
