### PR TITLE
Handle invalid DS values that where created with a wrong culture

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 - **Breaking change**: IByteSource interface has changed
 - VOI LUT Function with empty value causes a crash (#1891)
 - DicomElement.ValueRepresentation.ValidateString() now throws a DicomValidationException if a null value is passed (#1590)
+- Handle invalid DICOM files, that contain the german "," as decimal separator in DS values (#1296)
 
 ### 5.1.5 (2024-11-25)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 - **Breaking change**: IByteSource interface has changed
 - VOI LUT Function with empty value causes a crash (#1891)
 - DicomElement.ValueRepresentation.ValidateString() now throws a DicomValidationException if a null value is passed (#1590)
-- Handle invalid DICOM files, that contain the german "," as decimal separator in DS values (#1296)
+- Handle invalid DICOM files, that contain "," as decimal separator in DS values (#1296)
 
 ### 5.1.5 (2024-11-25)
 

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -873,7 +873,7 @@ namespace FellowOakDicom
             {
                 _values =
                     base.Get<string[]>()
-                        // #1296 some invalid file shave the german "," as decimal separator. because a comma is no valid character in DS, this cannot be misinterpretated and it is obvious to replace it by "."
+                        // #1296 some invalid files have "," as decimal separator. because a comma is no valid character in DS, this cannot be misinterpretated and it is obvious to replace it by "."
                         .Select(x => decimal.Parse(x.Replace(',','.'), NumberStyles.Any, CultureInfo.InvariantCulture))
                         .ToArray();
             }

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -873,7 +873,8 @@ namespace FellowOakDicom
             {
                 _values =
                     base.Get<string[]>()
-                        .Select(x => decimal.Parse(x, NumberStyles.Any, CultureInfo.InvariantCulture))
+                        // #1296 some invalid file shave the german "," as decimal separator. because a comma is no valid character in DS, this cannot be misinterpretated and it is obvious to replace it by "."
+                        .Select(x => decimal.Parse(x.Replace(',','.'), NumberStyles.Any, CultureInfo.InvariantCulture))
                         .ToArray();
             }
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH1296.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1296.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using Xunit;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    public class GH1296
+    {
+
+        [Fact]
+        public void OpenFileWithGermanNumbers()
+        {
+            // Arrange
+            var inputFile = DicomFile.Open(TestData.Resolve("GH1296.dcm"));
+
+            var expectedWindowCenter = 20958;
+            var actualWindowCenter = inputFile.Dataset.GetValue<double>(DicomTag.WindowCenter, 0);
+
+            Assert.Equal(expectedWindowCenter, actualWindowCenter, 0.001);
+        }
+
+    }
+}

--- a/Tests/FO-DICOM.Tests/Bugs/GH1296.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1296.cs
@@ -10,7 +10,7 @@ namespace FellowOakDicom.Tests.Bugs
     {
 
         [Fact]
-        public void OpenFileWithGermanNumbers()
+        public void OpenFileWithDSNumbersEncodedInCulture()
         {
             // Arrange
             var inputFile = DicomFile.Open(TestData.Resolve("GH1296.dcm"));


### PR DESCRIPTION
Fixes #1296 

there seem to be some invalid DICOM files, where the decimal string is encoded with the wrong culture and a "," is used instead a "." as decimal separator.
Because "," is an invalid character in DS, there is no risk of misinterpreting this character. So if there is a ",", then it safely can be replaced by a ".".

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- before parsing the string value, each "," are replaced by "."
