### PR TITLE
Fix test run to use the correct target framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,55 +9,42 @@ on:
     - development
   workflow_dispatch:
 
-jobs:
-  net-462:
-    runs-on: windows-2022
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build FO-DICOM.Core
-      run: dotnet build ./FO-DICOM.Core/FO-DICOM.Core.csproj --configuration Release --runtime win-x64
-    - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net462 --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet462.xml"
-    - name: Test FO-DICOM.Tests.Windows
-      run: dotnet test ./Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj --configuration Release --framework net462 --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet462.xml"
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      with:
-          name: test-v5-net-462.xml
-          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet462.xml
-      
-  net-60:
-    runs-on: windows-2022
+jobs:  
+  tests:
+    runs-on: ${{ matrix.os.ver }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ { name: Windows, ver: windows-latest } ]
+        frameworks: [
+           { name: ".NET Framework 4.6.2", common: "net462", win: "net462", coverage: "" },
+           { name: ".NET 6.0", common: "net6.0", win: "net6.0-windows", coverage: '' },
+           { name: ".NET 8.0", common: "net8.0", win: "net8.0-windows", coverage: '--collect:"XPlat Code Coverage" --settings coverlet.runsettings' }
+        ]
+    name: ${{ matrix.os.name }} (${{ matrix.frameworks.name }})
+
     steps:
     - uses: actions/checkout@v4
     - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net6.0-windows --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet60.xml"
-    - name: Test FO-DICOM.Tests.Windows
-      run: dotnet test ./Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj --configuration Release --framework net6.0-windows --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet60.xml"
+      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework ${{ matrix.frameworks.common }} --blame --runtime win-x64 --logger:"trx;LogFileName=.\results${{ matrix.frameworks.common }}.xml" ${{ matrix.frameworks.coverage }}
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-          name: test-v5-net-60.xml
-          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet60.xml
-      
-  net-80:
-    runs-on: windows-2022
-    steps:
-    - uses: actions/checkout@v4
-    - name: Test FO-DICOM.Tests
-      run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework net8.0-windows --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet80.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+          name: test-v5-${{ matrix.frameworks.common }}.xml
+          path: ./Tests/FO-DICOM.Tests/TestResults/results${{ matrix.frameworks.common }}.xml
     - name: Test FO-DICOM.Tests.Windows
-      run: dotnet test ./Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj --configuration Release --framework net8.0-windows --blame --runtime win-x64 --logger:"trx;LogFileName=.\resultsnet80.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+      run: dotnet test ./Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj --configuration Release --framework ${{ matrix.frameworks.win }} --blame --runtime win-x64 --logger:"trx;LogFileName=.\results-win-${{ matrix.frameworks.common }}.xml" ${{ matrix.frameworks.coverage }}
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-          name: test-v5-net-80.xml
-          path: ./Tests/FO-DICOM.Tests/TestResults/resultsnet80.xml
-    - name: Upload code coverage 
+          name: test-v5-${{ matrix.frameworks.win }}.xml
+          path: ./Tests/FO-DICOM.Tests/TestResults/results-win-${{ matrix.frameworks.common }}.xml
+    - name: Upload code coverage
+      if: matrix.frameworks.coverage != ''
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
+  
   benchmarks:
     runs-on: windows-2022
     steps:
@@ -74,4 +61,3 @@ jobs:
           ./BenchmarkDotNet.Artifacts/
           ./BenchmarkDotNet.Artifacts/results/
  
-


### PR DESCRIPTION
-  also use a matrix build instead of separate steps

This PR was initially to fix the code coverage by merging the results, but it turned out that the coverage worked fine, just the tests were not executed.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I am listed in the CONTRIBUTORS file
