### PR TITLE
Rework cleanup of finished clients in DicomServer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 - Fix issue where creating an instance of ImageData when Pixel Spacing DICOM tags are present but empty causes an exception (#2043)
 - Add support for constructing ImageData/VolumeData from multi-frame datasets (#2015)
 - Added some private tags to dictionary (#2027)
+- Rework disposing and cleanup of finished DICOM Clients in DicomServer (#2046)
 
 ### 5.2.4 (2025-10-03)
 - Fix issue where DicomFile.Clone did not do a deep-clone as expected (#2025)

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -3,7 +3,6 @@
 #nullable disable
 
 using FellowOakDicom.Network.Tls;
-using FellowOakDicom.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
@@ -11,7 +10,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
@@ -34,17 +32,6 @@ namespace FellowOakDicom.Network
         private readonly CancellationTokenSource _cancellationSource;
 
         private readonly CancellationToken _cancellationToken;
-
-        private readonly Channel<int> _servicesChannel = Channel.CreateUnbounded<int>(new UnboundedChannelOptions
-        {
-            SingleWriter = false,
-            SingleReader = true
-        });
-
-        /// <summary>
-        /// A task that will complete when the server is stopped
-        /// </summary>
-        private readonly TaskCompletionSource<bool> _stopped;
 
         private string _ipAddress;
 
@@ -84,7 +71,6 @@ namespace FellowOakDicom.Network
 
             _cancellationSource = new CancellationTokenSource();
             _cancellationToken = _cancellationSource.Token;
-            _stopped = TaskCompletionSourceFactory.Create<bool>();
 
             _services = new List<RunningDicomService>();
 
@@ -199,7 +185,7 @@ namespace FellowOakDicom.Network
                 ? new SemaphoreSlim(serverOptions.MaxClientsAllowed, serverOptions.MaxClientsAllowed)
                 : null;
             MaxClientsAllowedWaitInterval = TimeSpan.FromSeconds(60);
-            return Task.WhenAll(ListenForConnectionsAsync(), RemoveUnusedServicesAsync());
+            return ListenForConnectionsAsync();
         }
 
         /// <inheritdoc />
@@ -208,7 +194,6 @@ namespace FellowOakDicom.Network
             if (!_cancellationSource.IsCancellationRequested)
             {
                 _cancellationSource.Cancel();
-                _stopped.TrySetResult(true);
             }
         }
 
@@ -235,7 +220,6 @@ namespace FellowOakDicom.Network
                 Stop();
                 _cancellationSource.Dispose();
                 _maxClientsSemaphore?.Dispose();
-                _servicesChannel.Writer.TryComplete();
                 Registration?.Dispose();
                 ServiceScope?.Dispose();
             }
@@ -325,19 +309,17 @@ namespace FellowOakDicom.Network
 
                                 var serviceTask = scp.RunAsync();
                                 int numberOfServices;
+                                var runningService = new RunningDicomService(scp, serviceTask);
                                 lock (_services)
                                 {
-                                    _services.Add(new RunningDicomService(scp, serviceTask));
+                                    _services.Add(runningService);
                                     numberOfServices = _services.Count;
                                 }
+                                runningService.Task.ContinueWith((t) => RemoveCompletedService(runningService));
 
                                 Logger.LogDebug(
                                     "Accepted an incoming client connection, there are now {NumberOfServices} connected clients",
                                     numberOfServices);
-
-                                // We don't actually care about the values inside the channel, they just serve as a notification that a service has connected
-                                // Fire and forget
-                                _ = _servicesChannel.Writer.WriteAsync(numberOfServices, _cancellationToken);
 
                                 if (maxClientsAllowed > 0 && numberOfServices == maxClientsAllowed)
                                 {
@@ -375,168 +357,16 @@ namespace FellowOakDicom.Network
             }
         }
 
-        /// <summary>
-        /// Remove no longer used client connections.
-        /// </summary>
-        private async Task RemoveUnusedServicesAsync()
+        private void RemoveCompletedService(RunningDicomService runningService)
         {
-            int maxClientsAllowed = _serverOptions.MaxClientsAllowed;
-            while (!_cancellationToken.IsCancellationRequested)
+            // Avoid object disposed exception if we can
+            if (!_cancellationToken.IsCancellationRequested)
             {
-                try
-                {
-                    Logger.LogDebug("Waiting for incoming client connections");
-
-                    // First, we wait until at least one service is running
-                    // We don't actually care about the values inside the channel, they just serve as a notification that a service has connected
-                    // It is also possible that the DICOM server is stopped while are waiting here
-                    using (var readerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken))
-                    {
-                        var aServiceHasStarted = _servicesChannel.Reader.ReadAsync(readerCts.Token).AsTask();
-                        await Task.WhenAny(aServiceHasStarted, _stopped.Task).ConfigureAwait(false);
-                        readerCts.Cancel();
-                    } 
-                    _cancellationToken.ThrowIfCancellationRequested();
-
-                    // Then, we wait until at least one service completes
-                    // We must take into account that more services can start while we wait here
-                    while (true)
-                    {
-                        List<RunningDicomService> runningDicomServices;
-
-                        while (_servicesChannel.Reader.TryRead(out _))
-                        {
-                            // Discard queued new services, we're only interested in new arrivals after we start waiting                            
-                        }
-                        lock (_services)
-                        {
-                            runningDicomServices = _services.ToList();
-                        }
-                        var numberOfDicomServices = runningDicomServices.Count;
-                        Logger.LogDebug("There are {NumberOfDicomServices} running DICOM services", numberOfDicomServices);
-                        if (numberOfDicomServices == 0)
-                        {
-                            // No more services at all? Exit early
-                            break;
-                        }
-
-                        using (var readerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken))
-                        {
-                            var anotherServiceHasStarted = _servicesChannel.Reader.ReadAsync(readerCts.Token).AsTask();
-                            
-                            var tasks = new List<Task>(numberOfDicomServices + 1);
-                            tasks.Add(anotherServiceHasStarted);
-                            tasks.AddRange(runningDicomServices.Select(s => s.Task));
-                            var winner = await Task.WhenAny(tasks).ConfigureAwait(false);
-                            
-                            readerCts.Cancel();
-                            
-                            if (winner == anotherServiceHasStarted)
-                            {
-                                try
-                                {
-                                    await anotherServiceHasStarted;
-                                }
-                                catch (OperationCanceledException)
-                                {
-                                    // If the server is disposed while we were waiting, deal with that gracefully
-                                    break;
-                                }
-                                catch (ChannelClosedException)
-                                {
-                                    // If the server is disposed while we were waiting, deal with that gracefully
-                                    break;
-                                }
-
-                                // If another service started, we must restart the Task.WhenAny with the new set of running service tasks
-                                Logger.LogDebug("Another DICOM service has started while the cleanup was waiting for one or more DICOM services to complete");
-                            }
-                            else
-                            {
-                                Logger.LogDebug("One or more running DICOM services have completed");
-                                break;
-                            }
-                        }
-                    }
-
-                    int numberOfRemainingServices;
-                    var servicesToDispose = new List<RunningDicomService>();
-                    lock (_services)
-                    {
-                        for (var i = _services.Count - 1; i >= 0; i--)
-                        {
-                            var service = _services[i];
-                            if (service.Task.IsCompleted)
-                            {
-                                _services.RemoveAt(i);
-                                servicesToDispose.Add(service);
-                            }
-                        }
-
-                        numberOfRemainingServices = _services.Count;
-                    }
-                    var numberOfCompletedServices = servicesToDispose.Count;
-                    foreach (var service in servicesToDispose)
-                    {
-                        try
-                        {
-                            service.Dispose();
-                        }
-                        catch (Exception e)
-                        {
-                            Logger.LogWarning("An error occurred while trying to dispose a completed DICOM service: {@Error}", e);
-                        }
-                    }
-
-                    // Avoid object disposed exception if we can
-                    if (!_cancellationToken.IsCancellationRequested)
-                    {
-                        _maxClientsSemaphore?.Release(numberOfCompletedServices);
-                    }
-
-                    Logger.LogDebug("Cleaned up {NumberOfCompletedServices} completed DICOM services", numberOfCompletedServices);
-                    if (numberOfRemainingServices > 0)
-                    {
-                        Logger.LogDebug("There are still {NumberOfRemainingServices} clients connected now", numberOfRemainingServices);
-                    }
-                    else
-                    {
-                        Logger.LogDebug("There are no clients connected now");
-                    }
-
-                    if (maxClientsAllowed > 0)
-                    {
-                        if (numberOfRemainingServices == maxClientsAllowed)
-                        {
-                            Logger.LogDebug("Cannot accept more incoming client connections until one or more clients disconnect");
-                        }
-                        else
-                        {
-                            var numberOfExtraClientsAllowed = maxClientsAllowed - numberOfRemainingServices;
-                            Logger.LogDebug(
-                                "{NumberOfExtraServicesAllowed} more incoming client connections are allowed",
-                                numberOfExtraClientsAllowed);
-                        }
-                    }
-                    else
-                    {
-                        Logger.LogDebug("Unlimited more incoming client connections are allowed");
-                    }
-                }
-                catch (ChannelClosedException)
-                {
-                    Logger.LogInformation("Disconnected client cleanup manually terminated");
-                    ClearServices();
-                }
-                catch (OperationCanceledException)
-                {
-                    Logger.LogInformation("Disconnected client cleanup manually terminated");
-                    ClearServices();
-                }
-                catch (Exception e)
-                {
-                    Logger.LogWarning(e, "Exception removing disconnected clients");
-                }
+                _maxClientsSemaphore?.Release(1);
+            }
+            lock (_services)
+            {
+                _services.Remove(runningService);
             }
         }
 

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -315,7 +315,7 @@ namespace FellowOakDicom.Network
                                     _services.Add(runningService);
                                     numberOfServices = _services.Count;
                                 }
