### PR TITLE
Add unittest for validation of PN length

### DIFF
--- a/Tests/FO-DICOM.Tests/DicomValidationTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomValidationTest.cs
@@ -292,6 +292,20 @@ namespace FellowOakDicom.Tests
                 ds.AddOrUpdate(DicomTag.ReferringPhysicianName, "Doe^John^^^Ph.D.^Junior"));
         }
 
+        [Fact]
+        public void DicomValidation_ValidatePNLength()
+        {
+            // normal Length
+            var ds = new DicomDataset { { DicomTag.PatientName, "Doe^John=Doe^John=Doe^John" } };
+
+            // Length of one component group increases 64 characters
+            Assert.Throws<DicomValidationException>(() =>
+                ds.AddOrUpdate(DicomTag.PatientName, "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVery^Long"));
+
+            // 2 component groups, each of them shorter than 64 characters, but together more than 64 characters
+            ds.AddOrUpdate(DicomTag.OtherPatientNames, "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVery^Long=VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVery^Long");
+        }
+
         #endregion
 
     }


### PR DESCRIPTION
Fixes #1820  .

This unittest validates, that the validation of the length of component groups already works as defined in DICOM standard

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

