### PR TITLE
Fix DicomFile Deep-Clone

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 ### 5.2.4 (TBD)
-
+- Fix issue where DicomFile.Clone did not do a deep-clone as expected (#2025)
 
 ### 5.2.3 (2025-09-18)
 - Add Milliseconds to result in DicomDataset.GetDateTime (#1967)

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -16,7 +16,7 @@ namespace FellowOakDicom
     {
 
         /// <summary>
-        /// Clone a dataset.
+        /// Deep-Clone a dataset.
         /// </summary>
         /// <param name="dataset">Dataset to be cloned.</param>
         /// <returns>Clone of dataset.</returns>

--- a/FO-DICOM.Core/DicomFile.cs
+++ b/FO-DICOM.Core/DicomFile.cs
@@ -118,7 +118,7 @@ namespace FellowOakDicom
         /// <summary>
         /// Gets the DICOM dataset of the file.
         /// </summary>
-        public DicomDataset Dataset { get; protected set; }
+        public DicomDataset Dataset { get; internal set; }
 
         /// <summary>
         /// Gets whether the parsing of the file ended prematurely.

--- a/FO-DICOM.Core/DicomFileExtensions.cs
+++ b/FO-DICOM.Core/DicomFileExtensions.cs
@@ -19,8 +19,7 @@ namespace FellowOakDicom
         {
             var df = new DicomFile();
             df.FileMetaInfo.Add(original.FileMetaInfo);
-            df.Dataset.ValidateItems = false;
-            df.Dataset.Add(original.Dataset);
+            df.Dataset = original.Dataset.Clone();
             df.Dataset.ValidateItems = original.Dataset.ValidateItems;
             df.Dataset.InternalTransferSyntax = original.Dataset.InternalTransferSyntax;
             return df;

--- a/Tests/FO-DICOM.Tests/DicomFileTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomFileTest.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -427,6 +428,51 @@ namespace FellowOakDicom.Tests
             var bytes1 = File.ReadAllBytes("saveasynctofile1");
             var bytes2 = File.ReadAllBytes("saveasynctofile2");
             Assert.Equal(bytes1, bytes2);
+        }
+
+        [Fact]
+        public void Clone_ShouldDoADeepClone()
+        {
+            // prepare:
+            var seedDicomDataset = new DicomDataset();
+            var procedureCodeItem = new DicomDataset
+            {
+                { DicomTag.CodeValue, "12345" },
+                { DicomTag.CodingSchemeDesignator, "SRT" },
+                { DicomTag.CodeMeaning, "CT Abdomen" }
+            };
+            // Add the item as a sequence
+            seedDicomDataset.Add(DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage.UID);
+            seedDicomDataset.Add(DicomTag.StudyInstanceUID, "123");
+            seedDicomDataset.Add(DicomTag.SeriesInstanceUID, "123");
+            seedDicomDataset.Add(DicomTag.SOPInstanceUID, "123");
+            seedDicomDataset.Add(new DicomSequence(DicomTag.ProcedureCodeSequence, procedureCodeItem));
+            // wrap in DicomFile
+            var seedDicomFile = new DicomFile(seedDicomDataset);
+
+            // Act:
+            // clone seedDicomFile and update CodeValue
+            DicomFile cloneDicomFile = seedDicomFile.Clone();
+            cloneDicomFile.Dataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).AddOrUpdate(DicomTag.CodeValue, "UPDATE from DF");
+
+            // clone seedDataset and update CodeMeaning
+            DicomDataset cloneDicomDataset = seedDicomDataset.Clone();
+            cloneDicomDataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).AddOrUpdate(DicomTag.CodeMeaning, "UPDATE from DS");
+
+            // Verify:
+            // Expect unchanged content in seedDicomDataset and seedDicomFile
+            Assert.Equal("12345", seedDicomDataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeValue));
+            Assert.Equal("CT Abdomen", seedDicomDataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeMeaning));
+            Assert.Equal("12345", seedDicomFile.Dataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeValue));
+            Assert.Equal("CT Abdomen", seedDicomFile.Dataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeMeaning));
+
+            // expect changed CodeValue but unchanged CodeMeaning in cloneDicomFile
+            Assert.Equal("UPDATE from DF", cloneDicomFile.Dataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeValue));
+            Assert.Equal("CT Abdomen", cloneDicomFile.Dataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeMeaning));
+
+            // exptect chaned CodeMeaning but unchanged CodeValue in cloneDicomDataset
+            Assert.Equal("12345", cloneDicomDataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeValue));
+            Assert.Equal("UPDATE from DS", cloneDicomDataset.GetSequence(DicomTag.ProcedureCodeSequence).ElementAt(0).GetString(DicomTag.CodeMeaning));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #2025 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- DicomFile.Clone just copied items from the source DicomDataset to the new DicomDataset. but this does not do a deep clone. The DicomDataset.Clone method already does a deep clone, so DicomFile.Clone now uses DicomDataset.Clone internally.
