### PR TITLE
Use HttpClient instead of WebRequest in the JsonDicomConverter tests

### DIFF
--- a/Tests/FO-DICOM.Tests/Fixture.cs
+++ b/Tests/FO-DICOM.Tests/Fixture.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 
 using System;
+using System.Net.Http;
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.NativeCodec;
 using Microsoft.Extensions.DependencyInjection;
@@ -62,6 +63,21 @@ namespace FellowOakDicom.Tests
         }
     }
 
+    public class HttpClientFixture : IDisposable
+    {
+        public HttpClientFixture()
+        {
+            HttpClient = new HttpClient();
+        }
+
+        public HttpClient HttpClient { get; }
+
+        public void Dispose()
+        {
+            HttpClient.Dispose();
+        }
+    }
+
 
     [CollectionDefinition("General")]
     public class GeneralCollection : ICollectionFixture<GlobalFixture>
@@ -95,6 +111,11 @@ namespace FellowOakDicom.Tests
 
     [CollectionDefinition("WithTranscoder")]
     public class WithTranscoderCollection : ICollectionFixture<GlobalFixture>
+    {
+    }
+
+    [CollectionDefinition("WithHttpClient")]
+    public class WithHttpClientFixture : ICollectionFixture<HttpClientFixture>
     {
     }
 }

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,14 +22,16 @@ namespace FellowOakDicom.Tests.Serialization
     /// <summary>
     /// The json dicom converter test.
     /// </summary>
-    [Collection("General")]
+    [Collection("WithHttpClient")]
     public class JsonDicomConverterTest
     {
         private readonly ITestOutputHelper _output;
+        private readonly HttpClientFixture _httpClientFixture;
 
-        public JsonDicomConverterTest(ITestOutputHelper output)
+        public JsonDicomConverterTest(ITestOutputHelper output, HttpClientFixture httpClientFixture)
         {
-            _output = output;
+            _output = output ?? throw new ArgumentNullException(nameof(output));
+            _httpClientFixture = httpClientFixture ?? throw new ArgumentNullException(nameof(httpClientFixture));
         }
 
         /// <summary>
@@ -698,20 +701,18 @@ namespace FellowOakDicom.Tests.Serialization
             VerifyJsonTripleTrip(ds);
         }
 
-        private void DownloadBulkData(BulkDataUriByteBuffer bulkData)
+        private async Task DownloadBulkDataAsync(BulkDataUriByteBuffer bulkData)
         {
-            var request = WebRequest.Create(bulkData.BulkDataUri);
-            using var response = request.GetResponse();
-            using var responseStream = response.GetResponseStream();
-            bulkData.Data = new byte[response.ContentLength];
-            responseStream.Read(bulkData.Data, 0, (int)response.ContentLength);
+            var httpClient = _httpClientFixture.HttpClient;
+
+            bulkData.Data = await httpClient.GetByteArrayAsync(bulkData.BulkDataUri);
         }
 
         /// <summary>
         /// The bulk data read.
         /// </summary>
         [Fact]
-        public void BulkDataRead()
+        public async Task BulkDataRead()
         {
             File.WriteAllText("test.txt", "xxx!");
             var path = Path.GetFullPath("test.txt");
@@ -726,8 +727,8 @@ namespace FellowOakDicom.Tests.Serialization
             var json2 = JsonConvert.SerializeObject(reconstituated, Formatting.Indented, new JsonDicomConverter());
             Assert.Equal(json, json2);
 
-            DownloadBulkData(reconstituated.GetDicomItem<DicomElement>(DicomTag.PixelData).Buffer as BulkDataUriByteBuffer);
-            DownloadBulkData(bulkData);
+            await DownloadBulkDataAsync(reconstituated.GetDicomItem<DicomElement>(DicomTag.PixelData).Buffer as BulkDataUriByteBuffer);
+            await DownloadBulkDataAsync(bulkData);
 
             Assert.True(ValueEquals(target, reconstituated));
 

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -703,9 +703,18 @@ namespace FellowOakDicom.Tests.Serialization
 
         private async Task DownloadBulkDataAsync(BulkDataUriByteBuffer bulkData)
         {
-            var httpClient = _httpClientFixture.HttpClient;
-
-            bulkData.Data = await httpClient.GetByteArrayAsync(bulkData.BulkDataUri);
+            var uri = new UriBuilder(bulkData.BulkDataUri);
+            switch (uri.Scheme)
+            {
+                case "file":
+                    bulkData.Data = File.ReadAllBytes(uri.Path);
+                    break;
+                case "http":
+                case "https":
+                    var httpClient = _httpClientFixture.HttpClient;
+                    bulkData.Data = await httpClient.GetByteArrayAsync(bulkData.BulkDataUri);
+                    return;
+            }
         }
 
         /// <summary>

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -748,9 +748,18 @@ namespace FellowOakDicom.Tests.Serialization
 
         private async Task DownloadBulkDataAsync(BulkDataUriByteBuffer bulkData)
         {
-            var httpClient = _httpClientFixture.HttpClient;
-
-            bulkData.Data = await httpClient.GetByteArrayAsync(bulkData.BulkDataUri);
+            var uri = new UriBuilder(bulkData.BulkDataUri);
+            switch (uri.Scheme)
+            {
+                case "file":
+                    bulkData.Data = File.ReadAllBytes(uri.Path);
+                    break;
+                case "http":
+                case "https":
+                    var httpClient = _httpClientFixture.HttpClient;
+                    bulkData.Data = await httpClient.GetByteArrayAsync(bulkData.BulkDataUri);
+                    return;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Use HttpClient instead of (the obsolete) WebRequest in the JsonDicomConverter unit tests
