### PR TITLE
Add cancellation token support to DicomService

### DIFF
--- a/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnection.cs
+++ b/FO-DICOM.Core/Network/Client/Advanced/Connection/AdvancedDicomClientConnection.cs
@@ -76,25 +76,37 @@ namespace FellowOakDicom.Network.Client.Advanced.Connection
         }
 
         public new Task SendAssociationRequestAsync(DicomAssociation association) => base.SendAssociationRequestAsync(association);
+        
         public new Task SendAssociationReleaseRequestAsync() => base.SendAssociationReleaseRequestAsync();
+        
         public new Task SendAbortAsync(DicomAbortSource source, DicomAbortReason reason) => base.SendAbortAsync(source, reason);
+        
         public new Task SendRequestAsync(DicomRequest request) => base.SendRequestAsync(request);
-        public new Task SendNextMessageAsync() => base.SendNextMessageAsync();
+        
+        public Task SendNextMessageAsync() => base.SendNextMessageAsync(IsDisconnectedToken);
 
-        protected override Task OnSendQueueEmptyAsync() => _eventCollector.OnSendQueueEmptyAsync();
-        public Task OnReceiveAssociationAcceptAsync(DicomAssociation association) => _eventCollector.OnReceiveAssociationAcceptAsync(association);
+        protected override Task OnSendQueueEmptyAsync(CancellationToken cancellationToken) => _eventCollector.OnSendQueueEmptyAsync();
 
-        public Task OnReceiveAssociationRejectAsync(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason) =>
+        public Task OnReceiveAssociationAcceptAsync(DicomAssociation association, CancellationToken cancellationToken) => _eventCollector.OnReceiveAssociationAcceptAsync(association);
+        
+        public Task OnReceiveAssociationRejectAsync(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason, CancellationToken cancellationToken) =>
             _eventCollector.OnReceiveAssociationRejectAsync(result, source, reason);
-
-        public Task OnReceiveAssociationReleaseResponseAsync() => _eventCollector.OnReceiveAssociationReleaseResponseAsync();
-        public Task OnReceiveAbortAsync(DicomAbortSource source, DicomAbortReason reason) => _eventCollector.OnReceiveAbortAsync(source, reason);
+        
+        public Task OnReceiveAssociationReleaseResponseAsync(CancellationToken cancellationToken) => _eventCollector.OnReceiveAssociationReleaseResponseAsync();
+        
+        public Task OnReceiveAbortAsync(DicomAbortSource source, DicomAbortReason reason, CancellationToken cancellationToken) => _eventCollector.OnReceiveAbortAsync(source, reason);
+        
         public Task OnConnectionClosedAsync(Exception exception) => _eventCollector.OnConnectionClosedAsync(exception);
