### PR TITLE
Add dependabot.yml 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Github has an automated bot called "dependabot" that can scan your nuget dependencies and automatically create pull requests to update them. It's quite user friendly and might help us stay up to date with things like xunit and other dependencies.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add dependabot.yml
- Dependabot will scan the fo-dicom repository monthly and automatically open a pull request for each outdated nuget dependency

Read more here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates 