### PR TITLE
Add logging policy to documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,3 +9,4 @@ Here are a few guidelines for Pull Request submission.
 * List and describe *all* modifications.
 * Include a sufficient set of unit tests. 
 * If you add types, methods or properties to the (public) API, please include sufficient API documentation for these additions.
+* Adhere to the logging policy in [logging_config.md](../Documentation/v5/usage/logging_config.md)

--- a/Documentation/v5/usage/logging_config.md
+++ b/Documentation/v5/usage/logging_config.md
@@ -38,9 +38,9 @@ new DicomSetupBuilder()
 
 For all other logging libraries, you will have to provide your own implementation of `ILogManager` and `ILogger`.
 
-## Logging Policy — Data Protection (PHI)
+## Logging Policy - Data Protection (PHI)
 
-fo-dicom’s intent is to avoid emitting PHI in library-generated logs.
+fo-dicom's intent is to avoid emitting PHI in library-generated logs.
 
 * The library does not dump DICOM datasets or element values by default.
 * Dataset-to-log helpers exist but are opt-in and not invoked by the library.

--- a/Documentation/v5/usage/logging_config.md
+++ b/Documentation/v5/usage/logging_config.md
@@ -37,3 +37,12 @@ new DicomSetupBuilder()
 ```
 
 For all other logging libraries, you will have to provide your own implementation of `ILogManager` and `ILogger`.
+
+## Logging Policy — Data Protection (PHI)
+
+fo-dicom’s intent is to avoid emitting PHI in library-generated logs.
+
+* The library does not dump DICOM datasets or element values by default.
+* Dataset-to-log helpers exist but are opt-in and not invoked by the library.
+* PHI may still surface through application code, custom handlers, or exception payloads; therefore, fo-dicom cannot guarantee zero-PHI logging in all deployments.
+* If you observe a library message that exposes PHI, please open an issue with a minimal, redacted reproduction so we can evaluate and adjust.


### PR DESCRIPTION
Fixes #2042 .

#### Changes proposed in this pull request:
- Logging policy is added to the documentation about logging, it claims that sensible data should not be logged.
- This logging policy is referenced in githubs CONTRIBUTING.md
