### PR TITLE
Let dependabot also update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
       update-types: [ "version-update:semver-major" ]
     - dependency-name: "System.*"
       update-types: [ "version-update:semver-major" ]
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly


### PR DESCRIPTION
- avoids the use of deprecated versions

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation - not needed
- [ ] I have included unit tests - not needed
- [ ] I have updated the change log - not needed
- [x] I am listed in the CONTRIBUTORS file

I had noticed a bunch of warnings in the GH actions due to old action versions that use deprecated functions. This would update the actions periodically if there are new versions.