### PR TITLE
GH2046 - DicomServer can keep last finished DICOM Clients in memory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 ### 5.2.5 (TBD)
+- Fix issue where DicomServer can keep last finished DICOM Clients in memory (#2046)
 
 
 ### 5.2.4 (2025-10-03)

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -398,129 +398,149 @@ namespace FellowOakDicom.Network
                     } 
                     _cancellationToken.ThrowIfCancellationRequested();
 
-                    // Then, we wait until at least one service completes
-                    // We must take into account that more services can start while we wait here
-                    while (true)
-                    {
-                        List<RunningDicomService> runningDicomServices;
-
-                        while (_servicesChannel.Reader.TryRead(out _))
-                        {
-                            // Discard queued new services, we're only interested in new arrivals after we start waiting                            
-                        }
-                        lock (_services)
-                        {
-                            runningDicomServices = _services.ToList();
-                        }
-                        var numberOfDicomServices = runningDicomServices.Count;
-                        Logger.LogDebug("There are {NumberOfDicomServices} running DICOM services", numberOfDicomServices);
-                        if (numberOfDicomServices == 0)
-                        {
-                            // No more services at all? Exit early
-                            break;
-                        }
-
-                        using (var readerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken))
-                        {
-                            var anotherServiceHasStarted = _servicesChannel.Reader.ReadAsync(readerCts.Token).AsTask();
-                            
-                            var tasks = new List<Task>(numberOfDicomServices + 1);
-                            tasks.Add(anotherServiceHasStarted);
-                            tasks.AddRange(runningDicomServices.Select(s => s.Task));
-                            var winner = await Task.WhenAny(tasks).ConfigureAwait(false);
-                            
-                            readerCts.Cancel();
-                            
-                            if (winner == anotherServiceHasStarted)
-                            {
-                                try
-                                {
-                                    await anotherServiceHasStarted;
-                                }
-                                catch (OperationCanceledException)
-                                {
-                                    // If the server is disposed while we were waiting, deal with that gracefully
-                                    break;
-                                }
-                                catch (ChannelClosedException)
-                                {
-                                    // If the server is disposed while we were waiting, deal with that gracefully
-                                    break;
-                                }
-
-                                // If another service started, we must restart the Task.WhenAny with the new set of running service tasks
-                                Logger.LogDebug("Another DICOM service has started while the cleanup was waiting for one or more DICOM services to complete");
-                            }
-                            else
-                            {
-                                Logger.LogDebug("One or more running DICOM services have completed");
-                                break;
-                            }
-                        }
-                    }
-
                     int numberOfRemainingServices;
