### PR TITLE
Reduce performance impact of DicomDatasetComparer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 - **Breaking change**: Calculation of VOI LUT function LINEAR_EXACT changed as defined since DICOM Standard 2019d
 - Added core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
+- Reduce the memory impact of the DicomDatasetComparer (#1807)
 - Add support for parsing DICOM files where the pixel data is not properly closed with a SequenceDelimitationItem (#1339)
 - Update Dicom json converter to handle Infinity values for FL and FD VRs (#1725)
 - Fix rendering of files with photometric interpretation YBR_RCT or YBR_ICT (#1734)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 - **Breaking change**: Calculation of VOI LUT function LINEAR_EXACT changed as defined since DICOM Standard 2019d
 - Added core support for HTJ2K-based transfer syntaxes (not actual codec) (#1687)
-- Reduce the memory impact of the DicomDatasetComparer (#1807)
+- Reduce the memory impact of the DicomDatasetComparer. By a static property DicomDataset.CompareInstancesByContent the usage of DicomDatasetComparer in DicomDataset.Equals can be disabled globally. (#1807)
 - Add support for parsing DICOM files where the pixel data is not properly closed with a SequenceDelimitationItem (#1339)
 - Update Dicom json converter to handle Infinity values for FL and FD VRs (#1725)
 - Fix rendering of files with photometric interpretation YBR_RCT or YBR_ICT (#1734)

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -19,6 +19,17 @@ namespace FellowOakDicom
     /// </summary>
     public partial class DicomDataset : IEnumerable<DicomItem>, IEquatable<DicomDataset>
     {
+        #region Static Properties
+
+        /// <summary>
+        /// Gets or sets how two DicomDatasets are compared if dataset1 == dataset2 is called
+        /// If this property is true, then all items are iterated and the content is compared. Then two DicomDatasets are equal if the content is equal.
+        /// If this property is false, then the equalitycheck tests if the DicomDatasets are the same instance.
+        /// </summary>
+        public static bool CompareInstancesByContent { get; set; } = true;
+
+        #endregion
+
         #region FIELDS
 
         private readonly IDictionary<DicomTag, DicomItem> _items;
@@ -1591,7 +1602,10 @@ namespace FellowOakDicom
 
         public bool Equals(DicomDataset other)
         {
-            return new DicomDatasetComparer().Equals(this, other);
+            return
+                CompareInstancesByContent
+                ? new DicomDatasetComparer().Equals(this, other)
+                : ReferenceEquals(this, other);
         }
 
         public static bool operator ==(DicomDataset a, DicomDataset b)

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -1604,7 +1604,7 @@ namespace FellowOakDicom
         {
             return
                 CompareInstancesByContent
-                ? new DicomDatasetComparer().Equals(this, other)
+                ? DicomDatasetComparer.DefaultInstance.Equals(this, other)
                 : ReferenceEquals(this, other);
         }
 

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -61,6 +61,7 @@ namespace FellowOakDicom
 
         protected virtual void ValidateString() { }
 
+        public abstract bool Equals(DicomElement other);
     }
 
     /// <summary>
@@ -200,6 +201,15 @@ namespace FellowOakDicom
         {
             ValueRepresentation?.ValidateString(_value);
         }
+
+        public override bool Equals(DicomElement other)
+        {
+            if (other is DicomStringElement otherStringElement)
+            {
+                return this.StringValue == otherStringElement.StringValue;
+            }
+            return false;
+        }
     }
 
     public abstract class DicomMultiStringElement : DicomStringElement
@@ -302,6 +312,15 @@ namespace FellowOakDicom
             }
 
             throw new InvalidCastException($"Unable to convert DICOM {ValueRepresentation.Code} value to '{typeof(T).Name}'");
+        }
+
+        public override bool Equals(DicomElement other)
+        {
+            if (other is DicomMultiStringElement otherMultiString)
+            {
+                return otherMultiString.Count == this.Count && otherMultiString.StringValue == this.StringValue;
+            }
+            return false;
         }
 
         #endregion
@@ -559,6 +578,15 @@ namespace FellowOakDicom
             throw new InvalidCastException($"Unable to convert DICOM {ValueRepresentation.Code} value to '{typeof(T).Name}'");
         }
 
+        public override bool Equals(DicomElement other)
+        {
+            if (other is DicomValueElement<Tv> otherValue)
+            {
+                return this.Buffer.Data.SequenceEqual(otherValue.Buffer.Data);
+            }
+            return false;
+        }
+
         #endregion
 
     }
@@ -697,6 +725,17 @@ namespace FellowOakDicom
 
             throw new InvalidCastException(
                 $"Unable to convert DICOM {ValueRepresentation.Code} value to '{typeof(T).Name}'");
+        }
+
+        public override bool Equals(DicomElement other)
+        {
+            if (other is DicomAttributeTag otherAttribute)
+            {
+                return (this._values == null && otherAttribute._values == null)
+                    || (this._values != null && otherAttribute._values != null && 
+                        this._values.SequenceEqual(otherAttribute._values));
+            }
+            return false;
         }
 
         #endregion

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -731,9 +731,9 @@ namespace FellowOakDicom
         {
             if (other is DicomAttributeTag otherAttribute)
             {
-                return (this._values == null && otherAttribute._values == null)
-                    || (this._values != null && otherAttribute._values != null && 
-                        this._values.SequenceEqual(otherAttribute._values));
+                return (this.Values == null && otherAttribute.Values == null)
+                    || (this.Values != null && otherAttribute.Values != null && 
+                        this.Values.SequenceEqual(otherAttribute.Values));
             }
             return false;
         }
@@ -1260,6 +1260,16 @@ namespace FellowOakDicom
             return base.Get<T>(item);
         }
 
+
+        public override bool Equals(DicomElement other)
+        {
+            if (other is DicomOtherByte otherByte)
+            {
+                return this.Count == otherByte.Count;
+            }
+            return false;
+        }
+
         #endregion
 
         protected override void ValidateVM()
@@ -1289,6 +1299,15 @@ namespace FellowOakDicom
         #region Public Properties
 
         public override DicomVR ValueRepresentation => DicomVR.OW;
+
+        public override bool Equals(DicomElement other)
+        {
+            if (other is DicomOtherWord otherByte)
+            {
+                return this.Count == otherByte.Count;
+            }
+            return false;
+        }
 
         #endregion
 

--- a/FO-DICOM.Core/DicomItemComparer.cs
+++ b/FO-DICOM.Core/DicomItemComparer.cs
@@ -21,6 +21,11 @@ namespace FellowOakDicom
     {
         public bool Equals(DicomItem item1, DicomItem item2)
         {
+            if (ReferenceEquals(item1, item2))
+            {
+                // short circuit comparing the same item
+                return true;
+            }
             if (item1 is DicomElement xElement && item2 is DicomElement yElement)
             {
                 if (xElement.Buffer is BulkDataUriByteBuffer xBulkbuffer && !xBulkbuffer.IsMemory || 
@@ -30,10 +35,10 @@ namespace FellowOakDicom
                     return item1.Tag == item2.Tag;
                 }
 
-                var xValue = string.Join("\\", xElement.Get<string[]>());
-                var yValue = string.Join("\\", yElement.Get<string[]>());
+                //var xValue = string.Join("\\", xElement.Get<string[]>());
+                //var yValue = string.Join("\\", yElement.Get<string[]>());
 
-                return item1.Tag == item2.Tag && xValue == yValue;
+                return xElement.Tag == yElement.Tag && xElement.Equals(yElement);
             }
 
             if (item1 is DicomSequence xSequence && item2 is DicomSequence ySequence)
@@ -96,9 +101,10 @@ namespace FellowOakDicom
             }
 
             var valueComparer = new DicomValueComparer();
-            foreach (var elements in dataset1.Zip(dataset2, Tuple.Create))
+            foreach (var element in dataset1)
             {
-                if (!valueComparer.Equals(elements.Item1, elements.Item2))
+                var element2 = dataset2.GetDicomItem<DicomItem>(element.Tag);
+                if (!valueComparer.Equals(element, element2))
                 {
                     return false;
                 }

--- a/FO-DICOM.Core/DicomItemComparer.cs
+++ b/FO-DICOM.Core/DicomItemComparer.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using FellowOakDicom.IO.Buffer;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -19,6 +18,8 @@ namespace FellowOakDicom
 
     public class DicomValueComparer : IEqualityComparer<DicomItem>
     {
+        public static DicomValueComparer DefaultInstance { get; set; } = new DicomValueComparer();
+
         public bool Equals(DicomItem item1, DicomItem item2)
         {
             if (ReferenceEquals(item1, item2))
@@ -35,9 +36,6 @@ namespace FellowOakDicom
                     return item1.Tag == item2.Tag;
                 }
 
-                //var xValue = string.Join("\\", xElement.Get<string[]>());
-                //var yValue = string.Join("\\", yElement.Get<string[]>());
-
                 return xElement.Tag == yElement.Tag && xElement.Equals(yElement);
             }
 
@@ -49,12 +47,11 @@ namespace FellowOakDicom
                     return false;
                 }
 
-                var datasetComparer = new DicomDatasetComparer();
                 for (var i = 0; i < itemsCount; i++)
                 {
                     var dataset1 = xSequence.Items[i];
                     var dataset2 = ySequence.Items[i];
-                    if (!datasetComparer.Equals(dataset1, dataset2))
+                    if (!DicomDatasetComparer.DefaultInstance.Equals(dataset1, dataset2))
                     {
                         return false;
                     }
@@ -82,6 +79,9 @@ namespace FellowOakDicom
 
     public class DicomDatasetComparer : IEqualityComparer<DicomDataset>
     {
+
+        public static DicomDatasetComparer DefaultInstance { get; set; } = new DicomDatasetComparer();
+
         public bool Equals(DicomDataset dataset1, DicomDataset dataset2)
         {
             if ((dataset1 == null) != (dataset2 == null))
@@ -100,11 +100,10 @@ namespace FellowOakDicom
                 return false;
             }
 
-            var valueComparer = new DicomValueComparer();
             foreach (var element in dataset1)
             {
                 var element2 = dataset2.GetDicomItem<DicomItem>(element.Tag);
-                if (!valueComparer.Equals(element, element2))
+                if (!DicomValueComparer.DefaultInstance.Equals(element, element2))
                 {
                     return false;
                 }

--- a/Tests/FO-DICOM.Benchmark/CompareDatasetBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/CompareDatasetBenchmark.cs
@@ -17,14 +17,18 @@ namespace FellowOakDicom.Benchmark
         private DicomDataset _ctDataset;
         private DicomDataset _ctDataset1;
         private DicomDataset _ctDataset2;
+        private DicomDataset _ctDatasetClone;
         private MemoryStream _mrData;
         private DicomDataset _mrDataset;
         private DicomDataset _mrDataset1;
         private DicomDataset _mrDataset2;
+        private DicomDataset _mrDatasetClone;
+
         private MemoryStream _mgData;
         private DicomDataset _mgDataset;
         private DicomDataset _mgDataset1;
         private DicomDataset _mgDataset2;
+        private DicomDataset _mgDatasetClone;
 
         private MemoryStream _dicomdirData;
 
@@ -55,6 +59,9 @@ namespace FellowOakDicom.Benchmark
             _ctDataset2 = DicomFile.Open(Path.Combine(_rootpath, "Data\\ct.dcm")).Dataset;
             _mrDataset2 = DicomFile.Open(Path.Combine(_rootpath, "Data\\mr.dcm")).Dataset;
             _mgDataset2 = DicomFile.Open(Path.Combine(_rootpath, "Data\\mg.dcm")).Dataset;
+            _ctDatasetClone = _ctDataset.Clone();
+            _mrDatasetClone = _mrDataset.Clone();
+            _mgDatasetClone = _mgDataset.Clone();
         }
 
         [Benchmark]
@@ -76,13 +83,13 @@ namespace FellowOakDicom.Benchmark
         public object HashMg() => _mgDataset.GetHashCode();
 
         [Benchmark]
-        public object CompareCloneCt() => _ctDataset == _ctDataset.Clone();
+        public object CompareCloneCt() => _ctDataset == _ctDatasetClone;
 
         [Benchmark]
-        public object CompareCloneMR() => _mrDataset == _mrDataset.Clone();
+        public object CompareCloneMR() => _mrDataset == _mrDatasetClone;
 
         [Benchmark]
-        public object CompareCloneMg() => _mgDataset == _mgDataset.Clone();
+        public object CompareCloneMg() => _mgDataset == _mgDatasetClone;
 
     }
 }

--- a/Tests/FO-DICOM.Benchmark/CompareDatasetBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/CompareDatasetBenchmark.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) 2012-2023 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using BenchmarkDotNet.Attributes;
+using System.IO;
+using System.Reflection;
+
+namespace FellowOakDicom.Benchmark
+{
+    [MemoryDiagnoser]
+    public class CompareDatasetBenchmark
+    {
+        private readonly string _rootpath;
+
+        private MemoryStream _ctData;
+        private DicomDataset _ctDataset;
+        private DicomDataset _ctDataset1;
+        private DicomDataset _ctDataset2;
+        private MemoryStream _mrData;
+        private DicomDataset _mrDataset;
+        private DicomDataset _mrDataset1;
+        private DicomDataset _mrDataset2;
+        private MemoryStream _mgData;
+        private DicomDataset _mgDataset;
+        private DicomDataset _mgDataset1;
+        private DicomDataset _mgDataset2;
+
+        private MemoryStream _dicomdirData;
+
+
+        public CompareDatasetBenchmark()
+        {
+            _rootpath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _ctData = new MemoryStream(File.ReadAllBytes(Path.Combine(_rootpath, "Data\\ct.dcm")));
+            _mrData = new MemoryStream(File.ReadAllBytes(Path.Combine(_rootpath, "Data\\mr.dcm")));
+            _mgData = new MemoryStream(File.ReadAllBytes(Path.Combine(_rootpath, "Data\\mg.dcm")));
+            _dicomdirData = new MemoryStream(File.ReadAllBytes(Path.Combine(_rootpath, "Data\\DICOMDIR")));
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _ctDataset = DicomFile.Open(Path.Combine(_rootpath, "Data\\ct.dcm")).Dataset;
+            _mrDataset = DicomFile.Open(Path.Combine(_rootpath, "Data\\mr.dcm")).Dataset;
+            _mgDataset = DicomFile.Open(Path.Combine(_rootpath, "Data\\mg.dcm")).Dataset;
+            _ctDataset1 = DicomFile.Open(Path.Combine(_rootpath, "Data\\ct.dcm")).Dataset;
+            _mrDataset1 = DicomFile.Open(Path.Combine(_rootpath, "Data\\mr.dcm")).Dataset;
+            _mgDataset1 = DicomFile.Open(Path.Combine(_rootpath, "Data\\mg.dcm")).Dataset;
+            _ctDataset2 = DicomFile.Open(Path.Combine(_rootpath, "Data\\ct.dcm")).Dataset;
+            _mrDataset2 = DicomFile.Open(Path.Combine(_rootpath, "Data\\mr.dcm")).Dataset;
+            _mgDataset2 = DicomFile.Open(Path.Combine(_rootpath, "Data\\mg.dcm")).Dataset;
+        }
+
+        [Benchmark]
+        public object CompareCt() => _ctDataset1 == _ctDataset2;
+
+        [Benchmark]
+        public object CompareMR() => _mrDataset1 == _mrDataset2;
+
+        [Benchmark]
+        public object CompareMg() => _mgDataset1 == _mgDataset2;
+
+        [Benchmark]
+        public object HashCt() => _ctDataset.GetHashCode();
+
+        [Benchmark]
+        public object HashMr() => _mrDataset.GetHashCode();
+
+        [Benchmark]
+        public object HashMg() => _mgDataset.GetHashCode();
+
+        [Benchmark]
+        public object CompareCloneCt() => _ctDataset == _ctDataset.Clone();
+
+        [Benchmark]
+        public object CompareCloneMR() => _mrDataset == _mrDataset.Clone();
+
+        [Benchmark]
+        public object CompareCloneMg() => _mgDataset == _mgDataset.Clone();
+
+    }
+}

--- a/Tests/FO-DICOM.Benchmark/Program.cs
+++ b/Tests/FO-DICOM.Benchmark/Program.cs
@@ -12,8 +12,9 @@ namespace FellowOakDicom.Benchmark
         static void Main()
         {
             // Run all benchmarks in assembly
-            BenchmarkRunner.Run(typeof(Program).Assembly,
+//            BenchmarkRunner.Run(typeof(Program).Assembly,
 //            BenchmarkRunner.Run<RenderImageBenchmark>(
+            BenchmarkRunner.Run<CompareDatasetBenchmark>(
                 ManualConfig.Create(DefaultConfig.Instance)
                 .WithOptions(ConfigOptions.JoinSummary)
                 .WithOptions(ConfigOptions.DisableOptimizationsValidator)

--- a/Tests/FO-DICOM.Benchmark/Program.cs
+++ b/Tests/FO-DICOM.Benchmark/Program.cs
@@ -12,9 +12,8 @@ namespace FellowOakDicom.Benchmark
         static void Main()
         {
             // Run all benchmarks in assembly
-//            BenchmarkRunner.Run(typeof(Program).Assembly,
+            BenchmarkRunner.Run(typeof(Program).Assembly,
 //            BenchmarkRunner.Run<RenderImageBenchmark>(
-            BenchmarkRunner.Run<CompareDatasetBenchmark>(
                 ManualConfig.Create(DefaultConfig.Instance)
                 .WithOptions(ConfigOptions.JoinSummary)
                 .WithOptions(ConfigOptions.DisableOptimizationsValidator)


### PR DESCRIPTION
Fixes #1807 

#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- When comparing all items of a DicomDataset, then instead of generating the string representation to compare, there is a virtual method DicomElement.Equals(DicomElement other) that does a more performant comparison
- There are short circuits in case the two DicomElements acutally are the same instance
- in huge items like PixelData or EncapsulatedData there the bytewise comparison is skipped.
