### PR TITLE
Set OverlayBitsPosition to values as defined in DICOM standard when transforming an overlay

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 ### 5.2.6 (TBD)
 - Strong Name fo-dicom.Imaging.ImageSharp and fo-dicom.Imaging.ImageSharp.NetStandard projects
+- Set OverlayBitsPosition to value 0 as defined in dicom standard when transforming an overlay (#2087)
 
 ### 5.2.5 (2025-11-16)
 - Add INetoworkMetricsCollector, that is invoked by DicomService, to optionally collect metrics (#2039)

--- a/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
@@ -316,9 +316,7 @@ namespace FellowOakDicom.Imaging.Codec
                     continue;
                 }
 
-                // If embedded overlay, Overlay Bits Allocated should equal Bits Allocated (#110).
-                var bitsAlloc = output.GetSingleValueOrDefault(DicomTag.BitsAllocated, (ushort)1);
-                output.AddOrUpdate(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), bitsAlloc);
+                output.AddOrUpdate(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), (ushort)1);
                 output.AddOrUpdate(new DicomTag(overlay.Group, DicomTag.OverlayBitPosition.Element), (ushort)0);
 
                 var data = overlay.Data;

--- a/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
@@ -317,8 +317,9 @@ namespace FellowOakDicom.Imaging.Codec
                 }
 
                 // If embedded overlay, Overlay Bits Allocated should equal Bits Allocated (#110).
-                var bitsAlloc = output.GetSingleValueOrDefault(DicomTag.BitsAllocated, (ushort)0);
+                var bitsAlloc = output.GetSingleValueOrDefault(DicomTag.BitsAllocated, (ushort)1);
                 output.AddOrUpdate(new DicomTag(overlay.Group, DicomTag.OverlayBitsAllocated.Element), bitsAlloc);
+                output.AddOrUpdate(new DicomTag(overlay.Group, DicomTag.OverlayBitPosition.Element), (ushort)0);
 
                 var data = overlay.Data;
                 if (output.InternalTransferSyntax.IsExplicitVR)

--- a/FO-DICOM.Core/Imaging/DicomOverlayDataFactory.cs
+++ b/FO-DICOM.Core/Imaging/DicomOverlayDataFactory.cs
@@ -38,7 +38,7 @@ namespace FellowOakDicom.Imaging
                                   OriginX = 1,
                                   OriginY = 1,
                                   BitsAllocated = 1,
-                                  BitPosition = 1
+                                  BitPosition = 0
                               };
 
             var array = new BitList { Capacity = overlay.Rows * overlay.Columns };


### PR DESCRIPTION
Fixes #2087 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [ ] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the DICOM standard clearly defines that the values OverlayBitsAllocated has to be 1 and OverlayBitsPosition has to be 0. When transforming a retired overlay from pixel data into overlay module, the values are now set to these values