-        public Task OnRequestCompletedAsync(DicomRequest request, DicomResponse response) => _eventCollector.OnRequestCompletedAsync(request, response);
-        public Task OnRequestPendingAsync(DicomRequest request, DicomResponse response) => _eventCollector.OnRequestPendingAsync(request, response);
-        public Task OnRequestTimedOutAsync(DicomRequest request, TimeSpan timeout) => _eventCollector.OnRequestTimedOutAsync(request, timeout);
-        public Task<DicomResponse> OnCStoreRequestAsync(DicomCStoreRequest request) => _eventCollector.OnCStoreRequestAsync(request);
-        public Task<DicomResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request) => _eventCollector.OnNEventReportRequestAsync(request);
+        
+        public Task OnRequestCompletedAsync(DicomRequest request, DicomResponse response, CancellationToken cancellationToken) => _eventCollector.OnRequestCompletedAsync(request, response);
+        
+        public Task OnRequestPendingAsync(DicomRequest request, DicomResponse response, CancellationToken cancellationToken) => _eventCollector.OnRequestPendingAsync(request, response);
+        
+        public Task OnRequestTimedOutAsync(DicomRequest request, TimeSpan timeout, CancellationToken cancellationToken) => _eventCollector.OnRequestTimedOutAsync(request, timeout);
+        
+        public Task<DicomResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken) => _eventCollector.OnCStoreRequestAsync(request);
+        
+        public Task<DicomResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request, CancellationToken cancellationToken) => _eventCollector.OnNEventReportRequestAsync(request);
 
         public async Task<IAdvancedDicomClientAssociation> OpenAssociationAsync(AdvancedDicomClientAssociationRequest request, CancellationToken cancellationToken)
         {

--- a/FO-DICOM.Core/Network/Client/DicomClientConnection.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientConnection.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network.Client
@@ -63,7 +64,8 @@ namespace FellowOakDicom.Network.Client
         /// Callback for handling association accept scenarios.
         /// </summary>
         /// <param name="association">Accepted association.</param>
-        Task OnReceiveAssociationAcceptAsync(DicomAssociation association);
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnReceiveAssociationAcceptAsync(DicomAssociation association, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback for handling association reject scenarios.
@@ -71,19 +73,22 @@ namespace FellowOakDicom.Network.Client
         /// <param name="result">Specification of rejection result.</param>
         /// <param name="source">Source of rejection.</param>
         /// <param name="reason">Detailed reason for rejection.</param>
-        Task OnReceiveAssociationRejectAsync(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason);
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnReceiveAssociationRejectAsync(DicomRejectResult result, DicomRejectSource source, DicomRejectReason reason, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback on response from an association release.
         /// </summary>
-        Task OnReceiveAssociationReleaseResponseAsync();
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnReceiveAssociationReleaseResponseAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback on receiving an abort message.
         /// </summary>
         /// <param name="source">Abort source.</param>
         /// <param name="reason">Detailed reason for abort.</param>
-        Task OnReceiveAbortAsync(DicomAbortSource source, DicomAbortReason reason);
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnReceiveAbortAsync(DicomAbortSource source, DicomAbortReason reason, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback when connection is closed.
@@ -110,7 +115,8 @@ namespace FellowOakDicom.Network.Client
         /// </summary>
         /// <param name="request">The original request that was sent, which has now been fulfilled</param>
         /// <param name="response">The final response from the DICOM server</param>
-        Task OnRequestCompletedAsync(DicomRequest request, DicomResponse response);
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnRequestCompletedAsync(DicomRequest request, DicomResponse response, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback when a request has received a pending response (this is not the final response, the request is still in the pending queue)
@@ -118,35 +124,35 @@ namespace FellowOakDicom.Network.Client
         /// </summary>
         /// <param name="request">The original request that was sent</param>
         /// <param name="response">A pending response from the DICOM server</param>
-        Task OnRequestPendingAsync(DicomRequest request, DicomResponse response);
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnRequestPendingAsync(DicomRequest request, DicomResponse response, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback when a request has timed out (no final response was received, but the timeout was exceeded and the request has been removed from the pending queue)
         /// </summary>
         /// <param name="request">The original request that was sent, which could not be fulfilled</param>
         /// <param name="timeout">The timeout duration that has been exceeded</param>
-        Task OnRequestTimedOutAsync(DicomRequest request, TimeSpan timeout);
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnRequestTimedOutAsync(DicomRequest request, TimeSpan timeout, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback for handling a client related C-STORE request, typically emanating from the client's C-GET request.
         /// </summary>
-        /// <param name="request">
-        /// C-STORE request.
-        /// </param>
+        /// <param name="request">C-STORE request</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>
         /// The <see cref="DicomCStoreResponse"/> related to the C-STORE <paramref name="request"/>.
         /// </returns>
-        Task<DicomResponse> OnCStoreRequestAsync(DicomCStoreRequest request);
+        Task<DicomResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback for handling a client related N-EVENT-REPORT-RQ request, typically emanating from the client's N-ACTION request.
         /// </summary>
-        /// <param name="request">
-        /// N-EVENT-REPORT-RQ request.
-        /// </param>
+        /// <param name="request">N-EVENT-REPORT-RQ request</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>
         /// The <see cref="DicomNEventReportResponse"/> related to the N-EVENT-REPORT-RQ <paramref name="request"/>.
         /// </returns>
-        Task<DicomResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request);
+        Task<DicomResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request, CancellationToken cancellationToken);
     }
 }

--- a/FO-DICOM.Core/Network/DicomCEchoProvider.cs
+++ b/FO-DICOM.Core/Network/DicomCEchoProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FellowOakDicom.Network
 {
@@ -31,7 +32,7 @@ namespace FellowOakDicom.Network
         }
 
         /// <inheritdoc />
-        public virtual Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public virtual Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -44,7 +45,7 @@ namespace FellowOakDicom.Network
         }
 
         /// <inheritdoc />
-        public virtual Task OnReceiveAssociationReleaseRequestAsync()
+        public virtual Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => SendAssociationReleaseResponseAsync();
 
         /// <inheritdoc />
@@ -62,7 +63,7 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="request">C-ECHO request.</param>
         /// <returns>C-ECHO response with Success status.</returns>
-        public virtual Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        public virtual Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success));
     }
 }

--- a/FO-DICOM.Core/Network/IDicomCEchoProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCEchoProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
@@ -15,7 +16,8 @@ namespace FellowOakDicom.Network
         /// Event handler for C-ECHO request.
         /// </summary>
         /// <param name="request">C-ECHO request.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>C-ECHO response.</returns>
-        Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request);
+        Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken);
     }
 }

--- a/FO-DICOM.Core/Network/IDicomCFindProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCFindProvider.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace FellowOakDicom.Network
 {
@@ -15,8 +16,9 @@ namespace FellowOakDicom.Network
         /// Handler of C-FIND request.
         /// </summary>
         /// <param name="request">C-FIND request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>Collection of C-FIND responses based on <paramref name="request"/>.</returns>
-        IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request);
+        IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request, CancellationToken cancellationToken);
     }
 }
 

