### PR TITLE
Add support for saving new strings with multi-encoding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,10 +1,12 @@
 ### 5.1.4 (TBD)
 
+- Add support for saving new strings with multi-valued Specific Character Set (#1789)
+
 ### 5.1.3 (2024-06-27)
 
 - Update to DICOM Standard 2024c
 - **Breaking change**: Calculation of VOI LUT function LINEAR_EXACT changed as defined since DICOM Standard 2019d
-- Added core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
+- Add core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
 - Reduce the memory impact of the DicomDatasetComparer. By a static property DicomDataset.CompareInstancesByContent the usage of DicomDatasetComparer in DicomDataset.Equals can be disabled globally. (#1807)
 - Add support for parsing DICOM files where the pixel data is not properly closed with a SequenceDelimitationItem (#1339)
 - Update Dicom json converter to handle Infinity values for FL and FD VRs (#1725)

--- a/Documentation/v5/index.md
+++ b/Documentation/v5/index.md
@@ -29,5 +29,4 @@ Package | Description
 [fo-dicom.Imaging.Desktop](https://www.nuget.org/packages/fo-dicom.Imaging.Desktop/) | Library with referencte to System.Drawing, required for rendering into Bitmaps
 [fo-dicom.Imaging.ImageSharp](https://www.nuget.org/packages/fo-dicom.Imaging.ImageSharp/) | Library with reference to ImageSharp, can be used for platform independent rendering
 [fo-dicom.NLog](https://www.nuget.org/packages/fo-dicom.NLog/) | .NET connector to enable `fo-dicom` logging with NLog
-[fo-dicom.Codecs](https://www.nuget.org/packages/fo-dicom.Codecs/) | Cross-platform DICOM codecs for `fo-dicom`, developed by [Efferent Health] (https://github.com/Efferent-Health/fo-dicom.Codecs)
-
+[fo-dicom.Codecs](https://www.nuget.org/packages/fo-dicom.Codecs/) | Cross-platform DICOM codecs for `fo-dicom`, developed by [Efferent Health](https://github.com/Efferent-Health/fo-dicom.Codecs)

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2012-2023 fo-dicom contributors.
+﻿// Copyright (c) 2012-2024 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
@@ -185,9 +185,11 @@ namespace FellowOakDicom
                 return Array.Empty<byte>();
             }
 
-            // TODO: handle multi-charset
-            byte[] bytes = TargetEncoding.GetBytes(_value);
-
+            // the target encoding shall only be used for encoded strings;
+            // other strings must be encoded with the default encoding (ASCII)
+            var bytes = ValueRepresentation.IsStringEncoded
+                ? DicomEncoding.EncodeString(_value, TargetEncodings, ValueRepresentation == DicomVR.PN)
+                : DicomEncoding.Default.GetBytes(_value);
             if (bytes.Length.IsOdd())
             {
                 Array.Resize(ref bytes, bytes.Length + 1);

--- a/FO-DICOM.Core/DicomEncoding.cs
+++ b/FO-DICOM.Core/DicomEncoding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2012-2023 fo-dicom contributors.
+﻿// Copyright (c) 2012-2024 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -49,7 +50,7 @@ namespace FellowOakDicom
         /// <param name="charsets">List of character sets.</param>
         /// <returns>String encodings.</returns>
         public static Encoding[] GetEncodings(string[] charsets) =>
-            (from charset in charsets select GetEncoding(charset)).ToArray();
+            charsets.Select(GetEncoding).ToArray();
 
         /// <summary>
         /// Get encoding from Specific Character Set attribute value.
@@ -77,7 +78,7 @@ namespace FellowOakDicom
                 return encoding;
             }
 
-            Logger.LogWarning($"'{charset}' is not a valid DICOM encoding - using ASCII encoding instead.");
+            Logger.LogWarning("\'{Charset}\' is not a valid DICOM encoding - using ASCII encoding instead", charset);
 
             return Default;
         }
@@ -101,6 +102,15 @@ namespace FellowOakDicom
                 EncoderFallback.ExceptionFallback,
                 DecoderFallback.ExceptionFallback);
         }
+
+        /// <summary>
+        /// Get strict encodings for given encodings.
+        /// The encodings will throw EncoderFallbackException if applied to a string they cannot encode.
+        /// </summary>
+        /// <param name="encodings">The list of non-strict encodings.</param>
+        /// <returns>Array of string encoding.</returns>
+        private static Encoding[] GetStrictEncodings(Encoding[] encodings) =>
+            encodings.Select(StrictEncoding).ToArray();
 
         private static Encoding StrictEncoding(Encoding encoding)
         {
@@ -170,6 +180,26 @@ namespace FellowOakDicom
         };
 
         /// <summary>
+        /// The escape sequence that we need to insert ourselves for extended encodings
+        /// mapped against the code pages of the encodings.
+        /// </summary>
+        private static readonly IDictionary<int, byte[]> _escapeSequences = new Dictionary<int, byte[]>
+        {
+            { 28591, new byte[] { 0x1b, 0x2d, 0x41 } },   // Latin 1 (Western European)
+            { 28592, new byte[] { 0x1b, 0x2d, 0x42 } },   // Latin 2 (Central European)
+            { 28593, new byte[] { 0x1b, 0x2d, 0x43 } },   // Latin 3 (South European)
+            { 28594, new byte[] { 0x1b, 0x2d, 0x44 } },   // Latin 4 (North European)
+            { 28595, new byte[] { 0x1b, 0x2d, 0x4c } },   // Latin/Cyrillic
+            { 28596, new byte[] { 0x1b, 0x2d, 0x47 } },   // Latin/Arabic
+            { 28597, new byte[] { 0x1b, 0x2d, 0x46 } },   // Latin/Greek
+            { 28598, new byte[] { 0x1b, 0x2d, 0x48 } },   // Latin/Hebrew
+            { 28599, new byte[] { 0x1b, 0x2d, 0x4d } },   // Latin 5 (Turkish)
+            { 874, new byte[] { 0x1b, 0x2d, 0x54 } },     // Thai (Windows)
+            { 932, new byte[] { 0x1b, 0x28, 0x4a } },     // Japanese (Shift-JIS)
+            { 20949, new byte[] { 0x1b, 0x24, 0x29, 0x43 } },  // Korean Wansung
+        };
+    
+        /// <summary>
         /// The known encodings with character replacement fallback handlers.
         /// </summary>
         private static readonly IDictionary<string, Encoding> _knownEncodings =
@@ -182,7 +212,7 @@ namespace FellowOakDicom
         private static readonly IDictionary<int, Encoding> _strictEncodings =
             new Dictionary<int, Encoding>();
 
-        private static Encoding GetCodeForEncoding(byte code1, byte code2, byte code3) =>
+        private static Encoding GetEncodingForEscapeSequence(byte code1, byte code2, byte code3) =>
             code1 switch
             {
                 0x2d => code2 switch
@@ -231,22 +261,28 @@ namespace FellowOakDicom
             };
 
         // Delimiters in text values that reset the encoding
-        private static readonly byte[] _textDelimiters =
+        private static readonly byte[] _textDelimiterBytes =
         {
             0x0d, // CR
             0x0a, // LF
             0x09, // TAB
             0x0c // FF
         };
+        
+        private static readonly char[] _textDelimiterChars =
+            Encoding.ASCII.GetString(_textDelimiterBytes).ToCharArray();
 
         // Delimiters in PN values that reset the encoding
-        private static readonly byte[] _pnDelimiters =
+        private static readonly byte[] _pnDelimiterBytes =
         {
             0x5e, // ^
             0x3d, // =
         };
 
-        internal static string DecodeBytes(IByteBuffer buffer, Encoding[] encodings, bool isPN)
+        private static readonly char[] _pnDelimiterChars = 
+            Encoding.ASCII.GetString(_pnDelimiterBytes).ToCharArray();
+
+        internal static string DecodeBytes(IByteBuffer buffer, Encoding[] encodings, bool isPersonName)
         {
             var firstEncoding = encodings?.FirstOrDefault() ?? Default;
             var value = buffer.Data;
@@ -270,7 +306,7 @@ namespace FellowOakDicom
             }
 
             var decodedString = new StringBuilder();
-            var delimiters = isPN ? _pnDelimiters : _textDelimiters;
+            var delimiters = isPersonName ? _pnDelimiterBytes : _textDelimiterBytes;
             var memoryProvider = Setup.ServiceProvider.GetRequiredService<IMemoryProvider>();
             for (int i = 0; i < escapeIndexes.Count; i++)
             {
@@ -296,6 +332,56 @@ namespace FellowOakDicom
             return decodedString.ToString();
         }
 
+        internal static byte[] EncodeString(string value, Encoding[] encodings, bool isPersonName)
+        {
+            var strictEncodings = GetStrictEncodings(encodings);
+            try
+            {
+                // default case - can be encoded using the first encoding
+                return strictEncodings[0].GetBytes(value);
+            }
+            catch (EncoderFallbackException)
+            {
+                // could not encode the value with the first encoding, try all encodings
+                
+                // if there are delimiters in the string, the string has to be split into fragments
+                // for encoding, as a delimiter resets the encoding
+                var delimiters = isPersonName ? _pnDelimiterChars : _textDelimiterChars;
+                
+                MemoryStream stream = new MemoryStream();
+                using (BinaryWriter writer = new BinaryWriter(stream))
+                {
+                    var currentIndex = 0;
+                    while(true)
+                    {
+                        var delimiterIndex = -1;
+                        char currentDelimiter = '\0';
+                        foreach (var delimiter in delimiters)
+                        {
+                            var index = value.IndexOf(delimiter, currentIndex);
+                            if (index >= 0 && (delimiterIndex == -1 || index < delimiterIndex))
+                            {
+                                delimiterIndex = index;
+                                currentDelimiter = delimiter;
+                            }
+                        }
+
+                        if (delimiterIndex == -1)
+                        {
+                            // found last fragment
+                            EncodeFragment(value.Substring(currentIndex, value.Length - currentIndex), encodings, strictEncodings, writer);
+                            break;
+                        }
+                        EncodeFragment(value.Substring(currentIndex, delimiterIndex - currentIndex), encodings, strictEncodings, writer);
+                        writer.Write(Convert.ToByte(currentDelimiter));
+                        currentIndex = delimiterIndex + 1;
+                    }                    
+                }
+
+                return stream.ToArray();
+            }
+        }
+
         private static readonly int[] _codePagesForHandledEncodings =
         {
             50220, // iso-2022-jp
@@ -310,17 +396,17 @@ namespace FellowOakDicom
                 seqLength = fragmentLength >= 3 && fragment[1] == '$' && fragment[2] == '(' || fragment[2] == ')'
                     ? 4
                     : 3;
-                encoding = GetCodeForEncoding(fragment[1], fragment[2], seqLength == 4 ? fragment[3] : (byte)0);
+                encoding = GetEncodingForEscapeSequence(fragment[1], fragment[2], seqLength == 4 ? fragment[3] : (byte)0);
                 if (encoding == null)
                 {
-                    Logger.LogWarning("Unknown escape sequence found in string, using ASCII encoding.");
+                    Logger.LogWarning("Unknown escape sequence found in string, using ASCII encoding");
                     encoding = Default;
                 }
                 else if (encoding.CodePage != Default.CodePage && !encodings.Contains(encoding))
                 {
                     // maybe be shall try to use the encoding anyway? 
-                    Logger.LogWarning("Found escape sequence for '{encodingName}', which is " +
-                                "not defined in Specific Character Set, using ASCII encoding instead.",
+                    Logger.LogWarning("Found escape sequence for '{EncodingName}', which is " +
+                                "not defined in Specific Character Set, using ASCII encoding instead",
                         encoding.WebName);
                     encoding = Default;
                 }
@@ -352,6 +438,43 @@ namespace FellowOakDicom
             return GetStringFromEncoding(fragment, encoding, seqLength, fragmentLength - seqLength);
         }
 
+        private static void EncodeFragment(string fragment, Encoding[] encodings, Encoding[] strictEncodings, BinaryWriter writer)
+        {
+            try
+            {
+                writer.Write(strictEncodings[0].GetBytes(fragment));
+                return;
+            }
+            catch (EncoderFallbackException)
+            {
+                foreach (var encoding in strictEncodings.Skip(1))
+                {
+                    try
+                    {
+                        var bytes = encoding.GetBytes(fragment);
+                        // some escape sequences are already added by the encoder
+                        if (!_codePagesForHandledEncodings.Contains(encoding.CodePage))
+                        {
+                            var controlBytes = _escapeSequences[encoding.CodePage];
+                            writer.Write(controlBytes);
+                        }
+                        writer.Write(bytes);
+                        return;
+                    }
+                    catch (EncoderFallbackException)
+                    {
+                        // try next encoding if any
+                    }
+                }
+            }
+
+            // the fallback uses replacement characters
+            Logger.LogWarning("Could not encode string '{Fragment}' with given encodings, " +
+                              "using replacement characters for encoding", fragment);
+            var encoded = encodings[0].GetBytes(fragment);
+            writer.Write(encoded);
+        }
+
         private static string GetStringFromEncoding(byte[] fragment, Encoding encoding, int index, int count)
         {
             try
@@ -361,7 +484,7 @@ namespace FellowOakDicom
             catch (DecoderFallbackException)
             {
                 var decoded = encoding.GetString(fragment, index, count);
-                Logger.LogWarning("Could not decode string '{decoded}' with given encoding, using replacement characters.",
+                Logger.LogWarning("Could not decode string '{Decoded}' with given encoding, using replacement characters",
                     decoded);
                 return decoded;
             }

--- a/FO-DICOM.Core/IO/Buffer/LazyByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/LazyByteBuffer.cs
@@ -12,13 +12,15 @@ namespace FellowOakDicom.IO.Buffer
     public sealed class LazyByteBuffer : IByteBuffer
     {
         private readonly Func<byte[]> _bytes;
+        private byte[] _byteData;
+
 
         public LazyByteBuffer(Func<byte[]> bytes)
         {
             _bytes = bytes ?? throw new ArgumentNullException(nameof(bytes));
         }
 
-        private byte[] Bytes => _bytes();
+        private byte[] Bytes =>  _byteData ??= _bytes();
         
         public bool IsMemory => true;
 

--- a/Tests/FO-DICOM.Tests/DicomEncodingTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomEncodingTest.cs
@@ -30,7 +30,7 @@ namespace FellowOakDicom.Tests
             var actual = DicomEncoding.GetEncoding("Invalid").CodePage;
             Assert.Equal(expected, actual);
             Assert.Equal(1, logCollector.NumberOfWarnings);
-            var expectedWarning = "'Invalid' is not a valid DICOM encoding - using ASCII encoding instead.";
+            var expectedWarning = "'Invalid' is not a valid DICOM encoding - using ASCII encoding instead";
             Assert.Equal(expectedWarning, logCollector.WarningAt(0));
         }
 
@@ -94,7 +94,7 @@ namespace FellowOakDicom.Tests
             // a warning is issued on accessing the incorrectly decoded value
             Assert.Equal(1, logCollector.NumberOfWarnings);
             var expectedWarning =
-                "Could not decode string 'H?lzl^G?nther' with given encoding, using replacement characters.";
+                "Could not decode string 'H?lzl^G?nther' with given encoding, using replacement characters";
             Assert.Equal(1, logCollector.NumberOfWarnings);
             Assert.Equal(expectedWarning, logCollector.WarningAt(0));
 
@@ -246,7 +246,7 @@ namespace FellowOakDicom.Tests
             Assert.Equal("���������", ds.GetString(DicomTag.PatientName));
             Assert.Equal(1, logCollector.NumberOfWarnings);
             var expectedMessage =
-                "Could not decode string '���������' with given encoding, using replacement characters.";
+                "Could not decode string '���������' with given encoding, using replacement characters";
             Assert.Equal(expectedMessage, logCollector.WarningAt(0));
         }
 
@@ -272,7 +272,7 @@ namespace FellowOakDicom.Tests
                 "Found escape sequence for 'shift_jis', which is not defined";
             Assert.StartsWith(expectedMessage, logCollector.WarningAt(0));
             expectedMessage =
-                "Could not decode string 'J?r?me' with given encoding, using replacement characters.";
+                "Could not decode string 'J?r?me' with given encoding, using replacement characters";
             Assert.Equal(expectedMessage, logCollector.WarningAt(1));
         }
 
@@ -293,12 +293,55 @@ namespace FellowOakDicom.Tests
             ds.Add(patientName);
             Assert.Equal("Buc^J?r?me", ds.GetString(DicomTag.PatientName));
             Assert.Equal(2, logCollector.NumberOfWarnings);
+
             var expectedMessage =
-                "Unknown escape sequence found in string, using ASCII encoding.";
+                "Unknown escape sequence found in string, using ASCII encoding";
             Assert.Equal(expectedMessage, logCollector.WarningAt(0));
             expectedMessage =
-                "Could not decode string 'J?r?me' with given encoding, using replacement characters.";
+                "Could not decode string 'J?r?me' with given encoding, using replacement characters";
             Assert.Equal(expectedMessage, logCollector.WarningAt(1));
+        }
+
+        [Theory]
+        [MemberData(nameof(MultiEncodingNames))]
+        public void SavePatientNameWithMultiEncoding(string characterSet, string patientName)
+        {
+            var dataset = new DicomDataset
+            {
+                { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage },
+                { DicomTag.SOPInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
+                { DicomTag.SpecificCharacterSet, characterSet },
+                { DicomTag.PatientName, patientName}
+            };
+            var dicomFile = new DicomFile(dataset);
+            var stream = new MemoryStream();
+            dicomFile.Save(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var inFile = DicomFile.Open(stream);
+            Assert.Equal(patientName, inFile.Dataset.GetString(DicomTag.PatientName));
+        }
+
+        [Fact]
+        public void SavePatientNameWithWrongEncoding()
+        {
+            using var logCollector = NewLogCollector();
+            var patientName = "Yamada^Tarou=山田^太郎=やまだ^たろう";
+            var dataset = new DicomDataset
+            {
+                { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage },
+                { DicomTag.SOPInstanceUID, DicomUIDGenerator.GenerateDerivedFromUUID() },
+                { DicomTag.SpecificCharacterSet, "ISO_IR 100" },
+                { DicomTag.PatientName, patientName}
+            };
+            var dicomFile = new DicomFile(dataset);
+            var stream = new MemoryStream();
+            dicomFile.Save(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var inFile = DicomFile.Open(stream);
+            Assert.Equal("Yamada^Tarou=??^??=???^???", inFile.Dataset.GetString(DicomTag.PatientName));
+            var expectedWarning = "Could not encode string '山田' with given encodings, " +
+                                  "using replacement characters for encoding";
+            Assert.Equal(expectedWarning, logCollector.WarningAt(0));
         }
 
         public static readonly IEnumerable<object[]> FileNames = new[]
@@ -346,6 +389,22 @@ namespace FellowOakDicom.Tests
                 new byte[] { 0x1b, 0x2d, 0x4d, 0xc7, 0x61, 0x76, 0x75, 0xfe, 0x6f, 0xf0, 0x6c, 0x75 } },
             new object[] { "ISO 2022 IR 166", "นามสกุล",
                 new byte[] { 0x1b, 0x2d, 0x54, 0xb9, 0xd2, 0xc1, 0xca, 0xa1, 0xd8, 0xc5 } }
+        };
+
+        public static IEnumerable<object[]> MultiEncodingNames = new[]
+        {
+            new object[] { @"\ISO 2022 IR 87", "Yamada^Tarou=山田^太郎=やまだ^たろう" },
+            new object[] { @"\ISO 2022 IR 100\ISO 2022 IR 87", "Yamada^Tarou=山田^太郎=やまだ^たろう" },
+            new object[] { @"ISO 2022 IR 13\ISO 2022 IR 87", "ﾔﾏﾀﾞ^ﾀﾛｳ=山田^太郎=やまだ^たろう" },
+            new object[] { @"\ISO 2022 IR 101", "Wałęsa" },
+            new object[] { @"\ISO 2022 IR 109", "antaŭnomo" },
+            new object[] { @"\ISO 2022 IR 127", "قباني^لنزار" },
+            new object[] { @"\ISO 2022 IR 126", "Διονυσιος" },
+            new object[] { @"\ISO 2022 IR 138", "שרון^דבורה" },
+            new object[] { @"\ISO 2022 IR 144", "Люкceмбypг" },
+            new object[] { @"\ISO 2022 IR 148", "Çavuşoğlu" },
+            new object[] { @"\ISO 2022 IR 149", "김희중" },
+            new object[] { @"\ISO 2022 IR 166", "นามสก\u0e38ล" }
         };
 
         public static readonly IEnumerable<object[]> EncodingNames = new[]


### PR DESCRIPTION
See #1789.

This implements the most relevant use case (only one encoding per value/component). 
I did not think much about optimization of the case that the first encoding cannot encode the string, as it is relatively rare. The standard case should almost not be impacted.

The problem with JIS X 201 and JIS X 208 mentioned in the issue is not handled here.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
