### PR TITLE
Turn off validation when building temporary Dataset with values from Functional Groups

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Fix bug where under some circumstances (transcode a 8 bit image with odd row or column length from explicit to implicit TS) a odd length pixeldata is written (#1403)
 - Fix bug where DicomDataset.GetDicomTag thew an exception if the private tag does not exist in dataset (#1840)
 - FO-DICOM.Tests target net8.0-windows instead of net7.0-windows
+- Fix rendering of EnhancedMR or EnhancedCT images, that contain any invalid value in any item within the Functional Groups (#1862)
 
 ### 5.1.3 (2024-06-27)
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -788,9 +788,9 @@ namespace FellowOakDicom
 
         public DicomDataset FunctionalGroupValues(int frame)
         {
-            // If validation is disabled on the current data set
-            // it should also be disabled on the new dataset we create here
-            // because we will be copying data over from one to the other
+            // Validation should be disabled, because we will be copying data over from another dataset.
+            // that means, these values are either loaded from a source, or they have already been
+            // validated.
             var functionalDs = new DicomDataset { ValidateItems = false };
 
             // gets all items from SharedFunctionalGroups

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -791,7 +791,7 @@ namespace FellowOakDicom
             // If validation is disabled on the current data set
             // it should also be disabled on the new dataset we create here
             // because we will be copying data over from one to the other
-            var functionalDs = new DicomDataset { ValidateItems = ValidateItems };
+            var functionalDs = new DicomDataset { ValidateItems = false };
 
             // gets all items from SharedFunctionalGroups
             if (TryGetSequence(DicomTag.SharedFunctionalGroupsSequence, out var sharedFunctionalGroupsSequence))


### PR DESCRIPTION
Fixes #1862 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Turn off validation when building temporary Dataset with values from Functional Groups
