### PR TITLE
Core support for HTJ2K-based transfer syntaxes (#1687)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,7 @@
 - Improve robustness of DicomService when presented with HTTP requests. Bail early if the PDU type is not recognized (#1678)
 - Enhancement: Added IEquatable implementation and equality operators for DicomDataset class
 - Fix issue where a DICOM server could stop accepting incoming connections if MaxClientsAllowed is configured and one or more connections take longer than one minute to close (#1670)
+- Added core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
 
 #### 5.1.1 (2023-05-29)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 ### 5.1.3 (TBD)
 
+- Added core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
+
 ### 5.1.2 (2023-12-21)
 
 - Update to DICOM Standard 2023e
@@ -25,7 +27,6 @@
 - Improve robustness of DicomService when presented with HTTP requests. Bail early if the PDU type is not recognized (#1678)
 - Enhancement: Added IEquatable implementation and equality operators for DicomDataset class
 - Fix issue where a DICOM server could stop accepting incoming connections if MaxClientsAllowed is configured and one or more connections take longer than one minute to close (#1670)
-- Added core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
 
 #### 5.1.1 (2023-05-29)
 

--- a/Documentation/v4/usage/xfer_syntaxes.md
+++ b/Documentation/v4/usage/xfer_syntaxes.md
@@ -12,6 +12,9 @@ JPEG-LS Lossless Image Compression | 1.2.840.10008.1.2.4.80 | ✔️  | ✔️  
 JPEG-LS Lossy (Near-Lossless) Image Compression | 1.2.840.10008.1.2.4.81 | ✔️  | ✔️  |   |   |   |   |   | JPEG-LS Lossy (Near-Lossless) Image Compression
 JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.90 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression (Lossless Only)
 JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.91 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression
+High-Throughput JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.201 |   |   |   |   |   |   |   | High-Throughput JPEG 2000 Image Compression (Lossless Only)
+High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.202 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)
+High-Throughput JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.203 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 Image Compression
 RLE Lossless | 1.2.840.10008.1.2.5 | ✔️  | ✔️  | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | RLE Lossless
 
 <sup>1</sup>*.NET Framework* package  
@@ -23,7 +26,7 @@ RLE Lossless | 1.2.840.10008.1.2.5 | ✔️  | ✔️  | ✔️ | ✔️ | ✔�
 
 # Custom Transfer Syntaxes
 
-Since **version 4.0.1** and highter fo-dicom supports custom Transfer Syntaxes. If a DICOM image with a custom / unknown Transfer Syntax is received or opened then fo-dicom assumes that it is 
+Since **version 4.0.1** and higher fo-dicom supports custom Transfer Syntaxes. If a DICOM image with a custom / unknown Transfer Syntax is received or opened then fo-dicom assumes that it is 
 * Little Endian
 * Explicit VR
 * Encapsulated

--- a/Documentation/v4/usage/xfer_syntaxes.md
+++ b/Documentation/v4/usage/xfer_syntaxes.md
@@ -12,9 +12,6 @@ JPEG-LS Lossless Image Compression | 1.2.840.10008.1.2.4.80 | ✔️  | ✔️  
 JPEG-LS Lossy (Near-Lossless) Image Compression | 1.2.840.10008.1.2.4.81 | ✔️  | ✔️  |   |   |   |   |   | JPEG-LS Lossy (Near-Lossless) Image Compression
 JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.90 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression (Lossless Only)
 JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.91 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression
-High-Throughput JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.201 |   |   |   |   |   |   |   | High-Throughput JPEG 2000 Image Compression (Lossless Only)
-High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.202 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)
-High-Throughput JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.203 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 Image Compression
 RLE Lossless | 1.2.840.10008.1.2.5 | ✔️  | ✔️  | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | RLE Lossless
 
 <sup>1</sup>*.NET Framework* package  

--- a/Documentation/v5/usage/xfer_syntaxes.md
+++ b/Documentation/v5/usage/xfer_syntaxes.md
@@ -25,7 +25,7 @@ RLE Lossless | 1.2.840.10008.1.2.5 | ✔️  | ✔️  | ✔️ | ✔️ | ✔�
 
 # Custom Transfer Syntaxes
 
-Since **version 4.0.1** and highter fo-dicom supports custom Transfer Syntaxes. If a DICOM image with a custom / unknown Transfer Syntax is received or opened then fo-dicom assumes that it is 
+Since **version 4.0.1** and higher fo-dicom supports custom Transfer Syntaxes. If a DICOM image with a custom / unknown Transfer Syntax is received or opened then fo-dicom assumes that it is 
 * Little Endian
 * Explicit VR
 * Encapsulated

--- a/Documentation/v5/usage/xfer_syntaxes.md
+++ b/Documentation/v5/usage/xfer_syntaxes.md
@@ -14,6 +14,9 @@ JPEG-LS Lossless Image Compression | 1.2.840.10008.1.2.4.80 | ✔️  | ✔️  
 JPEG-LS Lossy (Near-Lossless) Image Compression | 1.2.840.10008.1.2.4.81 | ✔️  | ✔️  |   |   |   |   |   | JPEG-LS Lossy (Near-Lossless) Image Compression
 JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.90 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression (Lossless Only)
 JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.91 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression
+High-Throughput JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.201 |   |   |   |   |   |   |   | High-Throughput JPEG 2000 Image Compression (Lossless Only)
+High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.202 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)
+High-Throughput JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.203 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 Image Compression
 RLE Lossless | 1.2.840.10008.1.2.5 | ✔️  | ✔️  | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | RLE Lossless
 
 <sup>1</sup>*.NET Framework* package  

--- a/Documentation/v5/usage/xfer_syntaxes.md
+++ b/Documentation/v5/usage/xfer_syntaxes.md
@@ -14,9 +14,9 @@ JPEG-LS Lossless Image Compression | 1.2.840.10008.1.2.4.80 | ✔️  | ✔️  
 JPEG-LS Lossy (Near-Lossless) Image Compression | 1.2.840.10008.1.2.4.81 | ✔️  | ✔️  |   |   |   |   |   | JPEG-LS Lossy (Near-Lossless) Image Compression
 JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.90 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression (Lossless Only)
 JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.91 | ✔️  | ✔️ | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit | 8&#8209;bit |   | JPEG 2000 Image Compression
-High-Throughput JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.201 |   |   |   |   |   |   |   | High-Throughput JPEG 2000 Image Compression (Lossless Only)
-High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.202 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)
-High-Throughput JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.203 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 Image Compression
+High-Throughput JPEG 2000 Image Compression (Lossless Only)<sup>7</sup> | 1.2.840.10008.1.2.4.201 |   |   |   |   |   |   |   | High-Throughput JPEG 2000 Image Compression (Lossless Only)
+High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)<sup>7</sup> | 1.2.840.10008.1.2.4.202 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)
+High-Throughput JPEG 2000 Image Compression<sup>7</sup> | 1.2.840.10008.1.2.4.203 |   |   |    |   |   |   |   | High-Throughput JPEG 2000 Image Compression
 RLE Lossless | 1.2.840.10008.1.2.5 | ✔️  | ✔️  | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | RLE Lossless
 
 <sup>1</sup>*.NET Framework* package  
