### PR TITLE
Revise DicomClient creation instructions in upgrade guide

### DIFF
--- a/Documentation/v5/usage/upgrade4to5.md
+++ b/Documentation/v5/usage/upgrade4to5.md
@@ -58,7 +58,7 @@ The new interface `IServiceProviderHost` manages, if there is an internal Servic
 * There are now only asynchronous server provider interfaces. All synchronous methods have been replaced by asynchronous.
 
 * Instances of `DicomClient` and `DicomServer` are not created directly, but via a `DicomClientFactory` or a `DicomServerFactory`.
-  If you are in a "DI-Environment" like Asp.Net, then inject a `IDicomClientFactory` instance and use this to create a DicomClient. Otherwise call `DicomClientFactory.CreateDicomClient(...)`. This is a wrapper around accessing the internal DI container, getting the registered IDicomClientFactory and then calling this. So this is more overhead.
+  If you are in a "DI-Environment" like Asp.Net, then inject a `IDicomClientFactory` instance and use this to create a DicomClient. Otherwise call `DicomClientFactory.Create(...)`. This is a wrapper around accessing the internal DI container, getting the registered IDicomClientFactory and then calling this. So this is more overhead.
 
 * DicomServiceOptions cannot be passed as parameter to DicomServer constructor/factory any more, but the values of options have to be set to the created instance of DicomServer.
 


### PR DESCRIPTION
#### Checklist
- [X] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch

#### Changes proposed in this pull request:
- Assisting some guy upgrading 4 to 5, s/he found an inconsistency in documentation.
Upgrade guide mentions `DicomClientFactory.CreateDicomClient` function, which does not exist.
I assume it should be read as `DicomClientFactory.Client`.
