### PR TITLE
GH-1884

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,7 @@
 - Fix bug where DicomDataset.GetDicomTag thew an exception if the private tag does not exist in dataset (#1840)
 - FO-DICOM.Tests target net8.0-windows instead of net7.0-windows
 - Fix rendering of EnhancedMR or EnhancedCT images, that contain any invalid value in any item within the Functional Groups (#1862)
-- Fix issue where DicomDataset.FunctionalGroupValues throws IndexOutOfBounds in case of en empty SharedFunctionalGroupSequence (#1884)
+- Fix issue where DicomDataset.FunctionalGroupValues throws IndexOutOfBounds in case of an empty SharedFunctionalGroupSequence (#1884)
 
 ### 5.1.3 (2024-06-27)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
 - Fix bug where DicomDataset.GetDicomTag thew an exception if the private tag does not exist in dataset (#1840)
 - FO-DICOM.Tests target net8.0-windows instead of net7.0-windows
 - Fix rendering of EnhancedMR or EnhancedCT images, that contain any invalid value in any item within the Functional Groups (#1862)
+- Fix issue where DicomDataset.FunctionalGroupValues throws IndexOutOfBounds in case of en empty SharedFunctionalGroupSequence (#1884)
 
 ### 5.1.3 (2024-06-27)
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -794,7 +794,8 @@ namespace FellowOakDicom
             var functionalDs = new DicomDataset { ValidateItems = false };
 
             // gets all items from SharedFunctionalGroups
-            if (TryGetSequence(DicomTag.SharedFunctionalGroupsSequence, out var sharedFunctionalGroupsSequence))
+            if (TryGetSequence(DicomTag.SharedFunctionalGroupsSequence, out var sharedFunctionalGroupsSequence)
+                && sharedFunctionalGroupsSequence.Items.Count > 0)
             {
                 var sharedFunctionGroupItem = sharedFunctionalGroupsSequence.Items[0] ?? throw new DicomDataException("unexpected empty SharedFunctionalGroupsSequence");
                 foreach (var sequence in sharedFunctionGroupItem.OfType<DicomSequence>())
@@ -806,16 +807,20 @@ namespace FellowOakDicom
                     else
                     {
                         // skip empty sequences
-                        if (sequence.Items.Count > 0)
+                        if (sequence.Items.Count <= 0)
                         {
-                            foreach (var item in sequence.Items[0])
-                            {
-                                functionalDs.AddOrUpdate(item);
-                            }
+                            continue;
+                        }
+
+                        foreach (var item in sequence.Items[0])
+                        {
+                            functionalDs.AddOrUpdate(item);
                         }
                     }
                 }
             }
+            
+            // gets the specific items from PerFrameFunctionalGroups for this frame
             if (TryGetSequence(DicomTag.PerFrameFunctionalGroupsSequence, out var perFrameFunctionalGroupsSequence)
                 && perFrameFunctionalGroupsSequence.Items.Count > frame)
             {
@@ -829,17 +834,20 @@ namespace FellowOakDicom
                     else
                     {
                         // skip empty sequences
-                        if (sequence.Items.Count > 0)
+                        if (sequence.Items.Count <= 0)
                         {
-                            foreach (var item in sequence.Items[0])
-                            {
-                                functionalDs.AddOrUpdate(item);
-                            }
+                            continue;
+                        }
+
+                        foreach (var item in sequence.Items[0])
+                        {
+                            functionalDs.AddOrUpdate(item);
                         }
                     }
                 }
 
             }
+            
             return functionalDs;
         }
 

--- a/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
@@ -901,6 +901,21 @@ namespace FellowOakDicom.Tests
             );
             Assert.False(dataset.TryGetSingleValue(DicomTag.SeriesNumber, out int _));
         }
+        
+        [Fact]
+        public void FunctionalGroupValues_ShouldNotCrashWithEmptySharedFunctionalGroupsSequence()
+        {
+            //Arrange
+            var dataset = new DicomDataset();
+            var sequence = new DicomSequence(DicomTag.SharedFunctionalGroupsSequence);
+            dataset.Add(sequence);
+            
+            //Act
+            var result = dataset.FunctionalGroupValues(0);
+            
+            //Assert
+            Assert.Empty(result);
+        }
 
         #endregion
 


### PR DESCRIPTION
fix index out of bounds in FunctionalGroupValues in case of an empty SharedFunctionalGroupsSequence

Fixes #1884 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Don't crash in case of an empty SharedFunctionalGroupsSequence in DicomDataset.FunctionalGroupValues, just skip the sequence
