### PR TITLE
Fix bug, where miliseconds are cut off if a DateTime is added to a DicomDataset

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 - refactor the parser to make it better maintainable
 - **Breaking change**: IByteSource interface has changed
 - VOI LUT Function with empty value causes a crash (#1891)
+- Fixed bug, where milliseconds have been cut away when adding a Datetime to a DicomDataset (#1719)
 - DicomElement.ValueRepresentation.ValidateString() now throws a DicomValidationException if a null value is passed (#1590)
 - The optional AffectedSopInstanceUID is added to the CStoreResponse by default. (#1390)
 - Handle invalid DICOM files, that contain "," as decimal separator in DS values (#1296)

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -807,18 +807,15 @@ namespace FellowOakDicom
         {
             get
             {
-                if (_formats == null)
+                _formats ??= new[]
                 {
-                    _formats = new[]
-                                   {
-                                        "yyyyMMdd",
-                                        "yyyy.MM.dd",
-                                        "yyyy/MM/dd",
-                                        "yyyy",
-                                        "yyyyMM",
-                                        "yyyy.MM"
-                                   };
-                }
+                    "yyyyMMdd",
+                    "yyyy.MM.dd",
+                    "yyyy/MM/dd",
+                    "yyyy",
+                    "yyyyMM",
+                    "yyyy.MM"
+                };
                 return _formats;
             }
         }
@@ -934,12 +931,12 @@ namespace FellowOakDicom
         #region Public Constructors
 
         public DicomDateTime(DicomTag tag, params DateTime[] values)
-            : base(tag, PrivateDateFormats, values)
+            : base(tag, PrivateDateFormats, values.Select(x => FormatToString(x)).ToArray())
         {
         }
 
         public DicomDateTime(DicomTag tag, DicomDateRange range)
-            : base(tag, PrivateDateFormats, range)
+            : base(tag, PrivateDateFormats, FormatRangeToString(range))
         {
         }
 
@@ -955,9 +952,26 @@ namespace FellowOakDicom
 
         #endregion
 
+        #region Private Methods
+
+        private static string FormatToString(DateTime value) =>
+            value.Millisecond > 0
+                ? value.ToString(_formatWithFraction).Replace(":", string.Empty).TrimEnd('0')
+                : value.ToString(_formatWithoutFraction).Replace(":", string.Empty);
+
+        private static string FormatRangeToString(DicomDateRange range) =>
+            range.Minimum.Millisecond > 0 || range.Maximum.Millisecond > 0
+                ? range.ToString(_formatWithFraction).Replace(":", string.Empty)
+                : range.ToString(_formatWithoutFraction).Replace(":", string.Empty);
+
+        #endregion
+
         #region Public Properties
 
         public override DicomVR ValueRepresentation => DicomVR.DT;
+
+        private static readonly string _formatWithFraction = "yyyyMMddHHmmss.ffffff";
+        private static readonly string _formatWithoutFraction = "yyyyMMddHHmmss";
 
         private static string[] _formats;
 
@@ -965,37 +979,34 @@ namespace FellowOakDicom
         {
             get
             {
-                if (_formats == null)
+                _formats ??= new[]
                 {
-                    _formats = new[]
-                    {
-                        "yyyyMMddHHmmss",
-                        "yyyyMMddHHmmsszzz",
-                        "yyyyMMddHHmmsszz",
-                        "yyyyMMddHHmmssz",
-                        "yyyyMMddHHmmss.ffffff",
-                        "yyyyMMddHHmmss.fffff",
-                        "yyyyMMddHHmmss.ffff",
-                        "yyyyMMddHHmmss.fff",
-                        "yyyyMMddHHmmss.ff",
-                        "yyyyMMddHHmmss.f",
-                        "yyyyMMddHHmm",
-                        "yyyyMMddHH",
-                        "yyyyMMdd",
-                        "yyyyMM",
-                        "yyyy",
-                        "yyyyMMddHHmmss.ffffffzzz",
-                        "yyyyMMddHHmmss.fffffzzz",
-                        "yyyyMMddHHmmss.ffffzzz",
-                        "yyyyMMddHHmmss.fffzzz",
-                        "yyyyMMddHHmmss.ffzzz",
-                        "yyyyMMddHHmmss.fzzz",
-                        "yyyyMMddHHmmzzz",
-                        "yyyyMMddHHzzz",
-                        "yyyy.MM.dd",
-                        "yyyy/MM/dd"
-                    };
-                }
+                    "yyyyMMddHHmmss",
+                    "yyyyMMddHHmmsszzz",
+                    "yyyyMMddHHmmsszz",
+                    "yyyyMMddHHmmssz",
+                    "yyyyMMddHHmmss.ffffff",
+                    "yyyyMMddHHmmss.fffff",
+                    "yyyyMMddHHmmss.ffff",
+                    "yyyyMMddHHmmss.fff",
+                    "yyyyMMddHHmmss.ff",
+                    "yyyyMMddHHmmss.f",
+                    "yyyyMMddHHmm",
+                    "yyyyMMddHH",
+                    "yyyyMMdd",
+                    "yyyyMM",
+                    "yyyy",
+                    "yyyyMMddHHmmss.ffffffzzz",
+                    "yyyyMMddHHmmss.fffffzzz",
+                    "yyyyMMddHHmmss.ffffzzz",
+                    "yyyyMMddHHmmss.fffzzz",
+                    "yyyyMMddHHmmss.ffzzz",
+                    "yyyyMMddHHmmss.fzzz",
+                    "yyyyMMddHHmmzzz",
+                    "yyyyMMddHHzzz",
+                    "yyyy.MM.dd",
+                    "yyyy/MM/dd"
+                };
                 return _formats;
             }
         }
@@ -1679,12 +1690,12 @@ namespace FellowOakDicom
         #region Public Constructors
 
         public DicomTime(DicomTag tag, params DateTime[] values)
-            : base(tag, PrivateDateFormats, values)
+            : base(tag, PrivateDateFormats, values.Select(x => FormatToString(x)).ToArray())
         {
         }
 
         public DicomTime(DicomTag tag, DicomDateRange range)
-            : base(tag, PrivateDateFormats, range)
+            : base(tag, PrivateDateFormats, FormatRangeToString(range))
         {
         }
 
@@ -1700,59 +1711,72 @@ namespace FellowOakDicom
 
         #endregion
 
+        #region Private Methods
+
+        private static string FormatToString(DateTime value) =>
+            value.Millisecond > 0
+                ? value.ToString(_formatWithFraction).Replace(":", string.Empty).TrimEnd('0')
+                : value.ToString(_formatWithoutFraction).Replace(":", string.Empty);
+
+        private static string FormatRangeToString(DicomDateRange range) =>
+            range.Minimum.Millisecond > 0 || range.Maximum.Millisecond > 0
+                ? range.ToString(_formatWithFraction).Replace(":", string.Empty)
+                : range.ToString(_formatWithoutFraction).Replace(":", string.Empty);
+
+        #endregion
+
         #region Public Properties
 
         public override DicomVR ValueRepresentation => DicomVR.TM;
 
+        private static readonly string _formatWithFraction = "HHmmss.ffffff";
+        private static readonly string _formatWithoutFraction = "HHmmss";
         private static string[] _formats;
 
         private static string[] PrivateDateFormats
         {
             get
             {
-                if (_formats == null)
+                _formats ??= new[]
                 {
-                    _formats = new[]
-                                {
-                                    "HHmmss",
-                                    "HH",
-                                    "HHmm",
-                                    "HHmmssf",
-                                    "HHmmssff",
-                                    "HHmmssfff",
-                                    "HHmmssffff",
-                                    "HHmmssfffff",
-                                    "HHmmssffffff",
-                                    "HHmmss.f",
-                                    "HHmmss.ff",
-                                    "HHmmss.fff",
-                                    "HHmmss.ffff",
-                                    "HHmmss.fffff",
-                                    "HHmmss.ffffff",
-                                    "HH.mm",
-                                    "HH.mm.ss",
-                                    "HH.mm.ss.f",
-                                    "HH.mm.ss.ff",
-                                    "HH.mm.ss.fff",
-                                    "HH.mm.ss.ffff",
-                                    "HH.mm.ss.fffff",
-                                    "HH.mm.ss.ffffff",
-                                    "HH:mm",
-                                    "HH:mm:ss",
-                                    "HH:mm:ss:f",
-                                    "HH:mm:ss:ff",
-                                    "HH:mm:ss:fff",
-                                    "HH:mm:ss:ffff",
-                                    "HH:mm:ss:fffff",
-                                    "HH:mm:ss:ffffff",
-                                    "HH:mm:ss.f",
-                                    "HH:mm:ss.ff",
-                                    "HH:mm:ss.fff",
-                                    "HH:mm:ss.ffff",
-                                    "HH:mm:ss.fffff",
-                                    "HH:mm:ss.ffffff"
-                                };
-                }
+                    "HHmmss",
+                    "HH",
+                    "HHmm",
+                    "HHmmssf",
+                    "HHmmssff",
+                    "HHmmssfff",
+                    "HHmmssffff",
+                    "HHmmssfffff",
+                    "HHmmssffffff",
+                    "HHmmss.f",
+                    "HHmmss.ff",
+                    "HHmmss.fff",
+                    "HHmmss.ffff",
+                    "HHmmss.fffff",
+                    "HHmmss.ffffff",
+                    "HH.mm",
+                    "HH.mm.ss",
+                    "HH.mm.ss.f",
+                    "HH.mm.ss.ff",
+                    "HH.mm.ss.fff",
+                    "HH.mm.ss.ffff",
+                    "HH.mm.ss.fffff",
+                    "HH.mm.ss.ffffff",
+                    "HH:mm",
+                    "HH:mm:ss",
+                    "HH:mm:ss:f",
+                    "HH:mm:ss:ff",
+                    "HH:mm:ss:fff",
+                    "HH:mm:ss:ffff",
+                    "HH:mm:ss:fffff",
+                    "HH:mm:ss:ffffff",
+                    "HH:mm:ss.f",
+                    "HH:mm:ss.ff",
+                    "HH:mm:ss.fff",
+                    "HH:mm:ss.ffff",
+                    "HH:mm:ss.fffff",
+                    "HH:mm:ss.ffffff"
+                };
                 return _formats;
             }
         }

--- a/Tests/FO-DICOM.Tests/DicomDateTimeTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDateTimeTest.cs
@@ -44,5 +44,20 @@ namespace FellowOakDicom.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void AddDatetimeWithFraction()
+        {
+            var datetimeWithFraction = new DateTime(2007, 6, 28, 15, 19, 45, 406, DateTimeKind.Unspecified);
+            var dataset = new DicomDataset
+            {
+                { DicomTag.AcquisitionDateTime, datetimeWithFraction }
+            };
+            var actualDate = dataset.GetSingleValue<DateTime>(DicomTag.AcquisitionDateTime);
+            var actualDateString = dataset.GetString(DicomTag.AcquisitionDateTime);
+
+            Assert.Equal(datetimeWithFraction, actualDate);
+            Assert.Equal("20070628151945.406", actualDateString);
+        }
     }
 }