@@ -25,6 +25,7 @@ RLE Lossless | 1.2.840.10008.1.2.5 | ✔️  | ✔️  | ✔️ | ✔️ | ✔�
 <sup>4</sup>Default Transfer Syntax for Lossy JPEG 8-bit Image Compression  
 <sup>5</sup>Default Transfer Syntax for Lossy JPEG 12-bit Image Compression (Process 4 only)  
 <sup>6</sup>SV1 = Selection Value 1; Default Transfer Syntax for Lossless JPEG Image Compression  
+<sup>7</sup>Actual codec support to be implemented in the fo-dicom.Codecs package.
 
 # Custom Transfer Syntaxes
 

--- a/FO-DICOM.Core/DicomTransferSyntax.cs
+++ b/FO-DICOM.Core/DicomTransferSyntax.cs
@@ -636,6 +636,53 @@ namespace FellowOakDicom
                 Endian = Endian.Little
             };
 
+        /// <summary>High-Throughput JPEG 2000 Image Compression (Lossless Only)</summary>
+        public static readonly DicomTransferSyntax HTJ2KLossless =
+            new DicomTransferSyntax(DicomUID.HTJ2KLossless)
+            {
+                IsExplicitVR = true,
+                IsEncapsulated = true,
+                Endian = Endian.Little
+            };
+
+        /// <summary>High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)</summary>
+        public static readonly DicomTransferSyntax HTJ2KLosslessRPCL =
+            new DicomTransferSyntax(DicomUID.HTJ2KLosslessRPCL)
+            {
+                IsExplicitVR = true,
+                IsEncapsulated = true,
+                Endian = Endian.Little
+            };
+
+        ///<summary>High-Throughput JPEG 2000 Image Compression</summary>
+        public static readonly DicomTransferSyntax HTJ2K =
+            new DicomTransferSyntax(DicomUID.HTJ2K)
+            {
+                IsExplicitVR = true,
+                IsEncapsulated = true,
+                IsLossy = true,
+                LossyCompressionMethod = "ISO_15444_15",
+                Endian = Endian.Little
+            };
+
+        ///<summary>JPIP HTJ2K Referenced</summary>
+        public static readonly DicomTransferSyntax JPIPHTJ2KReferenced =
+            new DicomTransferSyntax(DicomUID.JPIPHTJ2KReferenced)
+            {
+                IsExplicitVR = true,
+                Endian = Endian.Little
+            };
+
+        ///<summary>JPIP HTJ2K Referenced Deflate</summary>
+        public static readonly DicomTransferSyntax JPIPHTJ2KReferencedDeflate =
+            new DicomTransferSyntax(DicomUID.JPIPHTJ2KReferencedDeflate)
+            {
+                IsExplicitVR = true,
+                IsDeflate = true,
+                Endian = Endian.Little
+            };
+
+
         /// <summary>RLE Lossless</summary>
         public static readonly DicomTransferSyntax RLELossless =
             new DicomTransferSyntax(DicomUID.RLELossless)