-                                runningService.Task.ContinueWith((t) => RemoveCompletedService(runningService));
+                                runningService.Task.ContinueWith((t) => RemoveCompletedService(runningService), TaskContinuationOptions.PreferFairness | TaskContinuationOptions.RunContinuationsAsynchronously);
 
                                 Logger.LogDebug(
                                     "Accepted an incoming client connection, there are now {NumberOfServices} connected clients",
@@ -405,7 +405,7 @@ namespace FellowOakDicom.Network
             {
                 Service = service ?? throw new ArgumentNullException(nameof(service));
                 Task = task ?? throw new ArgumentNullException(nameof(task));
-                Task.ContinueWith((t) => Service.Dispose());
+                Task.ContinueWith((t) => Service.Dispose(), TaskContinuationOptions.AttachedToParent);
             }
 
             public void Dispose() => Service.Dispose();

--- a/Tests/FO-DICOM.Tests/Bugs/GH1986.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1986.cs
@@ -1,4 +1,7 @@
-﻿using FellowOakDicom.Imaging;
+﻿// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
 using Xunit;
 
 namespace FellowOakDicom.Tests.Bugs

--- a/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using FellowOakDicom.Tests.Helpers;
+using FellowOakDicom.Tests.Network;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FellowOakDicom.Tests.Bugs
+{
+    [Collection(TestCollections.Network)]
+    public class GH2046
+    {
+        private readonly XUnitDicomLogger _logger;
+
+        public GH2046(ITestOutputHelper testOutputHelper)
+        {
+            _logger = new XUnitDicomLogger(testOutputHelper).IncludeTimestamps().IncludeThreadId();
+        }
+
+        [Fact]
+        public async Task RemoveUnusedServicesAsync_ShouldCleanupAllFinishedInternalServices()
+        {
+            var serverLogger = _logger.IncludePrefix("Server").WithMinimumLevel(LogLevel.Information);
+            var disposedDicomServices = new ConcurrentStack<DicomService>();
+            var cEchoRequestCount = 0;
+
+            using (var server = (DicomServerTest.DisposableDicomCEchoProviderServer)DicomServerFactory
+                       .Create<DicomServerTest.DisposableDicomCEchoProvider, DicomServerTest.DisposableDicomCEchoProviderServer>(
+                           "127.0.0.1", 0, logger: serverLogger))
+            {
+                server.OnDispose = service => disposedDicomServices.Push(service);
+
+                var numberOfClients = 50;
+
+                //First run to warm up
+                var tasks = new List<Task>();
+                for (int i = 0; i < numberOfClients; i++)
+                {
+                    tasks.Add(Task.Run(SendCEchoRequests));
+                }
+
+                await Task.WhenAll(tasks);
+
+                //Second run, so we're sure there are no more allocations happening
+                tasks.Clear();
+                for (int i = 0; i < numberOfClients; i++)
+                {
+                    tasks.Add(Task.Run(SendCEchoRequests));
+                }
+
+                await Task.WhenAll(tasks);
+
+                Assert.Equal(100, cEchoRequestCount); // Make sure all clients actually sent their request
+
+                await Task.Delay(500 + 100); //Wait a bit more than the RemoveUnusedServicesAsync busy wait loop (500ms) to be sure all disconnected services are cleaned up
+
+                var uniqueDisposedServices = new HashSet<DicomService>(disposedDicomServices);
+                Assert.Equal(100, uniqueDisposedServices.Count);
+
+                //Each service is disposed twice, once in RemoveUnusedServicesAsync, once by the continuation task in RunningDicomService
+                //Better would be to check `server._services.Count == 0` but that field is not accessible here
+                Assert.Equal(100 * 2, disposedDicomServices.Count);
+
+                server.Stop();
+
+                // Wait for the server to shut down gracefully
+                await server.Registration.Task;
+
+                async Task SendCEchoRequests()
+                {
+                    //Send a simple CEcho request
+                    var client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "AnySCU", "AnySCP");
+                    var request = new DicomCEchoRequest
+                    {
+                        OnResponseReceived = (echoRequest, response) =>
+                        {
+                            Interlocked.Increment(ref cEchoRequestCount);
+                        }
+                    };
+                    await client.AddRequestAsync(request);
+                    await client.SendAsync();
+
+                }
+            }
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
@@ -32,63 +32,60 @@ namespace FellowOakDicom.Tests.Bugs
             var disposedDicomServices = new ConcurrentStack<DicomService>();
             var cEchoRequestCount = 0;
 
-            using (var server = (DicomServerTest.DisposableDicomCEchoProviderServer)DicomServerFactory
+            using var server = (DicomServerTest.DisposableDicomCEchoProviderServer)DicomServerFactory
                        .Create<DicomServerTest.DisposableDicomCEchoProvider, DicomServerTest.DisposableDicomCEchoProviderServer>(
-                           "127.0.0.1", 0, logger: serverLogger))
+                           "127.0.0.1", 0, logger: serverLogger);
+            server.OnDispose = service => disposedDicomServices.Push(service);
+
+            var numberOfClients = 50;
+
+            //First run to warm up
+            var tasks = new List<Task>();
+            for (int i = 0; i < numberOfClients; i++)
             {
-                server.OnDispose = service => disposedDicomServices.Push(service);
+                tasks.Add(Task.Run(SendCEchoRequests));
+            }
 
-                var numberOfClients = 50;
+            await Task.WhenAll(tasks);
 
-                //First run to warm up
-                var tasks = new List<Task>();
-                for (int i = 0; i < numberOfClients; i++)
+            //Second run, so we're sure there are no more allocations happening
+            tasks.Clear();
+            for (int i = 0; i < numberOfClients; i++)
+            {
+                tasks.Add(Task.Run(SendCEchoRequests));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(100, cEchoRequestCount); // Make sure all clients actually sent their request
+
+            await Task.Delay(500 + 100); //Wait a bit more than the RemoveUnusedServicesAsync busy wait loop (500ms) to be sure all disconnected services are cleaned up
+
+            var uniqueDisposedServices = new HashSet<DicomService>(disposedDicomServices);
+            Assert.Equal(100, uniqueDisposedServices.Count);
+
+            // Better would be to check `server._services.Count == 0` but that field is not accessible here
+            Assert.Equal(100, disposedDicomServices.Count);
+
+            server.Stop();
+
+            // Wait for the server to shut down gracefully
+            await server.Registration.Task;
+
+            async Task SendCEchoRequests()
+            {
+                //Send a simple CEcho request
+                var client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "AnySCU", "AnySCP");
+                var request = new DicomCEchoRequest
                 {
-                    tasks.Add(Task.Run(SendCEchoRequests));
-                }
-
-                await Task.WhenAll(tasks);
-
-                //Second run, so we're sure there are no more allocations happening
-                tasks.Clear();
-                for (int i = 0; i < numberOfClients; i++)
-                {
-                    tasks.Add(Task.Run(SendCEchoRequests));
-                }
-
-                await Task.WhenAll(tasks);
-
-                Assert.Equal(100, cEchoRequestCount); // Make sure all clients actually sent their request
-
-                await Task.Delay(500 + 100); //Wait a bit more than the RemoveUnusedServicesAsync busy wait loop (500ms) to be sure all disconnected services are cleaned up
-
-                var uniqueDisposedServices = new HashSet<DicomService>(disposedDicomServices);
-                Assert.Equal(100, uniqueDisposedServices.Count);
-
-                //Each service is disposed twice, once in RemoveUnusedServicesAsync, once by the continuation task in RunningDicomService
-                //Better would be to check `server._services.Count == 0` but that field is not accessible here
-                Assert.Equal(100, disposedDicomServices.Count);
-
-                server.Stop();
-
-                // Wait for the server to shut down gracefully
-                await server.Registration.Task;
-
-                async Task SendCEchoRequests()
-                {
-                    //Send a simple CEcho request
-                    var client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "AnySCU", "AnySCP");
-                    var request = new DicomCEchoRequest
+                    OnResponseReceived = (echoRequest, response) =>
                     {
-                        OnResponseReceived = (echoRequest, response) =>
-                        {
-                            Interlocked.Increment(ref cEchoRequestCount);
-                        }
-                    };
-                    await client.AddRequestAsync(request);
-                    await client.SendAsync();
+                        Interlocked.Increment(ref cEchoRequestCount);
+                    }
+                };
+                await client.AddRequestAsync(request);
+                await client.SendAsync();
 
-                }
             }
         }
     }

