### PR TITLE
DicomServer performance

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 - Fix rendering of compressed data where the photometric interpretation changed while decompressing data.
 - DicomImage can cache decompressed pixel data, render-LUT or rendered image.
 - New properties CacheMode and AutoAplyLUTToAllFrames in DicomImage.
+- Fix performance regression in DicomServer (#1776)
 - Fix bug where reading parallel from the a stream file returned wrong data (#1653)
 - Fix issue with applying FallbackEncoding when SpecificCharacterSet tag is missing (#1159)
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -789,7 +789,7 @@ namespace FellowOakDicom
                 {
                     if (sequence.Tag == DicomTag.ReferencedImageSequence)
                     {
-                        functionalDs.Add(sequence);
+                        functionalDs.AddOrUpdate(sequence);
                     }
                     else
                     {
@@ -798,7 +798,7 @@ namespace FellowOakDicom
                         {
                             foreach (var item in sequence.Items[0])
                             {
-                                functionalDs.Add(item);
+                                functionalDs.AddOrUpdate(item);
                             }
                         }
                     }
@@ -812,7 +812,7 @@ namespace FellowOakDicom
                 {
                     if (sequence.Tag == DicomTag.ReferencedImageSequence)
                     {
-                        functionalDs.Add(sequence);
+                        functionalDs.AddOrUpdate(sequence);
                     }
                     else
                     {
@@ -821,7 +821,7 @@ namespace FellowOakDicom
                         {
                             foreach (var item in sequence.Items[0])
                             {
-                                functionalDs.Add(item);
+                                functionalDs.AddOrUpdate(item);
                             }
                         }
                     }

--- a/FO-DICOM.Core/IO/Buffer/CompositeByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/CompositeByteBuffer.cs
@@ -185,7 +185,7 @@ namespace FellowOakDicom.IO.Buffer
             
             foreach (var buffer in Buffers)
             {
-                await buffer.CopyToStreamAsync(stream, cancellationToken);
+                await buffer.CopyToStreamAsync(stream, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/FO-DICOM.Core/IO/Buffer/EndianByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/EndianByteBuffer.cs
@@ -149,7 +149,7 @@ namespace FellowOakDicom.IO.Buffer
 
                 GetByteRange(offset, count, buffer.Bytes);
 
-                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken);
+                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken).ConfigureAwait(false);
 
                 offset += count;
             }

--- a/FO-DICOM.Core/IO/Buffer/RangeByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/RangeByteBuffer.cs
@@ -101,7 +101,7 @@ namespace FellowOakDicom.IO.Buffer
 
                 GetByteRange(offset, count, buffer.Bytes);
 
-                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken);
+                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken).ConfigureAwait(false);
 
                 offset += count;
             }

--- a/FO-DICOM.Core/IO/Buffer/StreamByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/StreamByteBuffer.cs
@@ -140,7 +140,7 @@ namespace FellowOakDicom.IO.Buffer
             int bufferSize = 1024 * 1024;
             using IMemory buffer = _memoryProvider.Provide(bufferSize);
 
-            await _semaphore.WaitAsync(cancellationToken);
+            await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 Stream.Position = Position;

--- a/FO-DICOM.Core/IO/Buffer/SwapByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/SwapByteBuffer.cs
@@ -120,7 +120,7 @@ namespace FellowOakDicom.IO.Buffer
 
                 GetByteRange(offset, count, buffer.Bytes);
 
-                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken);
+                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken).ConfigureAwait(false);
 
                 offset += count;
             }

--- a/FO-DICOM.Core/IO/Buffer/TempFileBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/TempFileBuffer.cs
@@ -116,7 +116,7 @@ namespace FellowOakDicom.IO.Buffer
 
             using var fs = _file.OpenRead();
 
-            await fs.CopyToAsync(stream);
+            await fs.CopyToAsync(stream).ConfigureAwait(false);
         }
 
         #endregion

