### PR TITLE
Suppress "obsolete" warnings in valid use cases and unit tests that cover obsolete APIs

### DIFF
--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -16,6 +16,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
+// DICOM client still provides some obsolete APIs that should not be removed yet, but should also not provide obsolete compiler warnings
+#pragma warning disable CS0618
+#pragma warning disable CS0612
+
 namespace FellowOakDicom.Network.Client
 {
     public interface IDicomClient

--- a/FO-DICOM.Core/Network/DicomCFindRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCFindRequest.cs
@@ -310,7 +310,10 @@ namespace FellowOakDicom.Network
                 case DicomQueryRetrieveLevel.Series:
                 case DicomQueryRetrieveLevel.Image:
                     return DicomUID.StudyRootQueryRetrieveInformationModelFind;
+#pragma warning disable CS0618
+                // While this QR level is obsolete, we must still support it
                 case DicomQueryRetrieveLevel.Worklist:
+#pragma warning restore CS0618
                 case DicomQueryRetrieveLevel.NotApplicable:
                     return DicomUID.ModalityWorklistInformationModelFind;
                 default:

--- a/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
+// These tests cover some obsolete properties such as AutoValidate
+#pragma warning disable CS0618
+
 namespace FellowOakDicom.Tests
 {
 
@@ -64,7 +67,7 @@ namespace FellowOakDicom.Tests
                         new DicomUniqueIdentifier(DicomTag.SOPInstanceUID, "1.2.3"))
                         .Add(DicomTag.SourceApplicationEntityTitle, "ABCDEFG"));
 
-            var exception = Record.Exception(() => { Assert.Equal(metaInfo.SourceApplicationEntityTitle, "ABCDEFG"); });
+            var exception = Record.Exception(() => { Assert.Equal("ABCDEFG", metaInfo.SourceApplicationEntityTitle); });
             Assert.Null(exception);
         }
 

--- a/Tests/FO-DICOM.Tests/DicomValidationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomValidationTest.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) 2012-2021 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
-using System;
 using FellowOakDicom.Tests.Helpers;
 using System.IO;
 using Xunit;
+
+// These tests cover some obsolete properties such as AutoValidate
+#pragma warning disable CS0618
 
 namespace FellowOakDicom.Tests
 {

--- a/Tests/FO-DICOM.Tests/Media/DicomDirectoryTest.cs
+++ b/Tests/FO-DICOM.Tests/Media/DicomDirectoryTest.cs
@@ -9,6 +9,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
+// These tests cover some obsolete properties such as AutoValidate
+#pragma warning disable CS0618
+
 namespace FellowOakDicom.Tests.Media
 {
 

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
@@ -20,6 +20,9 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
+// These tests cover some obsolete properties
+#pragma warning disable CS0618
+
 namespace FellowOakDicom.Tests.Network.Client
 {
     [Collection("Network"), Trait("Category", "Network")]

--- a/Tests/FO-DICOM.Tests/Network/DicomCFindRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCFindRequestTest.cs
@@ -8,6 +8,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
+// These tests cover some obsolete methods or properties
+#pragma warning disable CS0618
+
 namespace FellowOakDicom.Tests.Network
 {
 


### PR DESCRIPTION
We have unit tests that verify the correct behavior of some of our obsolete APIs.
C# complains that we are using obsolete APIs.
The solution is to disable these warnings in the specific unit tests. 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Suppress obsolete warnings in unit tests that cover obsolete APIs.
