### PR TITLE
Explicitly mention the support of net8 and reference net8 in test projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,17 @@ jobs:
           name: test-v5-net-60.xml
           path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet60.xml
       
-  net-70:
+  net-80:
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
     - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net7.0-windows --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet70.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net8.0-windows --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet80.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-          name: test-v5-net-70.xml
-          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet70.xml
+          name: test-v5-net-80.xml
+          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet80.xml
     - name: Upload code coverage 
       uses: codecov/codecov-action@v4
       env:
@@ -57,9 +57,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build FO-DICOM..Benchmark
-      run: dotnet build ./Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj --configuration Release --framework net7.0
+      run: dotnet build ./Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj --configuration Release --framework net8.0
     - name: run benchmarks
-      run: ./Tests/FO-DICOM.Benchmark/bin/Release/net7.0/fo-dicom.Benchmark.exe
+      run: ./Tests/FO-DICOM.Benchmark/bin/Release/net8.0/fo-dicom.Benchmark.exe
     - name: Upload benchmark log
       uses: actions/upload-artifact@v4
       with:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 ### 5.1.4 (TBD)
 
 - Add support for saving new strings with multi-valued Specific Character Set (#1789)
+- FO-DICOM.Tests target net8.0-windows instead of net7.0-windows
 
 ### 5.1.3 (2024-06-27)
 

--- a/Documentation/FO-DICOM.Documentation.DocFx.csproj
+++ b/Documentation/FO-DICOM.Documentation.DocFx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>FO_DICOM.Documentation.DocFx</RootNamespace>
     <DocfxConfigFile>$(MSBuildProjectDirectory)/v5/docfx.json</DocfxConfigFile>
   </PropertyGroup>

--- a/Platform/FO-DICOM.Imaging.Desktop/FO-DICOM.Imaging.Desktop.csproj
+++ b/Platform/FO-DICOM.Imaging.Desktop/FO-DICOM.Imaging.Desktop.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <RootNamespace>FellowOakDicom.Imaging.Desktop</RootNamespace>
     <AssemblyName>fo-dicom.Imaging.Desktop</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Platform/FO-DICOM.Imaging.ImageSharp/FO-DICOM.Imaging.ImageSharp.csproj
+++ b/Platform/FO-DICOM.Imaging.ImageSharp/FO-DICOM.Imaging.ImageSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <RootNamespace>FellowOakDicom</RootNamespace>
     <AssemblyName>fo-dicom.Imaging.ImageSharp</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library is licensed under the [Microsoft Public License (MS-PL)](http://ope
 
 Fellow Oak DICOM officially supports the following runtimes:
 
-* .NET Core 7.0
+* .NET Core 8.0
 * .NET Core 6.0
 * .NET Framework 4.6.2
 

--- a/READMENuget.md
+++ b/READMENuget.md
@@ -24,7 +24,7 @@ This library is licensed under the [Microsoft Public License (MS-PL)](http://ope
 
 Fellow Oak DICOM officially supports the following runtimes:
 
-* .NET Core 7.0
+* .NET Core 8.0
 * .NET Core 6.0
 * .NET Framework 4.6.2
 

--- a/Tests/FO-DICOM.AspNetCoreTest/FO-DICOM.AspNetCoreTest.csproj
+++ b/Tests/FO-DICOM.AspNetCoreTest/FO-DICOM.AspNetCoreTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>FO_DICOM.AspNetCoreTest</RootNamespace>
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
+++ b/Tests/FO-DICOM.Benchmark/FO-DICOM.Benchmark.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>FellowOakDicom.Benchmark</RootNamespace>
     <AssemblyName>FO-DICOM.Benchmark</AssemblyName>
     <LangVersion>Latest</LangVersion>

--- a/Tests/FO-DICOM.Benchmark/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Tests/FO-DICOM.Benchmark/Properties/PublishProfiles/FolderProfile.pubxml
@@ -9,7 +9,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 </Project>

--- a/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
+++ b/Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0-windows;net8.0-windows</TargetFrameworks>
     <RootNamespace>FellowOakDicom.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/Tools/FO-DICOM.Dump/FO-DICOM.Dump.csproj
+++ b/Tools/FO-DICOM.Dump/FO-DICOM.Dump.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>FellowOakDicom.Dump</RootNamespace>
     <UseWPF>true</UseWPF>
     <AssemblyName>fo-dicom.Dump</AssemblyName>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.0",
+    "version": "8.0.0",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Fixes #1809 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- everywhere, where net7 has been referenced or mentioned, net8 is now referenced instead
