### PR TITLE
Add the AffectedSopInstanceUID in CStoreResponse by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 - **Breaking change**: IByteSource interface has changed
 - VOI LUT Function with empty value causes a crash (#1891)
 - DicomElement.ValueRepresentation.ValidateString() now throws a DicomValidationException if a null value is passed (#1590)
+- The optional AffectedSopInstanceUID is added to the CStoreResponse by default. (#1390)
 - Handle invalid DICOM files, that contain "," as decimal separator in DS values (#1296)
 
 ### 5.1.5 (2024-11-25)

--- a/FO-DICOM.Core/Network/DicomCStoreResponse.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreResponse.cs
@@ -29,6 +29,25 @@ namespace FellowOakDicom.Network
         public DicomCStoreResponse(DicomCStoreRequest request, DicomStatus status)
             : base(request, status)
         {
+            AffectedSOPInstanceUID = request.SOPInstanceUID;
+        }
+
+
+        /// <summary>Gets the SOP Instance UID of the DICOM file associated with this DICOM C-Store request.</summary>
+        public DicomUID AffectedSOPInstanceUID
+        {
+            get => Command.GetSingleValueOrDefault<DicomUID>(DicomTag.AffectedSOPInstanceUID, null);
+            set
+            {
+                if (value == null)
+                {
+                    Command.Remove(DicomTag.AffectedSOPInstanceUID);
+                }
+                else
+                {
+                    Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
+                }
+            }
         }
     }
 }

--- a/FO-DICOM.Core/Network/DicomCStoreResponse.cs
+++ b/FO-DICOM.Core/Network/DicomCStoreResponse.cs
@@ -45,6 +45,7 @@ namespace FellowOakDicom.Network
                 }
                 else
                 {
+                    using var unvalidatedCommand = new UnvalidatedScope(Command);
                     Command.AddOrUpdate(DicomTag.AffectedSOPInstanceUID, value);
                 }
             }

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -262,7 +262,11 @@ namespace FellowOakDicom.Tests.Network
                 DicomStatus status = null;
                 var request = new DicomCStoreRequest(TestData.Resolve("CT-MONO2-16-ankle"))
                 {
-                    OnResponseReceived = (req, res) => status = res.Status
+                    OnResponseReceived = (req, res) =>
+                    {
+                        status = res.Status;
+                        Assert.Equal(req.SOPInstanceUID, res.AffectedSOPInstanceUID);
+                    }
                 };
 
                 var client = DicomClientFactory.Create("127.0.0.1", port, false, "SCU", "ANY-SCP");


### PR DESCRIPTION
Fixes #1390 

The command of a CStoreResponse has an optional tag AffectedSopInstnaceUID. Some pacs-systems still require this tag and therefore the user would have to add it manually in the DicomServer.
Now this tag is added to the response by default.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the constructor of CStoreResponse immediatelly takes the value from CStoreRequest and copies it to the command.
