### PR TITLE
Correctly apply sign to the minutes part in DatetimeOffsetFromUTC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 - Add Milliseconds to result in DicomDataset.GetDateTime (#1967)
 - Add convenience function to open and save in DicomStructuredReport (#1968)
 - FO-DICOM.Tests target net9.0 instead of net6.0
+- Apply the sign to the minutes part of DatetimeOffsetFromUTC correctly (#1988)
 - Fix issue where rescale slope/intercept were used from dataset in case a Modality LUT Sequence is present (#1986)
 - allow rendering of images with empty rescale information (#1975)
 - Prevent stack overflow in DicomDirectory by changing recursive to iterative method (#1977)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 - Add convenience function to open and save in DicomStructuredReport (#1968)
 - FO-DICOM.Tests target net9.0 instead of net6.0
 - Apply the sign to the minutes part of DatetimeOffsetFromUTC correctly (#1988)
+- Add new functions TryGetDateTime and TryGetDateTimeOffset in DicomDataset (#1988)
 - Fix issue where rescale slope/intercept were used from dataset in case a Modality LUT Sequence is present (#1986)
 - allow rendering of images with empty rescale information (#1975)
 - Prevent stack overflow in DicomDirectory by changing recursive to iterative method (#1977)

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -71,12 +71,19 @@ namespace FellowOakDicom
             var timezone = (topLevelDataset ?? dataset).GetDicomItem<DicomShortString>(DicomTag.TimezoneOffsetFromUTC);
             if (timezone != null && timezone.Count > 0)
             {
-                // Explicit timezone information present in dataset
+                // Explicit timezone information present in dataset. The format is &XXZZ, where & is either '+' or '-' and XX or YY are the hours or minutes
                 string s = timezone.Get<string>();
-                int hh = int.Parse(s.Substring(0, 3));
+                DicomValidation.ValidateTimezoneOffset(s);
+                int sign = s[0] switch
+                {
+                    '+' => +1,
+                    '-' => -1,
+                    _ => throw new DicomValidationException(s, DicomVR.SH, "Invalid format for TimezoneOffsetFromUTC")
+                };
+                int hh = int.Parse(s.Substring(1, 2));
                 int mm = int.Parse(s.Substring(3, 2));
 
-                var offset = new TimeSpan(hh, mm, 00);
+                var offset = new TimeSpan(sign * hh, sign * mm, 00);
                 return new DateTimeOffset(datetime, offset);
             }
             else

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -71,7 +71,7 @@ namespace FellowOakDicom
             var timezone = (topLevelDataset ?? dataset).GetDicomItem<DicomShortString>(DicomTag.TimezoneOffsetFromUTC);
             if (timezone != null && timezone.Count > 0)
             {
-                // Explicit timezone information present in dataset. The format is &XXZZ, where & is either '+' or '-' and XX or YY are the hours or minutes
+                // Explicit timezone information present in dataset. The format is &XXYY, where & is either '+' or '-' and XX or YY are the hours or minutes
                 string s = timezone.Get<string>();
                 DicomValidation.ValidateTimezoneOffset(s);
                 int sign = s[0] switch

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -49,6 +49,35 @@ namespace FellowOakDicom
         }
 
         /// <summary>
+        /// Tries to get a composite <see cref="System.DateTime"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
+        /// </summary>
+        /// <param name="dataset">Dataset from which data should be retrieved.</param>
+        /// <param name="date">Tag associated with date value.</param>
+        /// <param name="time">Tag associated with time value.</param>
+        /// <param name="dateTime">Composite <see cref="System.DateTime"/>.</param>
+        /// <returns>Boolean if the composite DateTime could be extracted.</returns>
+        public static bool TryGetDateTime(this DicomDataset dataset, DicomTag date, DicomTag time, out DateTime dateTime)
+        {
+            try
+            {
+                var dd = dataset.GetDicomItem<DicomDate>(date);
+                var dt = dataset.GetDicomItem<DicomTime>(time);
+
+                var da = dd != null && dd.Count > 0 ? dd.Get<DateTime>(0) : DateTime.MinValue;
+                var tm = dt != null && dt.Count > 0 ? dt.Get<DateTime>(0) : DateTime.MinValue;
+
+                dateTime = new DateTime(da.Year, da.Month, da.Day, tm.Hour, tm.Minute, tm.Second, tm.Millisecond);
+                return true;
+            }
+            catch (Exception)
+            {
+                dateTime = DateTime.MinValue;
+                return false;
+            }
+        }
+
+
+        /// <summary>
         /// Get a composite <see cref="System.DateTimeOffset"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
         /// This will take any time zone information specified in the dataset into account. 
         /// If the dataset is a child sequence item, the <paramref name="topLevelDataset"/> must be specified to find time zone information.
@@ -93,6 +122,68 @@ namespace FellowOakDicom
                 // to get the offset for the specific date. Fortunately, this is
                 // the default of this class
                 return new DateTimeOffset(datetime);
+            }
+        }
+
+        /// <summary>
+        /// Tries to get a composite <see cref="System.DateTimeOffset"/> instance based on <paramref name="date"/> and <paramref name="time"/> values.
+        /// This will take any time zone information specified in the dataset into account. 
+        /// If the dataset is a child sequence item, the <paramref name="topLevelDataset"/> must be specified to find time zone information.
+        /// </summary>
+        /// <param name="dataset">Dataset from which data should be retrieved.</param>
+        /// <param name="date">Tag associated with date value.</param>
+        /// <param name="time">Tag associated with time value.</param>
+        /// <param name="datetimeoffset">Composite <see cref="System.DateTimeOffset"/>.</param>
+        /// <param name="topLevelDataset">The top-level dataset (if different from the current dataset). This is where the time zone information will be located</param>
+        /// <returns>Boolean if the composite DateTimeOffset could be extracted.</returns>
+        public static bool TryGetDateTimeOffset(this DicomDataset dataset, DicomTag date, DicomTag time, out DateTimeOffset datetimeoffset, DicomDataset topLevelDataset = null)
+        {
+            try
+            {
+                if (!TryGetDateTime(dataset, date, time, out var datetime) || datetime == DateTime.MinValue)
+                {
+                    // Don't specify timezone when no date or time is present. This will make
+                    // the behavior consistent with GetDateTime extension
+                    return false;
+                }
+
+                var timezone = (topLevelDataset ?? dataset).GetDicomItem<DicomShortString>(DicomTag.TimezoneOffsetFromUTC);
+                if (timezone != null && timezone.Count > 0)
+                {
+                    // Explicit timezone information present in dataset. The format is &XXYY, where & is either '+' or '-' and XX or YY are the hours or minutes
+                    string s = timezone.Get<string>();
+                    if (!DicomValidation.IsValidTimezoneOffset(s))
+                    {
+                        return false;
+                    }
+                    int sign = s[0] switch
+                    {
+                        '+' => +1,
+                        '-' => -1,
+                        _ => throw new DicomValidationException(s, DicomVR.SH, "Invalid format for TimezoneOffsetFromUTC")
+                    };
+                    if (!int.TryParse(s.Substring(1, 2), out var hh) || !int.TryParse(s.Substring(3, 2), out var mm))
+                    {
+                        return false;
+                    }
+
+                    var offset = new TimeSpan(sign * hh, sign * mm, 00);
+                    datetimeoffset = new DateTimeOffset(datetime, offset);
+                    return true;
+                }
+                else
+                {
+                    // Use local timezone when no explicit timezone info in dataset
+                    // Note! The local timezone may change with daylight savings, thus we need 
+                    // to get the offset for the specific date. Fortunately, this is
+                    // the default of this class
+                    datetimeoffset = new DateTimeOffset(datetime);
+                    return true;
+                }
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -452,15 +452,12 @@ namespace FellowOakDicom
                 }
                 else
                 {
-                    _values = new DateTime[vals.Length];
-                    for (int i = 0; i < vals.Length; i++)
-                    {
-                        _values[i] = DateTime.ParseExact(
-                            vals[i],
+                    _values = vals.Select(val => DateTime.ParseExact(
+                            val,
                             DateFormats,
                             _dicomDateElementFormat,
-                            _dicomDateElementStyle);
-                    }
+                            _dicomDateElementStyle))
+                        .ToArray();
                 }
             }
 

--- a/FO-DICOM.Core/DicomValidation.cs
+++ b/FO-DICOM.Core/DicomValidation.cs
@@ -706,6 +706,15 @@ namespace FellowOakDicom
             }
         }
 
+        public static void ValidateTimezoneOffset(string content)
+        {
+            // http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1.1.8
+            if (! Regex.IsMatch(content, @"^[+-]\d{4}$"))
+            {
+                throw new DicomValidationException(content, DicomVR.SH, "Invalid format for TimezoneOffsetFromUTC");
+            }
+        }
+
 
         private static bool IsControlExceptESC(char c)
             => char.IsControl(c) && (c != '\u001b');

--- a/FO-DICOM.Core/DicomValidation.cs
+++ b/FO-DICOM.Core/DicomValidation.cs
@@ -128,7 +128,7 @@ namespace FellowOakDicom
                 throw new DicomValidationException(content, DicomVR.DS, "value exceeds maximum length of 16 characters");
             }
 
-            content=content.Trim();
+            content = content.Trim();
             // This is not very inefficient - uses .NET regex caching
             if (!Regex.IsMatch(content, @"^[+-]?((\d+(\.\d*)?)|(\.\d+))([eE][-+]?\d+)?$"))
             {
@@ -379,12 +379,12 @@ namespace FellowOakDicom
             -2^31 <= n <= (2^31-1).
              */
 
-             if (string.IsNullOrEmpty(content))
+            if (string.IsNullOrEmpty(content))
             {
                 // empty value allowed
                 return;
             }
-       
+
             // leading or trailing spaces allowed
             content = content.Trim(' ');
 
@@ -513,7 +513,7 @@ namespace FellowOakDicom
             {
                 throw new DicomValidationException(content, DicomVR.PN, "value contains too many groups");
             }
-            foreach(var group in groups)
+            foreach (var group in groups)
             {
                 if (group.Length > 64)
                 {
@@ -709,11 +709,15 @@ namespace FellowOakDicom
         public static void ValidateTimezoneOffset(string content)
         {
             // http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1.1.8
-            if (! Regex.IsMatch(content, @"^[+-]\d{4}$"))
+            if (!IsValidTimezoneOffset(content))
             {
                 throw new DicomValidationException(content, DicomVR.SH, "Invalid format for TimezoneOffsetFromUTC");
             }
         }
+
+        public static bool IsValidTimezoneOffset(string content) =>
+            // http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1.1.8
+            Regex.IsMatch(content, @"^[+-]\d{4}$");
 
 
         private static bool IsControlExceptESC(char c)

--- a/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
@@ -180,6 +180,54 @@ namespace FellowOakDicom.Tests
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void ParseInvalidDateTimeOffset()
+        {
+            var ds1 = new DicomDataset
+            {
+                { DicomTag.SeriesDate, "20250701" },
+                { DicomTag.SeriesTime, "103000" },
+                { DicomTag.TimezoneOffsetFromUTC, "+01-3" } // Violating the DICOM standard
+            };
+
+            var ex = Record.Exception(() =>
+            {
+                var _ = ds1.GetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime);
+            });
+            Assert.NotNull(ex);
+        }
+
+        [Fact]
+        public void ParseInvalidDateTimeOffsetWithZoneName()
+        {
+            var ds1 = new DicomDataset
+            {
+                { DicomTag.SeriesDate, "20250701" },
+                { DicomTag.SeriesTime, "103000" },
+                { DicomTag.TimezoneOffsetFromUTC, "CET" } // Central European Time, is UTC+01:00
+            };
+
+            var ex = Record.Exception(() =>
+            {
+                var _ = ds1.GetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime);
+            });
+            Assert.NotNull(ex);
+        }
+
+        [Fact]
+        public void GetDateTimeOffset_NegativeMinutes()
+        {
+            var ds2 = new DicomDataset
+            {
+                { DicomTag.SeriesDate, "20250701" },
+                { DicomTag.SeriesTime, "103000" },
+                { DicomTag.TimezoneOffsetFromUTC, "-0130" }
+            };
+
+            var dateTimeOffset2 = ds2.GetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime);
+            Assert.Equal(new TimeSpan(hours: -1, minutes: -30, seconds: 0), dateTimeOffset2.Offset);
+        }
+
         #endregion
     }
 }

--- a/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetExtensionsTest.cs
@@ -24,6 +24,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTime(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetime);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetime);
         }
 
         [Fact]
@@ -37,6 +41,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTime(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetime);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetime);
         }
 
         [Fact]
