### PR TITLE
Make sure the default encoding is used as fallback on writing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 ### 5.1.5 (TBD)
+  - Fix regression which caused an exception if writing with an empty SpecificCharacterSet tag (#1879)
 
 
 ### 5.1.4 (2024-10-27)

--- a/FO-DICOM.Core/DicomEncoding.cs
+++ b/FO-DICOM.Core/DicomEncoding.cs
@@ -50,7 +50,7 @@ namespace FellowOakDicom
         /// <param name="charsets">List of character sets.</param>
         /// <returns>String encodings.</returns>
         public static Encoding[] GetEncodings(string[] charsets) =>
-            charsets.Select(GetEncoding).ToArray();
+            charsets.Length > 0 ? charsets.Select(GetEncoding).ToArray() : DefaultArray;
 
         /// <summary>
         /// Get encoding from Specific Character Set attribute value.
@@ -110,7 +110,7 @@ namespace FellowOakDicom
         /// <param name="encodings">The list of non-strict encodings.</param>
         /// <returns>Array of string encoding.</returns>
         private static Encoding[] GetStrictEncodings(Encoding[] encodings) =>
-            encodings.Select(StrictEncoding).ToArray();
+            encodings.Length > 0 ? encodings.Select(StrictEncoding).ToArray() : DefaultArray;
 
         private static Encoding StrictEncoding(Encoding encoding)
         {


### PR DESCRIPTION
- fixes #1879 (regression introduced in #1791)

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation - n/a
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

Completely had missed this case during writing (while it correctly works during reading).