-                    var servicesToDispose = new List<RunningDicomService>();
                     lock (_services)
                     {
-                        for (var i = _services.Count - 1; i >= 0; i--)
+                        numberOfRemainingServices = _services.Count;
+                    }
+
+                    while (numberOfRemainingServices > 0)
+                    {
+                        await Task.Delay(500, _cancellationToken); // Short delay to avoid busy waiting on a lot of DICOM Clients being stopped at the same time
+
+                        // Then, we wait until at least one service completes
+                        // We must take into account that more services can start while we wait here
+                        while (true)
                         {
-                            var service = _services[i];
-                            if (service.Task.IsCompleted)
+                            List<RunningDicomService> runningDicomServices;
+
+                            while (_servicesChannel.Reader.TryRead(out _))
                             {
-                                _services.RemoveAt(i);
-                                servicesToDispose.Add(service);
+                                // Discard queued new services, we're only interested in new arrivals after we start waiting                            
+                            }
+
+                            lock (_services)
+                            {
+                                runningDicomServices = _services.ToList();
+                            }
+
+                            var numberOfDicomServices = runningDicomServices.Count;
+                            Logger.LogDebug("There are {NumberOfDicomServices} running DICOM services",
+                                numberOfDicomServices);
+                            if (numberOfDicomServices == 0)
+                            {
+                                // No more services at all? Exit early
+                                break;
+                            }
+
+                            using (var readerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken))
+                            {
+                                var anotherServiceHasStarted =
+                                    _servicesChannel.Reader.ReadAsync(readerCts.Token).AsTask();
+
+                                var tasks = new List<Task>(numberOfDicomServices + 1);
+                                tasks.Add(anotherServiceHasStarted);
+                                tasks.AddRange(runningDicomServices.Select(s => s.Task));
+                                var winner = await Task.WhenAny(tasks).ConfigureAwait(false);
+
+                                readerCts.Cancel();
+
+                                if (winner == anotherServiceHasStarted)
+                                {
+                                    try
+                                    {
+                                        await anotherServiceHasStarted;
+                                    }
+                                    catch (OperationCanceledException)
+                                    {
+                                        // If the server is disposed while we were waiting, deal with that gracefully
+                                        break;
+                                    }
+                                    catch (ChannelClosedException)
+                                    {
+                                        // If the server is disposed while we were waiting, deal with that gracefully
+                                        break;
+                                    }
+
+                                    // If another service started, we must restart the Task.WhenAny with the new set of running service tasks
+                                    Logger.LogDebug(
+                                        "Another DICOM service has started while the cleanup was waiting for one or more DICOM services to complete");
+                                }
+                                else
+                                {
+                                    Logger.LogDebug("One or more running DICOM services have completed");
+                                    break;
+                                }
+                            }
+                        }
+                        
+                        var servicesToDispose = new List<RunningDicomService>();
+                        lock (_services)
+                        {
+                            for (var i = _services.Count - 1; i >= 0; i--)
+                            {
+                                var service = _services[i];
+                                if (service.Task.IsCompleted)
+                                {
+                                    _services.RemoveAt(i);
+                                    servicesToDispose.Add(service);
+                                }
+                            }
+
+                            numberOfRemainingServices = _services.Count;
+                        }
+
+                        var numberOfCompletedServices = servicesToDispose.Count;
+                        foreach (var service in servicesToDispose)
+                        {
+                            try
+                            {
+                                service.Dispose();
+                            }
+                            catch (Exception e)
+                            {
+                                Logger.LogWarning(
+                                    "An error occurred while trying to dispose a completed DICOM service: {@Error}", e);
                             }
                         }
 
-                        numberOfRemainingServices = _services.Count;
-                    }
-                    var numberOfCompletedServices = servicesToDispose.Count;
-                    foreach (var service in servicesToDispose)
-                    {
-                        try
+                        // Avoid object disposed exception if we can
+                        if (!_cancellationToken.IsCancellationRequested)
                         {
-                            service.Dispose();
+                            _maxClientsSemaphore?.Release(numberOfCompletedServices);
                         }
-                        catch (Exception e)
+
+                        Logger.LogDebug("Cleaned up {NumberOfCompletedServices} completed DICOM services",
+                            numberOfCompletedServices);
+                        if (numberOfRemainingServices > 0)
                         {
-                            Logger.LogWarning("An error occurred while trying to dispose a completed DICOM service: {@Error}", e);
-                        }
-                    }
-
-                    // Avoid object disposed exception if we can
-                    if (!_cancellationToken.IsCancellationRequested)
-                    {
-                        _maxClientsSemaphore?.Release(numberOfCompletedServices);
-                    }
-
-                    Logger.LogDebug("Cleaned up {NumberOfCompletedServices} completed DICOM services", numberOfCompletedServices);
-                    if (numberOfRemainingServices > 0)
-                    {
-                        Logger.LogDebug("There are still {NumberOfRemainingServices} clients connected now", numberOfRemainingServices);
-                    }
-                    else
-                    {
-                        Logger.LogDebug("There are no clients connected now");
-                    }
-
-                    if (maxClientsAllowed > 0)
-                    {
-                        if (numberOfRemainingServices == maxClientsAllowed)
-                        {
-                            Logger.LogDebug("Cannot accept more incoming client connections until one or more clients disconnect");
+                            Logger.LogDebug("There are still {NumberOfRemainingServices} clients connected now",
+                                numberOfRemainingServices);
                         }
                         else
                         {
-                            var numberOfExtraClientsAllowed = maxClientsAllowed - numberOfRemainingServices;
-                            Logger.LogDebug(
-                                "{NumberOfExtraServicesAllowed} more incoming client connections are allowed",
-                                numberOfExtraClientsAllowed);
+                            Logger.LogDebug("There are no clients connected now");
                         }
-                    }
-                    else
-                    {
-                        Logger.LogDebug("Unlimited more incoming client connections are allowed");
+
+                        if (maxClientsAllowed > 0)
+                        {
+                            if (numberOfRemainingServices == maxClientsAllowed)
+                            {
+                                Logger.LogDebug(
+                                    "Cannot accept more incoming client connections until one or more clients disconnect");
+                            }
+                            else
+                            {
+                                var numberOfExtraClientsAllowed = maxClientsAllowed - numberOfRemainingServices;
+                                Logger.LogDebug(
+                                    "{NumberOfExtraServicesAllowed} more incoming client connections are allowed",
+                                    numberOfExtraClientsAllowed);
+                            }
+                        }
+                        else
+                        {
+                            Logger.LogDebug("Unlimited more incoming client connections are allowed");
+                        }
                     }
                 }
                 catch (ChannelClosedException)

