### PR TITLE
ConnectionTimeout for DicomClient

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 - refactor the parser to make it better maintainable
 - **Breaking change**: IByteSource interface has changed
 - VOI LUT Function with empty value causes a crash (#1891)
+- Add ConnectionTimeout to ClientConnectionOptions (#1784)
 - Fixed bug, where milliseconds have been cut away when adding a Datetime to a DicomDataset (#1719)
 - DicomElement.ValueRepresentation.ValidateString() now throws a DicomValidationException if a null value is passed (#1590)
 - The optional AffectedSopInstanceUID is added to the CStoreResponse by default. (#1390)

--- a/FO-DICOM.Core/Network/Client/DicomClient.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClient.cs
@@ -346,7 +346,8 @@ namespace FellowOakDicom.Network.Client
                                 NoDelay = ServiceOptions.TcpNoDelay,
                                 ReceiveBufferSize = ServiceOptions.TcpReceiveBufferSize,
                                 SendBufferSize = ServiceOptions.TcpSendBufferSize,
-                                Timeout = TimeSpan.FromMilliseconds(ClientOptions.AssociationRequestTimeoutInMs)
+                                Timeout = TimeSpan.FromMilliseconds(ClientOptions.AssociationRequestTimeoutInMs),
+                                ConnectionTimeout = ClientOptions.ConnectionTimeoutInMs > 0 ? TimeSpan.FromMilliseconds(ClientOptions.ConnectionTimeoutInMs) : TimeSpan.FromMilliseconds(-1)
                             },
                             RequestHandlers = new AdvancedDicomClientConnectionRequestHandlers
                             {

--- a/FO-DICOM.Core/Network/Client/DicomClientOptions.cs
+++ b/FO-DICOM.Core/Network/Client/DicomClientOptions.cs
@@ -7,6 +7,11 @@ namespace FellowOakDicom.Network.Client
     public class DicomClientOptions
     {
         /// <summary>
+        /// Gets or sets the timeout (in ms) to wait for the TCP connection to establish
+        /// </summary>
+        public int ConnectionTimeoutInMs { get; set; } = 0;
+
+        /// <summary>
         /// Gets or sets the timeout (in ms) to wait for an association response after sending an association request
         /// </summary>
         public int AssociationRequestTimeoutInMs { get; set; } = 5000;

--- a/FO-DICOM.Core/Network/DesktopNetworkStream.cs
+++ b/FO-DICOM.Core/Network/DesktopNetworkStream.cs
@@ -54,7 +54,10 @@ namespace FellowOakDicom.Network
             {
                 _tcpClient.SendBufferSize = options.SendBufferSize.Value;
             }
-            _tcpClient.ConnectAsync(options.Host, options.Port).Wait();
+            if (!_tcpClient.ConnectAsync(options.Host, options.Port).Wait(options.ConnectionTimeout))
+            {
+                throw new TimeoutException();
+            }
 
             Stream stream = _tcpClient.GetStream();
             if (options.TlsInitiator != null)

--- a/FO-DICOM.Core/Network/NetworkStreamCreationOptions.cs
+++ b/FO-DICOM.Core/Network/NetworkStreamCreationOptions.cs
@@ -41,6 +41,11 @@ namespace FellowOakDicom.Network
         public TimeSpan Timeout { get; set; }
 
         /// <summary>
+        /// Geets or sets the timeout when the TCP connection is established
+        /// </summary>
+        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromMilliseconds(-1);
+
+        /// <summary>
         /// Gets or sets the size of the receive buffer of the underlying TCP connection
         /// If not configured, the default value of 8192 bytes will be used
         /// </summary>

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
@@ -686,8 +686,8 @@ namespace FellowOakDicom.Tests.Network.Client
             }
             stopWatch.Stop();
             
-            // the timeout was configured with 1 second, so assert that the method should at least wait this 1 second tieout, but returned after no longer than 2 seconds
-            Assert.InRange(stopWatch.Elapsed.Milliseconds, 900, 2000);
+            // the timeout was configured with 1 second, so assert that the method should at least wait this 1 second timeout, but returned after no longer than 2 seconds
+            Assert.InRange(stopWatch.Elapsed.TotalMilliseconds, 900, 2000);
             Assert.True(timedOut);
         }
 

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTimeoutTests.cs
@@ -687,7 +687,7 @@ namespace FellowOakDicom.Tests.Network.Client
             stopWatch.Stop();
             
             // the timeout was configured with 1 second, so assert that the method should at least wait this 1 second tieout, but returned after no longer than 2 seconds
-            Assert.InRange(stopWatch.Elapsed.Seconds, 1, 2);
+            Assert.InRange(stopWatch.Elapsed.Milliseconds, 900, 2000);
             Assert.True(timedOut);
         }
 


### PR DESCRIPTION
Fixes #1784  .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- The DicomClientOptions now also have a property to define the ConnectionTimeout, that applies when establishing a TCP connection. This is where usually the os-specific timeouts (20 seconds on windows, 130 seconds on unbuntu) have to be awaitet. with this property this waiting time can be shortened, but not extended.