--- a/FO-DICOM.Core/Network/IDicomCGetProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCGetProvider.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace FellowOakDicom.Network
 {
@@ -15,7 +16,8 @@ namespace FellowOakDicom.Network
         /// Generate collection of <see cref="DicomCGetResponse">C-GET responses</see> from a <see cref="DicomCGetRequest">C-GET request</see>.
         /// </summary>
         /// <param name="request">C-GET request.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>Collection of C-GET responses resulting from the <paramref name="request"/>.</returns>
-        IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request);
+        IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request, CancellationToken cancellationToken);
     }
 }

--- a/FO-DICOM.Core/Network/IDicomCMoveProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCMoveProvider.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace FellowOakDicom.Network
 {
@@ -15,7 +16,8 @@ namespace FellowOakDicom.Network
         /// Handler of C-MOVE request.
         /// </summary>
         /// <param name="request">C-MOVE request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>Collection of C-MOVE responses based on <paramref name="request"/>.</returns>
-        IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request);
+        IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request, CancellationToken cancellationToken);
     }
 }

--- a/FO-DICOM.Core/Network/IDicomCStoreProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomCStoreProvider.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
@@ -20,8 +21,9 @@ namespace FellowOakDicom.Network
         /// behavior (e.g. writing to your own custom stream and avoiding the temporary file)
         /// </summary>
         /// <param name="request">C-STORE request.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>C-STORE response.</returns>
-        Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request);
+        Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback for exceptions raised during the parsing of the received SopInstance.  Note that
@@ -29,7 +31,8 @@ namespace FellowOakDicom.Network
         /// desired.
         /// </summary>
         /// <param name="tempFileName">Name of the temporary file, may be null.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <param name="e">Thrown exception.</param>
-        Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e);
+        Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken);
     }
 }

--- a/FO-DICOM.Core/Network/IDicomNEventReportRequestProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomNEventReportRequestProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
@@ -16,7 +17,8 @@ namespace FellowOakDicom.Network
         /// It requires N-ACTION as the context
         /// </summary>
         /// <param name="request"></param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns></returns>
-        Task OnSendNEventReportRequestAsync(DicomNActionRequest request);
+        Task OnSendNEventReportRequestAsync(DicomNActionRequest request, CancellationToken cancellationToken);
     }
 }

--- a/FO-DICOM.Core/Network/IDicomNServiceProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomNServiceProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
@@ -15,42 +16,48 @@ namespace FellowOakDicom.Network
         /// Handler of N-ACTION request.
         /// </summary>
         /// <param name="request">N-ACTION request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>N-ACTION response based on <paramref name="request"/>.</returns>
-        Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request);
+        Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request, CancellationToken cancellationToken);
 
         /// <summary>
         /// Handler of N-CREATE request.
         /// </summary>
         /// <param name="request">N-CREATE request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>N-CREATE response based on <paramref name="request"/>.</returns>
-        Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request);
+        Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request, CancellationToken cancellationToken);
 
         /// <summary>
         /// Handler of N-DELETE request.
         /// </summary>
         /// <param name="request">N-DELETE request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>N-DELETE response based on <paramref name="request"/>.</returns>
-        Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request);
+        Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request, CancellationToken cancellationToken);
 
         /// <summary>
         /// Handler of N-EVENT-REPORT request.
         /// </summary>
         /// <param name="request">N-EVENT-REPORT request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>N-EVENT-REPORT response based on <paramref name="request"/>.</returns>
-        Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request);
+        Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request, CancellationToken cancellationToken);
 
         /// <summary>
         /// Handler of N-GET request.
         /// </summary>
         /// <param name="request">N-GET request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>N-GET response based on <paramref name="request"/>.</returns>
-        Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request);
+        Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request, CancellationToken cancellationToken);
 
         /// <summary>
         /// Handler of N-SET request.
         /// </summary>
         /// <param name="request">N-SET request subject to handling.</param>
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
         /// <returns>N-SET response based on <paramref name="request"/>.</returns>
-        Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request);
+        Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request, CancellationToken cancellationToken);
     }
 }

--- a/FO-DICOM.Core/Network/IDicomServiceProvider.cs
+++ b/FO-DICOM.Core/Network/IDicomServiceProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
@@ -16,11 +17,13 @@ namespace FellowOakDicom.Network
         /// Callback to invoke when receiving an association request.
         /// </summary>
         /// <param name="association">DICOM association corresponding to the request.</param>
-        Task OnReceiveAssociationRequestAsync(DicomAssociation association);
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken);
 
         /// <summary>
         /// Callback to invoke when receiving an association release request.
         /// </summary>
-        Task OnReceiveAssociationReleaseRequestAsync();
+        /// <param name="cancellationToken">A cancellation token that will trigger when the connection is lost</param>
+        Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken);
     }
 }

