### PR TITLE
Updated formula of VOI LUT Function LINEAR_EXACT according to DICOM Standard (#1730)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 ### 5.1.3 (TBD)
 
+- **Breaking change**: Calculation of VOI LUT function LINEAR_EXACT changed as defined since DICOM Standard 2019d
 - Added core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
 - Add support for parsing DICOM files where the pixel data is not properly closed with a SequenceDelimitationItem (#1339)
 - Update Dicom json converter to handle Infinity values for FL and FD VRs (#1725)

--- a/FO-DICOM.Core/Imaging/LUT/VOILUT.cs
+++ b/FO-DICOM.Core/Imaging/LUT/VOILUT.cs
@@ -184,7 +184,7 @@ namespace FellowOakDicom.Imaging.LUT
                     {
                         return Math.Min(MaximumOutputValue,
                             Math.Max(MinimumOutputValue,
-                            (value - WindowCenter) / WindowWidth * OutputRange + MinimumOutputValue
+                            ((value - WindowCenter) / WindowWidth + 0.5) * OutputRange + MinimumOutputValue
                             ));
                     }
                 }


### PR DESCRIPTION
Fixes #1730.

My Rendering-Test-Application now renders all images that I have in this test correctly.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the calculation now has an additional "+ 0.5"