@@ -48,6 +56,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTime(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetime);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetime);
         }
 
         [Fact]
@@ -60,6 +72,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTime(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetime);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetime);
         }
 
         [Fact]
@@ -72,7 +88,31 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTime(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetime);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetime);
         }
+
+        [Fact]
+        public void GetDateTime_DateInvalid_Throws()
+        {
+            var dataset = new DicomDataset().NotValidated().AddOrUpdate(
+                new DicomDate(DicomTag.CreationDate, "20163040"),
+                new DicomTime(DicomTag.CreationTime, "155431.750")
+            );
+            var ex = Record.Exception(() =>
+            {
+                var _ = dataset.GetDateTime(DicomTag.CreationDate, DicomTag.CreationTime);
+            });
+
+            Assert.NotNull(ex);
+
+            var result = dataset.TryGetDateTime(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetime);
+            Assert.False(result);
+        }
+
+
 
         [Fact]
         public void GetDateTimeOffset_DateAndTimeAndTimezoneAvailable_ReturnsSpecifiedDateTime()
@@ -87,6 +127,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetimeoffset);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetimeoffset);
         }
 
         [Fact]
@@ -102,6 +146,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetimeoffset);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetimeoffset);
         }
 
         [Fact]
@@ -117,6 +165,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetimeoffset);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetimeoffset);
         }
 
         [Fact]
