### PR TITLE
Add Icon Image Sequence generation for DICOMDIR (#654)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Added some private tags to dictionary (#2027)
 - Rework disposing and cleanup of finished DICOM Clients in DicomServer (#2046)
 - new interface IAsyncDicomService where OnConnectionClosedAsync and OnAbortAsync are invoked (#2056)
+- Add Icon Image Sequence generation for DICOMDIR with IIconGenerator interface and SkiaSharp implementation (#654)
 
 ### 5.2.4 (2025-10-03)
 - Fix issue where DicomFile.Clone did not do a deep-clone as expected (#2025)

--- a/FO-DICOM.Core/Media/DicomDirectory.cs
+++ b/FO-DICOM.Core/Media/DicomDirectory.cs
@@ -463,22 +463,23 @@ namespace FellowOakDicom.Media
         /// </summary>
         /// <param name="dicomFile">DICOM file to add.</param>
         /// <param name="referencedFileId">Referenced file ID.</param>
-        public DicomDirectoryEntry AddFile(DicomFile dicomFile, string referencedFileId = "")
+        /// <param name="iconGenerator">Optional icon generator for creating thumbnail images in DICOMDIR.</param>
+        public DicomDirectoryEntry AddFile(DicomFile dicomFile, string referencedFileId = "", IIconGenerator iconGenerator = null)
         {
             if (dicomFile == null)
             {
                 throw new ArgumentNullException(nameof(dicomFile));
             }
 
-            return AddNewRecord(dicomFile.FileMetaInfo, dicomFile.Dataset, referencedFileId);
+            return AddNewRecord(dicomFile.FileMetaInfo, dicomFile.Dataset, referencedFileId, iconGenerator);
         }
 
-        private DicomDirectoryEntry AddNewRecord(DicomFileMetaInformation metaFileInfo, DicomDataset dataset, string referencedFileId)
+        private DicomDirectoryEntry AddNewRecord(DicomFileMetaInformation metaFileInfo, DicomDataset dataset, string referencedFileId, IIconGenerator iconGenerator = null)
         {
             var patientRecord = CreatePatientRecord(dataset);
             var studyRecord = CreateStudyRecord(dataset, patientRecord);
             var seriesRecord = CreateSeriesRecord(dataset, studyRecord);
-            var imageRecord = CreateImageRecord(metaFileInfo, dataset, seriesRecord, referencedFileId);
+            var imageRecord = CreateImageRecord(metaFileInfo, dataset, seriesRecord, referencedFileId, iconGenerator);
             return new DicomDirectoryEntry
             {
                 PatientRecord = patientRecord,
@@ -492,7 +493,8 @@ namespace FellowOakDicom.Media
             DicomFileMetaInformation metaFileInfo,
             DicomDataset dataset,
             DicomDirectoryRecord seriesRecord,
-            string referencedFileId)
+            string referencedFileId,
+            IIconGenerator iconGenerator = null)
         {
             var currentImage = seriesRecord.LowerLevelDirectoryRecord;
             var imageInstanceUid = dataset.GetSingleValue<string>(DicomTag.SOPInstanceUID);
@@ -536,6 +538,24 @@ namespace FellowOakDicom.Media
                 new DicomUniqueIdentifier(DicomTag.ReferencedSOPInstanceUIDInFile, metaFileInfo.MediaStorageSOPInstanceUID.UID),
                 new DicomUniqueIdentifier(DicomTag.ReferencedTransferSyntaxUIDInFile, metaFileInfo.TransferSyntax.UID)
             );
+
+            // Generate and add icon image sequence if icon generator is provided
+            if (iconGenerator != null)
+            {
+                try
+                {
+                    var iconSequence = iconGenerator.GenerateIconImageSequence(dataset);
+                    if (iconSequence != null)
+                    {
+                        newImage.Add(iconSequence);
+                    }
+                }
+                catch
+                {
+                    // Icon generation failure should not prevent DICOMDIR creation
+                    // Silently continue without icon
+                }
+            }
 
             if (currentImage != null)
             {

--- a/FO-DICOM.Core/Media/DicomIconImageSequenceBuilder.cs
+++ b/FO-DICOM.Core/Media/DicomIconImageSequenceBuilder.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using System;
+
+namespace FellowOakDicom.Media
+{
+    /// <summary>
+    /// Utility for building DICOM Icon Image Sequences from grayscale pixel data.
+    /// Provides consistent icon formatting across all imaging implementations.
+    /// </summary>
+    public static class DicomIconImageSequenceBuilder
+    {
+        private const int BitsAllocated = 8;
+        private const int BitsStored = 8;
+        private const int HighBit = 7;
+
+        /// <summary>
+        /// Creates a DICOM Icon Image Sequence from 8-bit grayscale pixel data.
+        /// </summary>
+        /// <param name="width">Icon width in pixels.</param>
+        /// <param name="height">Icon height in pixels.</param>
+        /// <param name="grayscalePixelData">8-bit grayscale pixel data (Monochrome2 format).</param>
+        /// <returns>A <see cref="DicomSequence"/> containing the icon image data.</returns>
+        /// <exception cref="ArgumentNullException">If grayscalePixelData is null.</exception>
+        /// <exception cref="ArgumentException">If dimensions are invalid or pixel data size doesn't match dimensions.</exception>
+        public static DicomSequence Build(int width, int height, byte[] grayscalePixelData)
+        {
+            if (grayscalePixelData == null)
+            {
+                throw new ArgumentNullException(nameof(grayscalePixelData));
+            }
+
+            if (width <= 0 || height <= 0)
+            {
+                throw new ArgumentException($"Icon dimensions must be positive. Got width={width}, height={height}");
+            }
+
+            if (width > 128 || height > 128)
+            {
+                throw new ArgumentException($"Icon dimensions must not exceed 128 pixels. Got width={width}, height={height}");
+            }
+
+            var expectedPixelCount = width * height;
+            if (grayscalePixelData.Length != expectedPixelCount)
+            {
+                throw new ArgumentException(
+                    $"Pixel data length ({grayscalePixelData.Length}) does not match dimensions ({width}x{height}={expectedPixelCount})");
+            }
+
+            var iconDataset = new DicomDataset
+            {
+                new DicomUnsignedShort(DicomTag.Columns, (ushort)width),
+                new DicomUnsignedShort(DicomTag.Rows, (ushort)height),
+                new DicomUnsignedShort(DicomTag.SamplesPerPixel, 1),
+                new DicomUnsignedShort(DicomTag.BitsAllocated, BitsAllocated),
+                new DicomUnsignedShort(DicomTag.BitsStored, BitsStored),
+                new DicomUnsignedShort(DicomTag.HighBit, HighBit),
+                new DicomUnsignedShort(DicomTag.PixelRepresentation, 0), // Unsigned
+                new DicomCodeString(DicomTag.PhotometricInterpretation, PhotometricInterpretation.Monochrome2.Value),
+                new DicomCodeString(DicomTag.NumberOfFrames, "1"),
+                new DicomOtherByte(DicomTag.PixelData, grayscalePixelData)
+            };
+
+            return new DicomSequence(DicomTag.IconImageSequence, iconDataset);
+        }
+    }
+}

--- a/FO-DICOM.Core/Media/IIconGenerator.cs
+++ b/FO-DICOM.Core/Media/IIconGenerator.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+namespace FellowOakDicom.Media
+{
+    /// <summary>
+    /// Interface for generating DICOMDIR icon images from DICOM datasets.
+    /// Icons are 8-bit grayscale thumbnails, maximum 128x128 pixels with preserved aspect ratio.
+    /// </summary>
+    public interface IIconGenerator
+    {
+        /// <summary>
+        /// Generates an Icon Image Sequence for a DICOM dataset.
+        /// </summary>
+        /// <param name="dataset">The DICOM dataset containing the image data.</param>
+        /// <param name="frameIndex">Frame index to use for multi-frame images (default: 0).</param>
+        /// <returns>
+        /// A <see cref="DicomSequence"/> containing the icon image data conforming to DICOM standard,
+        /// or null if icon generation fails or is not applicable for this dataset.
+        /// </returns>
+        DicomSequence? GenerateIconImageSequence(DicomDataset dataset, int frameIndex = 0);
+    }
+}

--- a/Platform/FO-DICOM.Imaging.Desktop/Media/DesktopIconGenerator.cs
+++ b/Platform/FO-DICOM.Imaging.Desktop/Media/DesktopIconGenerator.cs
@@ -1,0 +1,157 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Media;
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+
+namespace FellowOakDicom.Imaging.Desktop.Media
+{
+    /// <summary>
+    /// Generates thumbnail icons for DICOMDIR using System.Drawing/GDI+.
+    /// Creates 8-bit grayscale icons, maximum 128x128 pixels with aspect ratio preserved.
+    /// Uses high-quality bicubic interpolation for optimal clarity.
+    /// </summary>
+    public class DesktopIconGenerator : IIconGenerator
+    {
+        private const int MaxIconDimension = 128;
+
+        /// <inheritdoc />
+        public DicomSequence? GenerateIconImageSequence(DicomDataset dataset, int frameIndex = 0)
+        {
+            if (dataset == null)
+            {
+                throw new ArgumentNullException(nameof(dataset));
+            }
+
+            try
+            {
+                // Render the DICOM image
+                var dicomImage = new DicomImage(dataset);
+                var renderedImage = dicomImage.RenderImage(frameIndex);
+
+                if (!(renderedImage is WinFormsImage winFormsImage))
+                {
+                    // Not a WinForms image, cannot process
+                    return null;
+                }
+
+                var sourceBitmap = winFormsImage.As<Bitmap>();
+                if (sourceBitmap == null)
+                {
+                    return null;
+                }
+
+                // Calculate scaled dimensions preserving aspect ratio
+                var (iconWidth, iconHeight) = CalculateIconDimensions(sourceBitmap.Width, sourceBitmap.Height);
+
+                // Generate grayscale pixel data
+                var pixelData = CreateGrayscaleIconPixelData(sourceBitmap, iconWidth, iconHeight);
+
+                // Use common builder to create DICOM sequence
+                return DicomIconImageSequenceBuilder.Build(iconWidth, iconHeight, pixelData);
+            }
+            catch
+            {
+                // Icon generation is optional - if it fails, return null
+                // This ensures DICOMDIR creation continues even if icon generation fails
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Calculate icon dimensions maintaining aspect ratio, max 128x128.
+        /// </summary>
+        private static (int width, int height) CalculateIconDimensions(int sourceWidth, int sourceHeight)
+        {
+            if (sourceWidth <= 0 || sourceHeight <= 0)
+            {
+                throw new ArgumentException("Source dimensions must be positive");
+            }
+
+            var aspectRatio = (double)sourceWidth / sourceHeight;
+
+            int iconWidth, iconHeight;
+
+            if (sourceWidth >= sourceHeight)
+            {
+                // Landscape or square
+                iconWidth = Math.Min(MaxIconDimension, sourceWidth);
+                iconHeight = (int)Math.Round(iconWidth / aspectRatio);
+            }
+            else
+            {
+                // Portrait
+                iconHeight = Math.Min(MaxIconDimension, sourceHeight);
+                iconWidth = (int)Math.Round(iconHeight * aspectRatio);
+            }
+
+            // Ensure dimensions are at least 1
+            iconWidth = Math.Max(1, iconWidth);
+            iconHeight = Math.Max(1, iconHeight);
+
+            return (iconWidth, iconHeight);
+        }
+
+        /// <summary>
+        /// Creates grayscale icon pixel data with high-quality interpolation.
+        /// </summary>
+        private static byte[] CreateGrayscaleIconPixelData(Bitmap source, int targetWidth, int targetHeight)
+        {
+            // Create 8-bit grayscale bitmap
+            using var iconBitmap = new Bitmap(targetWidth, targetHeight, PixelFormat.Format8bppIndexed);
+
+            // Set up grayscale palette
+            var palette = iconBitmap.Palette;
+            for (int i = 0; i < 256; i++)
+            {
+                palette.Entries[i] = Color.FromArgb(i, i, i);
+            }
+            iconBitmap.Palette = palette;
+
+            // Draw resized image with high-quality interpolation
+            using (var graphics = Graphics.FromImage(iconBitmap))
+            {
+                graphics.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                graphics.SmoothingMode = SmoothingMode.HighQuality;
+                graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                graphics.CompositingQuality = CompositingQuality.HighQuality;
+
+                graphics.DrawImage(source, 0, 0, targetWidth, targetHeight);
+            }
+
+            // Extract pixel data using LockBits
+            var pixelData = new byte[targetWidth * targetHeight];
+            var bitmapData = iconBitmap.LockBits(
+                new Rectangle(0, 0, targetWidth, targetHeight),
+                ImageLockMode.ReadOnly,
+                PixelFormat.Format8bppIndexed);
+
+            try
+            {
+                // Copy pixel data row by row
+                var sourcePtr = bitmapData.Scan0;
+                var stride = bitmapData.Stride;
+
+                for (int y = 0; y < targetHeight; y++)
+                {
+                    Marshal.Copy(
+                        sourcePtr + (y * stride),
+                        pixelData,
+                        y * targetWidth,
+                        targetWidth);
+                }
+            }
+            finally
+            {
+                iconBitmap.UnlockBits(bitmapData);
+            }
+
+            return pixelData;
+        }
+    }
+}

--- a/Platform/FO-DICOM.Imaging.ImageSharp.NetStandard/Media/ImageSharpIconGenerator.cs
+++ b/Platform/FO-DICOM.Imaging.ImageSharp.NetStandard/Media/ImageSharpIconGenerator.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Media;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using System;
+
+namespace FellowOakDicom.Imaging.ImageSharp.Media
+{
+    /// <summary>
+    /// Generates thumbnail icons for DICOMDIR using ImageSharp.
+    /// Creates 8-bit grayscale icons, maximum 128x128 pixels with aspect ratio preserved.
+    /// Uses high-quality Lanczos3 resampling for optimal clarity.
+    /// </summary>
+    public class ImageSharpIconGenerator : IIconGenerator
+    {
+        private const int MaxIconDimension = 128;
+
+        /// <summary>
+        /// Gets or sets whether to apply sharpening filter during downsampling for improved clarity.
+        /// Default is false. Enable for better visual quality at small icon sizes.
+        /// </summary>
+        public bool EnableSharpening { get; set; }
+
+        /// <inheritdoc />
+        public DicomSequence? GenerateIconImageSequence(DicomDataset dataset, int frameIndex = 0)
+        {
+            if (dataset == null)
+            {
+                throw new ArgumentNullException(nameof(dataset));
+            }
+
+            try
+            {
+                // Render the DICOM image
+                var dicomImage = new DicomImage(dataset);
+                var renderedImage = dicomImage.RenderImage(frameIndex);
+
+                if (!(renderedImage is ImageSharpImage imageSharpImage))
+                {
+                    // Not an ImageSharp image, cannot process
+                    return null;
+                }
+
+                var sourceImage = imageSharpImage.AsSharpImage();
+                if (sourceImage == null)
+                {
+                    return null;
+                }
+
+                // Calculate scaled dimensions preserving aspect ratio
+                var (iconWidth, iconHeight) = CalculateIconDimensions(sourceImage.Width, sourceImage.Height);
+
+                // Generate grayscale pixel data
+                var pixelData = CreateGrayscaleIconPixelData(sourceImage, iconWidth, iconHeight);
+
+                // Use common builder to create DICOM sequence
+                return DicomIconImageSequenceBuilder.Build(iconWidth, iconHeight, pixelData);
+            }
+            catch
+            {
+                // Icon generation is optional - if it fails, return null
+                // This ensures DICOMDIR creation continues even if icon generation fails
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Calculate icon dimensions maintaining aspect ratio, max 128x128.
+        /// </summary>
+        private static (int width, int height) CalculateIconDimensions(int sourceWidth, int sourceHeight)
+        {
+            if (sourceWidth <= 0 || sourceHeight <= 0)
+            {
+                throw new ArgumentException("Source dimensions must be positive");
+            }
+
+            var aspectRatio = (double)sourceWidth / sourceHeight;
+
+            int iconWidth, iconHeight;
+
+            if (sourceWidth >= sourceHeight)
+            {
+                // Landscape or square
+                iconWidth = Math.Min(MaxIconDimension, sourceWidth);
+                iconHeight = (int)Math.Round(iconWidth / aspectRatio);
+            }
+            else
+            {
+                // Portrait
+                iconHeight = Math.Min(MaxIconDimension, sourceHeight);
+                iconWidth = (int)Math.Round(iconHeight * aspectRatio);
+            }
+
+            // Ensure dimensions are at least 1
+            iconWidth = Math.Max(1, iconWidth);
+            iconHeight = Math.Max(1, iconHeight);
+
+            return (iconWidth, iconHeight);
+        }
+
+        /// <summary>
+        /// Creates grayscale icon pixel data with high-quality resampling.
+        /// </summary>
+        private byte[] CreateGrayscaleIconPixelData(Image<Bgra32> source, int targetWidth, int targetHeight)
+        {
+            // Create grayscale image at target size
+            using var iconImage = new Image<L8>(targetWidth, targetHeight);
+
+            // Resize with high-quality Lanczos3 resampler and convert to grayscale
+            iconImage.Mutate(ctx =>
+            {
+                // First resize the source
+                var resized = source.Clone(x => x.Resize(targetWidth, targetHeight, KnownResamplers.Lanczos3));
+
+                // Convert to grayscale and draw onto our L8 image
+                ctx.DrawImage(resized, 1.0f);
+
+                // Optional sharpening for better clarity at small sizes
+                if (EnableSharpening)
+                {
+                    ctx.GaussianSharpen(0.5f);
+                }
+
+                resized.Dispose();
+            });
+
+            // Extract pixel data using safe API
+            var pixelData = new byte[targetWidth * targetHeight];
+            iconImage.CopyPixelDataTo(pixelData);
+
+            return pixelData;
+        }
+    }
+}

--- a/Platform/FO-DICOM.Imaging.ImageSharp/Media/ImageSharpIconGenerator.cs
+++ b/Platform/FO-DICOM.Imaging.ImageSharp/Media/ImageSharpIconGenerator.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Media;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using System;
+
+namespace FellowOakDicom.Imaging.ImageSharp.Media
+{
+    /// <summary>
+    /// Generates thumbnail icons for DICOMDIR using ImageSharp.
+    /// Creates 8-bit grayscale icons, maximum 128x128 pixels with aspect ratio preserved.
+    /// Uses high-quality Lanczos3 resampling for optimal clarity.
+    /// </summary>
+    public class ImageSharpIconGenerator : IIconGenerator
+    {
+        private const int MaxIconDimension = 128;
+
+        /// <summary>
+        /// Gets or sets whether to apply sharpening filter during downsampling for improved clarity.
+        /// Default is false. Enable for better visual quality at small icon sizes.
+        /// </summary>
+        public bool EnableSharpening { get; set; }
+
+        /// <inheritdoc />
+        public DicomSequence? GenerateIconImageSequence(DicomDataset dataset, int frameIndex = 0)
+        {
+            if (dataset == null)
+            {
+                throw new ArgumentNullException(nameof(dataset));
+            }
+
+            try
+            {
+                // Render the DICOM image
+                var dicomImage = new DicomImage(dataset);
+                var renderedImage = dicomImage.RenderImage(frameIndex);
+
+                if (!(renderedImage is ImageSharpImage imageSharpImage))
+                {
+                    // Not an ImageSharp image, cannot process
+                    return null;
+                }
+
+                var sourceImage = imageSharpImage.AsSharpImage();
+                if (sourceImage == null)
+                {
+                    return null;
+                }
+
+                // Calculate scaled dimensions preserving aspect ratio
+                var (iconWidth, iconHeight) = CalculateIconDimensions(sourceImage.Width, sourceImage.Height);
+
+                // Generate grayscale pixel data
+                var pixelData = CreateGrayscaleIconPixelData(sourceImage, iconWidth, iconHeight);
+
+                // Use common builder to create DICOM sequence
+                return DicomIconImageSequenceBuilder.Build(iconWidth, iconHeight, pixelData);
+            }
+            catch
+            {
+                // Icon generation is optional - if it fails, return null
+                // This ensures DICOMDIR creation continues even if icon generation fails
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Calculate icon dimensions maintaining aspect ratio, max 128x128.
+        /// </summary>
+        private static (int width, int height) CalculateIconDimensions(int sourceWidth, int sourceHeight)
+        {
+            if (sourceWidth <= 0 || sourceHeight <= 0)
+            {
+                throw new ArgumentException("Source dimensions must be positive");
+            }
+
+            var aspectRatio = (double)sourceWidth / sourceHeight;
+
+            int iconWidth, iconHeight;
+
+            if (sourceWidth >= sourceHeight)
+            {
+                // Landscape or square
+                iconWidth = Math.Min(MaxIconDimension, sourceWidth);
+                iconHeight = (int)Math.Round(iconWidth / aspectRatio);
+            }
+            else
+            {
+                // Portrait
+                iconHeight = Math.Min(MaxIconDimension, sourceHeight);
+                iconWidth = (int)Math.Round(iconHeight * aspectRatio);
+            }
+
+            // Ensure dimensions are at least 1
+            iconWidth = Math.Max(1, iconWidth);
+            iconHeight = Math.Max(1, iconHeight);
+
+            return (iconWidth, iconHeight);
+        }
+
+        /// <summary>
+        /// Creates grayscale icon pixel data with high-quality resampling.
+        /// </summary>
+        private byte[] CreateGrayscaleIconPixelData(Image<Bgra32> source, int targetWidth, int targetHeight)
+        {
+            // Create grayscale image at target size
+            using var iconImage = new Image<L8>(targetWidth, targetHeight);
+
+            // Resize with high-quality Lanczos3 resampler and convert to grayscale
+            iconImage.Mutate(ctx =>
+            {
+                // First resize the source
+                var resized = source.Clone(x => x.Resize(targetWidth, targetHeight, KnownResamplers.Lanczos3));
+
+                // Convert to grayscale and draw onto our L8 image
+                ctx.DrawImage(resized, 1.0f);
+
+                // Optional sharpening for better clarity at small sizes
+                if (EnableSharpening)
+                {
+                    ctx.GaussianSharpen(0.5f);
+                }
+
+                resized.Dispose();
+            });
+
+            // Extract pixel data using safe API
+            var pixelData = new byte[targetWidth * targetHeight];
+            iconImage.CopyPixelDataTo(pixelData);
+
+            return pixelData;
+        }
+    }
+}

--- a/Platform/FO-DICOM.Imaging.SkiaSharp/Media/SkiaSharpIconGenerator.cs
+++ b/Platform/FO-DICOM.Imaging.SkiaSharp/Media/SkiaSharpIconGenerator.cs
@@ -1,0 +1,159 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Media;
+using SkiaSharp;
+using System;
+
+namespace FellowOakDicom.Imaging.SkiaSharp.Media
+{
+    /// <summary>
+    /// Generates thumbnail icons for DICOMDIR using SkiaSharp.
+    /// Creates 8-bit grayscale icons, maximum 128x128 pixels with aspect ratio preserved.
+    /// Uses high-quality downsampling with optional sharpening for optimal clarity.
+    /// </summary>
+    public class SkiaSharpIconGenerator : IIconGenerator
+    {
+        private const int MaxIconDimension = 128;
+
+        /// <summary>
+        /// Gets or sets whether to apply sharpening filter during downsampling for improved clarity.
+        /// Default is false. Enable for better visual quality at small icon sizes.
+        /// </summary>
+        public bool EnableSharpening { get; set; }
+
+        /// <inheritdoc />
+        public DicomSequence? GenerateIconImageSequence(DicomDataset dataset, int frameIndex = 0)
+        {
+            if (dataset == null)
+            {
+                throw new ArgumentNullException(nameof(dataset));
+            }
+
+            try
+            {
+                // Render the DICOM image
+                var dicomImage = new DicomImage(dataset);
+                var renderedImage = dicomImage.RenderImage(frameIndex);
+
+                if (renderedImage is not SkiaSharpImage skiaImage)
+                {
+                    // Not a SkiaSharp image, cannot process
+                    return null;
+                }
+
+                var sourceBitmap = skiaImage.AsSKBitmap();
+                if (sourceBitmap == null)
+                {
+                    return null;
+                }
+
+                // Calculate scaled dimensions preserving aspect ratio
+                var (iconWidth, iconHeight) = CalculateIconDimensions(sourceBitmap.Width, sourceBitmap.Height);
+
+                // Generate grayscale pixel data
+                using var iconBitmap = CreateGrayscaleIcon(sourceBitmap, iconWidth, iconHeight);
+                var pixelData = ExtractGrayscalePixelData(iconBitmap);
+
+                // Use common builder to create DICOM sequence
+                return DicomIconImageSequenceBuilder.Build(iconWidth, iconHeight, pixelData);
+            }
+            catch
+            {
+                // Icon generation is optional - if it fails, return null
+                // This ensures DICOMDIR creation continues even if icon generation fails
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Calculate icon dimensions maintaining aspect ratio, max 128x128.
+        /// </summary>
+        private static (int width, int height) CalculateIconDimensions(int sourceWidth, int sourceHeight)
+        {
+            if (sourceWidth <= 0 || sourceHeight <= 0)
+            {
+                throw new ArgumentException("Source dimensions must be positive");
+            }
+
+            var aspectRatio = (double)sourceWidth / sourceHeight;
+
+            int iconWidth, iconHeight;
+
+            if (sourceWidth >= sourceHeight)
+            {
+                // Landscape or square
+                iconWidth = Math.Min(MaxIconDimension, sourceWidth);
+                iconHeight = (int)Math.Round(iconWidth / aspectRatio);
+            }
+            else
+            {
+                // Portrait
+                iconHeight = Math.Min(MaxIconDimension, sourceHeight);
+                iconWidth = (int)Math.Round(iconHeight * aspectRatio);
+            }
+
+            // Ensure dimensions are at least 1
+            iconWidth = Math.Max(1, iconWidth);
+            iconHeight = Math.Max(1, iconHeight);
+
+            return (iconWidth, iconHeight);
+        }
+
+        /// <summary>
+        /// Creates a grayscale icon bitmap with high-quality filtering and optional sharpening.
+        /// </summary>
+        private SKBitmap CreateGrayscaleIcon(SKBitmap source, int targetWidth, int targetHeight)
+        {
+            // Create target bitmap in grayscale color space
+            var iconBitmap = new SKBitmap(targetWidth, targetHeight, SKColorType.Gray8, SKAlphaType.Opaque);
+
+            using var canvas = new SKCanvas(iconBitmap);
+            using var paint = new SKPaint
+            {
+                IsAntialias = true
+            };
+
+            // Optional sharpening for better clarity at small sizes
+            if (EnableSharpening)
+            {
+                // Subtle unsharp mask kernel for edge enhancement
+                paint.ImageFilter = SKImageFilter.CreateMatrixConvolution(
+                    new SKSizeI(3, 3),
+                    new float[]
+                    {
+                        0, -0.25f, 0,
+                        -0.25f, 2, -0.25f,
+                        0, -0.25f, 0
+                    },
+                    gain: 1.0f,
+                    bias: 0.0f,
+                    kernelOffset: new SKPointI(1, 1),
+                    tileMode: SKShaderTileMode.Clamp,
+                    convolveAlpha: false);
+            }
+
+            // Scale to target size with high-quality sampling
+            var destRect = new SKRect(0, 0, targetWidth, targetHeight);
+            canvas.DrawBitmap(source, destRect, paint);
+
+            return iconBitmap;
+        }
+
+        /// <summary>
+        /// Extracts 8-bit grayscale pixel data from SKBitmap using safe APIs.
+        /// </summary>
+        private static byte[] ExtractGrayscalePixelData(SKBitmap bitmap)
+        {
+            var pixelCount = bitmap.Width * bitmap.Height;
+            var pixels = new byte[pixelCount];
+
+            // Use safe Span<byte> API instead of unsafe pointers
+            var pixelSpan = bitmap.GetPixelSpan();
+            pixelSpan.CopyTo(pixels);
+
+            return pixels;
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests.Windows/DesktopIconGeneratorTests.cs
+++ b/Tests/FO-DICOM.Tests.Windows/DesktopIconGeneratorTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Imaging.Desktop.Media;
+using FellowOakDicom.Media;
+using System;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Imaging
+{
+    [Collection("Windows")]
+    public class DesktopIconGeneratorTests
+    {
+        [Fact]
+        public void GenerateIconImageSequence_ValidDicomImage_ProducesCorrectIcon()
+        {
+            // Arrange
+            var file = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var generator = new DesktopIconGenerator();
+
+            // Act
+            var iconSequence = generator.GenerateIconImageSequence(file.Dataset);
+
+            // Assert
+            Assert.NotNull(iconSequence);
+            Assert.Equal(DicomTag.IconImageSequence, iconSequence.Tag);
+            Assert.Single(iconSequence.Items);
+
+            var iconDataset = iconSequence.Items[0];
+            var width = iconDataset.GetSingleValue<ushort>(DicomTag.Columns);
+            var height = iconDataset.GetSingleValue<ushort>(DicomTag.Rows);
+
+            // Verify dimensions are within limits
+            Assert.InRange(width, 1, 128);
+            Assert.InRange(height, 1, 128);
+
+            // Verify 8-bit grayscale format
+            Assert.Equal((ushort)1, iconDataset.GetSingleValue<ushort>(DicomTag.SamplesPerPixel));
+            Assert.Equal((ushort)8, iconDataset.GetSingleValue<ushort>(DicomTag.BitsAllocated));
+            Assert.Equal("MONOCHROME2", iconDataset.GetSingleValue<string>(DicomTag.PhotometricInterpretation));
+
+            // Verify pixel data size matches dimensions
+            var pixelData = iconDataset.GetValues<byte>(DicomTag.PixelData);
+            Assert.Equal(width * height, pixelData.Length);
+        }
+
+        [Fact]
+        public void GenerateIconImageSequence_PreservesAspectRatio()
+        {
+            // Arrange - CT-MONO2-16-ankle is 512x512
+            var file = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var generator = new DesktopIconGenerator();
+
+            // Act
+            var iconSequence = generator.GenerateIconImageSequence(file.Dataset);
+
+            // Assert
+            var iconDataset = iconSequence.Items[0];
+            var width = iconDataset.GetSingleValue<ushort>(DicomTag.Columns);
+            var height = iconDataset.GetSingleValue<ushort>(DicomTag.Rows);
+
+            // Should be 128x128 for square image
+            Assert.Equal((ushort)128, width);
+            Assert.Equal((ushort)128, height);
+        }
+
+        [Fact]
+        public void GenerateIconImageSequence_NullDataset_ThrowsArgumentNullException()
+        {
+            var generator = new DesktopIconGenerator();
+            Assert.Throws<ArgumentNullException>(() => generator.GenerateIconImageSequence(null!));
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj
+++ b/Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj
@@ -80,4 +80,11 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Link TestData helper class from main test project -->
+    <Compile Include="..\FO-DICOM.Tests\TestData.cs">
+      <Link>TestData.cs</Link>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj
+++ b/Tests/FO-DICOM.Tests.Windows/FO-DICOM.Tests.Windows.csproj
@@ -72,4 +72,12 @@
     <ProjectReference Include="..\..\Serialization\FO-DICOM.Json\FO-DICOM.Json.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Copy test data from main test project -->
+    <None Include="..\FO-DICOM.Tests\Test Data\CT-MONO2-16-ankle">
+      <Link>Test Data\CT-MONO2-16-ankle</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Tests/FO-DICOM.Tests/Imaging/ImageSharpIconGeneratorTests.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/ImageSharpIconGeneratorTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Imaging.ImageSharp.Media;
+using FellowOakDicom.Media;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Imaging
+{
+    [Collection(TestCollections.General)]
+    public class ImageSharpIconGeneratorTests
+    {
+        public ImageSharpIconGeneratorTests()
+        {
+            // Setup ImageSharp as the image manager for these tests
+            var services = new ServiceCollection();
+            services.AddFellowOakDicom().AddImageManager<ImageSharpImageManager>();
+            var serviceProvider = services.BuildServiceProvider();
+            DicomSetupBuilder.UseServiceProvider(serviceProvider);
+        }
+
+        [Fact]
+        public void GenerateIconImageSequence_ValidDicomImage_ProducesCorrectIcon()
+        {
+            // Arrange
+            var file = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var generator = new ImageSharpIconGenerator();
+
+            // Act
+            var iconSequence = generator.GenerateIconImageSequence(file.Dataset);
+
+            // Assert
+            Assert.NotNull(iconSequence);
+            Assert.Equal(DicomTag.IconImageSequence, iconSequence.Tag);
+            Assert.Single(iconSequence.Items);
+
+            var iconDataset = iconSequence.Items[0];
+            var width = iconDataset.GetSingleValue<ushort>(DicomTag.Columns);
+            var height = iconDataset.GetSingleValue<ushort>(DicomTag.Rows);
+
+            // Verify dimensions are within limits
+            Assert.InRange(width, 1, 128);
+            Assert.InRange(height, 1, 128);
+
+            // Verify 8-bit grayscale format
+            Assert.Equal((ushort)1, iconDataset.GetSingleValue<ushort>(DicomTag.SamplesPerPixel));
+            Assert.Equal((ushort)8, iconDataset.GetSingleValue<ushort>(DicomTag.BitsAllocated));
+            Assert.Equal("MONOCHROME2", iconDataset.GetSingleValue<string>(DicomTag.PhotometricInterpretation));
+
+            // Verify pixel data size matches dimensions
+            var pixelData = iconDataset.GetValues<byte>(DicomTag.PixelData);
+            Assert.Equal(width * height, pixelData.Length);
+        }
+
+        [Fact]
+        public void GenerateIconImageSequence_PreservesAspectRatio()
+        {
+            // Arrange - CT-MONO2-16-ankle is 512x512
+            var file = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var generator = new ImageSharpIconGenerator();
+
+            // Act
+            var iconSequence = generator.GenerateIconImageSequence(file.Dataset);
+
+            // Assert
+            var iconDataset = iconSequence.Items[0];
+            var width = iconDataset.GetSingleValue<ushort>(DicomTag.Columns);
+            var height = iconDataset.GetSingleValue<ushort>(DicomTag.Rows);
+
+            // Should be 128x128 for square image
+            Assert.Equal((ushort)128, width);
+            Assert.Equal((ushort)128, height);
+        }
+
+        [Fact]
+        public void GenerateIconImageSequence_WithSharpening_Succeeds()
+        {
+            // Arrange
+            var file = DicomFile.Open(TestData.Resolve("CT-MONO2-16-ankle"));
+            var generator = new ImageSharpIconGenerator { EnableSharpening = true };
+
+            // Act
+            var iconSequence = generator.GenerateIconImageSequence(file.Dataset);
+
+            // Assert
+            Assert.NotNull(iconSequence);
+            var iconDataset = iconSequence.Items[0];
+            var pixelData = iconDataset.GetValues<byte>(DicomTag.PixelData);
+            
+            // Verify we have valid pixel data
+            Assert.NotEmpty(pixelData);
+            Assert.True(pixelData.Length > 0);
+        }
+
+        [Fact]
+        public void GenerateIconImageSequence_NullDataset_ThrowsArgumentNullException()
+        {
+            var generator = new ImageSharpIconGenerator();
+            Assert.Throws<ArgumentNullException>(() => generator.GenerateIconImageSequence(null!));
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests/Imaging/ImageSharpIconGeneratorTests.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/ImageSharpIconGeneratorTests.cs
@@ -3,28 +3,17 @@
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.ImageSharp.Media;
-using FellowOakDicom.Imaging.NativeCodec;
 using FellowOakDicom.Media;
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using Xunit;
 
 namespace FellowOakDicom.Tests.Imaging
 {
-    [Collection(TestCollections.General)]
+    [Collection(TestCollections.ImageSharp)]
     public class ImageSharpIconGeneratorTests
     {
-        public ImageSharpIconGeneratorTests()
-        {
-            // Setup ImageSharp as the image manager for these tests
-            // IMPORTANT: Must include NativeTranscoderManager to avoid breaking codec tests
-            var services = new ServiceCollection();
-            services.AddFellowOakDicom()
-                .AddTranscoderManager<NativeTranscoderManager>()
-                .AddImageManager<ImageSharpImageManager>();
-            var serviceProvider = services.BuildServiceProvider();
-            DicomSetupBuilder.UseServiceProvider(serviceProvider);
-        }
+        // No constructor needed - GlobalFixture already sets up ImageSharpImageManager
+        // for TestCollections.ImageSharp (see Fixture.cs lines 43-49)
 
         [Fact]
         public void GenerateIconImageSequence_ValidDicomImage_ProducesCorrectIcon()

--- a/Tests/FO-DICOM.Tests/Imaging/ImageSharpIconGeneratorTests.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/ImageSharpIconGeneratorTests.cs
@@ -3,6 +3,7 @@
 
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.ImageSharp.Media;
+using FellowOakDicom.Imaging.NativeCodec;
 using FellowOakDicom.Media;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -16,8 +17,11 @@ namespace FellowOakDicom.Tests.Imaging
         public ImageSharpIconGeneratorTests()
         {
             // Setup ImageSharp as the image manager for these tests
+            // IMPORTANT: Must include NativeTranscoderManager to avoid breaking codec tests
             var services = new ServiceCollection();
-            services.AddFellowOakDicom().AddImageManager<ImageSharpImageManager>();
+            services.AddFellowOakDicom()
+                .AddTranscoderManager<NativeTranscoderManager>()
+                .AddImageManager<ImageSharpImageManager>();
             var serviceProvider = services.BuildServiceProvider();
             DicomSetupBuilder.UseServiceProvider(serviceProvider);
         }

--- a/Tests/FO-DICOM.Tests/Media/DicomDirectoryIconGenerationTests.cs
+++ b/Tests/FO-DICOM.Tests/Media/DicomDirectoryIconGenerationTests.cs
@@ -1,0 +1,241 @@
+// Copyright (c) 2012-2025 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Media;
+using System;
+using Xunit;
+
+namespace FellowOakDicom.Tests.Media
+{
+    [Collection(TestCollections.General)]
+    public class DicomDirectoryIconGenerationTests
+    {
+        #region DicomIconImageSequenceBuilder Tests
+
+        [Fact]
+        public void Build_ValidInput_ProducesCorrectSequence()
+        {
+            // Arrange
+            var width = 64;
+            var height = 64;
+            var pixelData = new byte[width * height];
+            Array.Fill(pixelData, (byte)128);
+
+            // Act
+            var sequence = DicomIconImageSequenceBuilder.Build(width, height, pixelData);
+
+            // Assert
+            Assert.NotNull(sequence);
+            Assert.Equal(DicomTag.IconImageSequence, sequence.Tag);
+            Assert.Single(sequence.Items);
+
+            var iconDataset = sequence.Items[0];
+            Assert.Equal((ushort)width, iconDataset.GetSingleValue<ushort>(DicomTag.Columns));
+            Assert.Equal((ushort)height, iconDataset.GetSingleValue<ushort>(DicomTag.Rows));
+            Assert.Equal((ushort)1, iconDataset.GetSingleValue<ushort>(DicomTag.SamplesPerPixel));
+            Assert.Equal((ushort)8, iconDataset.GetSingleValue<ushort>(DicomTag.BitsAllocated));
+            Assert.Equal((ushort)8, iconDataset.GetSingleValue<ushort>(DicomTag.BitsStored));
+            Assert.Equal((ushort)7, iconDataset.GetSingleValue<ushort>(DicomTag.HighBit));
+            Assert.Equal((ushort)0, iconDataset.GetSingleValue<ushort>(DicomTag.PixelRepresentation));
+            Assert.Equal("MONOCHROME2", iconDataset.GetSingleValue<string>(DicomTag.PhotometricInterpretation));
+            Assert.Equal("1", iconDataset.GetSingleValue<string>(DicomTag.NumberOfFrames));
+
+            var embeddedPixelData = iconDataset.GetValues<byte>(DicomTag.PixelData);
+            Assert.Equal(pixelData.Length, embeddedPixelData.Length);
+            Assert.Equal(pixelData, embeddedPixelData);
+        }
+
+        [Fact]
+        public void Build_MaxDimensions_Succeeds()
+        {
+            // Arrange
+            var width = 128;
+            var height = 128;
+            var pixelData = new byte[width * height];
+
+            // Act
+            var sequence = DicomIconImageSequenceBuilder.Build(width, height, pixelData);
+
+            // Assert
+            Assert.NotNull(sequence);
+            var iconDataset = sequence.Items[0];
+            Assert.Equal((ushort)128, iconDataset.GetSingleValue<ushort>(DicomTag.Columns));
+            Assert.Equal((ushort)128, iconDataset.GetSingleValue<ushort>(DicomTag.Rows));
+        }
+
+        [Fact]
+        public void Build_NullPixelData_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                DicomIconImageSequenceBuilder.Build(64, 64, null!));
+        }
+
+        [Theory]
+        [InlineData(0, 64)]
+        [InlineData(64, 0)]
+        [InlineData(-1, 64)]
+        [InlineData(64, -1)]
+        public void Build_InvalidDimensions_ThrowsArgumentException(int width, int height)
+        {
+            var pixelData = new byte[Math.Abs(width * height)];
+            Assert.Throws<ArgumentException>(() =>
+                DicomIconImageSequenceBuilder.Build(width, height, pixelData));
+        }
+
+        [Theory]
+        [InlineData(129, 64)]
+        [InlineData(64, 129)]
+        [InlineData(200, 200)]
+        public void Build_DimensionsExceed128_ThrowsArgumentException(int width, int height)
+        {
+            var pixelData = new byte[width * height];
+            Assert.Throws<ArgumentException>(() =>
+                DicomIconImageSequenceBuilder.Build(width, height, pixelData));
+        }
+
+        [Fact]
+        public void Build_MismatchedPixelDataLength_ThrowsArgumentException()
+        {
+            var width = 64;
+            var height = 64;
+            var pixelData = new byte[100]; // Wrong size
+
+            Assert.Throws<ArgumentException>(() =>
+                DicomIconImageSequenceBuilder.Build(width, height, pixelData));
+        }
+
+        #endregion
+
+        #region DicomDirectory Integration Tests
+
+        [Fact]
+        public void AddFile_WithoutIconGenerator_WorksAsExpected()
+        {
+            // Arrange
+            var dicomDir = new DicomDirectory();
+            var dataset = CreateTestDicomDataset();
+            var file = new DicomFile(dataset);
+
+            // Act
+            var entry = dicomDir.AddFile(file, "TEST\\IMAGE001");
+
+            // Assert
+            Assert.NotNull(entry);
+            Assert.NotNull(entry.InstanceRecord);
+            Assert.False(entry.InstanceRecord.Contains(DicomTag.IconImageSequence));
+        }
+
+        [Fact]
+        public void AddFile_WithIconGenerator_AddsIconToImageRecord()
+        {
+            // Arrange
+            var dicomDir = new DicomDirectory();
+            var dataset = CreateTestDicomDataset();
+            var file = new DicomFile(dataset);
+
+            var mockIconGenerator = new MockIconGenerator
+            {
+                ReturnValue = CreateTestIconSequence()
+            };
+
+            // Act
+            var entry = dicomDir.AddFile(file, "TEST\\IMAGE001", mockIconGenerator);
+
+            // Assert
+            Assert.NotNull(entry);
+            Assert.NotNull(entry.InstanceRecord);
+            Assert.True(entry.InstanceRecord.Contains(DicomTag.IconImageSequence));
+
+            var iconSequence = entry.InstanceRecord.GetSequence(DicomTag.IconImageSequence);
+            Assert.NotNull(iconSequence);
+            Assert.Single(iconSequence.Items);
+        }
+
+        [Fact]
+        public void AddFile_IconGeneratorReturnsNull_DoesNotBreakDicomDir()
+        {
+            // Arrange
+            var dicomDir = new DicomDirectory();
+            var dataset = CreateTestDicomDataset();
+            var file = new DicomFile(dataset);
+
+            var mockIconGenerator = new MockIconGenerator
+            {
+                ReturnValue = null
+            };
+
+            // Act
+            var entry = dicomDir.AddFile(file, "TEST\\IMAGE001", mockIconGenerator);
+
+            // Assert
+            Assert.NotNull(entry);
+            Assert.NotNull(entry.InstanceRecord);
+            Assert.False(entry.InstanceRecord.Contains(DicomTag.IconImageSequence));
+        }
+
+        [Fact]
+        public void AddFile_IconGeneratorThrows_DoesNotBreakDicomDir()
+        {
+            // Arrange
+            var dicomDir = new DicomDirectory();
+            var dataset = CreateTestDicomDataset();
+            var file = new DicomFile(dataset);
+
+            var mockIconGenerator = new MockIconGenerator
+            {
+                ShouldThrow = true
+            };
+
+            // Act - Should not throw
+            var entry = dicomDir.AddFile(file, "TEST\\IMAGE001", mockIconGenerator);
+
+            // Assert
+            Assert.NotNull(entry);
+            Assert.NotNull(entry.InstanceRecord);
+            Assert.False(entry.InstanceRecord.Contains(DicomTag.IconImageSequence));
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private static DicomDataset CreateTestDicomDataset()
+        {
+            return new DicomDataset
+            {
+                { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage },
+                { DicomTag.SOPInstanceUID, DicomUID.Generate() },
+                { DicomTag.StudyInstanceUID, DicomUID.Generate() },
+                { DicomTag.SeriesInstanceUID, DicomUID.Generate() },
+                { DicomTag.PatientID, "12345" },
+                { DicomTag.PatientName, "Test^Patient" },
+                { DicomTag.Modality, "OT" }
+            };
+        }
+
+        private static DicomSequence CreateTestIconSequence()
+        {
+            var pixelData = new byte[64 * 64];
+            Array.Fill(pixelData, (byte)128);
+            return DicomIconImageSequenceBuilder.Build(64, 64, pixelData);
+        }
+
+        private class MockIconGenerator : IIconGenerator
+        {
+            public DicomSequence? ReturnValue { get; set; }
+            public bool ShouldThrow { get; set; }
+
+            public DicomSequence? GenerateIconImageSequence(DicomDataset dataset, int frameIndex = 0)
+            {
+                if (ShouldThrow)
+                {
+                    throw new InvalidOperationException("Test exception");
+                }
+                return ReturnValue;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Tests/FO-DICOM.Tests/Media/DicomDirectoryIconGenerationTests.cs
+++ b/Tests/FO-DICOM.Tests/Media/DicomDirectoryIconGenerationTests.cs
@@ -20,7 +20,11 @@ namespace FellowOakDicom.Tests.Media
             var width = 64;
             var height = 64;
             var pixelData = new byte[width * height];
+#if NET462
+            for (int i = 0; i < pixelData.Length; i++) pixelData[i] = 128;
+#else
             Array.Fill(pixelData, (byte)128);
+#endif
 
             // Act
             var sequence = DicomIconImageSequenceBuilder.Build(width, height, pixelData);
@@ -217,7 +221,11 @@ namespace FellowOakDicom.Tests.Media
         private static DicomSequence CreateTestIconSequence()
         {
             var pixelData = new byte[64 * 64];
+#if NET462
+            for (int i = 0; i < pixelData.Length; i++) pixelData[i] = 128;
+#else
             Array.Fill(pixelData, (byte)128);
+#endif
             return DicomIconImageSequenceBuilder.Build(64, 64, pixelData);
         }
 


### PR DESCRIPTION
## Summary

Implements 7-year-old feature request #654 for automatic thumbnail icon generation when creating DICOMDIR files.

This PR adds comprehensive icon generation support across all three fo-dicom imaging backends (SkiaSharp, ImageSharp, and Desktop/GDI+), with a clean extensible architecture.

## Changes

### Core Infrastructure
- **`IIconGenerator`** interface - Extensible contract for icon generation
- **`DicomIconImageSequenceBuilder`** - Shared utility for packaging grayscale pixel data into DICOM Icon Image Sequences
- **`DicomDirectory.AddFile()`** - New optional `IIconGenerator` parameter (non-breaking change)

### Implementations (all three imaging backends)
1. **SkiaSharpIconGenerator** - High-quality downsampling with optional sharpening
2. **ImageSharpIconGenerator** - Lanczos3 resampling with Gaussian sharpening
3. **DesktopIconGenerator** - GDI+ high-quality bicubic interpolation

## Technical Details

**Icon Specifications:**
- 8-bit grayscale (Monochrome2)
- Maximum 128x128 pixels
- Aspect ratio preserved
- High-quality resampling algorithms

**Code Quality:**
- ✅ Safe, modern C# - no `unsafe` blocks
- ✅ Uses `Span<byte>` and safe pixel APIs
- ✅ Proper resource disposal
- ✅ Graceful error handling (icon failures don't break DICOMDIR creation)
- ✅ Separation of concerns (pixel generation vs DICOM packaging)
- ✅ Consistent API across all backends

## Usage Example

```csharp
// Without icons (existing behavior - non-breaking)
dicomDir.AddFile(file, referencedFileId);

// With icons (new feature)
var iconGenerator = new SkiaSharpIconGenerator { EnableSharpening = true };
dicomDir.AddFile(file, referencedFileId, iconGenerator);
```

## Testing

- ✅ FO-DICOM.Core compiles successfully
- ✅ FO-DICOM.Imaging.SkiaSharp compiles successfully  
- ✅ FO-DICOM.Imaging.ImageSharp compiles successfully
- ✅ FO-DICOM.Imaging.Desktop (Windows-only, will compile in CI)

## Checklist

- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

## Notes

This implementation provides the foundation requested in #654. The VB.NET proof-of-concept from the original issue has been modernized and extended to support all three imaging backends with clean, maintainable architecture.

Closes #654