### PR TITLE
Only process even groups as Overlay Plane Module

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Fix issue where rescale slope/intercept were used from dataset in case a Modality LUT Sequence is present (#1986)
 - allow rendering of images with empty rescale information (#1975)
 - Prevent stack overflow in DicomDirectory by changing recursive to iterative method (#1977)
+- Only accept even groups as Overlay Plane Module (#1994)
 
 ### 5.2.2 (2025-04-22)
 - render images with window width < 1, but apply LINEAR_EXACT on rendering (#1905)

--- a/FO-DICOM.Core/Imaging/DicomOverlayData.cs
+++ b/FO-DICOM.Core/Imaging/DicomOverlayData.cs
@@ -83,9 +83,12 @@ namespace FellowOakDicom.Imaging
             get
             {
                 var type = Dataset.GetSingleValue<string>(OverlayTag(DicomTag.OverlayType));
-                if (type.StartsWith("R")) return DicomOverlayType.ROI;
-                if (type.StartsWith("G")) return DicomOverlayType.Graphics;
-                throw new DicomImagingException($"Unsupported overlay type: {type}");
+                return type switch
+                {
+                    string s when s.StartsWith("R") => DicomOverlayType.ROI,
+                    string s when s.StartsWith("G") => DicomOverlayType.Graphics,
+                    _ => throw new DicomImagingException($"Unsupported overlay type: {type}")
+                };
             }
             set => Dataset.AddOrUpdate(
                     OverlayTag(DicomTag.OverlayType),
@@ -186,6 +189,8 @@ namespace FellowOakDicom.Imaging
 
         #region Public Members
 
+        public static readonly Func<DicomItem, bool> IsOverlaySequence = x => x.Tag.Group >= 0x6000 && x.Tag.Group <= 0x60FF && x.Tag.Group.IsEven();
+
         /// <summary>
         /// Gets the overlay data as <see cref="int"/> values.
         /// </summary>
@@ -217,7 +222,7 @@ namespace FellowOakDicom.Imaging
         {
             var groups = new List<ushort>();
             groups.AddRange(
-                ds.Where(x => x.Tag.Group >= 0x6000 && x.Tag.Group <= 0x60FF && x.Tag.Element == 0x0010)
+                ds.Where(x => DicomOverlayData.IsOverlaySequence(x) && x.Tag.Element == 0x0010)
                     .Select(x => x.Tag.Group));
             var overlays = new List<DicomOverlayData>();
             foreach (var group in groups)
@@ -247,7 +252,7 @@ namespace FellowOakDicom.Imaging
         {
             var groups = new List<ushort>();
             groups.AddRange(
-                ds.Where(x => x.Tag.Group >= 0x6000 && x.Tag.Group <= 0x60FF && x.Tag.Element == 0x0010)
+                ds.Where(x => DicomOverlayData.IsOverlaySequence(x) && x.Tag.Element == 0x0010)
                     .Select(x => x.Tag.Group));
 
             foreach (var group in groups)

--- a/FO-DICOM.Core/Imaging/Reconstruction/VolumeData.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/VolumeData.cs
@@ -95,7 +95,7 @@ namespace FellowOakDicom.Imaging.Reconstruction
             var commonData = new DicomDataset().NotValidated();
             commonData.Add(
                 _slices
-                .Select(s => s.Dataset.Where(t => t.Tag != DicomTag.PixelData || (t.Tag.Group >= 0x6000 && t.Tag.Group < 0x6100)))
+                .Select(s => s.Dataset.Where(t => t.Tag != DicomTag.PixelData || (DicomOverlayData.IsOverlaySequence(t))))
                 .Aggregate((x, y) => x.Intersect(y, valueComparer))
                 );
             return commonData;

--- a/Tests/FO-DICOM.Tests/Imaging/DicomOverlayDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomOverlayDataTest.cs
@@ -191,5 +191,21 @@ namespace FellowOakDicom.Tests.Imaging
             Assert.Equal(expected, originY);
         }
 
+        [Fact]
+        public void OnlyReadOverlayFromEvenGroups()
+        {
+            var dicomFile = DicomFile.Open(TestData.Resolve("multiframe.dcm"));
+            var dataset = dicomFile.Dataset;
+            // Add a generic "overlay" tag in the dataset to simulate an overlay
+            dataset.AddOrUpdate(new DicomLongString(new DicomTag(0x6001, 0x0010), "Generic Data"));
+
+            var hasEmbeddedOverlay = DicomOverlayData.HasEmbeddedOverlays(dataset);
+            Assert.False(hasEmbeddedOverlay);
+
+            dataset.AddOrUpdate(new DicomLongString(new DicomTag(0x6002, 0x0010), "Generic Data"));
+            hasEmbeddedOverlay = DicomOverlayData.HasEmbeddedOverlays(dataset);
+            Assert.True(hasEmbeddedOverlay);
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #1994 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- An issue arised that rendering a DicomImage was slow, because fo-dicom found a private group 6001 and processed it as if there was an overlay plane module. But instead this is only a private group. So the logic to find overlay plane modules now only checks even groups
