### PR TITLE
New interface IDicomServiceAsync for async callbacks on connection close and on abort in DicomService

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 - Fix issue where creating an instance of ImageData when Pixel Spacing DICOM tags are present but empty causes an exception (#2043)
 - Add support for constructing ImageData/VolumeData from multi-frame datasets (#2015)
 - Added some private tags to dictionary (#2027)
+- new interface IDicomServiceAsync where OnConnectionClosedAsync and OnAbortAsync are invoked (#2056)
 
 ### 5.2.4 (2025-10-03)
 - Fix issue where DicomFile.Clone did not do a deep-clone as expected (#2025)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 - Fix issue where creating an instance of ImageData when Pixel Spacing DICOM tags are present but empty causes an exception (#2043)
 - Add support for constructing ImageData/VolumeData from multi-frame datasets (#2015)
 - Added some private tags to dictionary (#2027)
-- new interface IDicomServiceAsync where OnConnectionClosedAsync and OnAbortAsync are invoked (#2056)
+- new interface IAsyncDicomService where OnConnectionClosedAsync and OnAbortAsync are invoked (#2056)
 
 ### 5.2.4 (2025-10-03)
 - Fix issue where DicomFile.Clone did not do a deep-clone as expected (#2025)

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -679,7 +679,11 @@ namespace FellowOakDicom.Network
                                     LogID,
                                     pdu.Source,
                                     pdu.Reason);
-                                if (this is IDicomService service)
+                                if (this is IDicomServiceAsync asyncService)
+                                {
+                                    await asyncService.OnReceiveAbortAsync(pdu.Source, pdu.Reason).ConfigureAwait(false);
+                                }
+                                else if (this is IDicomService service)
                                 {
                                     service.OnReceiveAbort(pdu.Source, pdu.Reason);
                                 }
@@ -1144,9 +1148,7 @@ namespace FellowOakDicom.Network
                         dicomRequest.PendingSince = DateTime.Now;
 
                         // This call should not be awaited because it can only complete when the pending queue is empty
-#pragma warning disable 4014 
                         Task.Factory.StartNew(CheckForTimeouts, TaskCreationOptions.LongRunning).ConfigureAwait(false);
-#pragma warning restore 4014
                     }
                 }
 
@@ -1536,7 +1538,11 @@ namespace FellowOakDicom.Network
                     }
                 }
 
-                if (this is IDicomService dicomService)
+                if (this is IDicomServiceAsync asyncDicomService)
+                {
+                    await asyncDicomService.OnConnectionClosedAsync(exception).ConfigureAwait(false);
+                }
+                else if (this is IDicomService dicomService)
                 {
                     dicomService.OnConnectionClosed(exception);
                 }

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -679,7 +679,7 @@ namespace FellowOakDicom.Network
                                     LogID,
                                     pdu.Source,
                                     pdu.Reason);
-                                if (this is IDicomServiceAsync asyncService)
+                                if (this is IAsyncDicomService asyncService)
                                 {
                                     await asyncService.OnReceiveAbortAsync(pdu.Source, pdu.Reason).ConfigureAwait(false);
                                 }
@@ -1538,7 +1538,7 @@ namespace FellowOakDicom.Network
                     }
                 }
 
-                if (this is IDicomServiceAsync asyncDicomService)
+                if (this is IAsyncDicomService asyncDicomService)
                 {
                     await asyncDicomService.OnConnectionClosedAsync(exception).ConfigureAwait(false);
                 }

--- a/FO-DICOM.Core/Network/IDicomService.cs
+++ b/FO-DICOM.Core/Network/IDicomService.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System;
+using System.Threading.Tasks;
 
 namespace FellowOakDicom.Network
 {
@@ -11,6 +12,8 @@ namespace FellowOakDicom.Network
     /// </summary>
     public interface IDicomService
     {
+        // TODO: In next major release remove this interface in favour of IDicomServiceAsync
+
         /// <summary>
         /// Callback on recieving an abort message.
         /// </summary>
@@ -23,5 +26,24 @@ namespace FellowOakDicom.Network
         /// </summary>
         /// <param name="exception">Exception, if any, that forced connection to close.</param>
         void OnConnectionClosed(Exception exception);
+    }
+
+    /// <summary>
+    /// Common interface for DICOM service users and providers.
+    /// </summary>
+    public interface IDicomServiceAsync
+    {
+        /// <summary>
+        /// Callback on recieving an abort message.
+        /// </summary>
+        /// <param name="source">Abort source.</param>
+        /// <param name="reason">Detailed reason for abort.</param>
+        Task OnReceiveAbortAsync(DicomAbortSource source, DicomAbortReason reason);
+
+        /// <summary>
+        /// Callback when connection is closed.
+        /// </summary>
+        /// <param name="exception">Exception, if any, that forced connection to close.</param>
+        Task OnConnectionClosedAsync(Exception exception);
     }
 }

--- a/FO-DICOM.Core/Network/IDicomService.cs
+++ b/FO-DICOM.Core/Network/IDicomService.cs
@@ -12,7 +12,7 @@ namespace FellowOakDicom.Network
     /// </summary>
     public interface IDicomService
     {
-        // TODO: In next major release remove this interface in favour of IDicomServiceAsync
+        // TODO: In next major release remove this interface in favour of IAsyncDicomService
 
         /// <summary>
         /// Callback on recieving an abort message.
@@ -31,7 +31,7 @@ namespace FellowOakDicom.Network
     /// <summary>
     /// Common interface for DICOM service users and providers.
     /// </summary>
-    public interface IDicomServiceAsync
+    public interface IAsyncDicomService
     {
         /// <summary>
         /// Callback on recieving an abort message.

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
@@ -95,7 +95,7 @@ namespace FellowOakDicom.Tests.Network
             await Task.Yield();
             return new DicomCEchoResponse(request, DicomStatus.Success);
         }
-        }
+    }
 
 
     #endregion

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCEchoProviderTests.cs
@@ -95,7 +95,7 @@ namespace FellowOakDicom.Tests.Network
             await Task.Yield();
             return new DicomCEchoResponse(request, DicomStatus.Success);
         }
