### PR TITLE
Fix MaxClientsAllowed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,7 @@
 - Fix issue with missing known DicomTransferSyntax from static DicomTransferSyntax.Entries dictionary (#1644)
 - Improve robustness of DicomService when presented with HTTP requests. Bail early if the PDU type is not recognized (#1678)
 - Enhancement: Added IEquatable implementation and equality operators for DicomDataset class
+- Fix issue where a DICOM server could stop accepting incoming connections if MaxClientsAllowed is configured and one or more connections take longer than one minute to close (#1670)
 
 #### 5.1.1 (2023-05-29)
 

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -294,7 +294,7 @@ namespace FellowOakDicom.Network
                         // we need to wait until one of the existing clients closes its connection
                         while (!await _maxClientsSemaphore.WaitAsync(MaxClientsAllowedWaitInterval, _cancellationToken))
                         {
-                            _logger.LogWarning("Waited {MaxClientsAllowedInterval}, " +
+                            Logger.LogWarning("Waited {MaxClientsAllowedInterval}, " +
                                                "but we still cannot accept another incoming connection " +
                                                "because the maximum number of clients ({MaxClientsAllowed}) has been reached", 
                                 MaxClientsAllowedWaitInterval, maxClientsAllowed);
@@ -321,14 +321,14 @@ namespace FellowOakDicom.Network
                             numberOfServices = _services.Count;
                         }
                         
-                        _logger.LogDebug("Accepted an incoming client connection, there are now {NumberOfServices} connected clients", numberOfServices);
+                        Logger.LogDebug("Accepted an incoming client connection, there are now {NumberOfServices} connected clients", numberOfServices);
                         
                         // We don't actually care about the values inside the channel, they just serve as a notification that a service has connected
                         await _servicesChannel.Writer.WriteAsync(numberOfServices, _cancellationToken);
                         
                         if (maxClientsAllowed > 0 && numberOfServices == maxClientsAllowed)
                         {
-                            _logger.LogWarning("Reached the maximum number of simultaneously connected clients, further incoming connections will be blocked until one or more clients disconnect");
+                            Logger.LogWarning("Reached the maximum number of simultaneously connected clients, further incoming connections will be blocked until one or more clients disconnect");
                         }
                     }
                 }
@@ -361,7 +361,7 @@ namespace FellowOakDicom.Network
             {
                 try
                 {
-                    _logger.LogDebug("Waiting for incoming client connections");
+                    Logger.LogDebug("Waiting for incoming client connections");
                     
                     // First, we wait until at least one service is running
                     // We don't actually care about the values inside the channel, they just serve as a notification that a service has connected
@@ -385,7 +385,7 @@ namespace FellowOakDicom.Network
                             runningDicomServices = _services.ToList();
                         }
                         var numberOfDicomServices = runningDicomServices.Count;
-                        _logger.LogDebug("There are {NumberOfDicomServices} running DICOM services", numberOfDicomServices);
+                        Logger.LogDebug("There are {NumberOfDicomServices} running DICOM services", numberOfDicomServices);
                         if (numberOfDicomServices == 0)
                         {
                             // No more services at all? Exit early
@@ -415,11 +415,11 @@ namespace FellowOakDicom.Network
                             }
                             
                             // If another service started, we must restart the Task.WhenAny with the new set of running service tasks
-                            _logger.LogDebug("Another DICOM service has started while the cleanup was waiting for one or more DICOM services to complete");
+                            Logger.LogDebug("Another DICOM service has started while the cleanup was waiting for one or more DICOM services to complete");
                         }
                         else
                         {
-                            _logger.LogDebug("One or more running DICOM services have completed");
+                            Logger.LogDebug("One or more running DICOM services have completed");
                             break;
                         }
                     }
@@ -449,7 +449,7 @@ namespace FellowOakDicom.Network
                         }
                         catch (Exception e)
                         {
-                            _logger.LogWarning("An error occurred while trying to dispose a completed DICOM service: {@Error}", e);
+                            Logger.LogWarning("An error occurred while trying to dispose a completed DICOM service: {@Error}", e);
                         }
                     }
 
@@ -459,33 +459,33 @@ namespace FellowOakDicom.Network
                         _maxClientsSemaphore?.Release(numberOfCompletedServices);
                     }
 
-                    _logger.LogDebug("Cleaned up {NumberOfCompletedServices} completed DICOM services", numberOfCompletedServices);
+                    Logger.LogDebug("Cleaned up {NumberOfCompletedServices} completed DICOM services", numberOfCompletedServices);
                     if (numberOfRemainingServices > 0)
                     {
-                        _logger.LogDebug("There are still {NumberOfRemainingServices} clients connected now", numberOfRemainingServices);    
+                        Logger.LogDebug("There are still {NumberOfRemainingServices} clients connected now", numberOfRemainingServices);    
                     }
                     else
                     {
-                        _logger.LogDebug("There are no clients connected now");
+                        Logger.LogDebug("There are no clients connected now");
                     }
 
                     if (maxClientsAllowed > 0)
                     {
                         if (numberOfRemainingServices == maxClientsAllowed)
                         {
-                            _logger.LogDebug("Cannot accept more incoming client connections until one or more clients disconnect");
+                            Logger.LogDebug("Cannot accept more incoming client connections until one or more clients disconnect");
                         }
                         else 
                         {
                             var numberOfExtraClientsAllowed = maxClientsAllowed - numberOfRemainingServices;
-                            _logger.LogDebug(
+                            Logger.LogDebug(
                                 "{NumberOfExtraServicesAllowed} more incoming client connections are allowed",
                                 numberOfExtraClientsAllowed);
                         }
                     }
                     else
                     {
-                        _logger.LogDebug("Unlimited more incoming client connections are allowed");
+                        Logger.LogDebug("Unlimited more incoming client connections are allowed");
                     }
                 }
                 catch (ChannelClosedException)
