### PR TITLE
DicomSequence can be passed as parameter type in DicomDataset.AddOrUpdate

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - DicomElement.ValueRepresentation.ValidateString() now throws a DicomValidationException if a null value is passed (#1590)
 - The optional AffectedSopInstanceUID is added to the CStoreResponse by default. (#1390)
 - Handle invalid DICOM files, that contain "," as decimal separator in DS values (#1296)
+- DicomDataset.AddOrUpdate also allows passing DicomSequence as argument type (#1664)
 
 ### 5.1.5 (2024-11-25)
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -1438,6 +1438,7 @@ namespace FellowOakDicom
             if (vr == DicomVR.SQ)
             {
                 if (values == null) return DoAdd(new DicomSequence(tag), allowUpdate);
+                if (typeof(T) == typeof(DicomSequence) && values.Count == 1) return DoAdd(new DicomSequence(tag, (values[0] as DicomSequence).Items.ToArray()), allowUpdate);
                 if (typeof(T) == typeof(DicomContentItem)) return DoAdd(new DicomSequence(tag, values.Cast<DicomContentItem>().Select(x => x.Dataset).ToArray()), allowUpdate);
                 if (typeof(T) == typeof(DicomDataset) || typeof(T) == typeof(DicomCodeItem)
                     || typeof(T) == typeof(DicomMeasuredValue) || typeof(T) == typeof(DicomReferencedSOP)) return DoAdd(new DicomSequence(tag, values.Cast<DicomDataset>().ToArray()), allowUpdate);

--- a/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
@@ -642,6 +642,38 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void AddOrUpdate_Sequence_ViaDicomdatasets()
+        {
+            var dataset = new DicomDataset();
+            dataset.AddOrUpdate(DicomTag.ReferencedStudySequence,
+                new DicomDataset { { DicomTag.ReferencedSOPClassUID, DicomUID.CTImageStorage }, { DicomTag.ReferencedSOPInstanceUID, DicomUID.Generate() } },
+                new DicomDataset { { DicomTag.ReferencedSOPClassUID, DicomUID.CTImageStorage }, { DicomTag.ReferencedSOPInstanceUID, DicomUID.Generate() } }
+                    );
+
+            var refSequence = dataset.GetSequence(DicomTag.ReferencedStudySequence);
+            Assert.NotNull(refSequence);
+            Assert.Equal(2, refSequence.Count());
+            Assert.Equal(DicomUID.CTImageStorage, refSequence.ElementAt(0).GetSingleValue<DicomUID>(DicomTag.ReferencedSOPClassUID));
+        }
+
+        [Fact]
+        public void AddOrUpdate_Sequence_ViaDicomsequence()
+        {
+            var seq = new DicomSequence(DicomTag.ReferencedStudySequence,
+                new DicomDataset { { DicomTag.ReferencedSOPClassUID, DicomUID.CTImageStorage }, { DicomTag.ReferencedSOPInstanceUID, DicomUID.Generate() } },
+                new DicomDataset { { DicomTag.ReferencedSOPClassUID, DicomUID.CTImageStorage }, { DicomTag.ReferencedSOPInstanceUID, DicomUID.Generate() } }
+                    );
+
+            var dataset = new DicomDataset();
+            dataset.AddOrUpdate(DicomTag.ReferencedStudySequence, seq);
+
+            var refSequence = dataset.GetSequence(DicomTag.ReferencedStudySequence);
+            Assert.NotNull(refSequence);
+            Assert.Equal(2, refSequence.Count());
+            Assert.Equal(DicomUID.CTImageStorage, refSequence.ElementAt(0).GetSingleValue<DicomUID>(DicomTag.ReferencedSOPClassUID));
+        }
+
+        [Fact]
         public void AddOrUpdate_PrivateTagWithoutExplicitVR_ShouldThrow()
         {
             var dataset = new DicomDataset();


### PR DESCRIPTION
Fixes #1664 

When working with Structured Reports with the lot of nested DicomSequence, then it is a nice convenience enhancements, when DicomDataset also takes DicomSequence as parameter for AddOrUpdate

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