-    }
+        }
 
 
     #endregion

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
@@ -301,7 +301,7 @@ namespace FellowOakDicom.Tests.Network
 
     }
 
-    public class PendingAsyncDicomCFindProviderWithAsyncService : PendingAsyncDicomCFindProvider, IDicomServiceAsync
+    public class PendingAsyncDicomCFindProviderWithAsyncService : PendingAsyncDicomCFindProvider, IAsyncDicomService
     {
         public PendingAsyncDicomCFindProviderWithAsyncService(INetworkStream stream, Encoding fallbackEncoding, ILogger log, DicomServiceDependencies dependencies) : base(stream, fallbackEncoding, log, dependencies)
         {

--- a/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
+++ b/Tests/FO-DICOM.Tests/Network/AsyncDicomCFindProviderTests.cs
@@ -2,15 +2,18 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
+using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using FellowOakDicom.Network.Client.Advanced.Association;
+using FellowOakDicom.Network.Client.Advanced.Connection;
+using FellowOakDicom.Tests.Helpers;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-using FellowOakDicom.Network;
-using FellowOakDicom.Network.Client;
-using FellowOakDicom.Tests.Helpers;
-using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -56,7 +59,8 @@ namespace FellowOakDicom.Tests.Network
         [Fact]
         public async Task OnCFindRequestAsync_Pending_ShouldRespond()
         {
-            using var server = DicomServerFactory.Create<PendingAsyncDicomCFindProvider>(0, logger: _logger.IncludePrefix("DicomServer"));
+            var counter = new InvokeCounter();
+            using var server = DicomServerFactory.Create<PendingAsyncDicomCFindProvider>(0, logger: _logger.IncludePrefix("DicomServer"), userState: counter);
 
             var client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "SCU", "ANY-SCP");
             client.Logger = _logger.IncludePrefix(typeof(DicomClient).Name);
@@ -80,10 +84,125 @@ namespace FellowOakDicom.Tests.Network
                 response3 => Assert.Equal(DicomStatus.Success, response3.Status)
             );
             Assert.Null(timeout);
+
+            await Task.Delay(1000);
+            Assert.Equal(0, counter.AbortCounter);
+            Assert.Equal(1, counter.ConnectionClosedCounter);
+            Assert.Equal(0, counter.AbortAsyncCounter);
+            Assert.Equal(0, counter.ConnectionClosedAsyncCounter);
+        }
+
+        [Fact]
+        public async Task OnCFindRequestAsync_Pending_WithAsyncService_ShouldRespond()
+        {
+            var counter = new InvokeCounter();
+            using var server = DicomServerFactory.Create<PendingAsyncDicomCFindProviderWithAsyncService>(0, logger: _logger.IncludePrefix("DicomServer"), userState: counter);
+
+            var client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "SCU", "ANY-SCP");
+            client.Logger = _logger.IncludePrefix(typeof(DicomClient).Name);
+            client.ClientOptions.AssociationRequestTimeoutInMs = (int)TimeSpan.FromMinutes(5).TotalMilliseconds;
+
+            var responses = new ConcurrentQueue<DicomCFindResponse>();
+            DicomRequest.OnTimeoutEventArgs timeout = null;
+            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study)
+            {
+                OnResponseReceived = (req, res) => responses.Enqueue(res),
+                OnTimeout = (sender, args) => timeout = args
+            };
+
+            await client.AddRequestAsync(request);
+            await client.SendAsync();
+
+            Assert.Collection(
+                responses,
+                response1 => Assert.Equal(DicomStatus.Pending, response1.Status),
+                response2 => Assert.Equal(DicomStatus.Pending, response2.Status),
+                response3 => Assert.Equal(DicomStatus.Success, response3.Status)
+            );
+            Assert.Null(timeout);
+
+            await Task.Delay(1000);
+            Assert.Equal(0, counter.AbortCounter);
+            Assert.Equal(0, counter.ConnectionClosedCounter);
+            Assert.Equal(0, counter.AbortAsyncCounter);
+            Assert.Equal(1, counter.ConnectionClosedAsyncCounter);
+        }
+
+        [Fact]
+        public async Task OnCFindRequestAsync_Pending_WithAsyncService_ShouldCallAbortAsync()
+        {
+            var cancellationToken = CancellationToken.None;
+            var counter = new InvokeCounter();
+            using var server = DicomServerFactory.Create<PendingAsyncDicomCFindProviderWithAsyncService>(0, logger: _logger.IncludePrefix("DicomServer"), userState: counter);
+
+            var connectionRequest = new AdvancedDicomClientConnectionRequest
+            {
+                NetworkStreamCreationOptions = new NetworkStreamCreationOptions
+                {
+                    Host = "127.0.0.1",
+                    Port = server.Port
+                },
+                Logger = _logger.IncludePrefix("client"),
+                FallbackEncoding = DicomEncoding.Default,
+                DicomServiceOptions = new DicomServiceOptions()
+            };
+
+            using var connection = await AdvancedDicomClientConnectionFactory.OpenConnectionAsync(connectionRequest, cancellationToken);
+
+            var openAssociationRequest = new AdvancedDicomClientAssociationRequest
+            {
+                CallingAE = "SCU",
+                CalledAE = "ANY-SCP"
+            };
+
+            DicomRequest.OnTimeoutEventArgs timeout = null;
+            var request = new DicomCFindRequest(DicomQueryRetrieveLevel.Study)
+            {
+                OnTimeout = (sender, args) => timeout = args
+            };
+
+            openAssociationRequest.PresentationContexts.AddFromRequest(request);
+            openAssociationRequest.ExtendedNegotiations.AddFromRequest(request);
+
+            IAdvancedDicomClientAssociation association = null;
+            DicomAssociationRejectedException exception = null;
+            try
+            {
+                association = await connection.OpenAssociationAsync(openAssociationRequest, cancellationToken);
+                await association.AbortAsync(cancellationToken);
+            }
+            catch (DicomAssociationRejectedException e)
+            {
+                exception = e;
+            }
+            finally
+            {
+                if (association != null)
+                {
+                    await association.ReleaseAsync(cancellationToken);
+                    association.Dispose();
+                }
+            }
+
+            Assert.Null(timeout);
+
+            await Task.Delay(1000);
+            Assert.Equal(0, counter.AbortCounter);
+            Assert.Equal(0, counter.ConnectionClosedCounter);
+            Assert.Equal(1, counter.AbortAsyncCounter);
+            Assert.Equal(1, counter.ConnectionClosedAsyncCounter);
         }
     }
 
     #region helper classes
