### PR TITLE
Fix DicomMatchRules not matching any value

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
 - allow rendering of images with empty rescale information (#1975)
 - Prevent stack overflow in DicomDirectory by changing recursive to iterative method (#1977)
 - Only accept even groups as Overlay Plane Module (#1994)
+- Fix issue where all DicomMatchRules would not match any value (#2010)
 
 ### 5.2.2 (2025-04-22)
 - render images with window width < 1, but apply LINEAR_EXACT on rendering (#1905)

--- a/FO-DICOM.Core/DicomMatchRules.cs
+++ b/FO-DICOM.Core/DicomMatchRules.cs
@@ -235,7 +235,7 @@ namespace FellowOakDicom
 
         public bool Match(DicomDataset dataset)
         {
-            var value = dataset.GetValueOrDefault(_tag, -1, string.Empty);
+            var value = dataset.TryGetString(_tag, out string tagValue) ? tagValue : string.Empty;
             return _value == value;
         }
 
@@ -271,7 +271,7 @@ namespace FellowOakDicom
 
         public bool Match(DicomDataset dataset)
         {
-            var value = dataset.GetValueOrDefault(_tag, -1, string.Empty);
+            var value = dataset.TryGetString(_tag, out string tagValue) ? tagValue : string.Empty;
             return value.StartsWith(_value);
         }
 
@@ -307,7 +307,7 @@ namespace FellowOakDicom
 
         public bool Match(DicomDataset dataset)
         {
-            var value = dataset.GetValueOrDefault(_tag, -1, string.Empty);
+            var value = dataset.TryGetString(_tag, out string tagValue) ? tagValue : string.Empty;
             return value.EndsWith(_value);
         }
 
@@ -343,7 +343,7 @@ namespace FellowOakDicom
 
         public bool Match(DicomDataset dataset)
         {
-            var value = dataset.GetValueOrDefault(_tag, -1, string.Empty);
+            var value = dataset.TryGetString(_tag, out string tagValue) ? tagValue : string.Empty;
             return value.Contains(_value);
         }
 
@@ -379,7 +379,7 @@ namespace FellowOakDicom
 
         public bool Match(DicomDataset dataset)
         {
-            var value = dataset.GetValueOrDefault(_tag, -1, string.Empty);
+            var value = dataset.TryGetString(_tag, out string tagValue) ? tagValue : string.Empty;
             return value.Wildcard(_pattern);
         }
 
@@ -418,7 +418,7 @@ namespace FellowOakDicom
 
         public bool Match(DicomDataset dataset)
         {
-            var value = dataset.GetValueOrDefault(_tag, -1, string.Empty);
+            var value = dataset.TryGetString(_tag, out string tagValue) ? tagValue : string.Empty;
             return _regex.IsMatch(value);
         }
 
@@ -454,7 +454,7 @@ namespace FellowOakDicom
 
         public bool Match(DicomDataset dataset)
         {
-            var value = dataset.GetValueOrDefault(_tag, -1, string.Empty);
+            var value = dataset.TryGetString(_tag, out string tagValue) ? tagValue : string.Empty;
             return _values.Any(v => v == value);
         }
 

--- a/Tests/FO-DICOM.Tests/DicomMatchRulesTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomMatchRulesTest.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using Xunit;
+
+namespace FellowOakDicom.Tests
+{
+    [Collection(TestCollections.General)]
+    public class DicomMatchRulesTest
+    {
+        public DicomDataset TestDataset { get; } = new DicomDataset()
+        {
+            { DicomTag.PatientName, "Doe^John" },
+            { DicomTag.PatientID, "123456" },
+            { DicomTag.StudyDescription, "Test study 1" },
+            { DicomTag.SeriesDescription, "Test series 1" },
+        };
+
+        [Fact]
+        public void EqualsDicomMatchRule_MatchingString_ReturnsTrue()
+        {
+            var matchRule = new EqualsDicomMatchRule(DicomTag.PatientName, "Doe^John");
+            Assert.True(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void EqualsDicomMatchRule_NonMatchingString_ReturnsFalse()
+        {
+            var matchRule = new EqualsDicomMatchRule(DicomTag.PatientID, "Doe^John");
+            Assert.False(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void StartsWithDicomMatchRule_MatchingString_ReturnsTrue()
+        {
+            var matchRule = new StartsWithDicomMatchRule(DicomTag.PatientName, "Do");
+            Assert.True(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void StartsWithDicomMatchRule_NonMatchingString_ReturnsFalse()
+        {
+            var matchRule = new StartsWithDicomMatchRule(DicomTag.PatientID, "Do");
+            Assert.False(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void EndsWithDicomMatchRule_MatchingString_ReturnsTrue()
+        {
+            var matchRule = new EndsWithDicomMatchRule(DicomTag.PatientName, "ohn");
+            Assert.True(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void EndsWithDicomMatchRule_NonMatchingString_ReturnsFalse()
+        {
+            var matchRule = new EndsWithDicomMatchRule(DicomTag.PatientID, "ohn");
+            Assert.False(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void ContainsDicomMatchRule_MatchingString_ReturnsTrue()
+        {
+            var matchRule = new ContainsDicomMatchRule(DicomTag.StudyDescription, "study");
+            Assert.True(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void ContainsDicomMatchRule_NonMatchingString_ReturnsFalse()
+        {
+            var matchRule = new ContainsDicomMatchRule(DicomTag.SeriesDescription, "study");
+            Assert.False(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void WildcardDicomMatchRule_MatchingString_ReturnsTrue()
+        {
+            var matchRule = new WildcardDicomMatchRule(DicomTag.SeriesDescription, "*series?1");
+            Assert.True(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void WildcardDicomMatchRule_NonMatchingString_ReturnsFalse()
+        {
+            var matchRule = new WildcardDicomMatchRule(DicomTag.SeriesDescription, "?series 1");
+            Assert.False(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void RegexDicomMatchRule_MatchingString_ReturnsTrue()
+        {
+            var matchRule = new RegexDicomMatchRule(DicomTag.StudyDescription, @"^(?i)test StuDy \d{1}$");
+            Assert.True(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void RegexDicomMatchRule_NonMatchingString_ReturnsFalse()
+        {
+            var matchRule = new RegexDicomMatchRule(DicomTag.SeriesDescription, @"^(?i)test series \d{2}$");
+            Assert.False(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void OneOfDicomMatchRule_MatchingString_ReturnsTrue()
+        {
+            var matchRule1 = new OneOfDicomMatchRule(DicomTag.PatientID, "123456", "Doe^John");
+            var matchRule2 = new OneOfDicomMatchRule(DicomTag.PatientName, "123456", "Doe^John");
+            Assert.True(matchRule1.Match(TestDataset));
+            Assert.True(matchRule2.Match(TestDataset));
+        }
+
+        [Fact]
+        public void OneOfDicomMatchRule_NonMatchingString_ReturnsFalse()
+        {
+            var matchRule1 = new OneOfDicomMatchRule(DicomTag.SeriesDescription, "123456", "Doe^John", "series");
+            var matchRule2 = new OneOfDicomMatchRule(DicomTag.StudyDescription, "123456", "Doe^John", "study");
+            Assert.False(matchRule1.Match(TestDataset));
+            Assert.False(matchRule2.Match(TestDataset));
+        }
+
+        [Fact]
+        public void BoolDicomMatchRule_ReturnsTrue()
+        {
+            var matchRule = new BoolDicomMatchRule(true);
+            Assert.True(matchRule.Match(TestDataset));
+        }
+
+        [Fact]
+        public void BoolDicomMatchRule_ReturnsFalse()
+        {
+            var matchRule = new BoolDicomMatchRule(false);
+            Assert.False(matchRule.Match(TestDataset));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2010 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] ~~I have updated API documentation~~
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
All DicomMatchRules still used the old -1 index (used in the old Get method) for getting the whole value string representation.
Fixed by using `TryGetString` instead of 'GetValueOrDefault'.