--- a/Platform/FO-DICOM.AspNetCore/Server/GeneralPurposeDicomService.cs
+++ b/Platform/FO-DICOM.AspNetCore/Server/GeneralPurposeDicomService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FellowOakDicom.AspNetCore.Server
 {
@@ -33,7 +34,7 @@ namespace FellowOakDicom.AspNetCore.Server
         }
 
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             var builder = UserState as DicomServiceBuilder;
 
@@ -66,7 +67,7 @@ namespace FellowOakDicom.AspNetCore.Server
         }
 
 
-        public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
         {
             var builder = UserState as DicomServiceBuilder;
             if (builder?.EchoHandler == null)
@@ -85,11 +86,11 @@ namespace FellowOakDicom.AspNetCore.Server
         public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
         { }
 
-        public Task OnReceiveAssociationReleaseRequestAsync()
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
            => SendAssociationReleaseResponseAsync();
 
 
-        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
         {
             var builder = UserState as DicomServiceBuilder;
             var resultStatus = DicomStatus.Success;
@@ -107,7 +108,7 @@ namespace FellowOakDicom.AspNetCore.Server
         }
 
 
-        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e) => throw new NotImplementedException();
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken) => throw new NotImplementedException();
 
 
     }

--- a/Tests/FO-DICOM.AspNetCoreTest/Services/MyDicomService.cs
+++ b/Tests/FO-DICOM.AspNetCoreTest/Services/MyDicomService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FO_DICOM.AspNetCoreTest.Services
 {
@@ -20,7 +21,7 @@ namespace FO_DICOM.AspNetCoreTest.Services
         }
 
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach(var context in association.PresentationContexts)
             {
@@ -30,7 +31,7 @@ namespace FO_DICOM.AspNetCoreTest.Services
         }
 
 
-        public Task OnReceiveAssociationReleaseRequestAsync()
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => SendAssociationReleaseResponseAsync();
 
 

--- a/Tests/FO-DICOM.Benchmark/NopCStoreProvider.cs
+++ b/Tests/FO-DICOM.Benchmark/NopCStoreProvider.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom.Network;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FellowOakDicom.Benchmark
 {
@@ -25,7 +26,7 @@ namespace FellowOakDicom.Benchmark
         {
         }
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var presentationContext in association.PresentationContexts)
             {
@@ -39,15 +40,15 @@ namespace FellowOakDicom.Benchmark
             return SendAssociationAcceptAsync(association);
         }
 
-        public Task OnReceiveAssociationReleaseRequestAsync()
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
         {
             return SendAssociationReleaseResponseAsync();
         }
 
-        public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomCStoreResponse(request, DicomStatus.Success));
 
-        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
             => Task.CompletedTask;
 
     }

--- a/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
@@ -250,7 +250,7 @@ namespace FellowOakDicom.Tests.Bugs
 
         public void OnConnectionClosed(Exception exception) { }
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             if (_onAssociationRequest != null)
             {
@@ -269,17 +269,17 @@ namespace FellowOakDicom.Tests.Bugs
             return SendAssociationAcceptAsync(association);
         }
 
-        public Task OnReceiveAssociationReleaseRequestAsync()
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
         {
             return SendAssociationReleaseResponseAsync();
         }
 
-        public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
         {
             return Task.FromResult(_onCStoreRequest(Association, request));
         }
 
-        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/Tests/FO-DICOM.Tests/Bugs/GH1642.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1642.cs
@@ -5,7 +5,9 @@ using FellowOakDicom.Tests.Network;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -60,7 +62,7 @@ namespace FellowOakDicom.Tests.Bugs
         {
         }
 
-        public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
+        public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             yield return new DicomCFindResponse(request, DicomStatus.Pending)
             {
@@ -79,7 +81,7 @@ namespace FellowOakDicom.Tests.Bugs
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -90,7 +92,7 @@ namespace FellowOakDicom.Tests.Bugs
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
         {
             await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
         }

--- a/Tests/FO-DICOM.Tests/Bugs/GH306.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH306.cs
@@ -10,6 +10,7 @@ using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using FellowOakDicom.Tests.Network;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -83,13 +84,13 @@ namespace FellowOakDicom.Tests.Bugs
             {
             }
 
-            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
                 => Task.FromResult(new DicomCStoreResponse(request, DicomStatus.Success));
 
-            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -99,7 +100,7 @@ namespace FellowOakDicom.Tests.Bugs
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 return SendAssociationReleaseResponseAsync();
             }

--- a/Tests/FO-DICOM.Tests/Bugs/VideoCStoreProvider.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/VideoCStoreProvider.cs
@@ -11,6 +11,7 @@ using FellowOakDicom.Imaging.Codec;
 using Xunit;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FellowOakDicom.Tests.Bugs
 {
@@ -32,7 +33,7 @@ namespace FellowOakDicom.Tests.Bugs
         {
         }
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -42,7 +43,7 @@ namespace FellowOakDicom.Tests.Bugs
             return SendAssociationAcceptAsync(association);
         }
 
