### PR TITLE
Fallback Encoding of CStore service (#1159)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 - Fix rendering of compressed data where the photometric interpretation changed while decompressing data.
 - DicomImage can cache decompressed pixel data, render-LUT or rendered image.
 - New properties CacheMode and AutoAplyLUTToAllFrames in DicomImage.
+- Fix issue with applying FallbackEncoding when SpecificCharacterSet tag is missing (#1159)
 
 ### 5.1.2 (2023-12-21)
 

--- a/FO-DICOM.Core/DicomFile.cs
+++ b/FO-DICOM.Core/DicomFile.cs
@@ -220,7 +220,9 @@ namespace FellowOakDicom
             {
                 throw new ArgumentNullException(nameof(fallbackEncoding));
             }
+
             var df = new DicomFile();
+            df.Dataset.SetFallbackEncodings(new[] { fallbackEncoding });
 
             try
             {

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -756,6 +756,10 @@ namespace FellowOakDicom.Network
                                 var pc = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
 
                                 var file = new DicomFile();
+                                if (_fallbackEncoding != null)
+                                {
+                                    file.Dataset.SetFallbackEncodings(new[] { _fallbackEncoding });
+                                }
                                 file.FileMetaInfo.MediaStorageSOPClassUID = pc.AbstractSyntax;
                                 file.FileMetaInfo.MediaStorageSOPInstanceUID = _dimse.Command.GetSingleValue<DicomUID>(DicomTag.AffectedSOPInstanceUID);
                                 file.FileMetaInfo.TransferSyntax = pc.AcceptedTransferSyntax;
@@ -784,7 +788,8 @@ namespace FellowOakDicom.Network
                             var command = new DicomDataset().NotValidated();
 
                             var reader = new DicomReader(_memoryProvider) { IsExplicitVR = false };
-                            reader.Read(StreamByteSourceFactory.Create(_dimseStream, FileReadOption.Default), new DicomDatasetReaderObserver(command));
+                            reader.Read(StreamByteSourceFactory.Create(_dimseStream, FileReadOption.Default),
+                                new DicomDatasetReaderObserver(command, _fallbackEncoding ?? DicomEncoding.Default));
 
                             _dimseStream = null;
                             _dimseStreamFile = null;
@@ -844,7 +849,7 @@ namespace FellowOakDicom.Network
 
                                 // when receiving data via network, accept it and dont validate
                                 using var unvalidated = new UnvalidatedScope(_dimse.Dataset);
-                                reader.Read(source, new DicomDatasetReaderObserver(_dimse.Dataset));
+                                reader.Read(source, new DicomDatasetReaderObserver(_dimse.Dataset, _fallbackEncoding ?? DicomEncoding.Default));
 
                                 _dimseStream = null;
                                 _dimseStreamFile = null;

--- a/Tests/FO-DICOM.Tests/Network/DicomCStoreRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCStoreRequestTest.cs
@@ -3,6 +3,11 @@
 #nullable disable
 
 using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace FellowOakDicom.Tests.Network
@@ -24,6 +29,80 @@ namespace FellowOakDicom.Tests.Network
 
             var request = new DicomCStoreRequest(file);
             Assert.NotNull(request);
+        }
+
+
+        [Fact]
+        public async Task FallbackEncoding_Should_Handle_Missing_SpecificCharacterSet()
+        {
+            var actualEncoding = Encoding.GetEncoding("iso-8859-1");
+
+            // This test file from Olympus does not include Specific Charater Set,
+            // but it is clearly containing Swedish characters
+            var file = DicomFile.Open(TestData.Resolve("VL_Olympus1.dcm"), actualEncoding);
+            Assert.Equal("Efternamn^Förnamn^Mellannamn^^", file.Dataset.GetSingleValue<string>(DicomTag.PatientName));
+
+            var port = Ports.GetNext();
+
+            // Specify fallback encoding
+            using var server = DicomServerFactory.Create<CStoreScp>(port, null, actualEncoding);
+
+            var client = DicomClientFactory.Create("127.0.0.1", port, false, "SCU", "SCP");
+            await client.AddRequestAsync(new DicomCStoreRequest(file));
+            await client.SendAsync();
+
+            // Verify received instance correctly shows Swedish characters
+            var patientName = CStoreScp.LastReceivedSopInstance.GetSingleValue<string>(DicomTag.PatientName);
+            Assert.Equal("Efternamn^Förnamn^Mellannamn^^", patientName);
+        }
+
+
+        private class CStoreScp : DicomService, IDicomCStoreProvider, IDicomServiceProvider
+        {
+            public static DicomDataset LastReceivedSopInstance;
+
+            private readonly DicomTransferSyntax[] _acceptedImageTransferSyntaxes =
+            {
+                DicomTransferSyntax.ExplicitVRLittleEndian,
+                DicomTransferSyntax.ImplicitVRLittleEndian
+            };
+
+            public CStoreScp(INetworkStream stream, Encoding fallbackEncoding, ILogger log, DicomServiceDependencies dependencies)
+                : base(stream, fallbackEncoding, log, dependencies)
+            {
+            }
+
+            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+            {
+                LastReceivedSopInstance = request.Dataset;
+                return Task.FromResult(new DicomCStoreResponse(request, DicomStatus.Success));
+            }
+
+            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+                => Task.CompletedTask;
+
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            {
+                foreach (var pc in association.PresentationContexts)
+                {
+                    pc.AcceptTransferSyntaxes(_acceptedImageTransferSyntaxes);
+                }
+
+                return SendAssociationAcceptAsync(association);
+            }
+
+            public Task OnReceiveAssociationReleaseRequestAsync()
+            {
+                return SendAssociationReleaseResponseAsync();
+            }
+
+            public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+            {
+            }
+
+            public void OnConnectionClosed(Exception exception)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/fo-dicom/fo-dicom/issues/1159.

The fallback encoding specified when creating a service from DicomServerFactory should be applied to downstream objects.

This issue is not resolved in the repo, and this poses a problem when interacting with non-conformant modalitites, such as Olympus EndoAlpha (see excerpt from Olympus DCS).

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
