### PR TITLE
Open file from unseekable Networkstream

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
 - The optional AffectedSopInstanceUID is added to the CStoreResponse by default. (#1390)
 - Handle invalid DICOM files, that contain "," as decimal separator in DS values (#1296)
 - DicomDataset.AddOrUpdate also allows passing DicomSequence as argument type (#1664)
+- Fix parsing files from stream created by HttpClient (#1698)
 
 ### 5.1.5 (2024-11-25)
 

--- a/Tests/FO-DICOM.Tests/IO/Reader/DicomFileReaderTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Reader/DicomFileReaderTest.cs
@@ -6,6 +6,8 @@ using FellowOakDicom.IO;
 using FellowOakDicom.IO.Reader;
 using FellowOakDicom.Tests.Helpers;
 using System.IO;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -17,6 +19,19 @@ namespace FellowOakDicom.Tests.IO.Reader
     {
 
         #region Unit tests
+
+        [Fact]
+        public async Task ReadFromNetworkStreamAsync()
+        {
+            var client = new HttpClient();
+            using var stream = await client.GetStreamAsync("https://github.com/fo-dicom/fo-dicom/raw/refs/heads/development/Tests/FO-DICOM.Tests/Test%20Data/CT-MONO2-16-ankle");
+
+            var dicomfile = await DicomFile.OpenAsync(stream, FileReadOption.ReadAll);
+
+            Assert.NotNull(dicomfile);
+            Assert.Equal(47, dicomfile.Dataset.Count());
+        }
+
 
         [Fact]
         public void ReadLargeFileFromStream()


### PR DESCRIPTION
Fixes #1698 .
Where there already was a solution to read from a stream that cannot be seeked (stream within blazor), but the streams that a user gets from httpclient is even worse. Accessing the property Length already throws a NotImplementedException.
With the new parser implementation now it is possible to read from such a stream 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- The StreamByteSourceFactory now initiates a new Instance of ReadBufferedStream as wrapper around the stream if the stream is not seekable