--- a/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
@@ -1,0 +1,93 @@
+﻿using FellowOakDicom.Log;
+using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using FellowOakDicom.Tests.Helpers;
+using FellowOakDicom.Tests.Network;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    [Collection(TestCollections.Network)]
+    public class GH2046
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public GH2046(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper).IncludeTimestamps().IncludeThreadId();
+        }
+        
+        [Fact]
+        public async Task RemoveUnusedServicesAsync_ShouldCleanupAllFinishedInternalServices()
+        {
+            var serverLogger = _logger.IncludePrefix("Server").WithMinimumLevel(LogLevel.Information);
+            var disposedDicomServices = new ConcurrentStack<DicomService>();
+            var cEchoRequestCount = 0;
+
+            using (var server = (DicomServerTest.DisposableDicomCEchoProviderServer)DicomServerFactory
+                       .Create<DicomServerTest.DisposableDicomCEchoProvider, DicomServerTest.DisposableDicomCEchoProviderServer>(
+                           "127.0.0.1", 0, logger: serverLogger))
+            {
+                server.OnDispose = service => disposedDicomServices.Push(service);
+                
+                var numberOfClients = 50;
+                
+                //First run to warm up
+                var tasks = new List<Task>();
+                for (int i = 0; i < numberOfClients; i++)
+                {
+                    tasks.Add(Task.Run(SendCEchoRequests));
+                }
+
+                await Task.WhenAll(tasks);
+                
+                //Second run, so we're sure there are no more allocations happening
+                tasks.Clear();
+                for (int i = 0; i < numberOfClients; i++)
+                {
+                    tasks.Add(Task.Run(SendCEchoRequests));
+                }
+                
+                await Task.WhenAll(tasks);
+
+                Assert.Equal(100, cEchoRequestCount); // Make sure all clients actually sent their request
+                
+                await Task.Delay(500 + 100); //Wait a bit more than the RemoveUnusedServicesAsync busy wait loop (500ms) to be sure all disconnected services are cleaned up
+
+                var uniqueDisposedServices = new HashSet<DicomService>(disposedDicomServices);
+                Assert.Equal(100, uniqueDisposedServices.Count);
+                
+                //Each service is disposed twice, once in RemoveUnusedServicesAsync, once by the continuation task in RunningDicomService
+                //Better would be to check `server._services.Count == 0` but that field is not accessible here
+                Assert.Equal(100 * 2, disposedDicomServices.Count);
+                
+                server.Stop();
+
+                // Wait for the server to shut down gracefully
+                await server.Registration.Task;
+                
+                async Task SendCEchoRequests()
+                {
+                    //Send a simple CEcho request
+                    var client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "AnySCU", "AnySCP");
+                    var request = new DicomCEchoRequest
+                    {
+                        OnResponseReceived = (echoRequest, response) =>
+                        {
+                            Interlocked.Increment(ref cEchoRequestCount);
+                        }
+                    };
+                    await client.AddRequestAsync(request);
+                    await client.SendAsync();
+                    
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
DicomServer can keep last finished DICOM Clients in memory.

Fixes #2046.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- add extra loop to make sure as long as there are remaining services, we also await on their Tasks.
