### PR TITLE
Make flaky tests less flaky

### DIFF
--- a/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
@@ -96,12 +96,11 @@ namespace FellowOakDicom.Tests.Bugs
             };
 
             var receivedRequests = new List<DicomCStoreRequest>();
-            var random = new Random();
             server.OnCStoreRequest = (association, storeRequest) =>
             {
                 receivedRequests.Add(storeRequest);
 
-                Thread.Sleep(random.Next(0, 100));
+                Thread.Sleep(100);
 
                 return new DicomCStoreResponse(storeRequest, DicomStatus.Success);
             };
@@ -119,7 +118,7 @@ namespace FellowOakDicom.Tests.Bugs
             ));
             var client = clientFactory.Create("127.0.0.1", port, false, "AnySCU", "AnySCP");
             client.ClientOptions.AssociationLingerTimeoutInMs = 0;
-            client.ServiceOptions.RequestTimeout = TimeSpan.FromSeconds(1);
+            client.ServiceOptions.RequestTimeout = TimeSpan.FromSeconds(5);
             client.ServiceOptions.MaxPDULength = server.Options.MaxPDULength;
             client.Logger = _logger.IncludePrefix("Client");
             client.NegotiateAsyncOps(asyncInvoked, 1);


### PR DESCRIPTION
SendingCStoreRequest_AfterPreviousCStoreRequestTimedOut_ShouldUseSeparateAssociation failed again in a pull request that doesn't do any code changes! So this PR makes that test less flaky... 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Make SendingCStoreRequest_AfterPreviousCStoreRequestTimedOut_ShouldUseSeparateAssociation less flaky by removing randomness and increasing the timeout