@@ -131,6 +183,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetimeoffset);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetimeoffset);
         }
 
         [Fact]
@@ -145,6 +201,10 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTimeOffset(DicomTag.CreationDate, DicomTag.CreationTime, out var creationDatetimeoffset);
+            Assert.True(result);
+            Assert.Equal(expected, creationDatetimeoffset);
         }
 
         [Fact]
@@ -158,6 +218,9 @@ namespace FellowOakDicom.Tests
             var actual = dataset.GetDateTimeOffset(DicomTag.StudyDate, DicomTag.StudyTime);
 
             Assert.Equal(expected, actual);
+
+            var result = dataset.TryGetDateTimeOffset(DicomTag.StudyDate, DicomTag.StudyTime, out var studyDatetimeoffset);
+            Assert.False(result);
         }
 
         [Fact]
@@ -178,6 +241,10 @@ namespace FellowOakDicom.Tests
 
             var actual = scheduledProcedure.GetDateTimeOffset(DicomTag.ScheduledProcedureStepStartDate, DicomTag.ScheduledProcedureStepStartTime, dataset);
             Assert.Equal(expected, actual);
+
+            var result = scheduledProcedure.TryGetDateTimeOffset(DicomTag.ScheduledProcedureStepStartDate, DicomTag.ScheduledProcedureStepStartTime, out var scheduledDatetimeoffset, dataset);
+            Assert.True(result);
+            Assert.Equal(expected, scheduledDatetimeoffset);
         }
 
         [Fact]
