### PR TITLE
Fix memory leak in DicomServer.RemoveUnusedServicesAsync()

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
 - allow rendering of images with empty rescale information (#1975)
 - Prevent stack overflow in DicomDirectory by changing recursive to iterative method (#1977)
 - Only accept even groups as Overlay Plane Module (#1994)
+- Fix memory leak in DicomServer (#2009)
 
 ### 5.2.2 (2025-04-22)
 - render images with window width < 1, but apply LINEAR_EXACT on rendering (#1905)

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -389,8 +389,12 @@ namespace FellowOakDicom.Network
                     // First, we wait until at least one service is running
                     // We don't actually care about the values inside the channel, they just serve as a notification that a service has connected
                     // It is also possible that the DICOM server is stopped while are waiting here
-                    var aServiceHasStarted = _servicesChannel.Reader.ReadAsync(_cancellationToken).AsTask();
-                    await Task.WhenAny(aServiceHasStarted, _stopped.Task).ConfigureAwait(false);
+                    using (var readerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken))
+                    {
+                        var aServiceHasStarted = _servicesChannel.Reader.ReadAsync(readerCts.Token).AsTask();
+                        await Task.WhenAny(aServiceHasStarted, _stopped.Task).ConfigureAwait(false);
+                        readerCts.Cancel();
+                    } 
                     _cancellationToken.ThrowIfCancellationRequested();
 
                     // Then, we wait until at least one service completes
@@ -415,35 +419,42 @@ namespace FellowOakDicom.Network
                             break;
                         }
 
-                        var tasks = new List<Task>(numberOfDicomServices + 1);
-                        var anotherServiceHasStarted = _servicesChannel.Reader.ReadAsync(_cancellationToken).AsTask();
-                        tasks.Add(anotherServiceHasStarted);
-                        tasks.AddRange(runningDicomServices.Select(s => s.Task));
-                        var winner = await Task.WhenAny(tasks).ConfigureAwait(false);
-                        if (winner == anotherServiceHasStarted)
+                        using (var readerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken))
                         {
-                            try
+                            var anotherServiceHasStarted = _servicesChannel.Reader.ReadAsync(readerCts.Token).AsTask();
+                            
+                            var tasks = new List<Task>(numberOfDicomServices + 1);
+                            tasks.Add(anotherServiceHasStarted);
+                            tasks.AddRange(runningDicomServices.Select(s => s.Task));
+                            var winner = await Task.WhenAny(tasks).ConfigureAwait(false);
+                            
+                            readerCts.Cancel();
+                            
+                            if (winner == anotherServiceHasStarted)
                             {
-                                await anotherServiceHasStarted;
-                            }
-                            catch (OperationCanceledException)
-                            {
-                                // If the server is disposed while we were waiting, deal with that gracefully
-                                break;
-                            }
-                            catch (ChannelClosedException)
-                            {
-                                // If the server is disposed while we were waiting, deal with that gracefully
-                                break;
-                            }
+                                try
+                                {
+                                    await anotherServiceHasStarted;
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    // If the server is disposed while we were waiting, deal with that gracefully
+                                    break;
+                                }
+                                catch (ChannelClosedException)
+                                {
+                                    // If the server is disposed while we were waiting, deal with that gracefully
+                                    break;
+                                }
 
-                            // If another service started, we must restart the Task.WhenAny with the new set of running service tasks
-                            Logger.LogDebug("Another DICOM service has started while the cleanup was waiting for one or more DICOM services to complete");
-                        }
-                        else
-                        {
-                            Logger.LogDebug("One or more running DICOM services have completed");
-                            break;
+                                // If another service started, we must restart the Task.WhenAny with the new set of running service tasks
+                                Logger.LogDebug("Another DICOM service has started while the cleanup was waiting for one or more DICOM services to complete");
+                            }
+                            else
+                            {
+                                Logger.LogDebug("One or more running DICOM services have completed");
+                                break;
+                            }
                         }
                     }
 


### PR DESCRIPTION
fix memory leak by nicely cancelling the _servicesChannel.Reader.ReadAsync() cancellation token in case it hasn't finished yet to make sure there's always a single reader on the SingleConsumerUnboundedChannel
Fixes #2009 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests --> not sure how I could unit test this one
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