-        public Task OnReceiveAssociationReleaseRequestAsync()
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
         {
             return SendAssociationReleaseResponseAsync();
         }
@@ -57,7 +58,7 @@ namespace FellowOakDicom.Tests.Bugs
             _storedFiles.Clear();
         }
 
-        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
         {
             var tempName = Path.GetTempFileName();
             Logger.LogInformation(tempName);
@@ -68,7 +69,7 @@ namespace FellowOakDicom.Tests.Bugs
             return new DicomCStoreResponse(request, DicomStatus.Success);
         }
 
-        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
             => Task.CompletedTask;
 
     }

--- a/Tests/FO-DICOM.Tests/Helpers/ConfigurableDicomCEchoProvider.cs
+++ b/Tests/FO-DICOM.Tests/Helpers/ConfigurableDicomCEchoProvider.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom.Network;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FellowOakDicom.Tests.Helpers
 {
@@ -25,7 +26,7 @@ namespace FellowOakDicom.Tests.Helpers
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             var accept = await _onAssociationRequest(association);
 
@@ -48,7 +49,7 @@ namespace FellowOakDicom.Tests.Helpers
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
         {
             await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
         }
@@ -59,7 +60,7 @@ namespace FellowOakDicom.Tests.Helpers
         /// <inheritdoc />
         public void OnConnectionClosed(Exception exception) { }
 
-        public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
         {
             await _onRequest(request);
             return new DicomCEchoResponse(request, DicomStatus.Success);

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
@@ -9,6 +9,7 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -67,7 +68,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -78,7 +79,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -93,7 +94,7 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
         {
             await Task.Yield();
             return new DicomCEchoResponse(request, DicomStatus.Success);

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
@@ -11,6 +11,8 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -101,7 +103,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -112,7 +114,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -127,7 +129,7 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
+        public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
             yield return new DicomCFindResponse(request, DicomStatus.Success);
@@ -145,7 +147,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -156,7 +158,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -171,7 +173,7 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
+        public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
             yield return new DicomCFindResponse(request, DicomStatus.Pending);

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCGetProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCGetProviderTests.cs
@@ -11,6 +11,8 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -103,7 +105,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -114,7 +116,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -129,7 +131,7 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request)
+        public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
             yield return new DicomCGetResponse(request, DicomStatus.Success);
@@ -147,7 +149,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -158,7 +160,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -173,7 +175,7 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request)
+        public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
             yield return new DicomCGetResponse(request, DicomStatus.Pending);

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCMoveProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCMoveProviderTests.cs
@@ -10,6 +10,8 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -69,7 +71,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public virtual async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public virtual async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -80,7 +82,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -95,7 +97,7 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request)
+        public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             await Task.Yield();
             yield return new DicomCMoveResponse(request, DicomStatus.Pending);

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCStoreProviderTests.cs
@@ -10,6 +10,7 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -124,7 +125,7 @@ namespace FellowOakDicom.Tests.Network
             : base(stream, fallbackEncoding, log, dependencies)
         { }
 
-        public override Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public override Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -153,7 +154,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public virtual async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public virtual async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -164,7 +165,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -179,13 +180,13 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
         {
             await Task.Yield();
             return new DicomCStoreResponse(request, DicomStatus.Success);
         }
 
-        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
             => throw new NotImplementedException();
     }
 

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomNServiceProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomNServiceProviderTests.cs
@@ -9,6 +9,7 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -212,7 +213,7 @@ namespace FellowOakDicom.Tests.Network
 
     #region helper classes
 
-    public class AsyncDicomNServiceProvider : DicomService, IDicomServiceProvider, IDicomNServiceProvider
+    public class AsyncDicomNServiceProvider : DicomService, IDicomServiceProvider, IDicomNServiceProvider, IDicomNEventReportRequestProvider
     {
         public AsyncDicomNServiceProvider(INetworkStream stream, Encoding fallbackEncoding, ILogger log,
             DicomServiceDependencies dependencies)
@@ -221,7 +222,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -232,7 +233,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
         /// <inheritdoc />
-        public async Task OnReceiveAssociationReleaseRequestAsync()
+        public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
@@ -247,25 +248,25 @@ namespace FellowOakDicom.Tests.Network
             // do nothing here
         }
 
-        public Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request)
+        public Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNActionResponse(request, DicomStatus.Success));
 
-        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request)
+        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNCreateResponse(request, DicomStatus.Success));
 
-        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request)
+        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNDeleteResponse(request, DicomStatus.Success));
 
-        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request)
+        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNEventReportResponse(request, DicomStatus.Success));
 
-        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request)
+        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNGetResponse(request, DicomStatus.Success));
 
-        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request)
+        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNSetResponse(request, DicomStatus.Success));
 
