### PR TITLE
Add Milliseconds to result in DicomDataset.GetDateTime

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 ### 5.2.3 (TBD)
-
+- Add Milliseconds to result in DicomDataset.GetDateTime (#1967)
 
 ### 5.2.2 (2025-04-22)
 - render images with window width < 1, but apply LINEAR_EXACT on rendering (#1905)

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -45,7 +45,7 @@ namespace FellowOakDicom
             var da = dd != null && dd.Count > 0 ? dd.Get<DateTime>(0) : DateTime.MinValue;
             var tm = dt != null && dt.Count > 0 ? dt.Get<DateTime>(0) : DateTime.MinValue;
 
-            return new DateTime(da.Year, da.Month, da.Day, tm.Hour, tm.Minute, tm.Second);
+            return new DateTime(da.Year, da.Month, da.Day, tm.Hour, tm.Minute, tm.Second, tm.Millisecond);
         }
 
         /// <summary>

--- a/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
@@ -27,6 +27,19 @@ namespace FellowOakDicom.Tests
         }
 
         [Fact]
+        public void GetDateTime_DateAndTimeAvailable_ReturnsSpecifiedDateTimeWithMilliseconds()
+        {
+            var expected = new DateTime(2016, 5, 25, 15, 54, 31, 750);
+
+            var dataset = new DicomDataset(
+                new DicomDate(DicomTag.CreationDate, "20160525"),
+                new DicomTime(DicomTag.CreationTime, "155431.750"));
+            var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void GetDateTime_DateAndTimeMissing_ReturnsMinimumDateTime()
         {
             var expected = DateTime.MinValue;
@@ -69,6 +82,21 @@ namespace FellowOakDicom.Tests
             var dataset = new DicomDataset(
                 new DicomDate(DicomTag.CreationDate, "20160525"),
                 new DicomTime(DicomTag.CreationTime, "155431"),
+                new DicomShortString(DicomTag.TimezoneOffsetFromUTC, "+0400"));
+
+            var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetDateTimeOffset_DateAndTimeAndTimezoneAvailable_ReturnsSpecifiedDateTimeWithMilliseconds()
+        {
+            var expected = new DateTimeOffset(2016, 5, 25, 15, 54, 31, 750, new TimeSpan(04, 00, 00));
+
+            var dataset = new DicomDataset(
+                new DicomDate(DicomTag.CreationDate, "20160525"),
+                new DicomTime(DicomTag.CreationTime, "155431.750"),
                 new DicomShortString(DicomTag.TimezoneOffsetFromUTC, "+0400"));
 
             var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);


### PR DESCRIPTION
Fixes #1967 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Method GetDateTime returns also millisecond 