@@ -729,6 +776,11 @@ namespace FellowOakDicom
             Entries.Add(FragmentableMPEG4AVCH264StereoHighProfileLevel42.UID, FragmentableMPEG4AVCH264StereoHighProfileLevel42);
             Entries.Add(HEVCH265MainProfileLevel51.UID, HEVCH265MainProfileLevel51);
             Entries.Add(HEVCH265Main10ProfileLevel51.UID, HEVCH265Main10ProfileLevel51);
+            Entries.Add(HTJ2KLossless.UID, HTJ2KLossless);
+            Entries.Add(HTJ2KLosslessRPCL.UID, HTJ2KLosslessRPCL);
+            Entries.Add(HTJ2K.UID, HTJ2K);
+            Entries.Add(JPIPHTJ2KReferenced.UID, JPIPHTJ2KReferenced);
+            Entries.Add(JPIPHTJ2KReferencedDeflate.UID, JPIPHTJ2KReferencedDeflate);
             Entries.Add(RLELossless.UID, RLELossless);
             Entries.Add(RFC2557MIMEEncapsulation.UID, RFC2557MIMEEncapsulation);
             Entries.Add(XMLEncoding.UID, XMLEncoding);

--- a/FO-DICOM.Core/Imaging/Codec/DicomHtJpeg2000Codec.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomHtJpeg2000Codec.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) 2012-2023 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+namespace FellowOakDicom.Imaging.Codec
+{
+    public enum ProgressionOrder
+    {
+        LRCP,
+        RLCP, 
+        RPCL, 
+        PCRL, 
+        CPRL
+    }
+
+    public class DicomHtJpeg2000Params : DicomCodecParams
+    {
+        public DicomHtJpeg2000Params()
+        {
+            Irreversible = true;
+            NumberOfDecompositions = 5;
+            EmployColorTransform = true;
+            ProgressionOrder = ProgressionOrder.RPCL;
+            InsertTlmMarkers = false;
+        }
+
+        /// <summary>
+        /// Perform lossy compression using the 9/7 wavelet transform or
+        /// perform lossless compression using the 5/3 wavelet transform.
+        /// </summary>
+        public bool Irreversible { get; set; }
+
+        /// <summary>
+        /// Number of decompositions.
+        /// </summary>
+        public int NumberOfDecompositions { get; set; }
+
+        /// <summary>
+        /// Employs a color transform,
+        /// to transform RGB color images into the YUV domain.
+        /// </summary>
+        public bool EmployColorTransform { get; set; }
+
+        /// <summary>
+        /// Progression order.
+        /// </summary>
+        public ProgressionOrder ProgressionOrder { get; set; }
+
+        /// <summary>
+        /// Insert TLM markers.
+        /// </summary>
+        public bool InsertTlmMarkers { get; set; }
+    }
+
+    public abstract class DicomHtJpeg2000Codec : IDicomCodec
+    {
+        public string Name => TransferSyntax.UID.Name;
+
+        public abstract DicomTransferSyntax TransferSyntax { get; }
+
+        public DicomCodecParams GetDefaultParameters() => new DicomHtJpeg2000Params();
+
+        public abstract void Encode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+
+        public abstract void Decode(
+            DicomPixelData oldPixelData,
+            DicomPixelData newPixelData,
+            DicomCodecParams parameters);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library is licensed under the [Microsoft Public License (MS-PL)](http://ope
 * Targets .NET Standard 2.0
 * DICOM dictionary version 2023b
 * High-performance, fully asynchronous `async`/`await` API
-* JPEG (including lossless), JPEG-LS, JPEG2000, and RLE image compression (via additional package)
+* JPEG (including lossless), JPEG-LS, JPEG2000, HTJPEG2000, and RLE image compression (via additional package)
 * Supports very large datasets with content loading on demand
 * Image rendering to System.Drawing.Bitmap or SixLabors.ImageSharp
 * JSON and XML export/import

--- a/Tests/FO-DICOM.Tests/DicomElementTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomElementTest.cs
@@ -495,6 +495,7 @@ namespace FellowOakDicom.Tests
             new object[] { DicomUID.ImplicitVRLittleEndian, DicomTransferSyntax.ImplicitVRLittleEndian },
             new object[] { DicomUID.JPEGExtended12Bit, DicomTransferSyntax.JPEGProcess2_4 },
             new object[] { DicomUID.JPEG2000Lossless, DicomTransferSyntax.JPEG2000Lossless },
+            new object[] { DicomUID.HTJ2KLossless, DicomTransferSyntax.HTJ2KLossless },
             new object[] { DicomUID.ExplicitVRBigEndianRETIRED, DicomTransferSyntax.ExplicitVRBigEndian },
             new object[] { DicomUID.GEPrivateImplicitVRBigEndian, DicomTransferSyntax.GEPrivateImplicitVRBigEndian },
             new object[] { DicomUID.MPEG2MPML, DicomTransferSyntax.MPEG2 }

--- a/Tests/FO-DICOM.Tests/IO/Writer/DicomFileWriterTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Writer/DicomFileWriterTest.cs
@@ -33,7 +33,6 @@ namespace FellowOakDicom.Tests.IO.Writer
             _metaInfo = new DicomFileMetaInformation
                                {
                                    MediaStorageSOPClassUID = DicomUID.RTDoseStorage,
-                                   TransferSyntax = DicomTransferSyntax.JPEG2000Lossless
                                };
             _dataset = new DicomDataset(
                 new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.RTDoseStorage),
@@ -50,8 +49,10 @@ namespace FellowOakDicom.Tests.IO.Writer
         {
             lock (_locker)
             {
-                string fileName = TestData.Resolve("dicomfilewriter_write.dcm");
+                string fileName = TestData.Resolve("dicomfilewriter_write_j2k.dcm");
                 var file = new FileReference(fileName);
+
+                _metaInfo.TransferSyntax = DicomTransferSyntax.JPEG2000Lossless;
 
                 using (var target = new FileByteTarget(file))
                 {
@@ -66,6 +67,28 @@ namespace FellowOakDicom.Tests.IO.Writer
 
                 var syntax = readFile.FileMetaInfo.TransferSyntax;
                 Assert.Equal(DicomTransferSyntax.JPEG2000Lossless, syntax);
+            }
+
+            lock (_locker)
+            {
+                string fileName = TestData.Resolve("dicomfilewriter_write_htj2k.dcm");
+                var file = new FileReference(fileName);
+
+                _metaInfo.TransferSyntax = DicomTransferSyntax.HTJ2KLossless;
+
+                using (var target = new FileByteTarget(file))
+                {
+                    var writer = new DicomFileWriter(new DicomWriteOptions());
+                    writer.Write(target, _metaInfo, _dataset);
+                }
+
+                var expected = _comment;
+                var readFile = DicomFile.Open(fileName);
+                var actual = readFile.Dataset.GetSingleValue<string>(_doseCommentTag);
+                Assert.Equal(expected, actual);
+
+                var syntax = readFile.FileMetaInfo.TransferSyntax;
+                Assert.Equal(DicomTransferSyntax.HTJ2KLossless, syntax);
             }
         }
 

--- a/Tests/FO-DICOM.Tests/IO/Writer/DicomFileWriterTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Writer/DicomFileWriterTest.cs
@@ -33,6 +33,7 @@ namespace FellowOakDicom.Tests.IO.Writer
             _metaInfo = new DicomFileMetaInformation
                                {
                                    MediaStorageSOPClassUID = DicomUID.RTDoseStorage,
+                                   TransferSyntax = DicomTransferSyntax.JPEG2000Lossless
                                };
             _dataset = new DicomDataset(
                 new DicomUniqueIdentifier(DicomTag.SOPClassUID, DicomUID.RTDoseStorage),
@@ -49,10 +50,8 @@ namespace FellowOakDicom.Tests.IO.Writer
         {
             lock (_locker)
             {
-                string fileName = TestData.Resolve("dicomfilewriter_write_j2k.dcm");
+                string fileName = TestData.Resolve("dicomfilewriter_write.dcm");
                 var file = new FileReference(fileName);
-
-                _metaInfo.TransferSyntax = DicomTransferSyntax.JPEG2000Lossless;
 
                 using (var target = new FileByteTarget(file))
                 {
@@ -67,28 +66,6 @@ namespace FellowOakDicom.Tests.IO.Writer
 
                 var syntax = readFile.FileMetaInfo.TransferSyntax;
                 Assert.Equal(DicomTransferSyntax.JPEG2000Lossless, syntax);
-            }
-
-            lock (_locker)
-            {
-                string fileName = TestData.Resolve("dicomfilewriter_write_htj2k.dcm");
-                var file = new FileReference(fileName);
-
-                _metaInfo.TransferSyntax = DicomTransferSyntax.HTJ2KLossless;
-
-                using (var target = new FileByteTarget(file))
-                {
-                    var writer = new DicomFileWriter(new DicomWriteOptions());
-                    writer.Write(target, _metaInfo, _dataset);
-                }
-
-                var expected = _comment;
-                var readFile = DicomFile.Open(fileName);
-                var actual = readFile.Dataset.GetSingleValue<string>(_doseCommentTag);
-                Assert.Equal(expected, actual);
-
-                var syntax = readFile.FileMetaInfo.TransferSyntax;
-                Assert.Equal(DicomTransferSyntax.HTJ2KLossless, syntax);
             }
         }
 

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
@@ -108,6 +108,8 @@ namespace FellowOakDicom.Tests.Network
                // Lossless
                DicomTransferSyntax.JPEGLSLossless,
                DicomTransferSyntax.JPEG2000Lossless,
+               DicomTransferSyntax.HTJ2KLossless,
+               DicomTransferSyntax.HTJ2KLosslessRPCL,
                DicomTransferSyntax.JPEGProcess14SV1,
                DicomTransferSyntax.JPEGProcess14,
                DicomTransferSyntax.RLELossless,

--- a/Tests/FO-DICOM.Tests/Network/DicomPresentationContextTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomPresentationContextTest.cs
@@ -99,6 +99,7 @@ namespace FellowOakDicom.Tests.Network
         {
             new object[] { DicomPresentationContextResult.Accept, DicomTransferSyntax.DeflatedExplicitVRLittleEndian },
            new object[] { DicomPresentationContextResult.Accept, DicomTransferSyntax.JPEG2000Lossless },
+           new object[] { DicomPresentationContextResult.Accept, DicomTransferSyntax.HTJ2KLossless },
            new object[] { DicomPresentationContextResult.RejectAbstractSyntaxNotSupported, DicomTransferSyntax.ExplicitVRLittleEndian },
            new object[] { DicomPresentationContextResult.RejectNoReason, null },
            new object[] { DicomPresentationContextResult.RejectTransferSyntaxesNotSupported, null },

--- a/Tests/FO-DICOM.Tests/Network/SimpleCStoreProvider.cs
+++ b/Tests/FO-DICOM.Tests/Network/SimpleCStoreProvider.cs
@@ -29,6 +29,7 @@ namespace FellowOakDicom.Tests.Network
             // Lossless
             DicomTransferSyntax.JPEGLSLossless,
             DicomTransferSyntax.JPEG2000Lossless,
+            DicomTransferSyntax.HTJ2KLossless,
             DicomTransferSyntax.JPEGProcess14SV1,
             DicomTransferSyntax.JPEGProcess14,
             DicomTransferSyntax.RLELossless,


### PR DESCRIPTION
This pull request adds core support for the HTJ2K-based transfer syntaxes (https://dicom.nema.org/medical/dicom/Final/sup235_ft_HTJ2K.pdf). Essentially, it adds the HTJ2K-related UIDs, introduced in the DICOM Standard 2023e, as transfer syntax entries. This is not adding actual codec support, since this is going to be resolved with https://github.com/Efferent-Health/fo-dicom.Codecs/issues/54.

As a “quick/easy win” for HTJ2K syntax decoding, the OpenJPEG version that fo-dicom.Codecs is using (1.5.3) could be updated to 2.5.0, since this includes support for HTJ2K codestream decoding only. However, for full encoding/decoding support in the C++ land, the OpenJPH library should be considered (https://github.com/aous72/OpenJPH).

Sample HTJ2K-encoded datasets could be found in Chris Hafey’s DICOMHTJ2K repo (https://github.com/chafey/DICOMHTJ2K) which actually contains code to transcode any DICOM P10 dataset to an HTJ2K syntax.

Fixes #1687.

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [X] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Adds the HTJ2K-related UIDs, introduced in the DICOM Standard 2023e, as transfer syntax entries.
- Adds basic unit tests around the newly introduced syntaxes.
