### PR TITLE
Minor improvements and extra logging for DesktopNetworkListener

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@
 * Added null check for EscapeXml in DicomXML (#1392)
 * Added private tags from Varian official DICOM Conformance Statements (#1556)
 * Fix handling of negative overlay origin (#1559)
+* Add better logging for inbound connections (#1561)
 
 #### 5.0.3 (2022-05-23)
 * **Breaking change**: subclasses of DicomService will have to pass an instance of DicomServiceDependencies along to the DicomService base constructor. This replaces the old LogManager / NetworkManager / TranscoderManager dependencies. (Implemented in the context of #1291)

--- a/FO-DICOM.Core/Network/DesktopNetworkListener.cs
+++ b/FO-DICOM.Core/Network/DesktopNetworkListener.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2012-2021 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using Microsoft.Extensions.Logging;
+using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
@@ -14,11 +16,14 @@ namespace FellowOakDicom.Network
     /// </summary>
     public class DesktopNetworkListener : INetworkListener
     {
+
         #region FIELDS
 
         private readonly TcpListener _listener;
 
-        private X509Certificate _certificate = null;
+        private readonly IPEndPoint _endpoint;
+        
+        private X509Certificate _certificate;
 
         #endregion
 
@@ -38,7 +43,8 @@ namespace FellowOakDicom.Network
                 addr = IPAddress.Any;
             }
 
-            _listener = new TcpListener(addr, port);
+            _endpoint = new IPEndPoint(addr, port);
+            _listener = new TcpListener(_endpoint);
         }
 
         #endregion
@@ -59,27 +65,38 @@ namespace FellowOakDicom.Network
         public async Task<INetworkStream> AcceptNetworkStreamAsync(
             string certificateName,
             bool noDelay,
+            ILogger logger,
             CancellationToken token)
         {
             try
             {
-                Task awaiter;
-                Task<TcpClient> acceptTcpClientTask;
-                using var cancelSource = CancellationTokenSource.CreateLinkedTokenSource(token);
-                acceptTcpClientTask = _listener.AcceptTcpClientAsync();
-                awaiter = await Task.WhenAny(acceptTcpClientTask, Task.Delay(-1, cancelSource.Token)).ConfigureAwait(false);
-                cancelSource.Cancel();
-                if (awaiter is Task<TcpClient> tcpClientTask)
+                if (logger.IsEnabled(LogLevel.Debug))
                 {
-                    var tcpClient = tcpClientTask.Result;
+                    logger.LogDebug("Waiting for inbound client connection to {IPAddress}:{Port}",
+                        _endpoint.Address.ToString(), _endpoint.Port);                
+                }
+
+                using var cancelSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+                var acceptTcpClientTask = _listener.AcceptTcpClientAsync();
+                var awaiter = await Task.WhenAny(acceptTcpClientTask, Task.Delay(-1, cancelSource.Token)).ConfigureAwait(false);
+                cancelSource.Cancel();
+                if (awaiter == acceptTcpClientTask)
+                {
+                    var tcpClient = await acceptTcpClientTask;
                     tcpClient.NoDelay = noDelay;
+                    
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.LogDebug("Client connected to {IPAddress}:{Port}",
+                            _endpoint.Address.ToString(), _endpoint.Port);                
+                    }
 
                     if (!string.IsNullOrEmpty(certificateName) && _certificate == null)
                     {
                         _certificate = GetX509Certificate(certificateName);
                     }
 
-                    //  let DesktopNetworkStream to dispose tcpClient
+                    // let DesktopNetworkStream dispose the TcpClient
                     return new DesktopNetworkStream(tcpClient, _certificate, true);
                 }
 
@@ -88,8 +105,29 @@ namespace FellowOakDicom.Network
 
                 return null;
             }
-            catch
+            catch (OperationCanceledException)
             {
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug("Listener for {IPAddress}:{Port} has stopped because it was cancelled",
+                        _endpoint.Address.ToString(), _endpoint.Port);
+                }
+
+                return null;
+            }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.OperationAborted)
+            {
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug("Listener for {IPAddress}:{Port} has stopped because the connection was closed",
+                        _endpoint.Address.ToString(), _endpoint.Port);
+                }
+                return null;
+            }
+            catch(Exception exception)
+            {
+                logger.LogError(exception, "An error occurred while listening for inbound client connections to {IPAddress}:{Port}", 
+                    _endpoint.Address.ToString(), _endpoint.Port);
                 return null;
             }
         }

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -299,7 +299,7 @@ namespace FellowOakDicom.Network
                     }
 
                     var networkStream = await listener
-                        .AcceptNetworkStreamAsync(_certificateName, noDelay, _cancellationToken)
+                        .AcceptNetworkStreamAsync(_certificateName, noDelay, Logger, _cancellationToken)
                         .ConfigureAwait(false);
 
                     if (networkStream != null)

--- a/FO-DICOM.Core/Network/INetworkListener.cs
+++ b/FO-DICOM.Core/Network/INetworkListener.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2012-2021 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,8 +28,9 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="certificateName">Certificate name of authenticated connections.</param>
         /// <param name="noDelay">No delay?</param>
+        /// <param name="logger">The logger</param>
         /// <param name="token">Cancellation token.</param>
         /// <returns>Connected network stream.</returns>
-        Task<INetworkStream> AcceptNetworkStreamAsync(string certificateName, bool noDelay, CancellationToken token);
+        Task<INetworkStream> AcceptNetworkStreamAsync(string certificateName, bool noDelay, ILogger logger, CancellationToken token);
     }
 }


### PR DESCRIPTION
If a generic exception occurs while trying to listen for inbound connections, at the very least we should log that.
Secondly, exceptions that occur there would be wrapped inside an AggregateException because we used .Result.
Lastly, this PR also adds a little bit of debug logging.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add logging to DesktopNetworkListener
- Use referential equality to check for the Task.WhenAny winner
- Use `await` instead of `.Result` so exceptions are not wrapped in an unnecessary `AggregateException`