-        public Task OnSendNEventReportRequestAsync(DicomNActionRequest request)
+        public Task OnSendNEventReportRequestAsync(DicomNActionRequest request, CancellationToken cancellationToken)
             => SendRequestAsync(new DicomNEventReportRequest(DicomUID.StorageCommitmentPushModel, DicomUID.StorageCommitmentPushModel, 2)
             {
                 Dataset = request.Dataset

--- a/Tests/FO-DICOM.Tests/Network/Client/Advanced/AdvancedDicomClientAssociationTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/Advanced/AdvancedDicomClientAssociationTests.cs
@@ -561,7 +561,7 @@ namespace FellowOakDicom.Tests.Network.Client.Advanced
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -582,7 +582,7 @@ namespace FellowOakDicom.Tests.Network.Client.Advanced
                     DicomRejectReason.CalledAENotRecognized);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
                 => SendAssociationReleaseResponseAsync();
 
             public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
@@ -593,7 +593,7 @@ namespace FellowOakDicom.Tests.Network.Client.Advanced
             {
             }
 
-            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
                 => Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success));
         }
     }

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTest.cs
@@ -15,6 +15,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1483,7 +1484,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -1507,7 +1508,7 @@ namespace FellowOakDicom.Tests.Network.Client
                     DicomRejectReason.CalledAENotRecognized);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
                 => SendAssociationReleaseResponseAsync();
 
             public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
@@ -1518,7 +1519,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
                 => Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success));
         }
 
@@ -1539,7 +1540,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -1553,7 +1554,7 @@ namespace FellowOakDicom.Tests.Network.Client
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
                 => SendAssociationReleaseResponseAsync();
 
             public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
@@ -1564,10 +1565,10 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
                 => Task.FromResult(new DicomCStoreResponse(request, DicomStatus.Success));
 
-            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e) => Task.CompletedTask;
+            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken) => Task.CompletedTask;
         }
 
         public class RecordingDicomCEchoProvider : DicomService, IDicomServiceProvider, IDicomCEchoProvider
@@ -1591,7 +1592,7 @@ namespace FellowOakDicom.Tests.Network.Client
             }
 
             /// <inheritdoc />
-            public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -1604,7 +1605,7 @@ namespace FellowOakDicom.Tests.Network.Client
             }
 
             /// <inheritdoc />
-            public async Task OnReceiveAssociationReleaseRequestAsync()
+            public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
             }
@@ -1619,7 +1620,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+            public async Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
             {
                 _requests.Add(request);
 
@@ -1687,7 +1688,7 @@ namespace FellowOakDicom.Tests.Network.Client
             }
 
             /// <inheritdoc />
-            public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -1700,7 +1701,7 @@ namespace FellowOakDicom.Tests.Network.Client
             }
 
             /// <inheritdoc />
-            public async Task OnReceiveAssociationReleaseRequestAsync()
+            public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
             }
@@ -1715,7 +1716,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request)
+            public async IAsyncEnumerable<DicomCGetResponse> OnCGetRequestAsync(DicomCGetRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 _requests.Add(request);
                 yield return new DicomCGetResponse(request, DicomStatus.Pending);

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -989,7 +990,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var presentationContext in association.PresentationContexts)
                 {
@@ -1003,15 +1004,15 @@ namespace FellowOakDicom.Tests.Network.Client
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 return SendAssociationReleaseResponseAsync();
             }
 
-            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
                 => Task.FromResult(new DicomCStoreResponse(request, DicomStatus.Success));
 
-            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
         }
@@ -1036,7 +1037,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var presentationContext in association.PresentationContexts)
                 {
@@ -1050,19 +1051,19 @@ namespace FellowOakDicom.Tests.Network.Client
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 return SendAssociationReleaseResponseAsync();
             }
 
-            public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
+            public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 await Task.Yield();
                 _requests.Add(request);
                 yield break;
             }
 
-            public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request)
+            public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 await Task.Yield();
                 _requests.Add(request);
@@ -1086,7 +1087,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var presentationContext in association.PresentationContexts)
                 {
@@ -1100,12 +1101,12 @@ namespace FellowOakDicom.Tests.Network.Client
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 return SendAssociationReleaseResponseAsync();
             }
 
-            public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
+            public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 await Task.Delay(400);
                 yield return new DicomCFindResponse(request, DicomStatus.Pending);
@@ -1119,7 +1120,7 @@ namespace FellowOakDicom.Tests.Network.Client
                 yield return new DicomCFindResponse(request, DicomStatus.Success);
             }
 
-            public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request)
+            public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 await Task.Delay(400);
                 yield return new DicomCMoveResponse(request, DicomStatus.Pending);
@@ -1154,7 +1155,7 @@ namespace FellowOakDicom.Tests.Network.Client
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var presentationContext in association.PresentationContexts)
                 {
@@ -1168,19 +1169,19 @@ namespace FellowOakDicom.Tests.Network.Client
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 return SendAssociationReleaseResponseAsync();
             }
 
