### PR TITLE
Defensive service registration in UseFellowOakDicom()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 ### 5.2.1 (TBD)
-
+- UseFellowOakDicom registers the default services only if there are not yet some services registered (#1929)
 
 ### 5.2.0 (2025-02-03)
 - refactor the parser to make it better maintainable

--- a/FO-DICOM.Core/Setup.cs
+++ b/FO-DICOM.Core/Setup.cs
@@ -72,23 +72,32 @@ namespace FellowOakDicom
 
     public static class IServiceCollectionExtension
     {
+        /// <summary>
+        /// Adds default implementations of all required services to the collection if the services haven't already been registered
+        /// </summary>
         public static IServiceCollection AddFellowOakDicom(this IServiceCollection services)
             => services
-                .AddInternals()
+                .TryAddInternals()
                 .AddLogging()
-                .AddTranscoderManager<DefaultTranscoderManager>()
-                .AddImageManager<RawImageManager>()
-                .AddNetworkManager<DesktopNetworkManager>()
+                .TryAddTranscoderManager<DefaultTranscoderManager>()
+                .TryAddImageManager<RawImageManager>()
+                .TryAddNetworkManager<DesktopNetworkManager>()
                 .AddDicomClient()
                 .AddDicomServer();
 
-        private static IServiceCollection AddInternals(this IServiceCollection services)
+        private static IServiceCollection TryAddInternals(this IServiceCollection services)
         {
             services.TryAddSingleton<IFileReferenceFactory, FileReferenceFactory>();
             services.TryAddSingleton<IMemoryProvider, ArrayPoolMemoryProvider>();
             return services;
         }
 
+        /// <summary>
+        /// Adds DicomClient services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <param name="options">The <see cref="DicomClientOptions"/> configuration delegate.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
         public static IServiceCollection AddDicomClient(this IServiceCollection services, Action<DicomClientOptions> options = null)
         {
             services.TryAddSingleton<DicomServiceDependencies>();
@@ -103,6 +112,12 @@ namespace FellowOakDicom
             return services;
         }
 
+        /// <summary>
+        /// Adds DicomServer services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <param name="options">The <see cref="DicomServerOptions"/> configuration delegate.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
         public static IServiceCollection AddDicomServer(this IServiceCollection services, Action<DicomServerOptions> options = null)
         {
             services.TryAddSingleton<DicomServiceDependencies>();
@@ -118,24 +133,73 @@ namespace FellowOakDicom
             return services;
         }
 
+        /// <summary>
+        /// Adds <see cref="ITranscoderManager"/> services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
         public static IServiceCollection AddTranscoderManager<TTranscoderManager>(this IServiceCollection services) where TTranscoderManager : class, ITranscoderManager
         {
             services.Replace(ServiceDescriptor.Singleton<ITranscoderManager, TTranscoderManager>());
             return services;
         }
 
+        /// <summary>
+        /// Adds <see cref="ITranscoderManager"/> services to the specified <see cref="IServiceCollection" /> if they are not already registered.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
+        public static IServiceCollection TryAddTranscoderManager<TTranscoderManager>(this IServiceCollection services) where TTranscoderManager : class, ITranscoderManager
+        {
+            services.TryAddSingleton<ITranscoderManager, TTranscoderManager>();
+            return services;
+        }
+
+        /// <summary>
+        /// Adds <see cref="TImageManager"/> services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
         public static IServiceCollection AddImageManager<TImageManager>(this IServiceCollection services) where TImageManager : class, IImageManager
         {
             services.Replace(ServiceDescriptor.Singleton<IImageManager, TImageManager>());
             return services;
         }
 
+        /// <summary>
+        /// Adds <see cref="TImageManager"/> services to the specified <see cref="IServiceCollection" /> if they are not already registered.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
+        public static IServiceCollection TryAddImageManager<TImageManager>(this IServiceCollection services) where TImageManager : class, IImageManager
+        {
+            services.TryAddSingleton<IImageManager, TImageManager>();
+            return services;
+        }
+
+        /// <summary>
+        /// Adds <see cref="TNetworkManager"/> services to the specified <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
         public static IServiceCollection AddNetworkManager<TNetworkManager>(this IServiceCollection services) where TNetworkManager : class, INetworkManager
         {
             services.Replace(ServiceDescriptor.Singleton<INetworkManager, TNetworkManager>());
             return services;
         }
-        
+
+        /// <summary>
+        /// Adds <see cref="TNetworkManager"/> services to the specified <see cref="IServiceCollection" /> if they are not already registered.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>The IServiceCollection so that additional calls can be chained.</returns>
+        public static IServiceCollection TryAddNetworkManager<TNetworkManager>(this IServiceCollection services) where TNetworkManager: class, INetworkManager
+        {
+            services.TryAddSingleton<INetworkManager, TNetworkManager>();
+            return services;
+        }
+
+
         [Obsolete("Fellow Oak DICOM now supports Microsoft.Extensions.Logging")]
         public static IServiceCollection AddLogManager<TLogManager>(this IServiceCollection services) where TLogManager : class, ILogManager
         {

--- a/Platform/FO-DICOM.AspNetCore/ServiceCollectionExtensions.cs
+++ b/Platform/FO-DICOM.AspNetCore/ServiceCollectionExtensions.cs
@@ -16,6 +16,9 @@ namespace FellowOakDicom.AspNetCore
     public static class ServiceCollectionExtensions
     {
 
+        /// <summary>
+        /// Adds default implementations of all required services to the collection if the services haven't already been registered
+        /// </summary>
         public static IServiceCollection UseFellowOakDicom(this IServiceCollection services)
             => services.AddFellowOakDicom()
                 .AddTransient<IHostedService, DicomInitializationHelper>(provider => {

--- a/Tests/FO-DICOM.Tests/Network/DependencyInjectionTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DependencyInjectionTest.cs
@@ -5,6 +5,8 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.Network;
 using FellowOakDicom.Network.Client;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,6 +55,36 @@ namespace FellowOakDicom.Tests.Network
             Assert.False(string.IsNullOrEmpty(value));
         }
 
+        [Fact]
+        public void DependencyShouldNotOverwrite()
+        {
+            var serviceCollection = new ServiceCollection()
+                .AddFellowOakDicom()
+                .AddImageManager<MyCustomImageManager>()
+                .AddTranscoderManager<MyCustomTranscoderManager>()
+                .AddFellowOakDicom();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var imageService = serviceProvider.GetRequiredService<IImageManager>();
+            var transcoderService = serviceProvider.GetRequiredService<ITranscoderManager>();
+            Assert.IsType<MyCustomImageManager>(imageService);
+            Assert.IsType<MyCustomTranscoderManager>(transcoderService);
+        }
+
+    }
+
+
+    public class MyCustomImageManager : IImageManager
+    {
+        public IImage CreateImage(int width, int height) => throw new NotImplementedException();
+    }
+
+    public class MyCustomTranscoderManager : ITranscoderManager
+    {
+        public bool CanTranscode(DicomTransferSyntax inSyntax, DicomTransferSyntax outSyntax) => throw new NotImplementedException();
+        public IDicomCodec GetCodec(DicomTransferSyntax syntax) => throw new NotImplementedException();
+        public bool HasCodec(DicomTransferSyntax syntax) => throw new NotImplementedException();
+        public void LoadCodecs(string path = null, string search = null) => throw new NotImplementedException();
     }
 
 


### PR DESCRIPTION
Fixes #1929 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the ServiceCollectionExtension now offers more methods like AddxxxManager and TryAddxxxManager
- UseFellowOakDicom() now calls the TryAddxxxManager methods
