### PR TITLE
DicomDataset.GetDicomItem should not throw exception

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 ### 5.1.4 (TBD)
 
 - Add support for saving new strings with multi-valued Specific Character Set (#1789)
+- Fix bug where DicomDataset.GetDicomTag thew an exception if the private tag does not exist in dataset (#1840)
 
 ### 5.1.3 (2024-06-27)
 

--- a/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
@@ -634,9 +634,9 @@ namespace FellowOakDicom.Tests
             var dataset = new DicomDataset();
 
             // <tag group="0019" element="100d" vr="DS" vm="1">AP Offcenter</tag> is known private tag
-            var privateTag = new DicomTag(0x0019, 0x100a,"PHILIPS MR/PART");
+            var privateTag = new DicomTag(0x0019, 0x100a, "PHILIPS MR/PART");
 
-            dataset.Add<int>(privateTag,1);
+            dataset.Add<int>(privateTag, 1);
 
             Assert.Equal(privateTag, dataset.GetDicomItem<DicomItem>(privateTag).Tag);
         }
@@ -670,13 +670,28 @@ namespace FellowOakDicom.Tests
             var dataset = new DicomDataset();
 
             // <tag group="0019" element="100d" vr="DS" vm="1">AP Offcenter</tag> is known private tag
-            var privateTag = new DicomTag(0x0019, 0x100a,"PHILIPS MR/PART");
+            var privateTag = new DicomTag(0x0019, 0x100a, "PHILIPS MR/PART");
 
-            dataset.AddOrUpdate<int>(privateTag,1);
+            dataset.AddOrUpdate<int>(privateTag, 1);
 
             Assert.Equal(privateTag, dataset.GetDicomItem<DicomItem>(privateTag).Tag);
         }
 
+        [Fact]
+        public void Get_NonExistingPrivateTag_ShouldNotThrow()
+        {
+            var dataset = new DicomDataset();
+
+            // <tag group="0019" element="100d" vr="DS" vm="1">AP Offcenter</tag> is known private tag
+            var privateTagWithExplicitElement = new DicomTag(0x0019, 0x100a);
+            var privateTagWithPrivateCreator = new DicomTag(0x0019, 0x000a, "PHILIPS MR/PART");
+
+            var item = dataset.GetDicomItem<DicomItem>(privateTagWithExplicitElement);
+            Assert.Null(item);
+
+            item = dataset.GetDicomItem<DicomItem>(privateTagWithPrivateCreator);
+            Assert.Null(item);
+        }
 
         [Fact]
         public void Get_ByteArrayFromStringElement_ReturnsValidArray()


### PR DESCRIPTION
Fixes #1840 

The method `DicomDataset.GetDicomItem` behaved inconsistently. As described in the documentation the method most of the time returned null if a dicomtag was requested that is not present in the DicomDataset. but under certain circumastances getting a private tag that not exists threw an exception. This is now fixed.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

