### PR TITLE
Handle random network activity (like HTTP requests) better in DicomService

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@
 * Fix the issue of 'DicomAttribute not generated in XML when element is of type DicomFragmentSequence'
 * Prevent adding duplicate presentation contexts to an association request (#1596)
 * Fix issue with missing known DicomTransferSyntax from static DicomTransferSyntax.Entries dictionary (#1644)
+* Improve robustness of DicomService when presented with HTTP requests. Bail early if the PDU type is not recognized (#1678)
 
 #### 5.1.1 (2023-05-29)
 * Fix issue where DicomClient did not send requests when Async Ops Invoked was zero (#1597)

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -511,7 +511,7 @@ namespace FellowOakDicom.Network
                     // The second byte is reserved
                     // The remaining four bytes contain the PDU length
                     var pduTypeByte = rawPduCommonFieldsBuffer.Bytes[0];
-                    if (!Enum.IsDefined(typeof(RawPduType), pduTypeByte) && pduTypeByte != 0xFF)
+                    if (!Enum.IsDefined(typeof(RawPduType), pduTypeByte))
                     {
                         throw new DicomNetworkException("Unknown PDU type: " + pduTypeByte);
                     }
@@ -692,10 +692,6 @@ namespace FellowOakDicom.Network
                                     return;
                                 }
 
-                                break;
-                            }
-                        case (RawPduType) 0xFF:
-                            {
                                 break;
                             }
                         default:

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -543,7 +543,7 @@ namespace FellowOakDicom.Network
 
                     switch (raw.Type)
                     {
-                        case 0x01:
+                        case RawPduType.A_ASSOCIATE_RQ:
                             {
                                 Association = new DicomAssociation
                                 {
@@ -581,7 +581,7 @@ namespace FellowOakDicom.Network
 
                                 break;
                             }
-                        case 0x02:
+                        case RawPduType.A_ASSOCIATE_AC:
                             {
                                 var pdu = new AAssociateAC(Association, _memoryProvider);
                                 pdu.Read(raw);
@@ -597,7 +597,7 @@ namespace FellowOakDicom.Network
 
                                 break;
                             }
-                        case 0x03:
+                        case RawPduType.A_ASSOCIATE_RJ:
                             {
                                 var pdu = new AAssociateRJ(_memoryProvider);
                                 pdu.Read(raw);
@@ -620,7 +620,7 @@ namespace FellowOakDicom.Network
 
                                 break;
                             }
-                        case 0x04:
+                        case RawPduType.P_DATA_TF:
                             {
                                 using var pdu = new PDataTF(_memoryProvider);
                                 pdu.Read(raw);
@@ -632,7 +632,7 @@ namespace FellowOakDicom.Network
                                 await ProcessPDataTFAsync(pdu).ConfigureAwait(false);
                                 break;
                             }
-                        case 0x05:
+                        case RawPduType.A_RELEASE_RQ:
                             {
                                 var pdu = new AReleaseRQ(_memoryProvider);
                                 pdu.Read(raw);
@@ -644,7 +644,7 @@ namespace FellowOakDicom.Network
 
                                 break;
                             }
-                        case 0x06:
+                        case RawPduType.A_RELEASE_RP:
                             {
                                 var pdu = new AReleaseRP(_memoryProvider);
                                 pdu.Read(raw);
@@ -661,7 +661,7 @@ namespace FellowOakDicom.Network
 
                                 break;
                             }
-                        case 0x07:
+                        case RawPduType.A_ABORT:
                             {
                                 var pdu = new AAbort(_memoryProvider);
                                 pdu.Read(raw);
@@ -686,7 +686,7 @@ namespace FellowOakDicom.Network
 
                                 break;
                             }
-                        case 0xFF:
+                        case (RawPduType) 0xFF:
                             {
                                 break;
                             }

--- a/Tests/FO-DICOM.Tests/Bugs/GH1678.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1678.cs
@@ -34,7 +34,7 @@ namespace FellowOakDicom.Tests.Bugs
             // Act
             try
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
                 await httpClient.GetAsync($"http://localhost:{port}/", cts.Token);
             }
             catch (HttpRequestException e)

--- a/Tests/FO-DICOM.Tests/Bugs/GH1678.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1678.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FellowOakDicom.Memory;
+using FellowOakDicom.Network;
+using FellowOakDicom.Tests.Network;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    [Collection(TestCollections.Network)]
+    public class GH1678
+    {
+        [Fact]
+        public async Task WhenReceivingAnHttpRequest_ShouldCloseConnectionAndNotAllocateLargeBuffer()
+        {
+            // Arrange
+            var port = Ports.GetNext();
+            var recordingMemoryProvider = new RecordingMemoryProvider(new ArrayPoolMemoryProvider());
+            var serviceProvider = new ServiceCollection()
+                .AddFellowOakDicom()
+                .Replace(ServiceDescriptor.Singleton<IMemoryProvider>(recordingMemoryProvider))
+                .BuildServiceProvider();
+            var dicomServerFactory = serviceProvider.GetRequiredService<IDicomServerFactory>();
+            using var server = dicomServerFactory.Create<DicomCEchoProvider>(port);
+            using var httpClient = new HttpClient();
+            HttpRequestException capturedHttpRequestException = null;
+            OperationCanceledException capturedOperationCanceledException = null;
+
+            // Act
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await httpClient.GetAsync($"http://localhost:{port}/", cts.Token);
+            }
+            catch (HttpRequestException e)
+            {
+                capturedHttpRequestException = e;
+            }
+            catch (OperationCanceledException e)
+            {
+                capturedOperationCanceledException = e;
+            }
+
+            // Assert
+            const int oneGigaByte = 1024 * 1024 * 1024;
+            Assert.All(recordingMemoryProvider.RequestedLengths, length => Assert.True(length < oneGigaByte));
+            Assert.NotNull(capturedHttpRequestException);
+            Assert.Null(capturedOperationCanceledException);
+        }
+
+        private class RecordingMemoryProvider : IMemoryProvider
+        {
+            private readonly IMemoryProvider _inner;
+
+            public RecordingMemoryProvider(IMemoryProvider inner)
+            {
+                _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            }
+
+            public List<int> RequestedLengths { get; } = new List<int>();
+
+            public IMemory Provide(int length)
+            {
+                RequestedLengths.Add(length);
+                return _inner.Provide(length);
+            }
+        }
+
+    }
+}

--- a/Tests/FO-DICOM.Tests/Network/PDUTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/PDUTest.cs
@@ -49,7 +49,7 @@ namespace FellowOakDicom.Tests.Network
             var name = Path.Combine(path, "assoc.pdu");
             if (Directory.Exists(path)) Directory.Delete(path, true);
 
-            var pdu = new RawPDU(0x01, _memoryProvider);
+            var pdu = new RawPDU(RawPduType.A_ASSOCIATE_RQ, _memoryProvider);
             pdu.Save(new FileReference(name));
 
             Assert.True(File.Exists(name));


### PR DESCRIPTION
Fixes #1678 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When parsing incoming PDUs, immediately stop parsing if the PDU type is unrecognizable and close the connection
- Add enum RawPduType to improve DX
