### PR TITLE
Fix DicomStringElement StringValue returning null when the tag is present 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 ### 5.1.2 (TBD)
-
+* Fix issue where extracting a string from a DICOM dataset could return null if the tag was present but empty
 
 #### 5.1.1 (2023-05-29)
 * Fix issue where DicomClient did not send requests when Async Ops Invoked was zero (#1597)

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -134,7 +134,7 @@ namespace FellowOakDicom
         {
             get
             {
-                if (_value == null && Buffer != null && (Buffer != EmptyBuffer.Value))
+                if (_value == null && Buffer != null)
                 {
                     _value = Buffer == EmptyBuffer.Value
                         ? string.Empty

--- a/Tests/FO-DICOM.Tests/Bugs/GH1341.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1341.cs
@@ -1,0 +1,36 @@
+using System.IO;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    public class GH1341
+    {
+        [Fact]
+        public void DicomDataSetGetValueOrDefault_WhenTagIsPresentButEmpty_ShouldReturnEmptyString()
+        {
+            // Arrange
+            var originalDicomFile = new DicomFile
+            {
+                FileMetaInfo =
+                {
+                    TransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian
+                }
+            };
+            originalDicomFile.Dataset.Add(DicomTag.SOPInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID());
+            originalDicomFile.Dataset.Add(DicomTag.ImageComments, string.Empty);
+
+            // Roundtrip over a stream to simulate I/O
+            using var ms = new MemoryStream();
+            originalDicomFile.Save(ms);
+            ms.Seek(0, SeekOrigin.Begin);
+            var roundTrippedDicomFile = DicomFile.Open(ms);
+            var dicomDataSet = roundTrippedDicomFile.Dataset;
+
+            // Act
+            var imageComments = dicomDataSet.GetSingleValue<string>(DicomTag.ImageComments);
+
+            // Assert
+            Assert.Equal(string.Empty, imageComments);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1341

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Change DicomStringElement.StringValue to properly handle EmptyBuffer
- Add test to guard against future regressions
