### PR TITLE
Fix compiler warnings in core

### DIFF
--- a/FO-DICOM.Core/DicomTag.cs
+++ b/FO-DICOM.Core/DicomTag.cs
@@ -171,7 +171,7 @@ namespace FellowOakDicom
                     return ((uint)(Group << 16) | Element).GetHashCode();
                 }
 
-                return ((uint)(Group << 16) | (Element & 0xff)).GetHashCode() ^ PrivateCreator.GetHashCode();
+                return ((uint)(Group << 16) | (uint)(Element & 0xff)).GetHashCode() ^ PrivateCreator.GetHashCode();
             }
         }
 

--- a/FO-DICOM.Core/FO-DICOM.Core.csproj
+++ b/FO-DICOM.Core/FO-DICOM.Core.csproj
@@ -75,6 +75,7 @@ Version 5 has some breaking changes to version 4. Read here for more information
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />

--- a/FO-DICOM.Core/Network/DicomStatus.cs
+++ b/FO-DICOM.Core/Network/DicomStatus.cs
@@ -181,11 +181,9 @@ namespace FellowOakDicom.Network
         /// true if the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>; otherwise, false.
         /// </returns>
         /// <exception cref="T:System.NullReferenceException">The <paramref name="obj"/> parameter is null.</exception>
-        public override bool Equals(object obj)
-        {
-            return (DicomStatus)obj == this;
-        }
+        public override bool Equals(object obj) => (DicomStatus)obj == this;
 
+        public override int GetHashCode() => HashCode.Combine(Code, (int)State, Description, ErrorComment, _mask);
 
         #region Static
 

--- a/Tests/FO-DICOM.Tests/Network/DicomStatusTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomStatusTest.cs
@@ -76,12 +76,68 @@ namespace FellowOakDicom.Tests.Network
         }
 
         [Fact]
-        public void NullComparrison()
+        public void NullComparison()
         {
             Assert.True(DicomStatus.Success != null);
             Assert.True(((DicomStatus)null) == null);
             Assert.False(DicomStatus.Success == null);
             Assert.False(((DicomStatus)null) != null);
+        }
+
+        [Fact]
+        public void HashCodes()
+        {
+            Assert.Equal(DicomStatus.Success.GetHashCode(), DicomStatus.Success.GetHashCode());
+            Assert.Equal(
+                new DicomStatus( "DDDD", DicomState.Success, "DESC1").GetHashCode(),
+                new DicomStatus( "DDDD", DicomState.Success, "DESC1").GetHashCode()
+            );
+            Assert.Equal(
+                new DicomStatus("DDDD", DicomState.Success, "DESC1", "COMMENT1").GetHashCode(),
+                new DicomStatus("DDDD", DicomState.Success, "DESC1", "COMMENT1").GetHashCode()
+            );
+            Assert.Equal(
+                new DicomStatus( DicomStatus.Success, "COMMENT1").GetHashCode(),
+                new DicomStatus( DicomStatus.Success, "COMMENT1").GetHashCode()
+            );
+            Assert.Equal(
+                new DicomStatus(1, DicomStatus.Success).GetHashCode(),
+                new DicomStatus(1, DicomStatus.Success).GetHashCode()
+            );
+
+            Assert.NotEqual(DicomStatus.Success.GetHashCode(), DicomStatus.StorageStorageOutOfResources.GetHashCode());
+            Assert.NotEqual(
+                new DicomStatus("DDDD", DicomState.Success, "DESC1", "COMMENT1").GetHashCode(),
+                new DicomStatus("DDDE", DicomState.Success, "DESC1", "COMMENT1").GetHashCode()
+            );
+            Assert.NotEqual(
+                new DicomStatus("DDDD", DicomState.Success, "DESC1", "COMMENT1").GetHashCode(),
+                new DicomStatus("DDDD", DicomState.Cancel, "DESC1", "COMMENT1").GetHashCode()
+            );
+            Assert.NotEqual(
+                new DicomStatus("DDDD", DicomState.Success, "DESC1", "COMMENT1").GetHashCode(),
+                new DicomStatus("DDDD", DicomState.Success, "DESC2", "COMMENT1").GetHashCode()
+            );
+            Assert.NotEqual(
+                new DicomStatus("DDDD", DicomState.Success, "DESC1", "COMMENT1").GetHashCode(),
+                new DicomStatus("DDDD", DicomState.Success, "DESC2", "COMMENT2").GetHashCode()
+            );
+            Assert.NotEqual(
+                new DicomStatus( DicomStatus.Success, "COMMENT1").GetHashCode(),
+                new DicomStatus( DicomStatus.Success, "COMMENT2").GetHashCode()
+            );
+            Assert.NotEqual(
+                new DicomStatus( DicomStatus.Success, "COMMENT1").GetHashCode(),
+                new DicomStatus( DicomStatus.Cancel, "COMMENT1").GetHashCode()
+            );
+            Assert.NotEqual(
+                new DicomStatus(0xDDDD, DicomStatus.Success).GetHashCode(),
+                new DicomStatus(0xDDDE, DicomStatus.Success).GetHashCode()
+            );
+            Assert.NotEqual(
+                new DicomStatus(0xDDDD, DicomStatus.Success).GetHashCode(),
+                new DicomStatus(0xDDDD, DicomStatus.Cancel).GetHashCode()
+            );
         }
 
         #endregion


### PR DESCRIPTION
This PR fixes a few minor compiler warnings in the core project. 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Implement DicomStatus.GetHashCode. If you implement Equals you should also implement GetHashCode. This might affect consumers who use DicomStatus in a HashSet or as a key in a Dictionary, and are creating custom DicomStatus instances. ~~I wonder if this is worth mentioning in a release note~~ Added this to the release notes
- Microsoft.Bcl.HashCode is necessary for .NET Standard 2.0. (This is no longer necessary if you target .NET Standard 2.1, .NET Core 3.1 or higher). It provided System.HashCode, which contains APIs that are now the recommended way of implementing GetHashCode. 
- Explicitly cast to (uint)
