### PR TITLE
fix re-add negation sign after recheck

### DIFF
--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -587,11 +587,11 @@ namespace FellowOakDicom.Serialization
                 val = val.Substring(i);
             }
 
-            // Re-add negation sign
-            if (negative) { val = "-" + val; }
-
             if (IsValidJsonNumber(val))
             {
+                // Re-add negation sign
+                if (negative) { val = "-" + val; }
+                
                 return val;
             }
 

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -611,11 +611,11 @@ namespace FellowOakDicom.Serialization
                 val = val.Substring(i);
             }
 
-            // Re-add negation sign
-            if (negative) { val = "-" + val; }
-
             if (IsValidJsonNumber(val))
             {
+                // Re-add negation sign
+                if (negative) { val = "-" + val; }
+
                 return val;
             }
 


### PR DESCRIPTION
#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- I think we need to add the negation sign after checking again. In this case we will do the same check with the same value again.
