### PR TITLE
Gh 1975 empty rescale

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 - Add Milliseconds to result in DicomDataset.GetDateTime (#1967)
 - Add convenience function to open and save in DicomStructuredReport (#1968)
 - FO-DICOM.Tests target net9.0 instead of net6.0
+- allow rendering of images with empty rescale information (#1975)
 
 ### 5.2.2 (2025-04-22)
 - render images with window width < 1, but apply LINEAR_EXACT on rendering (#1905)

--- a/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
+++ b/FO-DICOM.Core/Imaging/GrayscaleRenderOptions.cs
@@ -131,7 +131,7 @@ namespace FellowOakDicom.Imaging
                 // If dataset contains WindowWidth and WindowCenter valid attributes used initially for the grayscale options
                 grayscaleRenderOptions = FromWindowLevel(dataset, frame);
             }
-            else if (dataset.FunctionalGroupValues(frame) is { } functionalGroupValues 
+            else if (dataset.FunctionalGroupValues(frame) is { } functionalGroupValues
                      && functionalGroupValues.TryGetValue(DicomTag.WindowWidth, 0, out double functionalWindowWidth) && functionalWindowWidth > 0
                      && functionalGroupValues.TryGetValue(DicomTag.WindowCenter, 0, out double _))
             {
@@ -149,7 +149,7 @@ namespace FellowOakDicom.Imaging
             {
                 // If reached here, minimum and maximum pixel values calculated from pixels data to calculate
                 // WindowWidth and WindowCenter
-                grayscaleRenderOptions = FromMinMax(dataset);    
+                grayscaleRenderOptions = FromMinMax(dataset);
             }
 
             /*
@@ -165,7 +165,7 @@ namespace FellowOakDicom.Imaging
                 (or more specifically prior to application of the VOI LUT Module attributes to the stored pixel data).
             */
             if (grayscaleRenderOptions.ModalityLUT != null
-                && dataset.TryGetSingleValue(DicomTag.SOPClassUID, out DicomUID sopClassUID) 
+                && dataset.TryGetSingleValue(DicomTag.SOPClassUID, out DicomUID sopClassUID)
                 && (sopClassUID == DicomUID.XRayAngiographicImageStorage
                 || sopClassUID == DicomUID.XRayRadiofluoroscopicImageStorage
                 || sopClassUID == DicomUID.XRayAngiographicBiPlaneImageStorageRETIRED))
@@ -208,15 +208,13 @@ namespace FellowOakDicom.Imaging
 
             var options = new GrayscaleRenderOptions(bits)
             {
-                RescaleSlope = dataset.Contains(DicomTag.RescaleSlope)
-                    ? dataset.GetSingleValue<double>(DicomTag.RescaleSlope)
-                    : functional.Contains(DicomTag.RescaleSlope)
-                    ? functional.GetSingleValue<double>(DicomTag.RescaleSlope)
+                RescaleSlope = dataset.TryGetSingleValue<double>(DicomTag.RescaleSlope, out var slope)
+                    || functional.TryGetSingleValue<double>(DicomTag.RescaleSlope, out slope)
+                    ? slope
                     : 1.0,
-                RescaleIntercept = dataset.Contains(DicomTag.RescaleIntercept)
-                    ? dataset.GetSingleValue<double>(DicomTag.RescaleIntercept)
-                    : functional.Contains(DicomTag.RescaleIntercept)
-                    ? functional.GetSingleValue<double>(DicomTag.RescaleIntercept)
+                RescaleIntercept = dataset.TryGetSingleValue<double>(DicomTag.RescaleIntercept, out var intercept)
+                    || functional.TryGetSingleValue(DicomTag.RescaleIntercept, out intercept)
+                    ? intercept
                     : 0.0,
 
                 WindowWidth = windowWidth,
@@ -253,7 +251,7 @@ namespace FellowOakDicom.Imaging
             {
                 return null;
             }
-            
+
             if (!functional.TryGetValue(DicomTag.WindowWidth, 0, out double windowWidth) ||
                 !functional.TryGetValue(DicomTag.WindowCenter, 0, out double windowCenter))
             {
@@ -276,15 +274,13 @@ namespace FellowOakDicom.Imaging
             var bits = BitDepth.FromDataset(dataset);
             var options = new GrayscaleRenderOptions(bits)
             {
-                RescaleSlope = dataset.Contains(DicomTag.RescaleSlope)
-                    ? dataset.GetSingleValue<double>(DicomTag.RescaleSlope)
-                    : functional.Contains(DicomTag.RescaleSlope)
-                    ? functional.GetSingleValue<double>(DicomTag.RescaleSlope)
+                RescaleSlope = dataset.TryGetSingleValue<double>(DicomTag.RescaleSlope, out var slope)
+                    || functional.TryGetSingleValue<double>(DicomTag.RescaleSlope, out slope)
+                    ? slope
                     : 1.0,
-                RescaleIntercept = dataset.Contains(DicomTag.RescaleIntercept)
-                    ? dataset.GetSingleValue<double>(DicomTag.RescaleIntercept)
-                    : functional.Contains(DicomTag.RescaleIntercept)
-                    ? functional.GetSingleValue<double>(DicomTag.RescaleIntercept)
+                RescaleIntercept = dataset.TryGetSingleValue<double>(DicomTag.RescaleIntercept, out var intercept)
+                    || functional.TryGetSingleValue(DicomTag.RescaleIntercept, out intercept)
+                    ? intercept
                     : 0.0,
 
                 WindowWidth = windowWidth,

--- a/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/GrayscaleRenderOptionsTest.cs
@@ -60,6 +60,40 @@ namespace FellowOakDicom.Tests.Imaging
             Assert.Equal(windowCenter, actual.WindowCenter);
         }
 
+        [Theory]
+        [InlineData((ushort)16, (ushort)12, (ushort)0, "1.0", "0.0", "500.0", "20.0", "LINEAR", 500.0, 20.0)]
+        [InlineData((ushort)16, (ushort)12, (ushort)0, "", "", "500.0", "20.0", "LINEAR", 500.0, 20.0)]
+        [InlineData((ushort)16, (ushort)12, (ushort)0, "1.0", "0.0", "", "", "LINEAR", null, null)]
+        public void FromWindowLevel_InvalidInput_CorrectOutput(
+          ushort bitsAllocated,
+          ushort bitsStored,
+          ushort pixelRepresentation,
+          string rescaleSlope,
+          string rescaleIntercept,
+          string windowWidth,
+          string windowCenter,
+          string voiLutFunction,
+          double? expectedWindowWith,
+          double? expectedWindowCenter)
+        {
+            var dataset = new DicomDataset(
+                new DicomCodeString(DicomTag.PhotometricInterpretation, "MONOCHROME1"),
+                new DicomUnsignedShort(DicomTag.BitsAllocated, bitsAllocated),
+                new DicomUnsignedShort(DicomTag.BitsStored, bitsStored),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, pixelRepresentation),
+                new DicomDecimalString(DicomTag.RescaleSlope, rescaleSlope),
+                new DicomDecimalString(DicomTag.RescaleIntercept, rescaleIntercept),
+                new DicomDecimalString(DicomTag.WindowWidth, windowWidth),
+                new DicomDecimalString(DicomTag.WindowCenter, windowCenter),
+                new DicomCodeString(DicomTag.VOILUTFunction, voiLutFunction));
+
+            var actual = GrayscaleRenderOptions.FromWindowLevel(dataset);
+
+            Assert.Equal(expectedWindowWith, actual?.WindowWidth);
+            Assert.Equal(expectedWindowCenter, actual?.WindowCenter);
+        }
+
+
         [Fact]
         public void FromDataset_WindowCenterWidth_Monochrome()
         {


### PR DESCRIPTION
Fixes #1975
There are invalid files, where the DicomTag RescaleIntersept and RescaleSlope are present but do not contain any value.
The code previously checked with Contains if there are Tags available, and then calls GetSingleValue. But this then failed.
So instead now TryGetSingleValue is called, which also checks if the tag is present and then tries if the content is parsable

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- use TryGetSingleValue instead of Contains and GetSingleValue