--- a/Tests/FO-DICOM.Tests/DicomDateTimeTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDateTimeTest.cs
@@ -45,19 +45,33 @@ namespace FellowOakDicom.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public void AddDatetimeWithFraction()
+
+        public static TheoryData<DicomTag, DateTime, string> Datetimes = new TheoryData<DicomTag, DateTime, string> 
+        { 
+            // with Fraction
+            { DicomTag.AcquisitionDateTime, new DateTime(2007, 6, 28, 15, 19, 45, 406, DateTimeKind.Unspecified), "20070628151945.406" },
+            { DicomTag.AcquisitionDateTime, new DateTime(2007, 6, 28, 15, 19, 45, 400, DateTimeKind.Unspecified), "20070628151945.4" },
+            { DicomTag.StudyTime, new DateTime(2007, 6, 28, 15, 19, 45, 406, DateTimeKind.Unspecified), "151945.406" },
+            { DicomTag.StudyTime, new DateTime(2007, 6, 28, 15, 19, 45, 400, DateTimeKind.Unspecified), "151945.4" },
+            // without Fraction
+            { DicomTag.AcquisitionDateTime, new DateTime(2007, 6, 28, 15, 19, 45, DateTimeKind.Unspecified), "20070628151945" },
+            { DicomTag.AcquisitionDateTime, new DateTime(2007, 6, 28, 15, 0, 0, DateTimeKind.Unspecified), "20070628150000" },
+            { DicomTag.StudyTime, new DateTime(2007, 6, 28, 15, 19, 45, DateTimeKind.Unspecified), "151945" },
+            { DicomTag.StudyTime, new DateTime(2007, 6, 28, 15, 0, 0, DateTimeKind.Unspecified), "150000" }
+        };
+
+        [Theory]
+        [MemberData(nameof(Datetimes))]
+        public void AddDatetimeWithOrWithoutFraction(DicomTag tag, DateTime date, string expectedString)
         {
-            var datetimeWithFraction = new DateTime(2007, 6, 28, 15, 19, 45, 406, DateTimeKind.Unspecified);
             var dataset = new DicomDataset
             {
-                { DicomTag.AcquisitionDateTime, datetimeWithFraction }
+                { tag, date }
             };
-            var actualDate = dataset.GetSingleValue<DateTime>(DicomTag.AcquisitionDateTime);
-            var actualDateString = dataset.GetString(DicomTag.AcquisitionDateTime);
+            var actualDateString = dataset.GetString(tag);
 
-            Assert.Equal(datetimeWithFraction, actualDate);
-            Assert.Equal("20070628151945.406", actualDateString);
+            Assert.Equal(expectedString, actualDateString);
         }
+
     }
 }


### PR DESCRIPTION
Fixes #1719 

The DicomElements that deal with times have a internal format-list that is used to parse date-strings in various formats. The first one of these was used to serialize a Datetime back into the format as defined in DICOM-standard. But this format was one without fraction (milliseconds).
Now there are to defined formats, one with fraction and one without, and the appropriate one is then used.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
