### PR TITLE
Evaluate windowing from dataset when bitsstored = 1 (#1432)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
 - DicomImage can cache decompressed pixel data, render-LUT or rendered image.
 - New properties CacheMode and AutoAplyLUTToAllFrames in DicomImage.
 - Fix bug where reading parallel from the a stream file returned wrong data (#1653)
+- Fix rendering of images with 1 bit stored, where the image does not povide windowing values (#1432)
 - Fix issue with applying FallbackEncoding when SpecificCharacterSet tag is missing (#1159)
 
 ### 5.1.2 (2023-12-21)

--- a/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
+++ b/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
@@ -348,37 +348,47 @@ namespace FellowOakDicom.Imaging
 
             int padding = dataset.GetValueOrDefault(DicomTag.PixelPaddingValue, 0, int.MinValue);
 
-            var transcoder = new DicomTranscoder(
-                dataset.InternalTransferSyntax,
-                DicomTransferSyntax.ExplicitVRLittleEndian);
-
-            var pixels = transcoder.DecodePixelData(dataset, 0);
-            var range = pixels.GetMinMax(padding);
-
-            if (range.Minimum < bits.MinimumValue || range.Minimum == double.MaxValue)
+            if (bits.BitsStored == 1)
             {
-                range.Minimum = bits.MinimumValue;
+                options.WindowWidth = 0.5;
+                options.WindowCenter = 0.5;
+                options.VOILUTFunction = "LINEAR_EXACT";
             }
-            if (range.Maximum > bits.MaximumValue || range.Maximum == double.MinValue)
+            else
             {
-                range.Maximum = bits.MaximumValue;
+                var transcoder = new DicomTranscoder(
+                    dataset.InternalTransferSyntax,
+                    DicomTransferSyntax.ExplicitVRLittleEndian);
+
+                var pixels = transcoder.DecodePixelData(dataset, 0);
+                var range = pixels.GetMinMax(padding);
+
+                if (range.Minimum < bits.MinimumValue || range.Minimum == double.MaxValue)
+                {
+                    range.Minimum = bits.MinimumValue;
+                }
+                if (range.Maximum > bits.MaximumValue || range.Maximum == double.MinValue)
+                {
+                    range.Maximum = bits.MaximumValue;
+                }
+
+                var min = range.Minimum * options.RescaleSlope + options.RescaleIntercept;
+                var max = range.Maximum * options.RescaleSlope + options.RescaleIntercept;
+
+                if (dataset.TryGetNonEmptySequence(DicomTag.ModalityLUTSequence, out DicomSequence modalityLutSequence))
+                {
+                    options.ModalityLUT = new ModalitySequenceLUT(modalityLutSequence.First(), bits.IsSigned);
+                    // if there is a modalityLUT sequence, then the values have to be mapped
+                    min = options.ModalityLUT[min];
+                    max = options.ModalityLUT[max];
+                }
+
+                options.WindowWidth = Math.Max(1, Math.Abs(max - min));
+                options.WindowCenter = (max + min) / 2.0;
+
+                options.VOILUTFunction = dataset.GetSingleValueOrDefault(DicomTag.VOILUTFunction, "LINEAR");
             }
 
-            var min = range.Minimum * options.RescaleSlope + options.RescaleIntercept;
-            var max = range.Maximum * options.RescaleSlope + options.RescaleIntercept;
-
-            if (dataset.TryGetNonEmptySequence(DicomTag.ModalityLUTSequence, out DicomSequence modalityLutSequence))
-            {
-                options.ModalityLUT = new ModalitySequenceLUT(modalityLutSequence.First(), bits.IsSigned);
-                // if there is a modalityLUT sequence, then the values have to be mapped
-                min = options.ModalityLUT[min];
-                max = options.ModalityLUT[max];
-            }
-
-            options.WindowWidth = Math.Max(1, Math.Abs(max - min));
-            options.WindowCenter = (max + min) / 2.0;
-
-            options.VOILUTFunction = dataset.GetSingleValueOrDefault(DicomTag.VOILUTFunction, "LINEAR");
             options.ColorMap = GetColorMap(dataset);
 
             if (dataset.TryGetNonEmptySequence(DicomTag.VOILUTSequence, out DicomSequence voiLutSequence))

--- a/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
+++ b/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
@@ -350,9 +350,9 @@ namespace FellowOakDicom.Imaging
 
             if (bits.BitsStored == 1)
             {
-                options.WindowWidth = 0.5;
-                options.WindowCenter = 0.5;
-                options.VOILUTFunction = "LINEAR_EXACT";
+                options.WindowWidth = 1;
+                options.WindowCenter = 1;
+                options.VOILUTFunction = "LINEAR";
             }
             else
             {

--- a/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
@@ -60,6 +60,22 @@ namespace FellowOakDicom.Tests.Imaging
             Assert.Equal(windowCenter, actual.WindowCenter);
         }
 
+        [Fact]
+        public void FromDataset_WindowCenterWidth_Monochrome()
+        {
+            var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME2"),
+                new DicomUnsignedShort(DicomTag.BitsAllocated, 1),
+                new DicomUnsignedShort(DicomTag.BitsStored, 1),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, 0));
+
+            var actual = GrayscaleRenderOptions.FromDataset(dataset, 0);
+
+            Assert.Equal(1, actual.WindowWidth);
+            Assert.Equal(1, actual.WindowCenter);
+            Assert.Equal("LINEAR", actual.VOILUTFunction);
+        }
+
         [Theory]
         [InlineData((ushort)16, (ushort)12, (ushort)0, 1.0, 0.0, 500.0, 20.0, "LINEAR")]
         public void FromDataset_WindowCenterWidth_ReturnsSameAsFromWindowLevel(


### PR DESCRIPTION
Fixes #1432 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- when bitsstored is 1 and no windowing data is stored, then fo-dicom evaluates the windowing-parameters based on min/max pixel values. Min is 0 and Max is 1, so windowcenter is 0.5 and windowwidth is 1. But with that formula, everything is evaluted to white.
- In case bitsstored is 1, then the pixeldata has not to be evaluted, the min and max are always 0 and 1. With the values of windowcenter 1 and windowwith 1 the images are rendered correctly