+
+    public class InvokeCounter
+    {
+        public int AbortCounter { get; set; }
+        public int AbortAsyncCounter { get; set; }
+        public int ConnectionClosedCounter { get; set; }
+        public int ConnectionClosedAsyncCounter { get; set; }
+    }
 
     public class ImmediateSuccessAsyncDicomCFindProvider : DicomService, IDicomServiceProvider, IDicomCFindProvider
     {
@@ -155,13 +274,19 @@ namespace FellowOakDicom.Tests.Network
         /// <inheritdoc />
         public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason)
         {
-            // do nothing here
+            if (UserState is InvokeCounter counter)
+            {
+                counter.AbortCounter++;
+            }
         }
 
         /// <inheritdoc />
         public void OnConnectionClosed(Exception exception)
         {
-            // do nothing here
+            if (UserState is InvokeCounter counter)
+            {
+                counter.ConnectionClosedCounter++;
+            }
         }
 
         public async IAsyncEnumerable<DicomCFindResponse> OnCFindRequestAsync(DicomCFindRequest request)
@@ -174,6 +299,31 @@ namespace FellowOakDicom.Tests.Network
             yield return new DicomCFindResponse(request, DicomStatus.Success);
         }
 
+    }
+
+    public class PendingAsyncDicomCFindProviderWithAsyncService : PendingAsyncDicomCFindProvider, IDicomServiceAsync
+    {
+        public PendingAsyncDicomCFindProviderWithAsyncService(INetworkStream stream, Encoding fallbackEncoding, ILogger log, DicomServiceDependencies dependencies) : base(stream, fallbackEncoding, log, dependencies)
+        {
+        }
+
+        public Task OnConnectionClosedAsync(Exception exception)
+        {
+            if (UserState is InvokeCounter counter)
+            {
+                counter.ConnectionClosedAsyncCounter++;
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task OnReceiveAbortAsync(DicomAbortSource source, DicomAbortReason reason)
+        {
+            if (UserState is InvokeCounter counter)
+            {
+                counter.AbortAsyncCounter++;
+            }
+            return Task.CompletedTask;
+        }
     }
 
     #endregion


### PR DESCRIPTION
Fixes #2056 .

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- There is a new interface IDicomServiceAsync, that inherited classes from DicomService can implement.
- If the DicomService, on receiving an abort or a connection closed from a client, notice that the inherited class has implemented this interface, then this async methods from that interface are injected instead of the synchronous methods.
- In future main release, the synchronous IDicomService will be removed and instead IDicomServiceAsync will be the only interface and IDicomServiceprovider will inherit from this async interface.
