### PR TITLE
Apply fallbackencoding of DicomServices to the DicomDatasets that are sent through this DicomService

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
 - New properties CacheMode and AutoAplyLUTToAllFrames in DicomImage.
 - Fix bug where reading parallel from the a stream file returned wrong data (#1653)
 - Fix issue with applying FallbackEncoding when SpecificCharacterSet tag is missing (#1159)
+- Apply FallbackEncoding of DicomServices to the DicomDatasets that are sent through this DicomService (#1642)
 - Fix race condition in GenericGrayscalePipeline that could trigger a NullReferenceException (#1759)
 - Add resiliency against WindowCenter or WindowWidth containing gibberish (#1756)
 - Ignore overlay data that is too small (#1728)

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -24,7 +24,6 @@ namespace FellowOakDicom
         private readonly IDictionary<DicomTag, DicomItem> _items;
 
         private DicomTransferSyntax _syntax;
-        internal Encoding[] _fallbackEncodings = DicomEncoding.DefaultArray;
 
         #endregion
 
@@ -128,13 +127,10 @@ namespace FellowOakDicom
         }
 
         /// <summary>
-        /// Sets the fallback encodings that are used for string-based values if the dataset does not contain an explicit SpecificCharacterSet entry.
+        /// Gets or sets the fallback encodings that are used for string-based values if the dataset does not contain an explicit SpecificCharacterSet entry.
         /// This value is set before serializing the Dataset into a stream and when some encodings are inherited from parent datasets.
         /// </summary>
-        internal void SetFallbackEncodings(Encoding[] value)
-        {
-            _fallbackEncodings = value;
-        }
+        internal Encoding[] FallbackEncodings { get; set; } = DicomEncoding.DefaultArray;
 
         /// <summary>
         /// Gets the encodings used for string-based values by evaluating SpecificCharacterSet value or by using the fallback-encoding if there is no explicit Tag.
@@ -145,7 +141,7 @@ namespace FellowOakDicom
         {
             return TryGetValues<string>(DicomTag.SpecificCharacterSet, out var charsets)
                 ? DicomEncoding.GetEncodings(charsets)
-                : _fallbackEncodings;
+                : FallbackEncodings;
         }
 
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -24,7 +24,7 @@ namespace FellowOakDicom
         private readonly IDictionary<DicomTag, DicomItem> _items;
 
         private DicomTransferSyntax _syntax;
-        private Encoding[] _fallbackEncodings = DicomEncoding.DefaultArray;
+        internal Encoding[] _fallbackEncodings = DicomEncoding.DefaultArray;
 
         #endregion
 

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -24,9 +24,9 @@ namespace FellowOakDicom
         {
             var clone = new DicomDataset(dataset, false)
             {
-                InternalTransferSyntax = dataset.InternalTransferSyntax
+                InternalTransferSyntax = dataset.InternalTransferSyntax,
+                FallbackEncodings = dataset.FallbackEncodings
             };
-            clone.SetFallbackEncodings(dataset._fallbackEncodings);
             return clone;
         }
 

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -21,10 +21,14 @@ namespace FellowOakDicom
         /// <param name="dataset">Dataset to be cloned.</param>
         /// <returns>Clone of dataset.</returns>
         public static DicomDataset Clone(this DicomDataset dataset)
-            => new DicomDataset(dataset, false)
+        {
+            var clone = new DicomDataset(dataset, false)
             {
                 InternalTransferSyntax = dataset.InternalTransferSyntax
             };
+            clone.SetFallbackEncodings(dataset._fallbackEncodings);
+            return clone;
+        }
 
         /// <summary>
         /// Get a composite <see cref="System.DateTime"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.

--- a/FO-DICOM.Core/DicomDatasetWalker.cs
+++ b/FO-DICOM.Core/DicomDatasetWalker.cs
@@ -235,7 +235,7 @@ namespace FellowOakDicom
                     items.Enqueue(item);
                     foreach (var sqi in sq)
                     {
-                        sqi.SetFallbackEncodings(dataset.GetEncodingsForSerialization());
+                        sqi.FallbackEncodings = dataset.GetEncodingsForSerialization();
                         sqi.OnBeforeSerializing();
                         items.Enqueue(new BeginDicomSequenceItem(sqi));
                         BuildWalkQueue(sqi, items);

--- a/FO-DICOM.Core/DicomFile.cs
+++ b/FO-DICOM.Core/DicomFile.cs
@@ -222,7 +222,7 @@ namespace FellowOakDicom
             }
 
             var df = new DicomFile();
-            df.Dataset.SetFallbackEncodings(new[] { fallbackEncoding });
+            df.Dataset.FallbackEncodings = new[] { fallbackEncoding };
 
             try
             {

--- a/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
@@ -115,7 +115,7 @@ namespace FellowOakDicom.IO.Reader
             _datasets.Push(item);
 
             var encoding = _encodings.Peek();
-            item.SetFallbackEncodings(encoding);
+            item.FallbackEncodings = encoding;
             _encodings.Push(encoding);
         }
 

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -758,7 +758,7 @@ namespace FellowOakDicom.Network
                                 var file = new DicomFile();
                                 if (_fallbackEncoding != null)
                                 {
-                                    file.Dataset.SetFallbackEncodings(new[] { _fallbackEncoding });
+                                    file.Dataset.FallbackEncodings = new[] { _fallbackEncoding };
                                 }
                                 file.FileMetaInfo.MediaStorageSOPClassUID = pc.AbstractSyntax;
                                 file.FileMetaInfo.MediaStorageSOPInstanceUID = _dimse.Command.GetSingleValue<DicomUID>(DicomTag.AffectedSOPInstanceUID);
@@ -1301,7 +1301,7 @@ namespace FellowOakDicom.Network
                 // force calculation of command group length as required by standard
                 if (_fallbackEncoding != null && msg.HasDataset)
                 {
-                    msg.Dataset.SetFallbackEncodings(new[] { _fallbackEncoding });
+                    msg.Dataset.FallbackEncodings = new[] { _fallbackEncoding };
                 }
                 msg.Command.OnBeforeSerializing();
                 msg.Command.RecalculateGroupLengths();

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -106,7 +106,7 @@ namespace FellowOakDicom.Network
             _pduQueueWatcher = new ManualResetEventSlim(true);
             _msgQueue = new Queue<DicomMessage>();
             _pending = new List<DicomRequest>();
-            _fallbackEncoding = fallbackEncoding ?? DicomEncoding.Default;
+            _fallbackEncoding = fallbackEncoding;
 
             MaximumPDUsInQueue = 16;
 
@@ -338,13 +338,13 @@ namespace FellowOakDicom.Network
                     _dimseStream.Dispose();
                 }
 
-                return DicomFile.Open(_dimseStreamFile, _fallbackEncoding);
+                return DicomFile.Open(_dimseStreamFile, _fallbackEncoding ?? DicomEncoding.Default);
             }
 
             if (_dimseStream != null && _dimseStream.CanSeek)
             {
                 _dimseStream.Seek(0, SeekOrigin.Begin);
-                return DicomFile.Open(_dimseStream, _fallbackEncoding);
+                return DicomFile.Open(_dimseStream, _fallbackEncoding ?? DicomEncoding.Default);
             }
 
             return null;

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -839,7 +839,7 @@ namespace FellowOakDicom.Network
                                 var pc = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
 
                                 _dimse.Dataset = new DicomDataset { InternalTransferSyntax = pc.AcceptedTransferSyntax };
-
+                                
                                 var source = new StreamByteSource(_dimseStream, FileReadOption.Default)
                                 {
                                     Endian = pc.AcceptedTransferSyntax.Endian
@@ -1299,6 +1299,11 @@ namespace FellowOakDicom.Network
             else
             {
                 // force calculation of command group length as required by standard
+                if (_fallbackEncoding != null && msg.HasDataset)
+                {
+                    msg.Dataset.SetFallbackEncodings(new[] { _fallbackEncoding });
+                }
+                msg.Command.OnBeforeSerializing();
                 msg.Command.RecalculateGroupLengths();
 
                 if (msg.HasDataset)

--- a/Tests/FO-DICOM.Tests/Bugs/GH1642.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1642.cs
@@ -29,7 +29,7 @@ namespace FellowOakDicom.Tests.Bugs
             var serverLogger = _logger.IncludePrefix("Server").WithMinimumLevel(LogLevel.Information);
             var clientLogger = _logger.IncludePrefix("Client").WithMinimumLevel(LogLevel.Information);
 
-            using (var server = DicomServerFactory.Create<CFindProvider>("127.0.0.1", port, logger: serverLogger))
+            using (var server = DicomServerFactory.Create<CFindProvider>("127.0.0.1", port, logger: serverLogger, fallbackEncoding: DicomEncoding.GetEncoding("ISO_IR 100")))
             {
                 var client = DicomClientFactory.Create("127.0.0.1", port, false, "CLIENT", "SERVER");
                 client.FallbackEncoding = DicomEncoding.GetEncoding("ISO_IR 100");

--- a/Tests/FO-DICOM.Tests/Bugs/GH1642.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1642.cs
@@ -1,0 +1,110 @@
+﻿using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using FellowOakDicom.Tests.Helpers;
+using FellowOakDicom.Tests.Network;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    [Collection(TestCollections.Network), Trait(TestTraits.Category, TestCategories.Network), TestCaseOrderer("FellowOakDicom.Tests.Helpers.PriorityOrderer", "fo-dicom.Tests")]
+    public class GH1642
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public GH1642(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper).IncludeTimestamps().IncludeThreadId();
+        }
+
+        [Fact]
+        public async Task DicomClientFallbackEncoding()
+        {
+            var port = Ports.GetNext();
+            var serverLogger = _logger.IncludePrefix("Server").WithMinimumLevel(LogLevel.Information);
+            var clientLogger = _logger.IncludePrefix("Client").WithMinimumLevel(LogLevel.Information);
+
+            using (var server = DicomServerFactory.Create<CFindProvider>("127.0.0.1", port, logger: serverLogger))
+            {
+                var client = DicomClientFactory.Create("127.0.0.1", port, false, "CLIENT", "SERVER");
+                client.FallbackEncoding = DicomEncoding.GetEncoding("ISO_IR 100");
+                var request = DicomCFindRequest.CreateWorklistQuery();
+                var responses = new List<DicomDataset>();
+                request.OnResponseReceived += (DicomCFindRequest req, DicomCFindResponse resp) =>
+                {
+                    if (resp.Status == DicomStatus.Pending)
+                    {
+                        responses.Add(resp.Dataset);
+                    }
+                };
+
+                await client.AddRequestAsync(request);
+                await client.SendAsync();
+
+                Assert.Equal(2, responses.Count);
+                Assert.Equal("Διονυσιος", responses[1].GetString(DicomTag.PatientName));
+                Assert.Equal("Müller^Günther", responses[0].GetString(DicomTag.PatientName));
+            }
+        }
+    }
+
+
+    public class CFindProvider : DicomService, IDicomServiceProvider, IDicomCFindProvider
+    {
+        public CFindProvider(INetworkStream stream, Encoding fallbackEncoding, ILogger logger, DicomServiceDependencies dependencies) : base(stream, fallbackEncoding, logger, dependencies)
+        {
+        }
+
+        public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
+        {
+            yield return new DicomCFindResponse(request, DicomStatus.Pending)
+            {
+                Dataset = new DicomDataset(
+                    new DicomPersonName(DicomTag.PatientName, "Müller^Günther")
+                    )
+            };
+            yield return new DicomCFindResponse(request, DicomStatus.Pending)
+            {
+                Dataset = new DicomDataset(
+                    new DicomCodeString(DicomTag.SpecificCharacterSet, "ISO 2022 IR 126"),
+                    new DicomPersonName(DicomTag.PatientName, "Διονυσιος")
+                    )
+            };
+            yield return new DicomCFindResponse(request, DicomStatus.Success);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        {
+            foreach (var pc in association.PresentationContexts)
+            {
+                pc.SetResult(DicomPresentationContextResult.Accept);
+            }
+
+            await SendAssociationAcceptAsync(association).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task OnReceiveAssociationReleaseRequestAsync()
+        {
+            await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
+        {
+        }
+
+        /// <inheritdoc />
+        public void OnConnectionClosed(Exception exception)
+        {
+        }
+    }
+
+
+}


### PR DESCRIPTION
Fixes #1642  .

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [X] I have included unit tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- If a DicomServer or a DicomClient has a fallbackencoding set, then until now only the reader of incomming data uses this. Now also the writer of outgoing messages applies this fallbackencoding

