### PR TITLE
Set up nullable annotations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,11 +4,13 @@
         <Company>fo-dicom</Company>
         <Copyright>Copyright © fo-dicom contributors 2012-2023</Copyright>
         <Description>fo-dicom</Description>
+        <LangVersion>8</LangVersion>
 
         <AssemblyVersion>5.1.1</AssemblyVersion>
         <FileVersion>5.1.1.0</FileVersion>
         <InformationalVersion>5.1.1</InformationalVersion>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(GenerateDocumentation)==1">

--- a/FO-DICOM.Core/AssemblyInfo.cs
+++ b/FO-DICOM.Core/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Runtime.CompilerServices;
 

--- a/FO-DICOM.Core/DicomAnonymizer.cs
+++ b/FO-DICOM.Core/DicomAnonymizer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/DicomAnonymizerGenerated.cs
+++ b/FO-DICOM.Core/DicomAnonymizerGenerated.cs
@@ -1,6 +1,7 @@
 ﻿
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom
 {

--- a/FO-DICOM.Core/DicomDataException.cs
+++ b/FO-DICOM.Core/DicomDataException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.StructuredReport;

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomDatasetWalker.cs
+++ b/FO-DICOM.Core/DicomDatasetWalker.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/DicomDateRange.cs
+++ b/FO-DICOM.Core/DicomDateRange.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomDictionary.cs
+++ b/FO-DICOM.Core/DicomDictionary.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/DicomDictionaryEntry.cs
+++ b/FO-DICOM.Core/DicomDictionaryEntry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom
 {

--- a/FO-DICOM.Core/DicomDictionaryReader.cs
+++ b/FO-DICOM.Core/DicomDictionaryReader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomEncoding.cs
+++ b/FO-DICOM.Core/DicomEncoding.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.Memory;

--- a/FO-DICOM.Core/DicomException.cs
+++ b/FO-DICOM.Core/DicomException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomFile.cs
+++ b/FO-DICOM.Core/DicomFile.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Reader;

--- a/FO-DICOM.Core/DicomFileException.cs
+++ b/FO-DICOM.Core/DicomFileException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomFileExtensions.cs
+++ b/FO-DICOM.Core/DicomFileExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom
 {

--- a/FO-DICOM.Core/DicomFileFormat.cs
+++ b/FO-DICOM.Core/DicomFileFormat.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom
 {

--- a/FO-DICOM.Core/DicomFileMetaInformation.cs
+++ b/FO-DICOM.Core/DicomFileMetaInformation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/DicomFragmentSequence.cs
+++ b/FO-DICOM.Core/DicomFragmentSequence.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomImplementation.cs
+++ b/FO-DICOM.Core/DicomImplementation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Reflection;
 

--- a/FO-DICOM.Core/DicomItem.cs
+++ b/FO-DICOM.Core/DicomItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomItemComparer.cs
+++ b/FO-DICOM.Core/DicomItemComparer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/DicomMaskedTag.cs
+++ b/FO-DICOM.Core/DicomMaskedTag.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Globalization;

--- a/FO-DICOM.Core/DicomMatchRules.cs
+++ b/FO-DICOM.Core/DicomMatchRules.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomParseable.cs
+++ b/FO-DICOM.Core/DicomParseable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Linq;
 using System.Reflection;

--- a/FO-DICOM.Core/DicomPrivateCreator.cs
+++ b/FO-DICOM.Core/DicomPrivateCreator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Runtime.Serialization;

--- a/FO-DICOM.Core/DicomRange.cs
+++ b/FO-DICOM.Core/DicomRange.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomSequence.cs
+++ b/FO-DICOM.Core/DicomSequence.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/DicomTag.cs
+++ b/FO-DICOM.Core/DicomTag.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using System;

--- a/FO-DICOM.Core/DicomTagGenerated.cs
+++ b/FO-DICOM.Core/DicomTagGenerated.cs
@@ -1,6 +1,7 @@
 ﻿
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom
 {

--- a/FO-DICOM.Core/DicomTagsIndex.cs
+++ b/FO-DICOM.Core/DicomTagsIndex.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomTransferSyntax.cs
+++ b/FO-DICOM.Core/DicomTransferSyntax.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using System;

--- a/FO-DICOM.Core/DicomTransformRules.cs
+++ b/FO-DICOM.Core/DicomTransformRules.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomUID.cs
+++ b/FO-DICOM.Core/DicomUID.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Concurrent;

--- a/FO-DICOM.Core/DicomUIDGenerated.cs
+++ b/FO-DICOM.Core/DicomUIDGenerated.cs
@@ -1,6 +1,7 @@
 ﻿
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomUIDGenerator.cs
+++ b/FO-DICOM.Core/DicomUIDGenerator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Concurrent;

--- a/FO-DICOM.Core/DicomUIDPrivate.cs
+++ b/FO-DICOM.Core/DicomUIDPrivate.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom
 {

--- a/FO-DICOM.Core/DicomVM.cs
+++ b/FO-DICOM.Core/DicomVM.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/DicomVR.cs
+++ b/FO-DICOM.Core/DicomVR.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomVRCode.cs
+++ b/FO-DICOM.Core/DicomVRCode.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/DicomValidation.cs
+++ b/FO-DICOM.Core/DicomValidation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Linq;

--- a/FO-DICOM.Core/DicomValidationException.cs
+++ b/FO-DICOM.Core/DicomValidationException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom
 {

--- a/FO-DICOM.Core/IO/Buffer/BulkDataUriByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/BulkDataUriByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/Buffer/ByteBufferByteSource.cs
+++ b/FO-DICOM.Core/IO/Buffer/ByteBufferByteSource.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/IO/Buffer/ByteBufferEnumerator.cs
+++ b/FO-DICOM.Core/IO/Buffer/ByteBufferEnumerator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections;

--- a/FO-DICOM.Core/IO/Buffer/ByteBufferExtensions.cs
+++ b/FO-DICOM.Core/IO/Buffer/ByteBufferExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/IO/Buffer/CompositeByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/CompositeByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/Buffer/EmptyBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/EmptyBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/Buffer/EndianByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/EndianByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/Buffer/EvenLengthBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/EvenLengthBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/Buffer/FileByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/FileByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/Buffer/IBulkDataUriByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/IBulkDataUriByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.IO.Buffer
 {

--- a/FO-DICOM.Core/IO/Buffer/IByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/IByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Threading;

--- a/FO-DICOM.Core/IO/Buffer/LazyByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/LazyByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/Buffer/MemoryByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/MemoryByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/Buffer/RangeByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/RangeByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/Buffer/StreamByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/StreamByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/Buffer/SwapByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/SwapByteBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/Buffer/TempFileBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/TempFileBuffer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/ByteConverter.cs
+++ b/FO-DICOM.Core/IO/ByteConverter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/IO/DicomIoException.cs
+++ b/FO-DICOM.Core/IO/DicomIoException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/IO/DirectoryReference.cs
+++ b/FO-DICOM.Core/IO/DirectoryReference.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.IO;

--- a/FO-DICOM.Core/IO/Endian.cs
+++ b/FO-DICOM.Core/IO/Endian.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/FileByteSource.cs
+++ b/FO-DICOM.Core/IO/FileByteSource.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/IO/FileByteTarget.cs
+++ b/FO-DICOM.Core/IO/FileByteTarget.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/FileReference.cs
+++ b/FO-DICOM.Core/IO/FileReference.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/IByteSource.cs
+++ b/FO-DICOM.Core/IO/IByteSource.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/IO/IByteTarget.cs
+++ b/FO-DICOM.Core/IO/IByteTarget.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/IO/IDirectoryReference.cs
+++ b/FO-DICOM.Core/IO/IDirectoryReference.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/IO/IFileReference.cs
+++ b/FO-DICOM.Core/IO/IFileReference.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/MergeStream.cs
+++ b/FO-DICOM.Core/IO/MergeStream.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/IO/PinnedArray.cs
+++ b/FO-DICOM.Core/IO/PinnedArray.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Runtime.InteropServices;

--- a/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/IO/Reader/DicomFileReader.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomFileReader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/Reader/DicomReader.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomReader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/IO/Reader/DicomReaderCallbackObserver.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomReaderCallbackObserver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/IO/Reader/DicomReaderEventArgs.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomReaderEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/IO/Reader/DicomReaderException.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomReaderException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/IO/Reader/DicomReaderMultiObserver.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomReaderMultiObserver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 

--- a/FO-DICOM.Core/IO/Reader/IDicomReader.cs
+++ b/FO-DICOM.Core/IO/Reader/IDicomReader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/IO/Reader/IDicomReaderObserver.cs
+++ b/FO-DICOM.Core/IO/Reader/IDicomReaderObserver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 

--- a/FO-DICOM.Core/IO/StreamByteSource.cs
+++ b/FO-DICOM.Core/IO/StreamByteSource.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/IO/StreamByteSourceFactory.cs
+++ b/FO-DICOM.Core/IO/StreamByteSourceFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/IO/StreamByteTarget.cs
+++ b/FO-DICOM.Core/IO/StreamByteTarget.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/IO/TemporaryFile.cs
+++ b/FO-DICOM.Core/IO/TemporaryFile.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.DependencyInjection;
 using System;

--- a/FO-DICOM.Core/IO/TemporaryFileRemover.cs
+++ b/FO-DICOM.Core/IO/TemporaryFileRemover.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/IO/UnseekableStreamByteSource.cs
+++ b/FO-DICOM.Core/IO/UnseekableStreamByteSource.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.Log;

--- a/FO-DICOM.Core/IO/Writer/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomDatasetExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/FO-DICOM.Core/IO/Writer/DicomFileWriter.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomFileWriter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.IO.Compression;

--- a/FO-DICOM.Core/IO/Writer/DicomWriteLengthCalculator.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomWriteLengthCalculator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/IO/Writer/DicomWriteOptions.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomWriteOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.IO.Writer
 {

--- a/FO-DICOM.Core/IO/Writer/DicomWriter.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomWriter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Imaging/Algorithms/BilinearInterpolation.cs
+++ b/FO-DICOM.Core/Imaging/Algorithms/BilinearInterpolation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Imaging/Algorithms/NearestNeighborInterpolation.cs
+++ b/FO-DICOM.Core/Imaging/Algorithms/NearestNeighborInterpolation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Imaging/BitDepth.cs
+++ b/FO-DICOM.Core/Imaging/BitDepth.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Text;
 

--- a/FO-DICOM.Core/Imaging/Codec/DefaultTranscoderManager.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DefaultTranscoderManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Linq;

--- a/FO-DICOM.Core/Imaging/Codec/DicomCodecException.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomCodecException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/Codec/DicomCodecExtensions.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomCodecExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec
 {

--- a/FO-DICOM.Core/Imaging/Codec/DicomCodecParams.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomCodecParams.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/FO-DICOM.Core/Imaging/Codec/DicomJpeg2000Codec.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomJpeg2000Codec.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec
 {

--- a/FO-DICOM.Core/Imaging/Codec/DicomJpegCodec.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomJpegCodec.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using FellowOakDicom.IO;

--- a/FO-DICOM.Core/Imaging/Codec/DicomJpegLosslessProcess14Decoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomJpegLosslessProcess14Decoder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec.JpegLossless;
 

--- a/FO-DICOM.Core/Imaging/Codec/DicomJpegLosslessProcess14SV1Decoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomJpegLosslessProcess14SV1Decoder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec.JpegLossless;
 

--- a/FO-DICOM.Core/Imaging/Codec/DicomRleCodec.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomRleCodec.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec
 {

--- a/FO-DICOM.Core/Imaging/Codec/DicomRleCodecImpl.Mono.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomRleCodecImpl.Mono.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Imaging/Codec/IDicomCodec.cs
+++ b/FO-DICOM.Core/Imaging/Codec/IDicomCodec.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec
 {

--- a/FO-DICOM.Core/Imaging/Codec/IDicomTranscoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/IDicomTranscoder.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Render;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/ComponentSpec.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/ComponentSpec.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec.JpegLossless
 {

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/DataStream.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/DataStream.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec.JpegLossless
 {

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/DicomJpegLosslessDecoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/DicomJpegLosslessDecoder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System.IO;

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/DicomJpegLosslessDecoderImpl.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/DicomJpegLosslessDecoderImpl.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/Frameheader.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/Frameheader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/HuffmanTable.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/HuffmanTable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/JaggedArrayFactory.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/JaggedArrayFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec.JpegLossless
 {

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/QuantizationTable.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/QuantizationTable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/ScanComponent.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/ScanComponent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Codec.JpegLossless
 {

--- a/FO-DICOM.Core/Imaging/Codec/JpegLossless/Scanheader.cs
+++ b/FO-DICOM.Core/Imaging/Codec/JpegLossless/Scanheader.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/FO-DICOM.Core/Imaging/Codec/TranscoderManager.cs
+++ b/FO-DICOM.Core/Imaging/Codec/TranscoderManager.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/Imaging/Color32.cs
+++ b/FO-DICOM.Core/Imaging/Color32.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/FO-DICOM.Core/Imaging/ColorSpace.cs
+++ b/FO-DICOM.Core/Imaging/ColorSpace.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/ColorTable.cs
+++ b/FO-DICOM.Core/Imaging/ColorTable.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using FellowOakDicom.IO;

--- a/FO-DICOM.Core/Imaging/DicomIconImage.cs
+++ b/FO-DICOM.Core/Imaging/DicomIconImage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.Imaging.Render;

--- a/FO-DICOM.Core/Imaging/DicomImage.cs
+++ b/FO-DICOM.Core/Imaging/DicomImage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.Imaging.Render;

--- a/FO-DICOM.Core/Imaging/DicomImagingException.cs
+++ b/FO-DICOM.Core/Imaging/DicomImagingException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/DicomOverlayData.cs
+++ b/FO-DICOM.Core/Imaging/DicomOverlayData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections;

--- a/FO-DICOM.Core/Imaging/DicomOverlayDataFactory.cs
+++ b/FO-DICOM.Core/Imaging/DicomOverlayDataFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Linq;

--- a/FO-DICOM.Core/Imaging/FrameGeometry.cs
+++ b/FO-DICOM.Core/Imaging/FrameGeometry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using System;

--- a/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
+++ b/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using FellowOakDicom.Imaging.Codec;

--- a/FO-DICOM.Core/Imaging/IImage.cs
+++ b/FO-DICOM.Core/Imaging/IImage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Imaging/IImageManager.cs
+++ b/FO-DICOM.Core/Imaging/IImageManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/FO-DICOM.Core/Imaging/ImageBase.cs
+++ b/FO-DICOM.Core/Imaging/ImageBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Imaging/ImageDisposableBase.cs
+++ b/FO-DICOM.Core/Imaging/ImageDisposableBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using FellowOakDicom.IO;

--- a/FO-DICOM.Core/Imaging/ImageManager.cs
+++ b/FO-DICOM.Core/Imaging/ImageManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/FO-DICOM.Core/Imaging/LUT/CompositeLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/CompositeLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/FO-DICOM.Core/Imaging/LUT/ILUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/ILUT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/IModalityLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/IModalityLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/InvertLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/InvertLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/ModalityRescaleLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/ModalityRescaleLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/ModalitySequenceLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/ModalitySequenceLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using System;

--- a/FO-DICOM.Core/Imaging/LUT/OutputLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/OutputLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/PaddingLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/PaddingLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/PaletteColorLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/PaletteColorLUT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/PrecalculatedLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/PrecalculatedLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.LUT
 {

--- a/FO-DICOM.Core/Imaging/LUT/VOILUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/VOILUT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/LUT/VOISequenceLUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/VOISequenceLUT.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using System;

--- a/FO-DICOM.Core/Imaging/Mathematics/BitList.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/BitList.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/Imaging/Mathematics/Extensions.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/Mathematics/Geometry3D.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Geometry3D.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/Mathematics/GeometryHelper.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/GeometryHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/FO-DICOM.Core/Imaging/Mathematics/Histogram.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Histogram.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Mathematics
 {

--- a/FO-DICOM.Core/Imaging/Mathematics/Interval.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Interval.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging.Mathematics
 {

--- a/FO-DICOM.Core/Imaging/Mathematics/Matrix.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Matrix.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Imaging/Mathematics/MovingAverage.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/MovingAverage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Linq;
 

--- a/FO-DICOM.Core/Imaging/Mathematics/Point2.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Point2.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/Mathematics/Point2D.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/Point2D.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/Mathematics/RectF.cs
+++ b/FO-DICOM.Core/Imaging/Mathematics/RectF.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Imaging/PhotometricInterpretation.cs
+++ b/FO-DICOM.Core/Imaging/PhotometricInterpretation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/FO-DICOM.Core/Imaging/PixelDataConverter.cs
+++ b/FO-DICOM.Core/Imaging/PixelDataConverter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Runtime.CompilerServices;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/Imaging/PixelRepresentation.cs
+++ b/FO-DICOM.Core/Imaging/PixelRepresentation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/FO-DICOM.Core/Imaging/PlanarConfiguration.cs
+++ b/FO-DICOM.Core/Imaging/PlanarConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/FO-DICOM.Core/Imaging/RawImage.cs
+++ b/FO-DICOM.Core/Imaging/RawImage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Imaging/RawImageManager.cs
+++ b/FO-DICOM.Core/Imaging/RawImageManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/FO-DICOM.Core/Imaging/Reconstruction/DicomGenerator.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/DicomGenerator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/Imaging/Reconstruction/ImageData.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/ImageData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.Imaging.Render;

--- a/FO-DICOM.Core/Imaging/Reconstruction/Slice.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/Slice.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using System.Linq;

--- a/FO-DICOM.Core/Imaging/Reconstruction/Stack.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/Stack.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Imaging/Reconstruction/VolumeData.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/VolumeData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.LUT;
 using FellowOakDicom.Imaging.Mathematics;

--- a/FO-DICOM.Core/Imaging/Render/CompositeGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/CompositeGraphic.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/FO-DICOM.Core/Imaging/Render/GenericGrayscalePipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/GenericGrayscalePipeline.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.LUT;
 

--- a/FO-DICOM.Core/Imaging/Render/IGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/IGraphic.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.LUT;
 

--- a/FO-DICOM.Core/Imaging/Render/IPipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/IPipeline.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.LUT;
 

--- a/FO-DICOM.Core/Imaging/Render/ImageGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/ImageGraphic.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Imaging/Render/OverlayGraphic.cs
+++ b/FO-DICOM.Core/Imaging/Render/OverlayGraphic.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/Imaging/Render/PaletteColorPipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/PaletteColorPipeline.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.LUT;
 

--- a/FO-DICOM.Core/Imaging/Render/PixelData.cs
+++ b/FO-DICOM.Core/Imaging/Render/PixelData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Algorithms;
 using FellowOakDicom.Imaging.LUT;

--- a/FO-DICOM.Core/Imaging/Render/RgbColorPipeline.cs
+++ b/FO-DICOM.Core/Imaging/Render/RgbColorPipeline.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.LUT;
 

--- a/FO-DICOM.Core/Imaging/SpatialTransform.cs
+++ b/FO-DICOM.Core/Imaging/SpatialTransform.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 

--- a/FO-DICOM.Core/Log/ConsoleExtensions.cs
+++ b/FO-DICOM.Core/Log/ConsoleExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Log/DicomDatasetDumper.cs
+++ b/FO-DICOM.Core/Log/DicomDatasetDumper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/Log/DicomDatasetLogger.cs
+++ b/FO-DICOM.Core/Log/DicomDatasetLogger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using Microsoft.Extensions.Logging;

--- a/FO-DICOM.Core/Log/DicomParserLogger.cs
+++ b/FO-DICOM.Core/Log/DicomParserLogger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/FO-DICOM.Core/Log/Extensions.cs
+++ b/FO-DICOM.Core/Log/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Log/FellowOakDicomLogger.cs
+++ b/FO-DICOM.Core/Log/FellowOakDicomLogger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/FO-DICOM.Core/Log/FellowOakDicomLoggerProvider.cs
+++ b/FO-DICOM.Core/Log/FellowOakDicomLoggerProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/FO-DICOM.Core/Log/HexWriter.cs
+++ b/FO-DICOM.Core/Log/HexWriter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Text;

--- a/FO-DICOM.Core/Log/LogCategories.cs
+++ b/FO-DICOM.Core/Log/LogCategories.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Log
 {

--- a/FO-DICOM.Core/Log/LogLevel.cs
+++ b/FO-DICOM.Core/Log/LogLevel.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Log/LogManager.cs
+++ b/FO-DICOM.Core/Log/LogManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Log/Logger.cs
+++ b/FO-DICOM.Core/Log/Logger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Media/DicomDirectory.cs
+++ b/FO-DICOM.Core/Media/DicomDirectory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Reader;

--- a/FO-DICOM.Core/Media/DicomDirectoryReaderObserver.cs
+++ b/FO-DICOM.Core/Media/DicomDirectoryReaderObserver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/FO-DICOM.Core/Media/DicomDirectoryRecord.cs
+++ b/FO-DICOM.Core/Media/DicomDirectoryRecord.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/FO-DICOM.Core/Media/DicomDirectoryRecordCollection.cs
+++ b/FO-DICOM.Core/Media/DicomDirectoryRecordCollection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections;

--- a/FO-DICOM.Core/Media/DicomDirectoryRecordType.cs
+++ b/FO-DICOM.Core/Media/DicomDirectoryRecordType.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/Media/DicomFileScanner.cs
+++ b/FO-DICOM.Core/Media/DicomFileScanner.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using FellowOakDicom.IO;

--- a/FO-DICOM.Core/Memory/ArrayPoolMemory.cs
+++ b/FO-DICOM.Core/Memory/ArrayPoolMemory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using CommunityToolkit.HighPerformance.Buffers;
 using System;

--- a/FO-DICOM.Core/Memory/ArrayPoolMemoryProvider.cs
+++ b/FO-DICOM.Core/Memory/ArrayPoolMemoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using CommunityToolkit.HighPerformance.Buffers;
 

--- a/FO-DICOM.Core/Memory/IMemory.cs
+++ b/FO-DICOM.Core/Memory/IMemory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Memory/IMemoryProvider.cs
+++ b/FO-DICOM.Core/Memory/IMemoryProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Memory
 {

--- a/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociation.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Client.Advanced.Connection;
 using Microsoft.Extensions.Logging;

--- a/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociationExtensions.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociationRequest.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Association/AdvancedDicomClientAssociationRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network.Client.Advanced.Association
 {

--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnection.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Client.Advanced.Association;
 using Microsoft.Extensions.Logging;

--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionEvent.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionEvent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionEventCollector.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionEventCollector.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionRequest.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.Logging;
 using System.Text;

--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionRequestHandlers.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnectionRequestHandlers.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network.Client.Advanced.Connection
 {

--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/DefaultAdvancedDicomClientConnectionFactory.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/DefaultAdvancedDicomClientConnectionFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Log;
 using Microsoft.Extensions.DependencyInjection;

--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Client.Advanced.Association;
 using FellowOakDicom.Network.Client.Advanced.Connection;

--- a/FO-DICOM.Core/Network/Client/DicomClientCStoreRequestHandler.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientCStoreRequestHandler.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Network/Client/DicomClientCancellationMode.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientCancellationMode.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network.Client
 {

--- a/FO-DICOM.Core/Network/Client/DicomClientConnection.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientConnection.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/Network/Client/DicomClientFactory.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Log;
 using FellowOakDicom.Network.Client.Advanced.Connection;

--- a/FO-DICOM.Core/Network/Client/DicomClientNEventReportRequestHandler.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientNEventReportRequestHandler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Network/Client/DicomClientOptions.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientOptions.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network.Client
 {

--- a/FO-DICOM.Core/Network/Client/EventArguments/AssociationAcceptedEventArgs.cs
+++ b/FO-DICOM.Core/Network/Client/EventArguments/AssociationAcceptedEventArgs.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/Client/EventArguments/AssociationRejectedEventArgs.cs
+++ b/FO-DICOM.Core/Network/Client/EventArguments/AssociationRejectedEventArgs.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/Client/EventArguments/AssociationRequestTimedOutEventArgs.cs
+++ b/FO-DICOM.Core/Network/Client/EventArguments/AssociationRequestTimedOutEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/Client/EventArguments/RequestTimedOutEventArgs.cs
+++ b/FO-DICOM.Core/Network/Client/EventArguments/RequestTimedOutEventArgs.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/Client/EventArguments/StateChangedEventArgs.cs
+++ b/FO-DICOM.Core/Network/Client/EventArguments/StateChangedEventArgs.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Client.States;
 using System;

--- a/FO-DICOM.Core/Network/Client/States/DicomClientState.cs
+++ b/FO-DICOM.Core/Network/Client/States/DicomClientState.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/ConnectionClosedPrematurelyException.cs
+++ b/FO-DICOM.Core/Network/ConnectionClosedPrematurelyException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DesktopNetworkListener.cs
+++ b/FO-DICOM.Core/Network/DesktopNetworkListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Tls;
 using Microsoft.Extensions.Logging;

--- a/FO-DICOM.Core/Network/DesktopNetworkManager.cs
+++ b/FO-DICOM.Core/Network/DesktopNetworkManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Globalization;

--- a/FO-DICOM.Core/Network/DesktopNetworkStream.cs
+++ b/FO-DICOM.Core/Network/DesktopNetworkStream.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Tls;
 using System;

--- a/FO-DICOM.Core/Network/DicomAssociation.cs
+++ b/FO-DICOM.Core/Network/DicomAssociation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Linq;
 using System.Text;

--- a/FO-DICOM.Core/Network/DicomAssociationAbortedException.cs
+++ b/FO-DICOM.Core/Network/DicomAssociationAbortedException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomAssociationRejectedException.cs
+++ b/FO-DICOM.Core/Network/DicomAssociationRejectedException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomAssociationRequestTimedOutException.cs
+++ b/FO-DICOM.Core/Network/DicomAssociationRequestTimedOutException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomCEchoProvider.cs
+++ b/FO-DICOM.Core/Network/DicomCEchoProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Network/DicomCEchoRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCEchoRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomCEchoResponse.cs
+++ b/FO-DICOM.Core/Network/DicomCEchoResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomCFindApplicationInfo.cs
+++ b/FO-DICOM.Core/Network/DicomCFindApplicationInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomCFindRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCFindRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomCFindResponse.cs
+++ b/FO-DICOM.Core/Network/DicomCFindResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Text;
 

--- a/FO-DICOM.Core/Network/DicomCGetApplicationInfo.cs
+++ b/FO-DICOM.Core/Network/DicomCGetApplicationInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomCGetRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCGetRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomCGetResponse.cs
+++ b/FO-DICOM.Core/Network/DicomCGetResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Network/DicomCMoveApplicationInfo.cs
+++ b/FO-DICOM.Core/Network/DicomCMoveApplicationInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomCMoveRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCMoveRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomCMoveResponse.cs
+++ b/FO-DICOM.Core/Network/DicomCMoveResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Network/DicomCStoreApplicationInfo.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreApplicationInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomCStoreRequest.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Client;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Network/DicomCStoreResponse.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomCommandField.cs
+++ b/FO-DICOM.Core/Network/DicomCommandField.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomExtendedNegotiation.cs
+++ b/FO-DICOM.Core/Network/DicomExtendedNegotiation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/FO-DICOM.Core/Network/DicomExtendedNegotiationCollection.cs
+++ b/FO-DICOM.Core/Network/DicomExtendedNegotiationCollection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections;

--- a/FO-DICOM.Core/Network/DicomMessage.cs
+++ b/FO-DICOM.Core/Network/DicomMessage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Log;
 using FellowOakDicom.Tools;

--- a/FO-DICOM.Core/Network/DicomNActionRequest.cs
+++ b/FO-DICOM.Core/Network/DicomNActionRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Text;
 

--- a/FO-DICOM.Core/Network/DicomNActionResponse.cs
+++ b/FO-DICOM.Core/Network/DicomNActionResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Text;
 

--- a/FO-DICOM.Core/Network/DicomNCreateRequest.cs
+++ b/FO-DICOM.Core/Network/DicomNCreateRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNCreateResponse.cs
+++ b/FO-DICOM.Core/Network/DicomNCreateResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNDeleteRequest.cs
+++ b/FO-DICOM.Core/Network/DicomNDeleteRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNDeleteResponse.cs
+++ b/FO-DICOM.Core/Network/DicomNDeleteResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNEventReportRequest.cs
+++ b/FO-DICOM.Core/Network/DicomNEventReportRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Text;
 

--- a/FO-DICOM.Core/Network/DicomNEventReportResponse.cs
+++ b/FO-DICOM.Core/Network/DicomNEventReportResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Network/DicomNGetRequest.cs
+++ b/FO-DICOM.Core/Network/DicomNGetRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNGetResponse.cs
+++ b/FO-DICOM.Core/Network/DicomNGetResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNSetRequest.cs
+++ b/FO-DICOM.Core/Network/DicomNSetRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNSetResponse.cs
+++ b/FO-DICOM.Core/Network/DicomNSetResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomNetworkException.cs
+++ b/FO-DICOM.Core/Network/DicomNetworkException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomPresentationContext.cs
+++ b/FO-DICOM.Core/Network/DicomPresentationContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
+++ b/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections;

--- a/FO-DICOM.Core/Network/DicomPriority.cs
+++ b/FO-DICOM.Core/Network/DicomPriority.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomPriorityRequest.cs
+++ b/FO-DICOM.Core/Network/DicomPriorityRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomQueryRetrieveLevel.cs
+++ b/FO-DICOM.Core/Network/DicomQueryRetrieveLevel.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomRequest.cs
+++ b/FO-DICOM.Core/Network/DicomRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomRequestTimedOutException.cs
+++ b/FO-DICOM.Core/Network/DicomRequestTimedOutException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomResponse.cs
+++ b/FO-DICOM.Core/Network/DicomResponse.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Tls;
 using FellowOakDicom.Tools;

--- a/FO-DICOM.Core/Network/DicomServerDependencies.cs
+++ b/FO-DICOM.Core/Network/DicomServerDependencies.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/FO-DICOM.Core/Network/DicomServerFactory.cs
+++ b/FO-DICOM.Core/Network/DicomServerFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/FO-DICOM.Core/Network/DicomServerOptions.cs
+++ b/FO-DICOM.Core/Network/DicomServerOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomServerRegistration.cs
+++ b/FO-DICOM.Core/Network/DicomServerRegistration.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/Network/DicomServerRegistry.cs
+++ b/FO-DICOM.Core/Network/DicomServerRegistry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Concurrent;

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.IO;

--- a/FO-DICOM.Core/Network/DicomServiceApplicationInfo.cs
+++ b/FO-DICOM.Core/Network/DicomServiceApplicationInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections;

--- a/FO-DICOM.Core/Network/DicomServiceDependencies.cs
+++ b/FO-DICOM.Core/Network/DicomServiceDependencies.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.Memory;

--- a/FO-DICOM.Core/Network/DicomServiceOptions.cs
+++ b/FO-DICOM.Core/Network/DicomServiceOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/DicomStatus.cs
+++ b/FO-DICOM.Core/Network/DicomStatus.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Network/DicomTimeout.cs
+++ b/FO-DICOM.Core/Network/DicomTimeout.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Network
 {

--- a/FO-DICOM.Core/Network/DicomUserIdentityNegotiation.cs
+++ b/FO-DICOM.Core/Network/DicomUserIdentityNegotiation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/IDicomCEchoProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCEchoProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Network/IDicomCFindProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCFindProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/Network/IDicomCGetProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCGetProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/Network/IDicomCMoveProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCMoveProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 

--- a/FO-DICOM.Core/Network/IDicomCStoreProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCStoreProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/Network/IDicomNEventReportRequestProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomNEventReportRequestProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Network/IDicomNServiceProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomNServiceProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Network/IDicomServer.cs
+++ b/FO-DICOM.Core/Network/IDicomServer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Tls;
 using System;

--- a/FO-DICOM.Core/Network/IDicomService.cs
+++ b/FO-DICOM.Core/Network/IDicomService.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/IDicomServiceProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomServiceProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Network/IDicomServiceRunner.cs
+++ b/FO-DICOM.Core/Network/IDicomServiceRunner.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/FO-DICOM.Core/Network/INetworkListener.cs
+++ b/FO-DICOM.Core/Network/INetworkListener.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Tls;
 using Microsoft.Extensions.Logging;

--- a/FO-DICOM.Core/Network/INetworkStream.cs
+++ b/FO-DICOM.Core/Network/INetworkStream.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/Network/NetworkManager.cs
+++ b/FO-DICOM.Core/Network/NetworkManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Network/NetworkStreamCreationOptions.cs
+++ b/FO-DICOM.Core/Network/NetworkStreamCreationOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network.Tls;
 using System;

--- a/FO-DICOM.Core/Network/PDU.cs
+++ b/FO-DICOM.Core/Network/PDU.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Network/Tls/DefaultTlsAcceptor.cs
+++ b/FO-DICOM.Core/Network/Tls/DefaultTlsAcceptor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/Network/Tls/DefaultTlsInitiator.cs
+++ b/FO-DICOM.Core/Network/Tls/DefaultTlsInitiator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/FO-DICOM.Core/Network/Tls/ITlsAcceptor.cs
+++ b/FO-DICOM.Core/Network/Tls/ITlsAcceptor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/FO-DICOM.Core/Network/Tls/ITlsInitiator.cs
+++ b/FO-DICOM.Core/Network/Tls/ITlsInitiator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/FO-DICOM.Core/NullableAnnotations.cs
+++ b/FO-DICOM.Core/NullableAnnotations.cs
@@ -1,0 +1,230 @@
+// ReSharper disable CheckNamespace
+
+// Note: these attributes exist in .NET Standard 2.1 or .NET Core 3.1 and up
+// If we ever move away from .NET Standard 2.0, this whole file can be removed
+// Until then, we can benefit from nullability analysis by copying these attributes inline
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies that null is allowed as an input even if the corresponding type disallows it.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Field |
+        AttributeTargets.Parameter |
+        AttributeTargets.Property,
+        Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class AllowNullAttribute : Attribute
+    {
+    }
+    
+    /// <summary>
+    /// Specifies that null is disallowed as an input even if the corresponding type allows it.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Field |
+        AttributeTargets.Parameter |
+        AttributeTargets.Property,
+        Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class DisallowNullAttribute : Attribute
+    {
+    }
+    
+    /// <summary>
+    /// Applied to a method that will never return under any circumstance.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+    
+    /// <summary>
+    /// Specifies that the method will not return if the associated Boolean parameter is passed the specified value.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes the attribute with the specified parameter value.
+        /// </summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable
+        /// by diagnostics if the argument to the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>
+        /// Gets the condition parameter value.
+        /// </summary>
+        public bool ParameterValue { get; }
+    }
+    
+    /// <summary>
+    /// Specifies that an output may be null even if the corresponding type disallows it.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Field |
+        AttributeTargets.Parameter |
+        AttributeTargets.Property |
+        AttributeTargets.ReturnValue,
+        Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class MaybeNullAttribute : Attribute
+    {
+    }
+    
+    /// <summary>
+    /// Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes the attribute with the specified return value condition.
+        /// </summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter may be null.</param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>
+        /// Gets the return value condition.
+        /// </summary>
+        public bool ReturnValue { get; }
+    }
+    
+    /// <summary>
+    /// Specifies that the method or property will ensure that the listed field and property members have not-null values.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Method |
+        AttributeTargets.Property,
+        Inherited = false, AllowMultiple = true)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes the attribute with a field or property member.
+        /// </summary>
+        /// <param name="member">The field or property member that is promised to be not-null.</param>
+        public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+        /// <summary>
+        /// Initializes the attribute with the list of field and property members.
+        /// </summary>
+        /// <param name="members">The list of field and property members that are promised to be not-null.</param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>
+        /// Gets field or property member names.
+        /// </summary>
+        public string[] Members { get; }
+    }
+    
+        /// <summary>
+    /// Specifies that the method or property will ensure that the listed field and property
+    /// members have not-null values when returning with the specified return value condition.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Method |
+        AttributeTargets.Property,
+        Inherited = false, AllowMultiple = true)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes the attribute with the specified return value condition and a field or property member.
+        /// </summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter will not be null.</param>
+        /// <param name="member">The field or property member that is promised to be not-null.</param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        /// <summary>
+        /// Initializes the attribute with the specified return value condition and list of field and property members.
+        /// </summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter will not be null.</param>
+        /// <param name="members">The list of field and property members that are promised to be not-null.</param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>
+        /// Gets the return value condition.
+        /// </summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>
+        /// Gets field or property member names.
+        /// </summary>
+        public string[] Members { get; }
+    }
+        
+    /// <summary>
+    /// Specifies that an output will not be null even if the corresponding type allows it.
+    /// Specifies that an input argument was not null when the call returns.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Field |
+        AttributeTargets.Parameter |
+        AttributeTargets.Property |
+        AttributeTargets.ReturnValue,
+        Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class NotNullAttribute : Attribute
+    {
+    }
+    
+    /// <summary>
+    /// Specifies that the output will be non-null if the named parameter is non-null.
+    /// </summary>
+    [AttributeUsage(
+        AttributeTargets.Parameter |
+        AttributeTargets.Property |
+        AttributeTargets.ReturnValue,
+        AllowMultiple = true, Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes the attribute with the associated parameter name.
+        /// </summary>
+        /// <param name="parameterName">The associated parameter name. The output will be non-null if the argument to the parameter specified is non-null.</param>
+        public NotNullIfNotNullAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        /// <summary>
+        /// Gets the associated parameter name.
+        /// </summary>
+        public string ParameterName { get; }
+    }
+    
+    /// <summary>
+    /// Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    [ExcludeFromCodeCoverage]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes the attribute with the specified return value condition.
+        /// </summary>
+        /// <param name="returnValue">The return value condition. If the method returns this value, the associated parameter will not be null.</param>
+        public NotNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+}

--- a/FO-DICOM.Core/Printing/FilmBox.cs
+++ b/FO-DICOM.Core/Printing/FilmBox.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Printing/FilmSession.cs
+++ b/FO-DICOM.Core/Printing/FilmSession.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Printing/ImageBox.cs
+++ b/FO-DICOM.Core/Printing/ImageBox.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using FellowOakDicom.IO;

--- a/FO-DICOM.Core/Printing/PresentationLut.cs
+++ b/FO-DICOM.Core/Printing/PresentationLut.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Serialization/DicomJson.cs
+++ b/FO-DICOM.Core/Serialization/DicomJson.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Text.Json;

--- a/FO-DICOM.Core/Serialization/DicomXML.cs
+++ b/FO-DICOM.Core/Serialization/DicomXML.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/FO-DICOM.Core/Serialization/Utf8JsonReaderExtensions.cs
+++ b/FO-DICOM.Core/Serialization/Utf8JsonReaderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Text.Json;
 

--- a/FO-DICOM.Core/ServiceProviderHost.cs
+++ b/FO-DICOM.Core/ServiceProviderHost.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Setup.cs
+++ b/FO-DICOM.Core/Setup.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Codec;

--- a/FO-DICOM.Core/StringExtensions.cs
+++ b/FO-DICOM.Core/StringExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/StructuredReport/DicomContentItem.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomContentItem.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/StructuredReport/DicomMeasuredValue.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomMeasuredValue.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.StructuredReport
 {

--- a/FO-DICOM.Core/StructuredReport/DicomReferencedSOP.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomReferencedSOP.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.StructuredReport
 {

--- a/FO-DICOM.Core/StructuredReport/DicomStructuredReport.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomStructuredReport.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.StructuredReport
 {

--- a/FO-DICOM.Core/StructuredReport/DicomStructuredReportException.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomStructuredReportException.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/FO-DICOM.Core/Tools/AsyncManualResetEvent.cs
+++ b/FO-DICOM.Core/Tools/AsyncManualResetEvent.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Threading.Tasks;

--- a/FO-DICOM.Core/Tools/LinqExtensions.cs
+++ b/FO-DICOM.Core/Tools/LinqExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/FO-DICOM.Core/Tools/TaskCompletionSourceFactory.cs
+++ b/FO-DICOM.Core/Tools/TaskCompletionSourceFactory.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 

--- a/Platform/FO-DICOM.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/Platform/FO-DICOM.AspNetCore/ApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.AspNetCore.Builder;
 

--- a/Platform/FO-DICOM.AspNetCore/Server/DicomServerService.cs
+++ b/Platform/FO-DICOM.AspNetCore/Server/DicomServerService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Microsoft.Extensions.Configuration;

--- a/Platform/FO-DICOM.AspNetCore/Server/DicomServerServiceOptions.cs
+++ b/Platform/FO-DICOM.AspNetCore/Server/DicomServerServiceOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.AspNetCore.Server
 {

--- a/Platform/FO-DICOM.AspNetCore/Server/DicomServiceBuilder.cs
+++ b/Platform/FO-DICOM.AspNetCore/Server/DicomServiceBuilder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Platform/FO-DICOM.AspNetCore/Server/GeneralPurposeDicomServerService.cs
+++ b/Platform/FO-DICOM.AspNetCore/Server/GeneralPurposeDicomServerService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Microsoft.Extensions.Configuration;
@@ -34,7 +35,7 @@ namespace FellowOakDicom.AspNetCore.Server
                 Options.Port,
                 userState: _serviceBuilder
                 );
-            
+
             return Task.CompletedTask;
         }
 

--- a/Platform/FO-DICOM.AspNetCore/Server/GeneralPurposeDicomService.cs
+++ b/Platform/FO-DICOM.AspNetCore/Server/GeneralPurposeDicomService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Platform/FO-DICOM.AspNetCore/Server/InstanceReceivedEventArgs.cs
+++ b/Platform/FO-DICOM.AspNetCore/Server/InstanceReceivedEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 

--- a/Platform/FO-DICOM.AspNetCore/ServiceCollectionExtensions.cs
+++ b/Platform/FO-DICOM.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.AspNetCore.Server;
 using FellowOakDicom.Network;

--- a/Platform/FO-DICOM.Imaging.Desktop/Imaging/ReconstructionExtensions.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Imaging/ReconstructionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Reconstruction;
 using System.Drawing;
@@ -37,7 +38,7 @@ namespace FellowOakDicom.Imaging.Desktop.Imaging
 
             bitmap.UnlockBits(bmpData);
 
-            //// The following code is to modify the index table of generating bitmaps, modified from the pseudoquoity to grayscale  
+            //// The following code is to modify the index table of generating bitmaps, modified from the pseudoquoity to grayscale
             System.Drawing.Imaging.ColorPalette tempPalette;
             using (var tempBmp = new Bitmap(1, 1, System.Drawing.Imaging.PixelFormat.Format8bppIndexed))
             {

--- a/Platform/FO-DICOM.Imaging.Desktop/Imaging/WPFImage.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Imaging/WPFImage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/Platform/FO-DICOM.Imaging.Desktop/Imaging/WPFImageManager.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Imaging/WPFImageManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/Platform/FO-DICOM.Imaging.Desktop/Imaging/WinFormsImage.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Imaging/WinFormsImage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Drawing;

--- a/Platform/FO-DICOM.Imaging.Desktop/Imaging/WinFormsImageManager.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Imaging/WinFormsImageManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/Platform/FO-DICOM.Imaging.Desktop/Printing/FilmBoxExtensions.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Printing/FilmBoxExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Drawing;

--- a/Platform/FO-DICOM.Imaging.Desktop/Printing/ImageBoxExtensions.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Printing/ImageBoxExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Drawing;

--- a/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ImageSharpImage.cs
+++ b/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ImageSharpImage.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Render;
 using FellowOakDicom.IO;
@@ -128,7 +129,7 @@ namespace FellowOakDicom.Imaging
                     .DrawImage(layer, new Point(graphic.ScaledOffsetX, graphic.ScaledOffsetY), 1));
             }
         }
- 
+
 
         /// <inheritdoc />
         public override IImage Clone()

--- a/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ImageSharpImageManager.cs
+++ b/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ImageSharpImageManager.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Imaging
 {

--- a/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ReconstructionExtensions.cs
+++ b/Platform/FO-DICOM.Imaging.ImageSharp/Imaging/ReconstructionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Reconstruction;
 using SixLabors.ImageSharp;

--- a/Serialization/FO-DICOM.Json/AssemblyInfo.cs
+++ b/Serialization/FO-DICOM.Json/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Runtime.CompilerServices;
 

--- a/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
+++ b/Serialization/FO-DICOM.Json/JsonDicomConverter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.AspNetCoreTest/Program.cs
+++ b/Tests/FO-DICOM.AspNetCoreTest/Program.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;

--- a/Tests/FO-DICOM.AspNetCoreTest/Services/MyDicomService.cs
+++ b/Tests/FO-DICOM.AspNetCoreTest/Services/MyDicomService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Tests/FO-DICOM.AspNetCoreTest/Startup.cs
+++ b/Tests/FO-DICOM.AspNetCoreTest/Startup.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.AspNetCore;
 using FellowOakDicom.AspNetCore.Server;

--- a/Tests/FO-DICOM.Benchmark/JsonBenchmarks.cs
+++ b/Tests/FO-DICOM.Benchmark/JsonBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using BenchmarkDotNet.Attributes;
 using FellowOakDicom.Serialization;

--- a/Tests/FO-DICOM.Benchmark/NopCStoreProvider.cs
+++ b/Tests/FO-DICOM.Benchmark/NopCStoreProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/Tests/FO-DICOM.Benchmark/OpenFileBenchmarks.cs
+++ b/Tests/FO-DICOM.Benchmark/OpenFileBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Reflection;

--- a/Tests/FO-DICOM.Benchmark/ParseDatasetBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/ParseDatasetBenchmark.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using BenchmarkDotNet.Attributes;
 using System.IO;

--- a/Tests/FO-DICOM.Benchmark/Program.cs
+++ b/Tests/FO-DICOM.Benchmark/Program.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using BenchmarkDotNet.Running;
 

--- a/Tests/FO-DICOM.Benchmark/SaveFileBenchmarks.cs
+++ b/Tests/FO-DICOM.Benchmark/SaveFileBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Reflection;

--- a/Tests/FO-DICOM.Benchmark/ServerBenchmarks.cs
+++ b/Tests/FO-DICOM.Benchmark/ServerBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Reflection;

--- a/Tests/FO-DICOM.Tests/Bugs/GH064.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH064.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Linq;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1049.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1049.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Render;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1103.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1103.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Memory;
 using FellowOakDicom.Network;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1146.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1146.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH1157.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1157.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1261.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1261.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1264.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1264.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1281.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1281.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1301.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1301.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Log;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1308.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1308.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH133.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH133.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Concurrent;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1376.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1376.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using FellowOakDicom.Imaging;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1442.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1442.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1453.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1453.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Bugs/GH1678.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1678.cs
@@ -1,3 +1,7 @@
+// Copyright (c) 2012-2023 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/Tests/FO-DICOM.Tests/Bugs/GH177.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH177.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH178.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH178.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH179.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH179.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH195.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH195.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH220.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH220.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH223.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH223.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH227.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH227.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/Bugs/GH265.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH265.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Tests.Helpers;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/Bugs/GH306.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH306.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/Tests/FO-DICOM.Tests/Bugs/GH319.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH319.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH328.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH328.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH340.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH340.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Render;

--- a/Tests/FO-DICOM.Tests/Bugs/GH342.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH342.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH364.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH364.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH426.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH426.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using FellowOakDicom.Network;

--- a/Tests/FO-DICOM.Tests/Bugs/GH433.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH433.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using FellowOakDicom.Network;

--- a/Tests/FO-DICOM.Tests/Bugs/GH487.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH487.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH526.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH526.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/Tests/FO-DICOM.Tests/Bugs/GH538.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH538.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/Tests/FO-DICOM.Tests/Bugs/GH549.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH549.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using System.Collections.Concurrent;

--- a/Tests/FO-DICOM.Tests/Bugs/GH597.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH597.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/Bugs/GH625.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH625.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/Tests/FO-DICOM.Tests/Bugs/GH626.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH626.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH645.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH645.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Bugs/GH745.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH745.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Linq;
 using System.Threading;

--- a/Tests/FO-DICOM.Tests/Bugs/GH846.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH846.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Bugs/GH859.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH859.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading;
 using System.Threading.Tasks;

--- a/Tests/FO-DICOM.Tests/Bugs/VideoCStoreProvider.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/VideoCStoreProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Tests/FO-DICOM.Tests/CollectingLogger.cs
+++ b/Tests/FO-DICOM.Tests/CollectingLogger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/CollectingLoggerProvider.cs
+++ b/Tests/FO-DICOM.Tests/CollectingLoggerProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.Logging;
 

--- a/Tests/FO-DICOM.Tests/CollectingLoggerSession.cs
+++ b/Tests/FO-DICOM.Tests/CollectingLoggerSession.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/Tests/FO-DICOM.Tests/DicomAnonymizerTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomAnonymizerTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 using System.Text;

--- a/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/DicomDatasetGetValuesTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetGetValuesTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.IO.Buffer;

--- a/Tests/FO-DICOM.Tests/DicomDatasetWalkerTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetWalkerTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/Tests/FO-DICOM.Tests/DicomDateRangeTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDateRangeTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/DicomDateTimeTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDateTimeTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/DicomDictionaryTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDictionaryTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/DicomElementTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomElementTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/Tests/FO-DICOM.Tests/DicomEncodingTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomEncodingTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileMetaInformationTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/DicomFileTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.IO.Writer;

--- a/Tests/FO-DICOM.Tests/DicomOtherByteTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomOtherByteTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/DicomParseableTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomParseableTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/DicomPersonNameTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomPersonNameTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Text;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/DicomTagTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomTagTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/DicomTagsIndexTests.cs
+++ b/Tests/FO-DICOM.Tests/DicomTagsIndexTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/DicomTransferSyntaxTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomTransferSyntaxTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/DicomUIDGeneratorTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomUIDGeneratorTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Globalization;

--- a/Tests/FO-DICOM.Tests/DicomUIDTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomUIDTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/DicomVMTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomVMTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/DicomVRTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomVRTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/DicomValidationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomValidationTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Tests.Helpers;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/Fixture.cs
+++ b/Tests/FO-DICOM.Tests/Fixture.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Net.Http;

--- a/Tests/FO-DICOM.Tests/Helpers/Extensions.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Tests.Helpers
 {

--- a/Tests/FO-DICOM.Tests/Helpers/IOHelpers.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/IOHelpers.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/Tests/FO-DICOM.Tests/Helpers/PriorityOrderer.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/PriorityOrderer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Helpers/SerializationExtensions.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/SerializationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Runtime.Serialization;

--- a/Tests/FO-DICOM.Tests/Helpers/TestPriorityAttribute.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/TestPriorityAttribute.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 

--- a/Tests/FO-DICOM.Tests/Helpers/XUnitDicomLogger.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/XUnitDicomLogger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/CompositeByteBufferTests.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/CompositeByteBufferTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/EndianByteBufferTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/EndianByteBufferTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/EvenLengthBufferTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/EvenLengthBufferTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/FileByteBufferTests.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/FileByteBufferTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/MemoryByteBufferTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/MemoryByteBufferTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/RangeByteBufferTests.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/RangeByteBufferTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/StreamByteBufferTests.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/StreamByteBufferTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/SwapByteBufferTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/SwapByteBufferTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/IO/Buffer/TempFileBufferTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Buffer/TempFileBufferTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using System;

--- a/Tests/FO-DICOM.Tests/IO/DesktopFileReferenceTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/DesktopFileReferenceTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using System;

--- a/Tests/FO-DICOM.Tests/IO/DesktopPathTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/DesktopPathTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/IO/Reader/DicomDatasetReaderObserverTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Reader/DicomDatasetReaderObserverTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.IO.Reader;

--- a/Tests/FO-DICOM.Tests/IO/Reader/DicomFileReaderTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Reader/DicomFileReaderTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Reader;

--- a/Tests/FO-DICOM.Tests/IO/Reader/DicomReaderTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Reader/DicomReaderTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/Tests/FO-DICOM.Tests/IO/Reader/MockObserver.cs
+++ b/Tests/FO-DICOM.Tests/IO/Reader/MockObserver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/Tests/FO-DICOM.Tests/IO/TemporaryFileTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/TemporaryFileTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using System;

--- a/Tests/FO-DICOM.Tests/IO/Writer/DicomFileWriterTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Writer/DicomFileWriterTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Writer;

--- a/Tests/FO-DICOM.Tests/IO/Writer/DicomWriterTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Writer/DicomWriterTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/Tests/FO-DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Codec;

--- a/Tests/FO-DICOM.Tests/Imaging/Codec/DicomTranscoderTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Codec/DicomTranscoderTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Codec;
 using Microsoft.Extensions.DependencyInjection;

--- a/Tests/FO-DICOM.Tests/Imaging/ColorTableTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/ColorTableTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Tests.Helpers;

--- a/Tests/FO-DICOM.Tests/Imaging/DicomIconImageTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomIconImageTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Log;

--- a/Tests/FO-DICOM.Tests/Imaging/DicomImageTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomImageTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using FellowOakDicom.Imaging;

--- a/Tests/FO-DICOM.Tests/Imaging/DicomJpegLossessTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomJpegLossessTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Codec;

--- a/Tests/FO-DICOM.Tests/Imaging/DicomOverlayDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomOverlayDataTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.IO.Buffer;

--- a/Tests/FO-DICOM.Tests/Imaging/FrameGeometryTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/FrameGeometryTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Mathematics;

--- a/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Imaging/ImageManagerTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/ImageManagerTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Imaging/ImageSharpRenderingTests.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/ImageSharpRenderingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using SixLabors.ImageSharp;

--- a/Tests/FO-DICOM.Tests/Imaging/InterpolationTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/InterpolationTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Algorithms;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Imaging/LUT/ModalityRescaleLUTTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/LUT/ModalityRescaleLUTTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.LUT;

--- a/Tests/FO-DICOM.Tests/Imaging/LUT/ModalitySequenceLUTTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/LUT/ModalitySequenceLUTTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.LUT;

--- a/Tests/FO-DICOM.Tests/Imaging/LUT/OutputLUTTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/LUT/OutputLUTTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.LUT;

--- a/Tests/FO-DICOM.Tests/Imaging/LUT/PrecalculatedLUTTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/LUT/PrecalculatedLUTTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.LUT;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Imaging/Mathematics/Point2Tests.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Mathematics/Point2Tests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using FellowOakDicom.Tests.Helpers;

--- a/Tests/FO-DICOM.Tests/Imaging/Mathematics/RectFTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Mathematics/RectFTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Imaging/Mathematics/Vector3DTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Mathematics/Vector3DTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging.Mathematics;
 using System;

--- a/Tests/FO-DICOM.Tests/Imaging/Render/OverlayGraphicTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Render/OverlayGraphicTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Imaging/Render/PixelDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Render/PixelDataTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Render;

--- a/Tests/FO-DICOM.Tests/Imaging/Render/RenderingTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Render/RenderingTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Imaging/SpatialTransformTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/SpatialTransformTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Mathematics;

--- a/Tests/FO-DICOM.Tests/Imaging/WPFImageTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/WPFImageTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Drawing;
 using System.Windows.Media.Imaging;

--- a/Tests/FO-DICOM.Tests/Imaging/WinFormsImageTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/WinFormsImageTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Drawing;
 using FellowOakDicom.Imaging;

--- a/Tests/FO-DICOM.Tests/Log/LogManagerTest.cs
+++ b/Tests/FO-DICOM.Tests/Log/LogManagerTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Log/TextWriterLogger.cs
+++ b/Tests/FO-DICOM.Tests/Log/TextWriterLogger.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/Tests/FO-DICOM.Tests/Media/DicomDirectoryReaderObserverTest.cs
+++ b/Tests/FO-DICOM.Tests/Media/DicomDirectoryReaderObserverTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO;
 using FellowOakDicom.IO.Buffer;

--- a/Tests/FO-DICOM.Tests/Media/DicomDirectoryTest.cs
+++ b/Tests/FO-DICOM.Tests/Media/DicomDirectoryTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Media;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Media/DicomFileScannerTest.cs
+++ b/Tests/FO-DICOM.Tests/Media/DicomFileScannerTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Media;
 using System.Threading;

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Concurrent;

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCGetProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCGetProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Concurrent;

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCMoveProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCMoveProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomNServiceProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomNServiceProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/Tests/FO-DICOM.Tests/Network/Client/Advanced/AdvancedDicomClientAssociationTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/Advanced/AdvancedDicomClientAssociationTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Network/Client/Advanced/AdvancedDicomClientConnectionTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/Advanced/AdvancedDicomClientConnectionTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Threading;

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientFactoryTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientFactoryTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using FellowOakDicom.Network.Client;

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTlsTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTlsTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;

--- a/Tests/FO-DICOM.Tests/Network/DependencyInjectionTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DependencyInjectionTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Text;

--- a/Tests/FO-DICOM.Tests/Network/DicomAcceptedPresentationContextTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomAcceptedPresentationContextTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Network/DicomCEchoProviderTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCEchoProviderTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using FellowOakDicom.Network;

--- a/Tests/FO-DICOM.Tests/Network/DicomCFindRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCFindRequestTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Tests/FO-DICOM.Tests/Network/DicomCGetRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCGetRequestTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Collections.Generic;
 using System.Threading;

--- a/Tests/FO-DICOM.Tests/Network/DicomCMoveRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCMoveRequestTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Network/DicomCStoreRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCStoreRequestTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Network/DicomExtendedNegotiationTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomExtendedNegotiationTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Tests/FO-DICOM.Tests/Network/DicomNActionResponseTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomNActionResponseTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Network/DicomNCreateRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomNCreateRequestTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Network/DicomNCreateResponseTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomNCreateResponseTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomNEventReportResponseTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Network/DicomPresentationContextCollectionTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomPresentationContextCollectionTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/Network/DicomPresentationContextTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomPresentationContextTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Concurrent;

--- a/Tests/FO-DICOM.Tests/Network/DicomServiceTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServiceTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Threading.Tasks;
 using FellowOakDicom.Network;

--- a/Tests/FO-DICOM.Tests/Network/DicomStatusTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomStatusTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using Xunit;

--- a/Tests/FO-DICOM.Tests/Network/DicomUserIdentityNegotiationTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomUserIdentityNegotiationTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;

--- a/Tests/FO-DICOM.Tests/Network/PDUTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/PDUTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Network/PDVTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/PDVTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Tests/FO-DICOM.Tests/Network/Ports.cs
+++ b/Tests/FO-DICOM.Tests/Network/Ports.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 namespace FellowOakDicom.Tests.Network
 {

--- a/Tests/FO-DICOM.Tests/Network/SimpleCStoreProvider.cs
+++ b/Tests/FO-DICOM.Tests/Network/SimpleCStoreProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Network;
 using System;

--- a/Tests/FO-DICOM.Tests/Printing/FilmBoxTest.cs
+++ b/Tests/FO-DICOM.Tests/Printing/FilmBoxTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Printing;
 using System.IO;

--- a/Tests/FO-DICOM.Tests/Printing/ImageBoxTest.cs
+++ b/Tests/FO-DICOM.Tests/Printing/ImageBoxTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Printing;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Printing/PresentationLutTest.cs
+++ b/Tests/FO-DICOM.Tests/Printing/PresentationLutTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Printing;
 using System.Collections.Generic;

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.Serialization;

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.Serialization;

--- a/Tests/FO-DICOM.Tests/Serialization/XmlDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/XmlDicomConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Serialization;
 using System;

--- a/Tests/FO-DICOM.Tests/StructuredReport/DicomContentItemTest.cs
+++ b/Tests/FO-DICOM.Tests/StructuredReport/DicomContentItemTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.StructuredReport;
 using System.Linq;

--- a/Tests/FO-DICOM.Tests/TestAttributes.cs
+++ b/Tests/FO-DICOM.Tests/TestAttributes.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using Xunit;
 

--- a/Tests/FO-DICOM.Tests/TestData.cs
+++ b/Tests/FO-DICOM.Tests/TestData.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.IO;
 

--- a/Tests/FO-DICOM.Tests/TestServiceProviderHost.cs
+++ b/Tests/FO-DICOM.Tests/TestServiceProviderHost.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tools/FO-DICOM.Dump/App.xaml.cs
+++ b/Tools/FO-DICOM.Dump/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/Tools/FO-DICOM.Dump/AssemblyInfo.cs
+++ b/Tools/FO-DICOM.Dump/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using System.Windows;
 

--- a/Tools/FO-DICOM.Dump/MainWindow.xaml.cs
+++ b/Tools/FO-DICOM.Dump/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) 2012-2023 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.NativeCodec;


### PR DESCRIPTION
This PR sets up nullable annotations, but does not add any anywhere.
In a nutshell, it enables nullable by default, but then disables it in every file.

I am making a separate PR from #1699 so that this can be merged first. It introduces 0 actual code changes. 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Add `<Nullable>Enable</Nullable>` in Directory.Build.props
- Add `#nullable disable` to every file
- Add `FO-DICOM.Core/NullableAnnotations.cs`, a file that contains extra attributes to help the compiler with nullability. (These are included in the runtime starting from .NET Standard 2.1, but can be manually included in older runtimes, and they will work the same)