-            public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
+            public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 yield return new DicomCFindResponse(request, DicomStatus.Pending);
                 await Task.Delay(Delay);
                 yield return new DicomCFindResponse(request, DicomStatus.Success);
             }
 
-            public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request)
+            public async IAsyncEnumerable<DicomCMoveResponse> OnCMoveRequestAsync(DicomCMoveRequest request, [EnumeratorCancellation] CancellationToken cancellationToken)
             {
                 yield return new DicomCMoveResponse(request, DicomStatus.Pending);
                 await Task.Delay(Delay);

--- a/Tests/FO-DICOM.Tests/Network/DependencyInjectionTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DependencyInjectionTest.cs
@@ -9,6 +9,7 @@ using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using Xunit;
 
 namespace FellowOakDicom.Tests.Network
@@ -68,7 +69,7 @@ namespace FellowOakDicom.Tests.Network
             _someInterface = someInterface ?? throw new ArgumentNullException(nameof(someInterface));
         }
 
-        public override Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        public override Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
         {
             var response = new DicomCEchoResponse(request, DicomStatus.Success)
             {

--- a/Tests/FO-DICOM.Tests/Network/DicomAcceptedPresentationContextTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomAcceptedPresentationContextTest.cs
@@ -12,6 +12,7 @@ using FellowOakDicom.Network.Client;
 using FellowOakDicom.Printing;
 using FellowOakDicom.Tests.Helpers;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -173,7 +174,7 @@ namespace FellowOakDicom.Tests.Network
         {
         }
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -186,7 +187,7 @@ namespace FellowOakDicom.Tests.Network
             return SendAssociationAcceptAsync(association);
         }
 
-        public Task OnReceiveAssociationReleaseRequestAsync()
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
         {
             return SendAssociationReleaseResponseAsync();
         }
@@ -199,31 +200,31 @@ namespace FellowOakDicom.Tests.Network
         {
         }
 
-        public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomCStoreResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
 
-        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
             => Task.CompletedTask;
 
-        public Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request)
+        public Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNActionResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
 
-        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request)
+        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNCreateResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
 
-        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request)
+        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNDeleteResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
 
-        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request)
+        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNEventReportResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
 
-        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request)
+        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNGetResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
 
-        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request)
+        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomNSetResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
 
-        public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+        public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
             => Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success) { Dataset = request.Dataset });
     }
 

--- a/Tests/FO-DICOM.Tests/Network/DicomCStoreRequestTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomCStoreRequestTest.cs
@@ -7,6 +7,7 @@ using FellowOakDicom.Network.Client;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -72,16 +73,16 @@ namespace FellowOakDicom.Tests.Network
             {
             }
 
-            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+            public Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
             {
                 LastReceivedSopInstance = request.Dataset;
                 return Task.FromResult(new DicomCStoreResponse(request, DicomStatus.Success));
             }
 
-            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+            public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
                 => Task.CompletedTask;
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -91,7 +92,7 @@ namespace FellowOakDicom.Tests.Network
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 return SendAssociationReleaseResponseAsync();
             }

--- a/Tests/FO-DICOM.Tests/Network/DicomNEventReportResponseTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomNEventReportResponseTest.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom.Network.Client;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FellowOakDicom.Tests.Network
 {
@@ -131,7 +132,7 @@ namespace FellowOakDicom.Tests.Network
         {
         }
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -141,7 +142,7 @@ namespace FellowOakDicom.Tests.Network
             return SendAssociationAcceptAsync(association);
         }
 