--- a/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH2046.cs
@@ -67,7 +67,7 @@ namespace FellowOakDicom.Tests.Bugs
 
                 //Each service is disposed twice, once in RemoveUnusedServicesAsync, once by the continuation task in RunningDicomService
                 //Better would be to check `server._services.Count == 0` but that field is not accessible here
-                Assert.Equal(100 * 2, disposedDicomServices.Count);
+                Assert.Equal(100, disposedDicomServices.Count);
 
                 server.Stop();
 

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -604,12 +604,12 @@ namespace FellowOakDicom.Tests.Network
 
                 // Wait for the server to shut down gracefully
                 await server.Registration.Task;
-
-                // Wait for the ContinueWith-Task to be executed
-                // In previous versions, the server.Registration.Task also included the RemoveUnusedServicesAsync.
-                // This method now no longer exists, so the server.Registration.Task only awaits the StartAsync method, which listens and accepts clients.
-                await Task.Delay(TimeSpan.FromMilliseconds(50));
             }
+
+            // Wait for the ContinueWith-Task to be executed
+            // In previous versions, the server.Registration.Task also included the RemoveUnusedServicesAsync.
+            // This method now no longer exists, so the server.Registration.Task only awaits the StartAsync method, which listens and accepts clients.
+            await Task.Delay(1000); //Wait a bit more than to be sure all disconnected services are cleaned up
 
             var uniqueDisposedServices = new HashSet<DicomService>(disposedDicomServices);
             Assert.Single(uniqueDisposedServices);

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -604,6 +604,11 @@ namespace FellowOakDicom.Tests.Network
 
                 // Wait for the server to shut down gracefully
                 await server.Registration.Task;
+
+                // Wait for the ContinueWith-Task to be executed
+                // In previous versions, the server.Registration.Task also included the RemoveUnusedServicesAsync.
+                // This method now no longer exists, so the server.Registration.Task only awaits the StartAsync method, which listens and accepts clients.
+                await Task.Delay(TimeSpan.FromMilliseconds(50));
             }
 
             var uniqueDisposedServices = new HashSet<DicomService>(disposedDicomServices);


### PR DESCRIPTION
Fixes #2046 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the tasks of the clients now get a ContinueWith where the client-service is immediatelly disposed, removed from the collections of current services, and release a max-clients-semaphor
- Then the method RemoveUnusedServices, that runs in a separate thread and is responsible for removing the finished services, is not necessary any more
- the communication between the ListenAndProcess data and the RemoveUnusedService required some inter-thread-communication mechanisms. Like Channels and TaskCompletionSources. These now can be removed
