### PR TITLE
Send Command and Data in separate PDUs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 ### 5.2.2 (TBD)
 - render images with window width < 1, but apply LINEAR_EXACT on rendering (#1905)
 - new package Fo-Dicom.Imaging.SkiaSharp (#1956)
+- Send Command and Data in separate PDUs (#1960)
 
 ### 5.2.1 (2025-03-13)
 - Fixed regression in parser where group length of VR UN was parsed wrong (#1941)

--- a/Contributors.md
+++ b/Contributors.md
@@ -96,3 +96,4 @@
 * [Viktoria Salociova](https://github.com/ViktoriaSalociova)
 * [Arun Mohan Kumar](https://github.com/arunmk-ms)
 * [DMIAOCHEN](https://github.com/DMIAOCHEN)
+* [BrunoMilutin](https://github.com/BrunoMilutin)

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -43,7 +43,7 @@ namespace FellowOakDicom.Network
         private bool _isInitialized;
 
         private readonly INetworkStream _network;
-        
+
         private readonly IMemoryProvider _memoryProvider;
 
         private readonly Stream _writeStream;
@@ -75,7 +75,7 @@ namespace FellowOakDicom.Network
         protected IFileReference _dimseStreamFile;
 
         private int _isCheckingForTimeouts = 0;
-        
+
         private bool _canStillProcessPDataTF;
 
         #endregion
@@ -117,17 +117,17 @@ namespace FellowOakDicom.Network
 
             Options = new DicomServiceOptions();
         }
-        
+
         #endregion
-        
+
         #region FINALIZER 
-        
+
         /// <summary>
         /// The finalizer will be called when this instance is not disposed properly.
         /// </summary>
         /// <remarks>Failing to dispose indicates wrong usage</remarks>
         ~DicomService() => Dispose(false);
-        
+
         #endregion
 
         #region PROPERTIES
@@ -191,7 +191,7 @@ namespace FellowOakDicom.Network
                 }
             }
         }
-        
+
         /// <summary>
         /// Gets whether or not the connection can still process P-DATA-TF
         /// </summary>
@@ -221,11 +221,11 @@ namespace FellowOakDicom.Network
         /// The transcoder manager being used by this DICOM service
         /// </summary>
         private ITranscoderManager TranscoderManager { get; }
-        
+
         #endregion
 
         #region METHODS
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ThrowIfAlreadyDisposed()
         {
@@ -236,7 +236,7 @@ namespace FellowOakDicom.Network
 
             ThrowDisposedException();
         }
-        
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void ThrowDisposedException() => throw new ObjectDisposedException("This DICOM service is already disposed and can no longer be used");
 
@@ -265,7 +265,7 @@ namespace FellowOakDicom.Network
                 {
                     _writeStream?.Dispose();
                 }
-                catch(IOException)
+                catch (IOException)
                 {
                     // The buffered stream will try to flush its contents upon disposal, which might fail if the underlying network stream is already closed
                     // This can be ignored here
@@ -286,7 +286,7 @@ namespace FellowOakDicom.Network
         public virtual Task SendRequestAsync(DicomRequest request)
         {
             ThrowIfAlreadyDisposed();
-            
+
             return SendMessageAsync(request);
         }
 
@@ -297,7 +297,7 @@ namespace FellowOakDicom.Network
         protected Task SendResponseAsync(DicomResponse response)
         {
             ThrowIfAlreadyDisposed();
-            
+
             return SendMessageAsync(response);
         }
 
@@ -361,7 +361,7 @@ namespace FellowOakDicom.Network
             {
                 throw new DicomNetworkException("Cannot send PDU because the connection to the DICOM server is lost");
             }
-            
+
             try
             {
                 while (IsConnected && !_pduQueueWatcher.Wait(60 * 1000))
@@ -375,7 +375,7 @@ namespace FellowOakDicom.Network
                 // When the DICOM service is disposed, the _pduQueueWatcher is also disposed
                 throw new DicomNetworkException("Cannot send PDU because the association has already been disposed");
             }
-            
+
             if (!IsConnected)
             {
                 throw new DicomNetworkException("Cannot send PDU because the connection to the DICOM server is lost");
@@ -389,7 +389,7 @@ namespace FellowOakDicom.Network
                         "Cannot write P-DATA-TF over current DICOM association because a previous P-DATA-TF timed out before it was sent completely"
                     );
                 }
-                
+
                 _pduQueue.Enqueue(pdu);
                 if (_pduQueue.Count >= MaximumPDUsInQueue)
                 {
@@ -426,7 +426,7 @@ namespace FellowOakDicom.Network
                         _pduQueueWatcher.Set();
                     }
                 }
-                
+
                 if (pdu is PDataTF && !_canStillProcessPDataTF)
                 {
                     throw new DicomNetworkException(
@@ -486,7 +486,7 @@ namespace FellowOakDicom.Network
 
                     // This is the (extremely small) buffer we use to read the raw PDU header
                     using var rawPduCommonFieldsBuffer = _memoryProvider.Provide(RawPDU.CommonFieldsLength);
-                    
+
                     var count = await stream.ReadAsync(rawPduCommonFieldsBuffer.Bytes, 0, rawPduCommonFieldsBuffer.Length).ConfigureAwait(false);
 
                     do
@@ -500,14 +500,14 @@ namespace FellowOakDicom.Network
                         }
 
                         _bytesToRead -= count;
-                        
+
                         if (_bytesToRead > 0)
                         {
                             count = await stream.ReadAsync(rawPduCommonFieldsBuffer.Bytes, rawPduCommonFieldsBuffer.Length - _bytesToRead, _bytesToRead).ConfigureAwait(false);
                         }
                     }
                     while (_bytesToRead > 0);
-                    
+
                     // The first byte contains the PDU type
                     // The second byte is reserved
                     // The remaining four bytes contain the PDU length
@@ -523,10 +523,10 @@ namespace FellowOakDicom.Network
 
                     // Read PDU
                     var rawPduLength = pduLength + RawPDU.CommonFieldsLength;
-                    
+
                     // This is the buffer that will hold the entire Raw PDU at once
                     using var rawPduBuffer = _memoryProvider.Provide(rawPduLength);
-                    
+
                     Array.Copy(rawPduCommonFieldsBuffer.Bytes, 0, rawPduBuffer.Bytes, 0, RawPDU.CommonFieldsLength);
                     int rawPduOffset = RawPDU.CommonFieldsLength;
                     while (_bytesToRead > 0)
@@ -557,7 +557,7 @@ namespace FellowOakDicom.Network
                                 Association = new DicomAssociation
                                 {
                                     RemoteHost = _network.RemoteHost,
-                                    RemotePort = _network.RemotePort, 
+                                    RemotePort = _network.RemotePort,
                                     Options = Options
                                 };
 
@@ -839,7 +839,7 @@ namespace FellowOakDicom.Network
                                 var pc = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
 
                                 _dimse.Dataset = new DicomDataset { InternalTransferSyntax = pc.AcceptedTransferSyntax };
-                                
+
                                 var source = new StreamByteSource(_dimseStream, FileReadOption.Default)
                                 {
                                     Endian = pc.AcceptedTransferSyntax.Endian
@@ -880,7 +880,7 @@ namespace FellowOakDicom.Network
                                     string errorComment = e.Message;
                                     if (errorComment.Length > DicomVR.LO.MaximumLength)
                                     {
-                                        errorComment = errorComment.Substring(0, (int) DicomVR.LO.MaximumLength - 2) + "..";
+                                        errorComment = errorComment.Substring(0, (int)DicomVR.LO.MaximumLength - 2) + "..";
                                     }
                                     await SendResponseAsync(new DicomCStoreResponse(request, new DicomStatus(DicomStatus.ProcessingFailure, errorComment))).ConfigureAwait(false);
 
@@ -946,7 +946,7 @@ namespace FellowOakDicom.Network
                         else
                         {
                             req.LastPendingResponseReceived = DateTime.Now;
-                            
+
                             if (this is IDicomClientConnection connection)
                             {
                                 await connection.OnRequestPendingAsync(req, rsp).ConfigureAwait(false);
@@ -1102,7 +1102,7 @@ namespace FellowOakDicom.Network
         internal async Task SendNextMessageAsync()
         {
             ThrowIfAlreadyDisposed();
-            
+
             var sendQueueEmpty = false;
 
             while (true)
@@ -1353,57 +1353,65 @@ namespace FellowOakDicom.Network
 
                 Logger.LogInformation("{logId} -> {dicomMessage}", LogID, msg.ToString(Options.LogDimseDatasets));
 
-                // This specialized Stream will write byte contents as PDUs with nested PDVs
-                PDataTFStream pDataStream = null;
-                // When the accepted transfer syntax is deflated, we must deflate the DICOM data set (not the command!)
-                DeflateStream deflateStream = null;
                 try
                 {
-                    pDataStream = new PDataTFStream(this, _memoryProvider, pc.ID, Association.MaximumPDULength, msg);
+                    DicomWriter writer;
 
-                    var writer = new DicomWriter(
-                        DicomTransferSyntax.ImplicitVRLittleEndian,
-                        DicomWriteOptions.Default,
-                        new StreamByteTarget(pDataStream));
+                    // This specialized Stream will write byte contents as PDUs with nested PDVs
+                    using (var pCommandStream = new PDataTFStream(this, _memoryProvider, pc.ID, Association.MaximumPDULength, true, msg))
+                    {
 
-                    var commandWalker = new DicomDatasetWalker(msg.Command);
-                    await commandWalker.WalkAsync(writer).ConfigureAwait(false);
+                        writer = new DicomWriter(
+                            DicomTransferSyntax.ImplicitVRLittleEndian,
+                            DicomWriteOptions.Default,
+                            new StreamByteTarget(pCommandStream));
+
+                        var commandWalker = new DicomDatasetWalker(msg.Command);
+                        await commandWalker.WalkAsync(writer).ConfigureAwait(false);
+
+                        await pCommandStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
 
                     if (msg.HasDataset)
                     {
-                        await pDataStream.SetIsCommandAsync(false).ConfigureAwait(false);
-
-                        Stream outputStream;
-                        if (pc.AcceptedTransferSyntax.IsDeflate)
+                        // Use seperate DATA-TF for command and data (Some older DICOM receivers can't read the data when sent together in one DATA-TF)
+                        using (var pDataStream = new PDataTFStream(this, _memoryProvider, pc.ID, Association.MaximumPDULength, false, msg))
                         {
-                            deflateStream = new DeflateStream(pDataStream, CompressionMode.Compress, true);
-                            outputStream = deflateStream;
+                            // When the accepted transfer syntax is deflated, we must deflate the DICOM data set (not the command!)
+                            DeflateStream deflateStream = null;
+
+                            Stream outputStream;
+                            if (pc.AcceptedTransferSyntax.IsDeflate)
+                            {
+                                deflateStream = new DeflateStream(pDataStream, CompressionMode.Compress, true);
+                                outputStream = deflateStream;
+                            }
+                            else
+                            {
+                                outputStream = pDataStream;
+                            }
+
+                            writer = new DicomWriter(
+                                pc.AcceptedTransferSyntax,
+                                DicomWriteOptions.Default,
+                                new StreamByteTarget(outputStream));
+
+                            var datasetWalker = new DicomDatasetWalker(msg.Dataset);
+
+                            await datasetWalker.WalkAsync(writer).ConfigureAwait(false);
+
+                            if (deflateStream != null)
+                            {
+                                await deflateStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+
+                                // Deflate stream in .NET Framework only fully flushes when disposed...
+                                deflateStream.Dispose();
+                            }
+
+                            await pDataStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
                         }
-                        else
-                        {
-                            outputStream = pDataStream;
-                        }
-
-                        writer = new DicomWriter(
-                            pc.AcceptedTransferSyntax,
-                            DicomWriteOptions.Default,
-                            new StreamByteTarget(outputStream));
-
-                        var datasetWalker = new DicomDatasetWalker(msg.Dataset);
-                        
-                        await datasetWalker.WalkAsync(writer).ConfigureAwait(false);
-                        
-                        if (deflateStream != null)
-                        {
-                            await deflateStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
-                            
-                            // Deflate stream in .NET Framework only fully flushes when disposed...
-                            deflateStream.Dispose();
-                        }                    
                     }
-                    
-                    await pDataStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
-                    
+
                     msg.LastPDUSent = DateTime.Now;
                     msg.AllPDUsWereSentSuccessfully();
 
@@ -1417,11 +1425,6 @@ namespace FellowOakDicom.Network
                     msg.NotAllPDUsWereSentSuccessfully();
                     Logger.LogError(e, "An error occurred while sending a DICOM message");
                     throw new DicomNetworkException($"Failed to send DICOM message {msg}", e);
-                }
-                finally
-                {
-                    deflateStream?.Dispose();
-                    pDataStream?.Dispose();
                 }
             }
         }
@@ -1470,7 +1473,7 @@ namespace FellowOakDicom.Network
                                 lock (_lock)
                                 {
                                     _pending.Remove(timedOutPendingRequest);
-                                    
+
                                     if (timedOutPendingRequest.AllPDUsSent.Status != TaskStatus.RanToCompletion)
                                     {
                                         _canStillProcessPDataTF = false;
@@ -1583,7 +1586,7 @@ namespace FellowOakDicom.Network
         protected Task SendAssociationRequestAsync(DicomAssociation association)
         {
             ThrowIfAlreadyDisposed();
-            
+
             LogID = association.CalledAE;
             if (Options.UseRemoteAEForLogName)
             {
@@ -1603,7 +1606,7 @@ namespace FellowOakDicom.Network
         protected Task SendAssociationAcceptAsync(DicomAssociation association)
         {
             ThrowIfAlreadyDisposed();
-            
+
             Association = association;
 
             // reject all presentation contexts that have not already been accepted or rejected
@@ -1720,20 +1723,18 @@ namespace FellowOakDicom.Network
         }
 
         #endregion
-        
+
         #region INNER TYPES 
-        
+
         internal class PDataTFStream : Stream
         {
             #region Private Members
 
             private readonly DicomService _service;
 
-            private bool _command;
+            private readonly bool _command;
 
-            private readonly uint _pduMax;
-
-            private uint _max;
+            private readonly uint _max;
 
             private readonly byte _pcid;
 
@@ -1753,43 +1754,31 @@ namespace FellowOakDicom.Network
 
             #region Public Constructors
 
-            public PDataTFStream(DicomService service, IMemoryProvider memoryProvider, byte pcid, uint max, DicomMessage dicomMessage)
+            public PDataTFStream(DicomService service, IMemoryProvider memoryProvider, byte pcid, uint max, bool isCommand, DicomMessage dicomMessage)
             {
                 _service = service ?? throw new ArgumentNullException(nameof(service));
                 _memoryProvider = memoryProvider ?? throw new ArgumentNullException(nameof(memoryProvider));
-                _command = true;
+                _command = isCommand;
                 _pcid = pcid;
                 _dicomMessage = dicomMessage;
-                _pduMax = Math.Min(max, int.MaxValue);
-                _max = _pduMax == 0
-                    ? _service.Options.MaxCommandBuffer
-                    : Math.Min(_pduMax, _service.Options.MaxCommandBuffer);
+
+                // the configured maximum PDU-size depends if this is a command pdu or data pdu
+                var pduMaxByOptions = isCommand ? _service.Options.MaxCommandBuffer : _service.Options.MaxDataBuffer;
+
+                _max = max == 0
+                    ? pduMaxByOptions // if the requested max pdu size is 0, then we use the configured default MaxSize
+                    : Math.Min(max, pduMaxByOptions); // else we agree on the minimum of the requested MaxSize and the configured MaxSize
 
                 _pdu = new PDataTF(_memoryProvider);
 
                 // Max PDU Size - Current Size - Size of PDV header
-                _memory = ProvideEvenLengthMemory((int) (_max - CurrentPduSize() - RawPDU.CommonFieldsLength));
+                _memory = ProvideEvenLengthMemory((int)(_max - CurrentPduSize() - RawPDU.CommonFieldsLength));
             }
 
             #endregion
 
             #region Public Properties
 
-            public async Task SetIsCommandAsync(bool value)
-            {
-                // recalculate maximum PDU buffer size
-                if (_command != value)
-                {
-                    _max = _pduMax == 0
-                        ? _service.Options.MaxCommandBuffer
-                        : Math.Min(
-                            _pduMax,
-                            value ? _service.Options.MaxCommandBuffer : _service.Options.MaxDataBuffer);
-
-                    await CreatePDVAsync(true).ConfigureAwait(false);
-                    _command = value;
-                }
-            }
 
             #endregion
 
@@ -1829,17 +1818,17 @@ namespace FellowOakDicom.Network
 
                     var pdv = new PDV(_pcid, memory, _length, _command, last);
                     _pdu.PDVs.Add(pdv);
-                    
+
                     // reset length in case we recurse into WritePDU()
                     _length = 0;
                     // is the current PDU at its maximum size or do we have room for another PDV?
                     if ((_service.Options.MaxPDVsPerPDU != 0 && _pdu.PDVs.Count >= _service.Options.MaxPDVsPerPDU)
-                        || CurrentPduSize() + RawPDU.CommonFieldsLength >= _max 
-                        || (!_command && last))
+                        || CurrentPduSize() + RawPDU.CommonFieldsLength >= _max
+                        || (last))
                     {
                         await WritePDUAsync(last).ConfigureAwait(false);
                     }
-                    
+
                     if (!last)
                     {
                         // Max PDU Size - Current Size - Size of PDV header
@@ -1888,7 +1877,7 @@ namespace FellowOakDicom.Network
                     }
                 }
             }
-            
+
             private IMemory ProvideEvenLengthMemory(int length)
             {
                 // Since these byte arrays will be used to create PDVs
@@ -1957,7 +1946,7 @@ namespace FellowOakDicom.Network
                     if (_memory == null)
                     {
                         // Max PDU Size - Current Size - Size of PDV header
-                        var memoryLength = (int) (_max - CurrentPduSize() - RawPDU.CommonFieldsLength);
+                        var memoryLength = (int)(_max - CurrentPduSize() - RawPDU.CommonFieldsLength);
                         _memory = ProvideEvenLengthMemory(memoryLength);
                     }
 
@@ -1966,7 +1955,7 @@ namespace FellowOakDicom.Network
                         var c = Math.Min(count, _memory.Length - _length);
 
                         buffer.AsSpan(offset, c).CopyTo(_memory.Span.Slice(_length, c));
-                        
+
                         _length += c;
                         offset += c;
                         count -= c;
@@ -1999,9 +1988,9 @@ namespace FellowOakDicom.Network
             }
 
             #endregion
-            
+
             #region Disposable Members
-            
+
             protected override void Dispose(bool disposing)
             {
                 var bytes = Interlocked.Exchange(ref _memory, null);
@@ -2012,12 +2001,13 @@ namespace FellowOakDicom.Network
 
                 base.Dispose(disposing);
             }
-            
+
             #endregion
         }
 
-        
-        #endregion 
+
+        #endregion
     }
 }
+
 

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -735,8 +735,9 @@ namespace FellowOakDicom.Network
         {
             try
             {
-                foreach (var pdv in pdu.PDVs)
+                for (var i = 0; i < pdu.PDVs.Count; i++)
                 {
+                    var pdv = pdu.PDVs[i];
                     if (_dimse == null)
                     {
                         // create stream for receiving command
@@ -1817,7 +1818,7 @@ namespace FellowOakDicom.Network
                     }
 
                     var pdv = new PDV(_pcid, memory, _length, _command, last);
-                    _pdu.PDVs.Add(pdv);
+                    _pdu.AddPDV(pdv);
 
                     // reset length in case we recurse into WritePDU()
                     _length = 0;

--- a/FO-DICOM.Core/Network/PDU.cs
+++ b/FO-DICOM.Core/Network/PDU.cs
@@ -1563,6 +1563,7 @@ namespace FellowOakDicom.Network
     {
         private readonly IMemoryProvider _memoryProvider;
         private List<PDV> _pdVs;
+        private uint _sumLengthOfPDVs = 0;
 
         /// <summary>
         /// Initializes new P-DATA-TF
@@ -1579,24 +1580,31 @@ namespace FellowOakDicom.Network
         ~PDataTF() => Dispose(false);
 
         /// <summary>PDVs in this P-DATA-TF</summary>
-        public List<PDV> PDVs => _pdVs;
+        public IReadOnlyList<PDV> PDVs => _pdVs;
+
+        /// <summary>Adds a PDV to the PDVs in this P-DATA-TF</summary>
+        public void AddPDV(PDV pdv)
+        {
+            _pdVs.Add(pdv);
+            _sumLengthOfPDVs += pdv.PDVLength;
+        }
 
         /// <summary>Calculates the total length of the PDVs in this P-DATA-TF</summary>
         /// <returns>Length of PDVs</returns>
         public uint GetLengthOfPDVs()
         {
-            return (uint)_pdVs.Sum(pdv => pdv.PDVLength);
+            return _sumLengthOfPDVs;
         }
 
         public override string ToString()
         {
-            var value = $"P-DATA-TF [Length: {RawPDU.CommonFieldsLength + GetLengthOfPDVs()}]";
-            foreach (var pdv in PDVs)
+            var value = new StringBuilder("P-DATA-TF [Length: ").Append(RawPDU.CommonFieldsLength + GetLengthOfPDVs()).Append("]");
+            for (var i = 0; i < _pdVs.Count; i++)
             {
-                value += "\n\t" + pdv;
+                value.Append("\n\t").Append(_pdVs[i].ToString());
             }
 
-            return value;
+            return value.ToString();
         }
 
         #region Write
@@ -1622,9 +1630,9 @@ namespace FellowOakDicom.Network
 
         private void Write(RawPDU pdu)
         {
-            foreach (var pdv in _pdVs)
+            for (var i = 0; i < _pdVs.Count; i++)
             {
-                pdv.Write(pdu);
+                _pdVs[i].Write(pdu);
             }
         }
 
@@ -1644,7 +1652,7 @@ namespace FellowOakDicom.Network
             {
                 var pdv = new PDV(_memoryProvider);
                 read += pdv.Read(raw);
-                _pdVs.Add(pdv);
+                AddPDV(pdv);
             }
         }
 
@@ -1657,11 +1665,14 @@ namespace FellowOakDicom.Network
 
         private void Dispose(bool disposing)
         {
-            var pdvs = Interlocked.Exchange(ref _pdVs, new List<PDV>());
-            
-            foreach (var pdv in pdvs)
+            var pdvs = Interlocked.Exchange(ref _pdVs, null);
+            if (pdvs != null)
             {
-                pdv.Dispose();
+
+                for (var i = 0; i < pdvs.Count; i++)
+                {
+                    pdvs[i].Dispose();
+                }
             }
         }
     }

--- a/FO-DICOM.Core/Network/PDU.cs
+++ b/FO-DICOM.Core/Network/PDU.cs
@@ -26,7 +26,7 @@ namespace FellowOakDicom.Network
         private readonly Encoding _encoding;
 
         private readonly Stream _stream;
-        
+
         private readonly bool _leaveOpen;
 
         private readonly BinaryReader _br;
@@ -34,11 +34,11 @@ namespace FellowOakDicom.Network
         private readonly BinaryWriter _bw;
 
         private readonly Stack<long> _m16;
-        
+
         private readonly IMemoryProvider _memoryProvider;
 
         #endregion
-        
+
         #region Internal members
 
         internal const ushort CommonFieldsLength = 6;
@@ -97,7 +97,7 @@ namespace FellowOakDicom.Network
             _leaveOpen = true;
             _encoding = encoding ?? DicomEncoding.Default;
             _br = EndianBinaryReader.Create(_stream, _encoding, Endian.Big, _leaveOpen);
-            Type = (RawPduType) _br.ReadByte();
+            Type = (RawPduType)_br.ReadByte();
             _stream.Seek(CommonFieldsLength, SeekOrigin.Begin);
         }
 
@@ -116,7 +116,7 @@ namespace FellowOakDicom.Network
             _leaveOpen = true;
             _stream.Seek(0, SeekOrigin.Begin);
             _br = EndianBinaryReader.Create(_stream, Endian.Big, _leaveOpen);
-            Type = (RawPduType) _br.ReadByte();
+            Type = (RawPduType)_br.ReadByte();
             _stream.Seek(CommonFieldsLength, SeekOrigin.Begin);
         }
 
@@ -160,7 +160,7 @@ namespace FellowOakDicom.Network
             await s.WriteAsync(preamble.Bytes, 0, preamble.Length, cancellationToken).ConfigureAwait(false);
             _stream.Seek(0, SeekOrigin.Begin);
             await _stream.CopyToAsync(s, 81920, cancellationToken).ConfigureAwait(false);
-       }
+        }
 
         /// <summary>
         /// Saves PDU to file
@@ -264,7 +264,7 @@ namespace FellowOakDicom.Network
         }
 
         private readonly char[] _trimChars = { ' ', '\0' };
-        
+
 
         /// <summary>
         /// Reads string from PDU
@@ -425,7 +425,7 @@ namespace FellowOakDicom.Network
         {
             _br?.Dispose();
             _bw?.Dispose();
-            if(!_leaveOpen)
+            if (!_leaveOpen)
             {
                 _stream.Dispose();
             }
@@ -444,10 +444,10 @@ namespace FellowOakDicom.Network
         internal void GetCommonFields(IMemory buffer, uint length)
         {
             var span = buffer.Span;
-            
+
             unchecked
             {
-                span[0] = (byte) Type;
+                span[0] = (byte)Type;
                 span[1] = 0;
                 span[2] = (byte)((length & 0xff000000U) >> 24);
                 span[3] = (byte)((length & 0x00ff0000U) >> 16);
@@ -537,7 +537,7 @@ namespace FellowOakDicom.Network
             using var ms = new MemoryStream(buffer.Bytes, RawPDU.CommonFieldsLength, ushort.MaxValue - RawPDU.CommonFieldsLength);
             await using var rawPdu = new RawPDU(RawPduType.A_ASSOCIATE_RQ, _memoryProvider, DicomEncoding.Default, ms, true);
             Write(rawPdu);
-            var length = (ushort) ms.Position;
+            var length = (ushort)ms.Position;
             rawPdu.GetCommonFields(buffer, length);
             await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
         }
@@ -904,7 +904,7 @@ namespace FellowOakDicom.Network
             using var ms = new MemoryStream(buffer.Bytes, RawPDU.CommonFieldsLength, ushort.MaxValue - RawPDU.CommonFieldsLength);
             await using var rawPdu = new RawPDU(RawPduType.A_ASSOCIATE_AC, _memoryProvider, DicomEncoding.Default, ms, true);
             Write(rawPdu);
-            var length = (ushort) ms.Position;
+            var length = (ushort)ms.Position;
             rawPdu.GetCommonFields(buffer, length);
             await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
         }
@@ -1332,7 +1332,7 @@ namespace FellowOakDicom.Network
         /// Initializes a new A-RELEASE-RQ
         /// </summary>
         /// <param name="memoryProvider">The memory provider that will be used to allocate buffers</param>
-        public AReleaseRQ(IMemoryProvider memoryProvider) 
+        public AReleaseRQ(IMemoryProvider memoryProvider)
         {
             _memoryProvider = memoryProvider ?? throw new ArgumentNullException(nameof(memoryProvider));
         }
@@ -1383,12 +1383,12 @@ namespace FellowOakDicom.Network
     public class AReleaseRP : PDU
     {
         private readonly IMemoryProvider _memoryProvider;
-        
+
         /// <summary>
         /// Initializes a new A-RELEASE-RP
         /// </summary>
         /// <param name="memoryProvider">The memory provider that will be used to allocate buffers</param>
-        public AReleaseRP(IMemoryProvider memoryProvider) 
+        public AReleaseRP(IMemoryProvider memoryProvider)
         {
             _memoryProvider = memoryProvider ?? throw new ArgumentNullException(nameof(memoryProvider));
         }
@@ -1413,7 +1413,7 @@ namespace FellowOakDicom.Network
             await using var rawPdu = new RawPDU(RawPduType.A_RELEASE_RP, _memoryProvider, DicomEncoding.Default, ms, true);
             Write(rawPdu);
             rawPdu.GetCommonFields(buffer, length);
-            await stream.WriteAsync(buffer.Bytes,0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
         }
 
         private void Write(RawPDU pdu)
@@ -1508,7 +1508,7 @@ namespace FellowOakDicom.Network
         public override string ToString() => "A-ABORT";
 
         #region Write
-        
+
         /// <summary>
         /// Writes A-ABORT to the provided stream
         /// </summary>
@@ -1526,7 +1526,7 @@ namespace FellowOakDicom.Network
             rawPdu.GetCommonFields(buffer, length);
             await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
         }
-        
+
         private void Write(RawPDU pdu)
         {
             pdu.Write("Reserved", 0x00);
@@ -1619,12 +1619,13 @@ namespace FellowOakDicom.Network
         {
             // Instead of using rented byte arrays, P-DATA-TF PDVs are written directly to the underlying stream
             await using var pdu = new RawPDU(RawPduType.P_DATA_TF, _memoryProvider, DicomEncoding.Default, stream, true);
-            
+
             // For P-DATA-TF, we manually compose the preamble because we cannot use the length of the memory stream (because there is no memory stream) 
             using var preamble = _memoryProvider.Provide(RawPDU.CommonFieldsLength);
             var length = GetLengthOfPDVs();
             pdu.GetCommonFields(preamble, length);
-            await stream.WriteAsync(preamble.Bytes, 0, RawPDU.CommonFieldsLength, cancellationToken).ConfigureAwait(false);
+            // write synchronously, so that the pdu is flushed to the network at once if possible
+            stream.Write(preamble.Bytes, 0, RawPDU.CommonFieldsLength);
             Write(pdu);
         }
 
@@ -1670,7 +1671,7 @@ namespace FellowOakDicom.Network
             {
 
                 for (var i = 0; i < pdvs.Count; i++)
-                {
+            {
                     pdvs[i].Dispose();
                 }
             }
@@ -1682,7 +1683,7 @@ namespace FellowOakDicom.Network
     #region PDV
 
     /// <summary>PDV</summary>
-    public class PDV: IDisposable
+    public class PDV : IDisposable
     {
         private readonly IMemoryProvider _memoryProvider;
 
@@ -1690,7 +1691,7 @@ namespace FellowOakDicom.Network
         /// Flag to avoid double disposal
         /// </summary>
         private int _isDisposed;
-        
+
         /// <summary>
         /// Initializes new PDV
         /// </summary>
@@ -1758,7 +1759,7 @@ namespace FellowOakDicom.Network
         public void Write(RawPDU pdu)
         {
             var mch = (byte)((IsLastFragment ? 2 : 0) + (IsCommand ? 1 : 0));
-            pdu.Write("PDV-Length", 2 + (uint) ValueLength);
+            pdu.Write("PDV-Length", 2 + (uint)ValueLength);
             pdu.Write("Presentation Context ID", PCID);
             pdu.Write("Message Control Header", mch);
             pdu.Write("PDV Value", Value.Bytes, 0, ValueLength);


### PR DESCRIPTION
Fixes #1960 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- when DicomService sends the data to the network stream, then there is a separate PDataTFStream for the command data and another one for the actual dataset-data, so that the PDUs containing the command and the data are not mixed up together
- reduce memory consuption and increate performance by avoiding linq-methods
- a very frequently called method pdu.GetLengthOfPDVs which everytime summed up the sizes is now cached.
