### PR TITLE
Fix compiler warnings in unit tests

### DIFF
--- a/Tests/FO-DICOM.Tests/Bugs/GH1281.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1281.cs
@@ -31,7 +31,7 @@ namespace FellowOakDicom.Tests.Bugs
             dicomClient.ServiceOptions.LogDimseDatasets = true;
             dicomClient.Logger = _logger.IncludePrefix("Client");
 
-            DicomCStoreResponse? response = null;
+            DicomCStoreResponse response = null;
 
             var file = "Test Data/Issue1097_FailToOpenDeflatedFileWithSQ.dcm";
 

--- a/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
@@ -148,6 +148,8 @@ namespace FellowOakDicom.Tests.Imaging
 
             Assert.Equal(expected.WindowWidth, actual.WindowWidth);
             Assert.Equal(expected.WindowCenter, actual.WindowCenter);
+            Assert.Equal(expectedWindowWidth, actual.WindowWidth);
+            Assert.Equal(expectedWindowCenter, actual.WindowCenter);
         }
 
         [Theory]

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
@@ -94,6 +94,7 @@ namespace FellowOakDicom.Tests.Network
 
         public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
         {
+            await Task.Yield();
             return new DicomCEchoResponse(request, DicomStatus.Success);
         }
     }

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
@@ -128,6 +128,7 @@ namespace FellowOakDicom.Tests.Network
 
         public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
         {
+            await Task.Yield();
             yield return new DicomCFindResponse(request, DicomStatus.Success);
         }
 

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCGetProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCGetProviderTests.cs
@@ -130,6 +130,7 @@ namespace FellowOakDicom.Tests.Network
 
         public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request)
         {
+            await Task.Yield();
             yield return new DicomCGetResponse(request, DicomStatus.Success);
         }
 
@@ -173,6 +174,7 @@ namespace FellowOakDicom.Tests.Network
 
         public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request)
         {
+            await Task.Yield();
             yield return new DicomCGetResponse(request, DicomStatus.Pending);
             yield return new DicomCGetResponse(request, DicomStatus.Pending);
             yield return new DicomCGetResponse(request, DicomStatus.Success);

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
@@ -178,6 +178,7 @@ namespace FellowOakDicom.Tests.Network
 
         public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
         {
+            await Task.Yield();
             return new DicomCStoreResponse(request, DicomStatus.Success);
         }
 

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
@@ -474,9 +474,7 @@ namespace FellowOakDicom.Tests.Network.Client
         public async Task SendAsync_WithSocketException_ShouldNotLoopInfinitely()
         {
             var port = Ports.GetNext();
-            var logger = _logger.IncludePrefix("UnitTest");
 
-            IDicomServer server = null;
             DicomCStoreResponse response1 = null, response2 = null, response3 = null;
             DicomRequest.OnTimeoutEventArgs timeout1 = null, timeout2 = null, timeout3 = null;
             using (CreateServer<InMemoryDicomCStoreProvider>(port))
@@ -1071,12 +1069,14 @@ namespace FellowOakDicom.Tests.Network.Client
 
             public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
             {
+                await Task.Yield();
                 _requests.Add(request);
                 yield break;
             }
 
             public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request)
             {
+                await Task.Yield();
                 _requests.Add(request);
                 yield break;
             }

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
@@ -965,11 +965,6 @@ namespace FellowOakDicom.Tests.Network.Client
                 set => _inner.WriteTimeout = value;
             }
 
-            public override object InitializeLifetimeService()
-            {
-                return _inner.InitializeLifetimeService();
-            }
-
             public override string ToString()
             {
                 return _inner.ToString();

--- a/Tests/FO-DICOM.Tests/Network/PDUTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/PDUTest.cs
@@ -121,6 +121,7 @@ namespace FellowOakDicom.Tests.Network
             var actual = reject.Reason.ToString();
 
             Assert.Equal(expected, actual);
+            Assert.NotNull(_);
         }
 
         [Theory]
@@ -132,6 +133,7 @@ namespace FellowOakDicom.Tests.Network
             var actual = rawMs.ToArray();
 
             Assert.Equal(expected, actual);
+            Assert.NotNull(_);
         }
 
         [Theory]
@@ -162,6 +164,7 @@ namespace FellowOakDicom.Tests.Network
             var actual = stream.ToArray();
 
             Assert.Equal(expected, actual);
+            Assert.NotNull(_);
         }
 
         #endregion

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -7,7 +7,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;


### PR DESCRIPTION
Fixes compiler warnings in unit tests

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit test
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

 I guess things like API documentation and unit tests are irrelevant for this PR.

#### Changes proposed in this pull request:
- Remove nullable annotations (fo-dicom doesn't do nullable annotations yet, and let's not open that can of worms for now)
- Use unused xunit parameters
- Do something async in async methods
- etc