-        public Task OnReceiveAssociationReleaseRequestAsync() => SendAssociationReleaseResponseAsync();
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken) => SendAssociationReleaseResponseAsync();
 
         public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
         {
@@ -151,7 +152,7 @@ namespace FellowOakDicom.Tests.Network
         {
         }
 
-        public Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request)
+        public Task<DicomNActionResponse> OnNActionRequestAsync(DicomNActionRequest request, CancellationToken cancellationToken)
         {
             /*
             // first return the success-response
@@ -188,7 +189,7 @@ namespace FellowOakDicom.Tests.Network
             return Task.FromResult(new DicomNActionResponse(request, DicomStatus.Success));
         }
 
-        public async Task OnSendNEventReportRequestAsync(DicomNActionRequest request)
+        public async Task OnSendNEventReportRequestAsync(DicomNActionRequest request, CancellationToken cancellationToken)
         {
             // synchronously send NEvents
             if (request.Dataset.Contains(DicomTag.ReferencedSOPSequence))
@@ -212,11 +213,11 @@ namespace FellowOakDicom.Tests.Network
             }
         }
 
-        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request) => throw new NotImplementedException();
-        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request) => throw new NotImplementedException();
-        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request) => throw new NotImplementedException();
-        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request) => throw new NotImplementedException();
-        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request) => throw new NotImplementedException();
+        public Task<DicomNCreateResponse> OnNCreateRequestAsync(DicomNCreateRequest request, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<DicomNDeleteResponse> OnNDeleteRequestAsync(DicomNDeleteRequest request, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<DicomNEventReportResponse> OnNEventReportRequestAsync(DicomNEventReportRequest request, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<DicomNGetResponse> OnNGetRequestAsync(DicomNGetRequest request, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<DicomNSetResponse> OnNSetRequestAsync(DicomNSetRequest request, CancellationToken cancellationToken) => throw new NotImplementedException();
 
     }
 }

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -868,7 +868,7 @@ namespace FellowOakDicom.Tests.Network
             }
 
             /// <inheritdoc />
-            public async Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public async Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -879,7 +879,7 @@ namespace FellowOakDicom.Tests.Network
             }
 
             /// <inheritdoc />
-            public async Task OnReceiveAssociationReleaseRequestAsync()
+            public async Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             {
                 await SendAssociationReleaseResponseAsync().ConfigureAwait(false);
             }
@@ -894,7 +894,7 @@ namespace FellowOakDicom.Tests.Network
             {
             }
 
-            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
             {
                 return Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success));
             }

--- a/Tests/FO-DICOM.Tests/Network/DicomUserIdentityNegotiationTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomUserIdentityNegotiationTest.cs
@@ -883,7 +883,7 @@ namespace FellowOakDicom.Tests.Network
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -935,7 +935,7 @@ namespace FellowOakDicom.Tests.Network
                     DicomRejectReason.NoReasonGiven);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
                 => SendAssociationReleaseResponseAsync();
 
             public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
@@ -946,7 +946,7 @@ namespace FellowOakDicom.Tests.Network
             {
             }
 
-            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
                 => Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success));
         }
 
@@ -958,7 +958,7 @@ namespace FellowOakDicom.Tests.Network
             {
             }
 
-            public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
             {
                 foreach (var pc in association.PresentationContexts)
                 {
@@ -971,7 +971,7 @@ namespace FellowOakDicom.Tests.Network
                 return SendAssociationAcceptAsync(association);
             }
 
-            public Task OnReceiveAssociationReleaseRequestAsync()
+            public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
                 => SendAssociationReleaseResponseAsync();
 
             public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
@@ -982,7 +982,7 @@ namespace FellowOakDicom.Tests.Network
             {
             }
 
-            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request)
+            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request, CancellationToken cancellationToken)
                 => Task.FromResult(new DicomCEchoResponse(request, DicomStatus.Success));
         }
     }

--- a/Tests/FO-DICOM.Tests/Network/SimpleCStoreProvider.cs
+++ b/Tests/FO-DICOM.Tests/Network/SimpleCStoreProvider.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FellowOakDicom.Tests.Network
 {
@@ -52,7 +53,7 @@ namespace FellowOakDicom.Tests.Network
         {
         }
 
-        public Task OnReceiveAssociationRequestAsync(DicomAssociation association)
+        public Task OnReceiveAssociationRequestAsync(DicomAssociation association, CancellationToken cancellationToken)
         {
             foreach (var pc in association.PresentationContexts)
             {
@@ -63,7 +64,7 @@ namespace FellowOakDicom.Tests.Network
             return SendAssociationAcceptAsync(association);
         }
 
-        public Task OnReceiveAssociationReleaseRequestAsync()
+        public Task OnReceiveAssociationReleaseRequestAsync(CancellationToken cancellationToken)
             => SendAssociationReleaseResponseAsync();
 
         public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
@@ -76,7 +77,7 @@ namespace FellowOakDicom.Tests.Network
             _storedFiles.Clear();
         }
 
-        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request)
+        public async Task<DicomCStoreResponse> OnCStoreRequestAsync(DicomCStoreRequest request, CancellationToken cancellationToken)
         {
             var tempName = Path.GetTempFileName();
             Logger.LogInformation(tempName);
@@ -95,7 +96,7 @@ namespace FellowOakDicom.Tests.Network
             };
         }
 
-        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e)
+        public Task OnCStoreRequestExceptionAsync(string tempFileName, Exception e, CancellationToken cancellationToken)
             => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Fixes #1810 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Use a `CancellationToken` inside DicomService that triggers when the connection is closed
- Use this new `CancellationToken` in various methods like `OnCStoreRequestAsync` to stop performing work ASAP when the connection is closed
- This is a breaking change:
  - The signatures of IDicomCStoreProvider, IDicomCFindProvider, have changed with the addition of CancellationToken. Even if I made the cancellation token an optional parameter (it currently isn't), it would still require fo-dicom consumers to go and update their classes
  - The behavior of DicomService has changed. It will now short-circuit in multiple scenarios in case the connection is lost. While I consider this "better" than the current behavior, we might be breaking someone's workflow.

@gofal and @mrbean-bremen I'm interested in your thoughts on this one. Is this a good idea? If the risk is too high, we might be able to make this whole thing optional behind a config setting. If cancellation support is "disabled", we would just pass around CancellationToken.None
