### PR TITLE
Fix incorrect results from DicomEncoding.GetCharset

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 ### 5.1.2 (TBD)
 * Fix issue where extracting a string from a DICOM dataset could return null if the tag was present but empty
+* Fix incorrect values returned from `DicomEncoding.GetCharset()` (#1624)
+* Tolerate `Specific Character Set` values misspelled as "ISO-IR ###" additionally
+  to "ISO IR ###"
 
 #### 5.1.1 (2023-05-29)
 * Fix issue where DicomClient did not send requests when Async Ops Invoked was zero (#1597)

--- a/FO-DICOM.Core/DicomEncoding.cs
+++ b/FO-DICOM.Core/DicomEncoding.cs
@@ -36,33 +36,42 @@ namespace FellowOakDicom
         static void RegisterEncodingProvider() => Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
         /// <summary>
-        /// Default DICOM encoding.
+        /// Default encoding used in DICOM.
         /// </summary>
         public static readonly Encoding Default = Encoding.ASCII;
 
         public static readonly Encoding[] DefaultArray = { Default };
 
         /// <summary>
-        /// Get multiple encodings from charsets.
+        /// Get multiple encodings from Specific Character Set attribute values.
         /// </summary>
         /// <param name="charsets">List of character sets.</param>
-        /// <returns>DICOM encodings.</returns>
+        /// <returns>String encodings.</returns>
         public static Encoding[] GetEncodings(string[] charsets) =>
             (from charset in charsets select GetEncoding(charset)).ToArray();
 
         /// <summary>
-        /// Get encoding from charset.
+        /// Get encoding from Specific Character Set attribute value.
+        /// Tolerates some common misspellings.
         /// </summary>
-        /// <param name="charset">Charset.</param>
-        /// <returns>DICOM encoding.</returns>
+        /// <param name="charset">DICOM character set.</param>
+        /// <returns>String encoding.</returns>
         public static Encoding GetEncoding(string charset)
         {
-            if (string.IsNullOrEmpty(charset?.Trim()))
+            charset = charset?.Trim();
+            if (string.IsNullOrEmpty(charset))
             {
                 return Default;
             }
 
-            if (_knownEncodings.TryGetValue(charset.Trim().Replace("_", " "), out Encoding encoding))
+            if (_knownEncodings.TryGetValue(charset, out Encoding encoding))
+            {
+                return encoding;
+            }
+
+            // Also allow some common misspellings (ISO-IR ### or ISO IR ### instead of ISO_IR ###)
+            if (_knownEncodings.TryGetValue(charset.Replace("ISO IR", "ISO_IR")
+                    .Replace("ISO-IR", "ISO_IR"), out encoding))
             {
                 return encoding;
             }
@@ -125,19 +134,19 @@ namespace FellowOakDicom
 
         private static readonly IDictionary<string, string> _knownEncodingNames = new Dictionary<string, string>
         {
-            { "ISO IR 13", "shift_jis" }, // JIS X 0201 (Shift JIS)
-            { "ISO IR 100", "iso-8859-1" }, // Latin Alphabet No. 1
-            { "ISO IR 101", "iso-8859-2" }, // Latin Alphabet No. 2
-            { "ISO IR 109", "iso-8859-3" }, // Latin Alphabet No. 3
-            { "ISO IR 110", "iso-8859-4" }, // Latin Alphabet No. 4
-            { "ISO IR 126", "iso-8859-7" }, // Greek
-            { "ISO IR 127", "iso-8859-6" }, // Arabic
-            { "ISO IR 138", "iso-8859-8" }, // Hebrew
-            { "ISO IR 144", "iso-8859-5" }, // Cyrillic
-            { "ISO IR 148", "iso-8859-9" }, // Latin Alphabet No. 5 (Turkish)
-            { "ISO IR 149", "x-cp20949" }, // KS X 1001 (Hangul and Hanja)
-            { "ISO IR 166", "windows-874" }, // TIS 620-2533 (Thai)
-            { "ISO IR 192", "utf-8" }, // Unicode in UTF-8
+            { "ISO_IR 13", "shift_jis" }, // JIS X 0201 (Shift JIS)
+            { "ISO_IR 100", "iso-8859-1" }, // Latin Alphabet No. 1
+            { "ISO_IR 101", "iso-8859-2" }, // Latin Alphabet No. 2
+            { "ISO_IR 109", "iso-8859-3" }, // Latin Alphabet No. 3
+            { "ISO_IR 110", "iso-8859-4" }, // Latin Alphabet No. 4
+            { "ISO_IR 126", "iso-8859-7" }, // Greek
+            { "ISO_IR 127", "iso-8859-6" }, // Arabic
+            { "ISO_IR 138", "iso-8859-8" }, // Hebrew
+            { "ISO_IR 144", "iso-8859-5" }, // Cyrillic
+            { "ISO_IR 148", "iso-8859-9" }, // Latin Alphabet No. 5 (Turkish)
+            { "ISO_IR 149", "x-cp20949" }, // KS X 1001 (Hangul and Hanja)
+            { "ISO_IR 166", "windows-874" }, // TIS 620-2533 (Thai)
+            { "ISO_IR 192", "utf-8" }, // Unicode in UTF-8
             { "GBK", "GBK" }, // Chinese (Simplified)
             { "GB18030", "gb18030" }, // Chinese (supersedes GBK)
             { "ISO 2022 IR 6", "us-ascii" }, // ASCII

--- a/Tests/FO-DICOM.Tests/DicomEncodingTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomEncodingTest.cs
@@ -34,6 +34,21 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void GetEncoding_WorksWithCommonMisspellings()
+        {
+            var expected = Encoding.GetEncoding("utf-8");
+            // correct spelling
+            var actual = DicomEncoding.GetEncoding("ISO_IR 192");
+            Assert.Equal(expected, actual);
+
+            // common misspellings
+            actual = DicomEncoding.GetEncoding("ISO IR 192");
+            Assert.Equal(expected, actual);
+            actual = DicomEncoding.GetEncoding("ISO-IR 192");
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void GetEncoding_GB18030() //https://github.com/fo-dicom/fo-dicom/issues/481
         {
             int codePage = 0;
@@ -99,6 +114,26 @@ namespace FellowOakDicom.Tests
             var actualName = dataset.GetSingleValue<string>(DicomTag.PatientName);
             Assert.Equal(patientName, actualName);
         }
+
+        [Theory]
+        [MemberData(nameof(EncodingNames))]
+        public void GetCharset(string encodingName, string charSetName)
+        {
+            var encoding = Encoding.GetEncoding(encodingName);
+            var actual = DicomEncoding.GetCharset(encoding);
+            Assert.Equal(charSetName, actual);
+        }
+
+
+        [Theory]
+        [MemberData(nameof(EncodingNamesExtended))]
+        public void GetCharsetExtended(string encodingName, string charSetName)
+        {
+            var encoding = Encoding.GetEncoding(encodingName);
+            var actual = DicomEncoding.GetCharset(encoding, extended:true);
+            Assert.Equal(charSetName, actual);
+        }
+
 
         [Theory]
         [MemberData(nameof(EncodedNames))]
@@ -307,6 +342,35 @@ namespace FellowOakDicom.Tests
                 new byte[] { 0x1b, 0x2d, 0x4d, 0xc7, 0x61, 0x76, 0x75, 0xfe, 0x6f, 0xf0, 0x6c, 0x75 } },
             new object[] { "ISO 2022 IR 166", "นามสกุล",
                 new byte[] { 0x1b, 0x2d, 0x54, 0xb9, 0xd2, 0xc1, 0xca, 0xa1, 0xd8, 0xc5 } }
+        };
+
+        public static readonly IEnumerable<object[]> EncodingNames = new[]
+        {
+            new object[] { "iso-8859-1", "ISO_IR 100" },
+            new object[] { "iso-8859-2", "ISO_IR 101" },
+            new object[] { "iso-8859-3", "ISO_IR 109" },
+            new object[] { "iso-8859-4", "ISO_IR 110" },
+            new object[] { "iso-8859-5", "ISO_IR 144" },
+            new object[] { "iso-8859-6", "ISO_IR 127" },
+            new object[] { "iso-8859-7", "ISO_IR 126" },
+            new object[] { "iso-8859-8", "ISO_IR 138" },
+            new object[] { "iso-8859-9", "ISO_IR 148" },
+            new object[] { "windows-874", "ISO_IR 166" },
+            new object[] { "utf-8", "ISO_IR 192" },
+        };
+
+        public static readonly IEnumerable<object[]> EncodingNamesExtended = new[]
+        {
+            new object[] { "iso-8859-1", "ISO 2022 IR 100" },
+            new object[] { "iso-8859-2", "ISO 2022 IR 101" },
+            new object[] { "iso-8859-3", "ISO 2022 IR 109" },
+            new object[] { "iso-8859-4", "ISO 2022 IR 110" },
+            new object[] { "iso-8859-5", "ISO 2022 IR 144" },
+            new object[] { "iso-8859-6", "ISO 2022 IR 127" },
+            new object[] { "iso-8859-7", "ISO 2022 IR 126" },
+            new object[] { "iso-8859-8", "ISO 2022 IR 138" },
+            new object[] { "iso-8859-9", "ISO 2022 IR 148" },
+            new object[] { "windows-874", "ISO 2022 IR 166" },
         };
 
         private CollectingLoggerSession NewLogCollector()


### PR DESCRIPTION
* single value encodings have been returned as "ISO IR ###" instead of "ISO_IR ###"
* Tolerate Specific Character Set values misspelled as "ISO-IR ###" additionally to "ISO IR ###"
* fixes #1624

I had introduced this in some refactoring, sorry for that.
I added tolerating  "ISO-IR ###" which is not directly related because this is a common mistake I have seen several times in the field. As there was never a warning for the also supported "ISO IR ###" spelling, I added none here, but I can change that if wanted.


#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

