### PR TITLE
Close tcp connection in case of error in DicomServer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 ### 5.2.6 (TBD)
 - Strong Name fo-dicom.Imaging.ImageSharp and fo-dicom.Imaging.ImageSharp.NetStandard projects
+- Close the tcpClient in cae an exception happens within DicomServer (#1991)
 
 ### 5.2.5 (2025-11-16)
 - Add INetoworkMetricsCollector, that is invoked by DicomService, to optionally collect metrics (#2039)

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -340,6 +340,7 @@ namespace FellowOakDicom.Network
                             catch (Exception e)
                             {
                                 Logger.LogError(e, "An exception occurred while accepting an incoming client connection");
+                                tcpClient.Close();
                             }
                         }, _cancellationToken);
                     }

--- a/Tests/FO-DICOM.Tests/Network/Client/DicomClientTlsTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/Client/DicomClientTlsTest.cs
@@ -258,6 +258,63 @@ namespace FellowOakDicom.Tests.Network.Client
         }
 
         [Fact]
+        public async Task SendWithoutTlsToTlsServerShouldFail()
+        {
+            // Arrange
+            var serverLogger = _logger.IncludePrefix(nameof(IDicomServer));
+
+            var tlsAcceptor = new DefaultTlsAcceptor("./Test Data/FellowOakDicom.p12", "FellowOakDicom")
+            {
+                RequireMutualAuthentication = false,
+                CertificateValidationCallback = (sender, x509Certificate, chain, errors) =>
+                {
+                    return false;
+                }
+            };
+
+            // create a server expecting tls
+            using var server = CreateServer<RecordingDicomCEchoProvider, RecordingDicomCEchoProviderServer>("127.0.0.1", 0, tlsAcceptor: tlsAcceptor);
+
+            // create a client not using tls
+            var client = CreateClient("127.0.0.1", server.Port, null, "SCU", "ANY-SCP");
+
+            DicomCEchoResponse actualResponse = null;
+            var dicomCEchoRequest = new DicomCEchoRequest
+            {
+                OnResponseReceived = (request, response) =>
+                {
+                    actualResponse = response;
+                }
+            };
+            await client.AddRequestAsync(dicomCEchoRequest);
+
+            Exception exception = null;
+            try
+            {
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60)))
+                {
+                    await client.SendAsync(cts.Token);
+                }
+            }
+            catch (AggregateException aggEx)
+            {
+                exception = aggEx.InnerException;
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            Assert.NotNull(exception);
+#if NET462
+            // for some reason, in .net there is still a requesttimeout instead of a network error
+            Assert.IsType<DicomAssociationRequestTimedOutException>(exception);
+#else
+            Assert.IsType<DicomNetworkException>(exception);
+#endif
+        }
+
+        [Fact]
         public async Task SendAsync_WithFrozenSslHandshake_ShouldAcceptMoreConnections()
         {
             // Arrange


### PR DESCRIPTION
Fixes #1991 

implements the change proposed in issue 1991 by pvrobays

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the excpetion handler in the main tcp-processing loop of DicomServer now also closes the tcp connection. In newer net versions now the client receives an network exception immediatelly instead of waiting for a timeout. only net netframework 4 there is still a timeout.
