### PR TITLE
Refactor FrameGeometry initialization to handle empty position and orientation arrays

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
 ### 5.2.6 (TBD)
+- Fix FrameGeometry initialization to handle empty position and orientation arrays (#2067)
 
 ### 5.2.5 (2025-11-16)
 - Add INetoworkMetricsCollector, that is invoked by DicomService, to optionally collect metrics (#2039)

--- a/FO-DICOM.Core/Imaging/FrameGeometry.cs
+++ b/FO-DICOM.Core/Imaging/FrameGeometry.cs
@@ -146,16 +146,11 @@ namespace FellowOakDicom.Imaging
             if (imagePatientPosition.Length == 0 && imagePatientOrientation.Length == 0)
             {
                 Orientation = FrameOrientation.None;
-                PointTopLeft = new Point3D(0, 0, 0);
-                DirectionRow = new Vector3D(1, 0, 0);
-                DirectionColumn = new Vector3D(0, 1, 0);
             }
-            else
-            {
-                PointTopLeft = new Point3D(imagePatientPosition);
-                DirectionRow = new Vector3D(imagePatientOrientation, 0);
-                DirectionColumn = new Vector3D(imagePatientOrientation, 3);
-            }
+
+            PointTopLeft = imagePatientPosition.Length >= 3 ? new Point3D(imagePatientPosition) : new Point3D(0, 0, 0);
+            DirectionRow = imagePatientOrientation.Length >= 3 ? new Vector3D(imagePatientOrientation, 0) : new Vector3D(1, 0, 0);
+            DirectionColumn = imagePatientOrientation.Length >= 6 ? new Vector3D(imagePatientOrientation, 3) : new Vector3D(0, 1, 0);
 
             DirectionNormal = DirectionRow.CrossProduct(DirectionColumn);
             if (DirectionNormal.IsZero)

--- a/Tests/FO-DICOM.Tests/Imaging/FrameGeometryTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/FrameGeometryTest.cs
@@ -319,5 +319,32 @@ namespace FellowOakDicom.Tests.Imaging
         }
 
 
+        [Theory]
+        [InlineData(0, 0)]  // Both missing
+        [InlineData(1, 0)]  // Position has 1 value, orientation missing
+        [InlineData(2, 0)]  // Position has 2 values, orientation missing
+        [InlineData(3, 0)]  // Position complete, orientation missing
+        [InlineData(0, 3)]  // Position missing, orientation has 3 values
+        [InlineData(0, 5)]  // Position missing, orientation has 5 values
+        [InlineData(0, 6)]  // Position missing, orientation complete
+        [InlineData(3, 3)]  // Position complete, orientation has only row direction
+        [InlineData(3, 5)]  // Position complete, orientation missing one value for column direction
+        [InlineData(2, 5)]  // Both incomplete
+        public void FrameGeometry_HandlesIncompletePositionAndOrientationArrays(int positionLength, int orientationLength)
+        {
+            var positionValues = Enumerable.Range(0, positionLength).Select(i => (decimal)i).ToArray();
+            var orientationValues = Enumerable.Range(0, orientationLength).Select(i => i < 3 ? (decimal)1.0 : (decimal)0.0).ToArray();
+
+            var dataset = new DicomDataset { ValidateItems = false };
+            dataset.Add(DicomTag.PixelSpacing, new decimal[] { 0.5m, 0.5m });
+            dataset.Add(DicomTag.Rows, (ushort)500);
+            dataset.Add(DicomTag.Columns, (ushort)500);
+
+            dataset.AddOrUpdate(DicomTag.ImagePositionPatient, positionValues);
+            dataset.AddOrUpdate(DicomTag.ImageOrientationPatient, orientationValues);
+
+            var exception = Record.Exception(() => new FrameGeometry(dataset));
+            Assert.Null(exception);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2067.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- Fix `FrameGeometry` to handle incomplete `ImagePositionPatient` and `ImageOrientationPatient` arrays without throwing `IndexOutOfRangeException`
- Add length checks before accessing array elements, falling back to default values when arrays are too short
- Add parameterized unit test covering various incomplete array scenarios