--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -701,7 +701,7 @@ namespace FellowOakDicom.Network.Client
             {
                 try
                 {
-                    await association.ReleaseAsync(cts.Token);
+                    await association.ReleaseAsync(cts.Token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -724,7 +724,7 @@ namespace FellowOakDicom.Network.Client
             {
                 try
                 {
-                    await association.AbortAsync(cts.Token);
+                    await association.AbortAsync(cts.Token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/FO-DICOM.Core/Network/DesktopNetworkListener.cs
+++ b/FO-DICOM.Core/Network/DesktopNetworkListener.cs
@@ -83,7 +83,7 @@ namespace FellowOakDicom.Network
                 cancelSource.Cancel();
                 if (awaiter == acceptTcpClientTask)
                 {
-                    var tcpClient = await acceptTcpClientTask;
+                    var tcpClient = await acceptTcpClientTask.ConfigureAwait(false);
                     tcpClient.NoDelay = noDelay;
                     if (receiveBufferSize.HasValue)
                     {

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -293,7 +293,7 @@ namespace FellowOakDicom.Network
                     {
                         // If max clients is configured and the limit is reached
                         // we need to wait until one of the existing clients closes its connection
-                        while (!await _maxClientsSemaphore.WaitAsync(MaxClientsAllowedWaitInterval, _cancellationToken))
+                        while (!await _maxClientsSemaphore.WaitAsync(MaxClientsAllowedWaitInterval, _cancellationToken).ConfigureAwait(false))
                         {
                             Logger.LogWarning("Waited {MaxClientsAllowedInterval}, " +
                                                "but we still cannot accept another incoming connection " +
@@ -325,7 +325,8 @@ namespace FellowOakDicom.Network
                         Logger.LogDebug("Accepted an incoming client connection, there are now {NumberOfServices} connected clients", numberOfServices);
                         
                         // We don't actually care about the values inside the channel, they just serve as a notification that a service has connected
-                        await _servicesChannel.Writer.WriteAsync(numberOfServices, _cancellationToken);
+                        // Fire and forget
+                        _ = _servicesChannel.Writer.WriteAsync(numberOfServices, _cancellationToken);
                         
                         if (maxClientsAllowed > 0 && numberOfServices == maxClientsAllowed)
                         {

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -321,9 +321,9 @@ namespace FellowOakDicom.Network
                             _services.Add(new RunningDicomService(scp, serviceTask));
                             numberOfServices = _services.Count;
                         }
-                        
+
                         Logger.LogDebug("Accepted an incoming client connection, there are now {NumberOfServices} connected clients", numberOfServices);
-                        
+
                         // We don't actually care about the values inside the channel, they just serve as a notification that a service has connected
                         // Fire and forget
                         _ = _servicesChannel.Writer.WriteAsync(numberOfServices, _cancellationToken);
@@ -542,6 +542,7 @@ namespace FellowOakDicom.Network
             {
                 Service = service ?? throw new ArgumentNullException(nameof(service));
                 Task = task ?? throw new ArgumentNullException(nameof(task));
+                Task.ContinueWith((t) => Service.Dispose());
             }
 
             public void Dispose() => Service.Dispose();

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1390,14 +1390,14 @@ namespace FellowOakDicom.Network
                         
                         if (deflateStream != null)
                         {
-                            await deflateStream.FlushAsync(CancellationToken.None);
+                            await deflateStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
                             
                             // Deflate stream in .NET Framework only fully flushes when disposed...
                             deflateStream.Dispose();
                         }                    
                     }
                     
-                    await pDataStream.FlushAsync(CancellationToken.None);
+                    await pDataStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
                     
                     msg.LastPDUSent = DateTime.Now;
                     msg.AllPDUsWereSentSuccessfully();

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -714,7 +714,7 @@ namespace FellowOakDicom.Tests.Network
                 await Task.Delay(1000);
 
                 // Verify that the 2 services were that already disconnected are disposed
-                numberOfDisposedDicomServices = disposedDicomServices.Count;
+                numberOfDisposedDicomServices = disposedDicomServices.Distinct().Count();
                 Assert.True(numberOfDisposedDicomServices >= 2);
 
                 // Stop the server
@@ -725,7 +725,7 @@ namespace FellowOakDicom.Tests.Network
             }
 
             // Verify that, after the server is disposed, all 3 services were disposed (even the one that never dropped its connection)
-            numberOfDisposedDicomServices = disposedDicomServices.Count;
+            numberOfDisposedDicomServices = disposedDicomServices.Distinct().Count();
             Assert.Equal(3, numberOfDisposedDicomServices);
         }
 


### PR DESCRIPTION
Fixes #1776 

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- ConfigureAwait(false) was missing in some time critical paths of DicomServer
- a blocking await of some notification was changed to fire-and-forget in DicomServer.ListenForConnectionAsync()
- DicomServices in DicomServer are disposed immediatelly after their Task has finished
