### PR TITLE
typo "System.Text.Json" instead of Newtonsoft Json

### DIFF
--- a/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
+++ b/FO-DICOM.Core/Serialization/JsonDicomConverter.cs
@@ -112,7 +112,7 @@ namespace FellowOakDicom.Serialization
     }
 
     /// <summary>
-    /// Converts a DicomDataset object to and from JSON using the NewtonSoft Json.NET library
+    /// Converts a DicomDataset object to and from JSON using the System.Text.Json library
     /// </summary>
     public class DicomJsonConverter : JsonConverter<DicomDataset>
     {


### PR DESCRIPTION
Fixes # .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- fix summary comment to state "System.Text.Json" instead of "NewtonSoft Json.NET" for JsonDicomConverter (using System.Text.Json)
