### PR TITLE
Replace MacOs13 runners and fix some flaky tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
             { name: Windows-arm, ver: windows-11-arm, runtime: win-arm64 },
             { name: Ubuntu-x64, ver: ubuntu-24.04, runtime: linux-x64 },
             { name: Ubuntu-arm, ver: ubuntu-24.04-arm, runtime: linux-arm64 },
-            { name: macOS-x64, ver: macos-13, runtime: osx-x64 },
-            { name: macOS-arm, ver: macos-14, runtime: osx-arm64 }
+            { name: macOS-x64, ver: macos-15-intel, runtime: osx-x64 },
+            { name: macOS-arm, ver: macos-15, runtime: osx-arm64 }
           ]
         frameworks: [
             { name: ".NET 9.0", common: "net9.0", win: "net9.0-windows", coverage: '' },
@@ -39,11 +39,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - name: Setup .NET 9.0
-      if: ${{ startsWith(matrix.os.name, 'Ubuntu') }}
+    - name: Setup .NET
+      if: ${{ matrix.frameworks.common != 'net462' }}
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: ${{ matrix.frameworks.common == 'net8.0' && '8.0.x' || '9.0.x' }}
+      env:
+        DOTNET_INSTALL_ARCH: ${{ contains(matrix.os.runtime, 'arm') && 'arm64' || 'x64' }}
     - name: Test FO-DICOM.Tests
       run: dotnet test ./Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj --configuration Release --framework ${{ matrix.frameworks.common }} --blame --runtime ${{ matrix.os.runtime }} --logger:"trx;LogFileName=.\results-${{ matrix.os.name }}-${{ matrix.frameworks.common }}.xml" ${{ matrix.frameworks.coverage }}
     - name: Upload test results

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTlsTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTlsTest.cs
@@ -178,7 +178,13 @@ namespace FellowOakDicom.Tests.Network.Client
                 };
             if (requireMutualAuthentication)
             {
-                tlsInitiator.Certificates = new X509CertificateCollection { new X509Certificate(TestData.Resolve("testclienteku.contoso.com.pfx"), "PLACEHOLDER") };
+#if NET9_0_OR_GREATER
+                var cert = System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12FromFile(
+                    TestData.Resolve("testclienteku.contoso.com.pfx"), "PLACEHOLDER");
+#else
+                var cert = new X509Certificate(TestData.Resolve("testclienteku.contoso.com.pfx"), "PLACEHOLDER");
+#endif
+                tlsInitiator.Certificates = new X509CertificateCollection { cert };
             }
 
 

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomConverterTest.cs
@@ -156,10 +156,10 @@ namespace FellowOakDicom.Tests.Serialization
                 }
             });
 
+            var dict = DicomDictionary.Default.ToDictionary(dde => dde.Keyword, dde => dde.Tag);
             var millisecondsPerCallC = TimeCall(100, () =>
             {
-                var dict = DicomDictionary.Default.ToDictionary(dde => dde.Keyword, dde => dde.Tag);
-                foreach (var kw in DicomDictionary.Default.Select(dde => dde.Keyword))
+                foreach (var kw in dict.Keys)
                 {
                     var tag = dict[kw];
                     Assert.NotNull(tag);

--- a/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
+++ b/Tests/FO-DICOM.Tests/Serialization/JsonDicomCoreConverterTest.cs
@@ -174,10 +174,10 @@ namespace FellowOakDicom.Tests.Serialization
                 }
             });
 
+            var dict = DicomDictionary.Default.ToDictionary(dde => dde.Keyword, dde => dde.Tag);
             var millisecondsPerCallC = TimeCall(100, () =>
             {
-                var dict = DicomDictionary.Default.ToDictionary(dde => dde.Keyword, dde => dde.Tag);
-                foreach (var kw in DicomDictionary.Default.Select(dde => dde.Keyword))
+                foreach (var kw in dict.Keys)
                 {
                     var tag = dict[kw];
                     Assert.NotNull(tag);

--- a/Tests/FO-DICOM.Tests/StructuredReport/DicomStructuredReportTest.cs
+++ b/Tests/FO-DICOM.Tests/StructuredReport/DicomStructuredReportTest.cs
@@ -48,7 +48,12 @@ namespace FellowOakDicom.Tests.StructuredReport
             // Save the SR to a stream
             report.Save(stream);
 
-            Assert.True(stream.Length > 930);
+            // Ensure writer buffer is flushed before checking length
+            stream.Flush();
+
+            // Verify file size is reasonable (accommodates full range of UID length variation)
+            // UIDs from DicomUID.Generate() vary in length (2.25.{random-128bit-number})
+            Assert.InRange(stream.Length, 744, 934);
 
             stream.Position = 0;
             var report2 = DicomStructuredReport.Open(stream);


### PR DESCRIPTION
@gofal Mini test fix PR. Just replaces the macos13 runners Github is retiring, fixes the SR object size limits check (it assumed random 128 bits numbers were at least 38 digits long, which is _nearly_ always true - replace with actual range, 1-39 digits) and two TOCTOU issues (it copies the default tag dictionary then checks the keys of the copy against the values of the original for consistency - while some other tests make changes to that dictionary; by getting the values from the same copy as the keys, that race is avoided). Also reflect one API change, MS deprecated the old PFX certificate loading wording in .Net 9 to prefer `System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12FromFile` over `new X509Certificate`.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [ ] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
-
-
-