@@ -522,7 +522,7 @@ namespace FellowOakDicom.Network
                 }
                 catch (Exception e)
                 {
-                    _logger.LogWarning("An error occurred while trying to dispose a DICOM service: {@Error}", e);
+                    Logger.LogWarning("An error occurred while trying to dispose a DICOM service: {@Error}", e);
                 }
             }
         }

--- a/Tests/FO-DICOM.Tests/Bugs/GH1669.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1669.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using FellowOakDicom.Tests.Helpers;
+using FellowOakDicom.Tests.Network;
+using FellowOakDicom.Tests.Network.Client;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    [Collection(TestCollections.Network)]
+    public sealed class GH1669
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public GH1669(ITestOutputHelper output) 
+        {
+            _logger = new XUnitDicomLogger(output)
+                .IncludeTimestamps()
+                .IncludeThreadId()
+                .WithMinimumLevel(LogLevel.Debug);
+        }
+        
+        [Fact]
+        public async Task ShouldAcceptMaxClientsAllowedConnectionsAtAllTimes()
+        {
+            // Arrange
+            const int numberOfClients = 6;
+            const int maxClientsAllowed = 3;
+            var delayPerClient = TimeSpan.FromSeconds(5);
+            var serverDelay = TimeSpan.FromSeconds(1);
+            
+            var port = Ports.GetNext();
+            using var server = (DicomClientTimeoutTest.ConfigurableDicomCEchoProviderServer)
+                DicomServerFactory.Create<
+                    DicomClientTimeoutTest.ConfigurableDicomCEchoProvider,
+                    DicomClientTimeoutTest.ConfigurableDicomCEchoProviderServer>(
+                    NetworkManager.IPv4Any,
+                    port,
+                    configure: o => o.MaxClientsAllowed = maxClientsAllowed
+                );
+            server.Logger = _logger.IncludePrefix("Server").WithMinimumLevel(LogLevel.Debug);
+            server.OnRequest(async dicomCEchoRequest =>
+            {
+                // Simulate a delay upon every C-ECHO request to keep the connection open
+                await Task.Delay(delayPerClient);
+            });
+            server.MaxClientsAllowedWaitInterval = serverDelay;
+
+            var clients = new List<IDicomClient>(numberOfClients);
+            for (var i = 1; i <= numberOfClients; i++)
+            {
+                var client = DicomClientFactory.Create("127.0.0.1", port, false, "SCU", "ANY-SCP");
+                client.ClientOptions.AssociationRequestTimeoutInMs = (int) TimeSpan.FromMinutes(1).TotalMilliseconds;
+                client.ServiceOptions.RequestTimeout = TimeSpan.FromMinutes(1);
+                client.Logger = _logger.IncludePrefix($"Client{i}").WithMinimumLevel(LogLevel.Debug);
+                clients.Add(client);
+            }
+
+            // Act
+            var responses = new ConcurrentQueue<DicomCEchoResponse>();
+            var sendTasks = new List<Task>();
+            foreach (var client in clients)
+            {
+                var request = new DicomCEchoRequest
+                {
+                    OnResponseReceived = (request, response) => responses.Enqueue(response),
+                };
+                await client.AddRequestAsync(request);
+            }
+            foreach (var client in clients)
+            {
+                sendTasks.Add(client.SendAsync());
+            }
+            await Task.WhenAll(sendTasks);
+
+            // Assert
+            Assert.Equal(responses.Count, clients.Count);
+            foreach (var response in responses)
+            {
+                Assert.Equal(DicomState.Success, response.Status.State);
+            }
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests/Bugs/GH1669.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1669.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2012-2023 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -6,7 +9,6 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using FellowOakDicom.Tests.Network;
-using FellowOakDicom.Tests.Network.Client;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,10 +38,10 @@ namespace FellowOakDicom.Tests.Bugs
             var serverDelay = TimeSpan.FromSeconds(1);
             
             var port = Ports.GetNext();
-            using var server = (DicomClientTimeoutTest.ConfigurableDicomCEchoProviderServer)
+            using var server = (ConfigurableDicomCEchoProviderServer)
                 DicomServerFactory.Create<
-                    DicomClientTimeoutTest.ConfigurableDicomCEchoProvider,
-                    DicomClientTimeoutTest.ConfigurableDicomCEchoProviderServer>(
+                    ConfigurableDicomCEchoProvider,
+                    ConfigurableDicomCEchoProviderServer>(
                     NetworkManager.IPv4Any,
                     port,
                     configure: o => o.MaxClientsAllowed = maxClientsAllowed

--- a/Tests/FO-DICOM.Tests/Helpers/ConfigurableDicomCEchoProvider.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/ConfigurableDicomCEchoProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2012-2023 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom.Network;

--- a/Tests/FO-DICOM.Tests/Helpers/ConfigurableDicomCEchoProviderServer.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/ConfigurableDicomCEchoProviderServer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2012-2023 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom.Network;


### PR DESCRIPTION
Fixes #1669 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Use Semaphore.WaitAsync with timeout to avoid entering the Semaphore and causing MaxClientsAllowed to get stuck
