### PR TITLE
Do not allow more than one PatientName value

### DIFF
--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -1467,14 +1467,6 @@ namespace FellowOakDicom
 
         #endregion
 
-        protected override void ValidateVM()
-        {
-            if (Tag == DicomTag.PatientName && Count > 3)
-            {
-                throw new DicomValidationException(ToString(), DicomVR.PN, $"Number of items {Count} does not match ValueMultiplicity 1-3");
-            }
-        }
-
         #region Public Functions
 
         public static bool HaveSameContent(DicomPersonName nameA, DicomPersonName nameB)

--- a/Tests/FO-DICOM.Tests/DicomValidationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomValidationTest.cs
@@ -259,6 +259,22 @@ namespace FellowOakDicom.Tests
             Assert.Throws<DicomValidationException>(() => ds.AddOrUpdate(DicomTag.ScheduledProcedureStepStartDateTime, $"20081-200812{zone}"));
         }
 
+        [Fact]
+        public void DicomValidation_ValidatePN()
+        {
+            var ds = new DicomDataset { { DicomTag.PatientName, "Doe^John=Doe^John=Doe^John" } };
+            // PatientName has VM 1
+            Assert.Throws<DicomValidationException>(() => 
+                ds.AddOrUpdate(DicomTag.PatientName, "Doe^John", "Doe^John"));
+            // OtherPatientNames has VM 1-n
+            ds.AddOrUpdate(DicomTag.OtherPatientNames, "Doe^John", "Doe^John");
+            // more than 3 component groups
+            Assert.Throws<DicomValidationException>(() => 
+                ds.AddOrUpdate(DicomTag.ReferringPhysicianName, "Doe^Jane=Doe^Jane=Doe^Jane=Doe^Jane"));
+            // more than 5 components
+            Assert.Throws<DicomValidationException>(() => 
+                ds.AddOrUpdate(DicomTag.ReferringPhysicianName, "Doe^John^^^Ph.D.^Junior"));
+        }
 
         #endregion
 

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -996,14 +996,15 @@ namespace FellowOakDicom.Tests.Serialization
         {
             var target = new DicomDataset
                            {
-                             new DicomPersonName(DicomTag.PatientName, new[] { "Anna^Pelle", null, "Olle^Jöns^Pyjamas" }),
+                               new DicomPersonName(DicomTag.PatientName, new[] { "Doe^John" }),
+                               new DicomPersonName(DicomTag.OtherPatientNames, new[] { "Anna^Pelle", null, "Olle^Jöns^Pyjamas" }),
                              { DicomTag.SOPClassUID, DicomUID.RTPlanStorage },
                              { DicomTag.SOPInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
                              { DicomTag.SeriesInstanceUID, Array.Empty<DicomUID>() },
                              { DicomTag.DoseType, new[] { "HEJ" } },
+                             { DicomTag.ControlPointSequence, (DicomSequence[])null }
                            };
 
-            target.Add(DicomTag.ControlPointSequence, (DicomSequence[])null);
             var beams = new[] { 1, 2, 3 }.Select(beamNumber =>
             {
                 var beam = new DicomDataset

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -1002,14 +1002,15 @@ namespace FellowOakDicom.Tests.Serialization
         {
             var target = new DicomDataset
                            {
-                             new DicomPersonName(DicomTag.PatientName, new[] { "Anna^Pelle", null, "Olle^Jöns^Pyjamas" }),
+                             new DicomPersonName(DicomTag.PatientName, new[] { "Doe^John" }),
+                             new DicomPersonName(DicomTag.OtherPatientNames, new[] { "Anna^Pelle", null, "Olle^Jöns^Pyjamas" }),
                              { DicomTag.SOPClassUID, DicomUID.RTPlanStorage },
                              { DicomTag.SOPInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
                              { DicomTag.SeriesInstanceUID, Array.Empty<DicomUID>() },
                              { DicomTag.DoseType, new[] { "HEJ" } },
+                             { DicomTag.ControlPointSequence, (DicomSequence[])null }
                            };
 
-            target.Add(DicomTag.ControlPointSequence, (DicomSequence[])null);
             var beams = new[] { 1, 2, 3 }.Select(beamNumber =>
             {
                 var beam = new DicomDataset


### PR DESCRIPTION
- for some reason, 3 values had been allowed

This is a minor change, I noticed this accidentally while looking at the decoding issue. I did not add an entry in the release notes, let me know if one is needed.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation - not needed
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