@@ -195,6 +262,9 @@ namespace FellowOakDicom.Tests
                 var _ = ds1.GetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime);
             });
             Assert.NotNull(ex);
+
+            var result = ds1.TryGetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime, out var _);
+            Assert.False(result);
         }
 
         [Fact]
@@ -212,11 +282,15 @@ namespace FellowOakDicom.Tests
                 var _ = ds1.GetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime);
             });
             Assert.NotNull(ex);
+
+            var result = ds1.TryGetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime, out var _);
+            Assert.False(result);
         }
 
         [Fact]
         public void GetDateTimeOffset_NegativeMinutes()
         {
+            var expected = new TimeSpan(hours: -1, minutes: -30, seconds: 0);
             var ds2 = new DicomDataset
             {
                 { DicomTag.SeriesDate, "20250701" },
@@ -225,7 +299,11 @@ namespace FellowOakDicom.Tests
             };
 
             var dateTimeOffset2 = ds2.GetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime);
-            Assert.Equal(new TimeSpan(hours: -1, minutes: -30, seconds: 0), dateTimeOffset2.Offset);
+            Assert.Equal(expected, dateTimeOffset2.Offset);
+
+            var result = ds2.TryGetDateTimeOffset(DicomTag.SeriesDate, DicomTag.SeriesTime, out var seriesDatetimeoffset);
+            Assert.True(result);
+            Assert.Equal(expected, seriesDatetimeoffset.Offset);
         }
 
         #endregion


### PR DESCRIPTION
Fixes #1988 
The content of DatetimeOffsetFromUTC was parsed to integer directly without any validation of the format. So if there is some wrong data, then any random exception might have been raised. Now there is a call to a regex validator and in case of invalid format a DicomValidationException is thrown.
Furthermore the sign of the offset is parsed separately and applied to both, the hour and the minutes part.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- validate the content of DatetimeOffsetFromUTC and apply the sign correctly
