### PR TITLE
Performance optimizations .NET8+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,4 +81,3 @@ jobs:
         path: |
           ./BenchmarkDotNet.Artifacts/
           ./BenchmarkDotNet.Artifacts/results/
- 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 ### 6.0.0-alpha1 (TBD)
 - breaking change: update targetframeworks to net8, net9 and net10, netstandard2.0 is dropped
 - make fo-dicom.core AOT compilant (#2005)
+- Performance optimizations in FO-DICOM.Core
 
 ### 5.2.6 (2026-03-30)
 - Fix FrameGeometry initialization to handle empty position and orientation arrays (#2067)

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -53,8 +53,18 @@ namespace FellowOakDicom
         /// </summary>
         /// <param name="internalTransferSyntax">Internal transfer syntax representation of the dataset.</param>
         public DicomDataset(DicomTransferSyntax internalTransferSyntax)
+            : this(internalTransferSyntax, 64)
         {
-            _items = new SortedList<DicomTag, DicomItem>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DicomDataset"/> class.
+        /// </summary>
+        /// <param name="internalTransferSyntax">Internal transfer syntax representation of the dataset.</param>
+        /// <param name="capacity">Initial capacity of the internal collection.</param>
+        internal DicomDataset(DicomTransferSyntax internalTransferSyntax, int capacity)
+        {
+            _items = new SortedList<DicomTag, DicomItem>(capacity);
             InternalTransferSyntax = internalTransferSyntax;
         }
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -1041,7 +1041,21 @@ namespace FellowOakDicom
         /// <returns>Current Dataset</returns>
         public DicomDataset Remove(Func<DicomItem, bool> selector)
         {
-            _items.Values.Where(selector).ToList().Each(item => _items.Remove(item.Tag));
+            List<DicomTag> toRemove = null;
+            foreach (var item in _items.Values)
+            {
+                if (selector(item))
+                {
+                    (toRemove ??= new List<DicomTag>()).Add(item.Tag);
+                }
+            }
+            if (toRemove != null)
+            {
+                foreach (var tag in toRemove)
+                {
+                    _items.Remove(tag);
+                }
+            }
             return this;
         }
 

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -1615,10 +1615,12 @@ namespace FellowOakDicom
 
         private void SetTargetEncodingsToStringElements(Encoding[] values)
         {
-
-            foreach (var txt in this.FilterByType<DicomStringElement>())
+            foreach (var item in this)
             {
-                txt.TargetEncodings = values;
+                if (item is DicomStringElement txt)
+                {
+                    txt.TargetEncodings = values;
+                }
             }
         }
 

--- a/FO-DICOM.Core/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/DicomDatasetExtensions.cs
@@ -138,6 +138,7 @@ namespace FellowOakDicom
         /// <returns>Boolean if the composite DateTimeOffset could be extracted.</returns>
         public static bool TryGetDateTimeOffset(this DicomDataset dataset, DicomTag date, DicomTag time, out DateTimeOffset datetimeoffset, DicomDataset topLevelDataset = null)
         {
+            datetimeoffset = default;
             try
             {
                 if (!TryGetDateTime(dataset, date, time, out var datetime) || datetime == DateTime.MinValue)

--- a/FO-DICOM.Core/DicomElement.cs
+++ b/FO-DICOM.Core/DicomElement.cs
@@ -268,7 +268,10 @@ namespace FellowOakDicom
         protected override void ValidateString()
         {
             EnsureSplitValues();
-            _values.ToList().ForEach(ValueRepresentation.ValidateString);
+            foreach (var v in _values)
+            {
+                ValueRepresentation.ValidateString(v);
+            }
         }
 
         public override T Get<T>(int item = -1)
@@ -864,11 +867,17 @@ namespace FellowOakDicom
 
             if (_values == null)
             {
-                _values =
-                    base.Get<string[]>()
-                        // #1296 some invalid files have "," as decimal separator. because a comma is no valid character in DS, this cannot be misinterpretated and it is obvious to replace it by "."
-                        .Select(x => decimal.Parse(x.Replace(',','.'), NumberStyles.Any, CultureInfo.InvariantCulture))
-                        .ToArray();
+                var parts = base.Get<string[]>();
+                var parsed = new decimal[parts.Length];
+                for (var i = 0; i < parts.Length; i++)
+                {
+                    var s = parts[i];
+                    // #1296 some invalid files have "," as decimal separator. because a comma is no valid character in DS, this cannot be misinterpretated and it is obvious to replace it by "."
+                    parsed[i] = s.IndexOf(',') < 0
+                        ? decimal.Parse(s.AsSpan(), NumberStyles.Any, CultureInfo.InvariantCulture)
+                        : decimal.Parse(s.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture);
+                }
+                _values = parsed;
             }
 
             if (typeof(T).GetTypeInfo().IsArray)
@@ -1103,7 +1112,13 @@ namespace FellowOakDicom
 
             if (_values == null)
             {
-                _values = base.Get<string[]>().Select(x => int.Parse(x, NumberStyles.Integer | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture)).ToArray();
+                var parts = base.Get<string[]>();
+                var parsed = new int[parts.Length];
+                for (var i = 0; i < parts.Length; i++)
+                {
+                    parsed[i] = int.Parse(parts[i].AsSpan(), NumberStyles.Integer | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture);
+                }
+                _values = parsed;
             }
 
             if (typeof(T) == typeof(int) || typeof(T) == typeof(object))

--- a/FO-DICOM.Core/DicomEncoding.cs
+++ b/FO-DICOM.Core/DicomEncoding.cs
@@ -302,7 +302,7 @@ namespace FellowOakDicom
 
             if (escapeIndexes.Count == 0)
             {
-                return GetStringFromEncoding(buffer.Data, firstEncoding, 0, (int)buffer.Size);
+                return GetStringFromEncoding(value, firstEncoding, 0, (int)buffer.Size);
             }
 
             var decodedString = new StringBuilder();

--- a/FO-DICOM.Core/DicomTagsIndex.cs
+++ b/FO-DICOM.Core/DicomTagsIndex.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) 2012-2026 fo-dicom contributors.
+// Copyright (c) 2012-2026 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -14,14 +15,14 @@ namespace FellowOakDicom
     /// </summary>
     internal static class DicomTagsIndex
     {
-        private static readonly Lazy<Dictionary<uint, DicomTag>> _index = new Lazy<Dictionary<uint, DicomTag>>(BuildIndex);
-        
+        private static readonly Lazy<FrozenDictionary<uint, DicomTag>> _index = new Lazy<FrozenDictionary<uint, DicomTag>>(BuildIndex);
+
         /// <summary>
         /// This builds a dictionary of known DICOM tags
         /// Benchmarking showed that this consumes about 0.8MB of memory.
         /// See https://github.com/fo-dicom/fo-dicom/pull/1417#discussion_r916766088 for benchmarks
         /// </summary>
-        private static Dictionary<uint, DicomTag> BuildIndex()
+        private static FrozenDictionary<uint, DicomTag> BuildIndex()
         {
             var allDicomTags = typeof(DicomTag)
                 .GetFields(BindingFlags.Public | BindingFlags.Static)
@@ -40,17 +41,16 @@ namespace FellowOakDicom
                 }
             }
 
-
-            return index;
+            return index.ToFrozenDictionary();
         }
-        
+
         /// <summary>
         /// Looks up or creates a DICOM tag based on its group and element
         /// </summary>
         /// <param name="group">The group of the DICOM tag</param>
         /// <param name="element">The element of the DICOM tag</param>
         /// <returns>A tag from the known DICOM tag index or a newly created instance of <see cref="DicomTag"/> otherwise</returns>
-        public static DicomTag LookupOrCreate(ushort group, ushort element) => 
+        public static DicomTag LookupOrCreate(ushort group, ushort element) =>
             _index.Value.TryGetValue(((uint)group << 16) | element, out var tag)
                 ? tag
                 : new DicomTag(group, element);

--- a/FO-DICOM.Core/DicomTransferSyntax.cs
+++ b/FO-DICOM.Core/DicomTransferSyntax.cs
@@ -4,6 +4,7 @@
 
 using FellowOakDicom.IO;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace FellowOakDicom
@@ -721,7 +722,7 @@ namespace FellowOakDicom
 
         #region Static Methods
 
-        private static readonly IDictionary<DicomUID, DicomTransferSyntax> Entries = new Dictionary<DicomUID, DicomTransferSyntax>();
+        private static readonly ConcurrentDictionary<DicomUID, DicomTransferSyntax> Entries = new ConcurrentDictionary<DicomUID, DicomTransferSyntax>();
 
         public static IEnumerable<DicomTransferSyntax> KnownEntries => Entries.Values;
 
@@ -729,62 +730,62 @@ namespace FellowOakDicom
         {
             #region Load Transfer Syntax List
 
-            Entries.Add(GEPrivateImplicitVRBigEndian.UID, GEPrivateImplicitVRBigEndian);
-            Entries.Add(ImplicitVRLittleEndian.UID, ImplicitVRLittleEndian);
-            Entries.Add(ExplicitVRLittleEndian.UID, ExplicitVRLittleEndian);
-            Entries.Add(ExplicitVRBigEndian.UID, ExplicitVRBigEndian);
-            Entries.Add(DeflatedExplicitVRLittleEndian.UID, DeflatedExplicitVRLittleEndian);
-            Entries.Add(JPEGProcess1.UID, JPEGProcess1);
-            Entries.Add(JPEGProcess2_4.UID, JPEGProcess2_4);
-            Entries.Add(JPEGProcess3_5Retired.UID, JPEGProcess3_5Retired);
-            Entries.Add(JPEGProcess6_8Retired.UID, JPEGProcess6_8Retired);
-            Entries.Add(JPEGProcess7_9Retired.UID, JPEGProcess7_9Retired);
-            Entries.Add(JPEGProcess10_12Retired.UID, JPEGProcess10_12Retired);
-            Entries.Add(JPEGProcess11_13Retired.UID, JPEGProcess11_13Retired);
-            Entries.Add(JPEGProcess14.UID, JPEGProcess14);
-            Entries.Add(JPEGProcess15Retired.UID, JPEGProcess15Retired);
-            Entries.Add(JPEGProcess16_18Retired.UID, JPEGProcess16_18Retired);
-            Entries.Add(JPEGProcess17_19Retired.UID, JPEGProcess17_19Retired);
-            Entries.Add(JPEGProcess20_22Retired.UID, JPEGProcess20_22Retired);
-            Entries.Add(JPEGProcess21_23Retired.UID, JPEGProcess21_23Retired);
-            Entries.Add(JPEGProcess24_26Retired.UID, JPEGProcess24_26Retired);
-            Entries.Add(JPEGProcess25_27Retired.UID, JPEGProcess25_27Retired);
-            Entries.Add(JPEGProcess28Retired.UID, JPEGProcess28Retired);
-            Entries.Add(JPEGProcess29Retired.UID, JPEGProcess29Retired);
-            Entries.Add(JPEGProcess14SV1.UID, JPEGProcess14SV1);
-            Entries.Add(JPEGLSLossless.UID, JPEGLSLossless);
-            Entries.Add(JPEGLSNearLossless.UID, JPEGLSNearLossless);
-            Entries.Add(JPEG2000Lossless.UID, JPEG2000Lossless);
-            Entries.Add(JPEG2000Lossy.UID, JPEG2000Lossy);
-            Entries.Add(JPEG2000Part2MultiComponentLosslessOnly.UID, JPEG2000Part2MultiComponentLosslessOnly);
-            Entries.Add(JPEG2000Part2MultiComponent.UID, JPEG2000Part2MultiComponent);
-            Entries.Add(JPIPReferenced.UID, JPIPReferenced);
-            Entries.Add(JPIPReferencedDeflate.UID, JPIPReferencedDeflate);
-            Entries.Add(MPEG2.UID, MPEG2);
-            Entries.Add(FragmentableMPEG2.UID, FragmentableMPEG2);
-            Entries.Add(MPEG2MainProfileHighLevel.UID, MPEG2MainProfileHighLevel);
-            Entries.Add(FragmentableMPEG2MainProfileHighLevel.UID, FragmentableMPEG2MainProfileHighLevel);
-            Entries.Add(MPEG4AVCH264HighProfileLevel41.UID, MPEG4AVCH264HighProfileLevel41);
-            Entries.Add(FragmentableMPEG4AVCH264HighProfileLevel41.UID, FragmentableMPEG4AVCH264HighProfileLevel41);
-            Entries.Add(MPEG4AVCH264BDCompatibleHighProfileLevel41.UID, MPEG4AVCH264BDCompatibleHighProfileLevel41);
-            Entries.Add(FragmentableMPEG4AVCH264BDCompatibleHighProfileLevel41.UID, FragmentableMPEG4AVCH264BDCompatibleHighProfileLevel41);
-            Entries.Add(MPEG4AVCH264HighProfileLevel42For2DVideo.UID, MPEG4AVCH264HighProfileLevel42For2DVideo);
-            Entries.Add(FragmentableMPEG4AVCH264HighProfileLevel42For2DVideo.UID, FragmentableMPEG4AVCH264HighProfileLevel42For2DVideo);
-            Entries.Add(MPEG4AVCH264HighProfileLevel42For3DVideo.UID, MPEG4AVCH264HighProfileLevel42For3DVideo);
-            Entries.Add(FragmentableMPEG4AVCH264HighProfileLevel42For3DVideo.UID, FragmentableMPEG4AVCH264HighProfileLevel42For3DVideo);
-            Entries.Add(MPEG4AVCH264StereoHighProfileLevel42.UID, MPEG4AVCH264StereoHighProfileLevel42);
-            Entries.Add(FragmentableMPEG4AVCH264StereoHighProfileLevel42.UID, FragmentableMPEG4AVCH264StereoHighProfileLevel42);
-            Entries.Add(HEVCH265MainProfileLevel51.UID, HEVCH265MainProfileLevel51);
-            Entries.Add(HEVCH265Main10ProfileLevel51.UID, HEVCH265Main10ProfileLevel51);
-            Entries.Add(HTJ2KLossless.UID, HTJ2KLossless);
-            Entries.Add(HTJ2KLosslessRPCL.UID, HTJ2KLosslessRPCL);
-            Entries.Add(HTJ2K.UID, HTJ2K);
-            Entries.Add(JPIPHTJ2KReferenced.UID, JPIPHTJ2KReferenced);
-            Entries.Add(JPIPHTJ2KReferencedDeflate.UID, JPIPHTJ2KReferencedDeflate);
-            Entries.Add(RLELossless.UID, RLELossless);
-            Entries.Add(RFC2557MIMEEncapsulation.UID, RFC2557MIMEEncapsulation);
-            Entries.Add(XMLEncoding.UID, XMLEncoding);
-            Entries.Add(Papyrus3ImplicitVRLittleEndianRetired.UID, Papyrus3ImplicitVRLittleEndianRetired);
+            Entries.TryAdd(GEPrivateImplicitVRBigEndian.UID, GEPrivateImplicitVRBigEndian);
+            Entries.TryAdd(ImplicitVRLittleEndian.UID, ImplicitVRLittleEndian);
+            Entries.TryAdd(ExplicitVRLittleEndian.UID, ExplicitVRLittleEndian);
+            Entries.TryAdd(ExplicitVRBigEndian.UID, ExplicitVRBigEndian);
+            Entries.TryAdd(DeflatedExplicitVRLittleEndian.UID, DeflatedExplicitVRLittleEndian);
+            Entries.TryAdd(JPEGProcess1.UID, JPEGProcess1);
+            Entries.TryAdd(JPEGProcess2_4.UID, JPEGProcess2_4);
+            Entries.TryAdd(JPEGProcess3_5Retired.UID, JPEGProcess3_5Retired);
+            Entries.TryAdd(JPEGProcess6_8Retired.UID, JPEGProcess6_8Retired);
+            Entries.TryAdd(JPEGProcess7_9Retired.UID, JPEGProcess7_9Retired);
+            Entries.TryAdd(JPEGProcess10_12Retired.UID, JPEGProcess10_12Retired);
+            Entries.TryAdd(JPEGProcess11_13Retired.UID, JPEGProcess11_13Retired);
+            Entries.TryAdd(JPEGProcess14.UID, JPEGProcess14);
+            Entries.TryAdd(JPEGProcess15Retired.UID, JPEGProcess15Retired);
+            Entries.TryAdd(JPEGProcess16_18Retired.UID, JPEGProcess16_18Retired);
+            Entries.TryAdd(JPEGProcess17_19Retired.UID, JPEGProcess17_19Retired);
+            Entries.TryAdd(JPEGProcess20_22Retired.UID, JPEGProcess20_22Retired);
+            Entries.TryAdd(JPEGProcess21_23Retired.UID, JPEGProcess21_23Retired);
+            Entries.TryAdd(JPEGProcess24_26Retired.UID, JPEGProcess24_26Retired);
+            Entries.TryAdd(JPEGProcess25_27Retired.UID, JPEGProcess25_27Retired);
+            Entries.TryAdd(JPEGProcess28Retired.UID, JPEGProcess28Retired);
+            Entries.TryAdd(JPEGProcess29Retired.UID, JPEGProcess29Retired);
+            Entries.TryAdd(JPEGProcess14SV1.UID, JPEGProcess14SV1);
+            Entries.TryAdd(JPEGLSLossless.UID, JPEGLSLossless);
+            Entries.TryAdd(JPEGLSNearLossless.UID, JPEGLSNearLossless);
+            Entries.TryAdd(JPEG2000Lossless.UID, JPEG2000Lossless);
+            Entries.TryAdd(JPEG2000Lossy.UID, JPEG2000Lossy);
+            Entries.TryAdd(JPEG2000Part2MultiComponentLosslessOnly.UID, JPEG2000Part2MultiComponentLosslessOnly);
+            Entries.TryAdd(JPEG2000Part2MultiComponent.UID, JPEG2000Part2MultiComponent);
+            Entries.TryAdd(JPIPReferenced.UID, JPIPReferenced);
+            Entries.TryAdd(JPIPReferencedDeflate.UID, JPIPReferencedDeflate);
+            Entries.TryAdd(MPEG2.UID, MPEG2);
+            Entries.TryAdd(FragmentableMPEG2.UID, FragmentableMPEG2);
+            Entries.TryAdd(MPEG2MainProfileHighLevel.UID, MPEG2MainProfileHighLevel);
+            Entries.TryAdd(FragmentableMPEG2MainProfileHighLevel.UID, FragmentableMPEG2MainProfileHighLevel);
+            Entries.TryAdd(MPEG4AVCH264HighProfileLevel41.UID, MPEG4AVCH264HighProfileLevel41);
+            Entries.TryAdd(FragmentableMPEG4AVCH264HighProfileLevel41.UID, FragmentableMPEG4AVCH264HighProfileLevel41);
+            Entries.TryAdd(MPEG4AVCH264BDCompatibleHighProfileLevel41.UID, MPEG4AVCH264BDCompatibleHighProfileLevel41);
+            Entries.TryAdd(FragmentableMPEG4AVCH264BDCompatibleHighProfileLevel41.UID, FragmentableMPEG4AVCH264BDCompatibleHighProfileLevel41);
+            Entries.TryAdd(MPEG4AVCH264HighProfileLevel42For2DVideo.UID, MPEG4AVCH264HighProfileLevel42For2DVideo);
+            Entries.TryAdd(FragmentableMPEG4AVCH264HighProfileLevel42For2DVideo.UID, FragmentableMPEG4AVCH264HighProfileLevel42For2DVideo);
+            Entries.TryAdd(MPEG4AVCH264HighProfileLevel42For3DVideo.UID, MPEG4AVCH264HighProfileLevel42For3DVideo);
+            Entries.TryAdd(FragmentableMPEG4AVCH264HighProfileLevel42For3DVideo.UID, FragmentableMPEG4AVCH264HighProfileLevel42For3DVideo);
+            Entries.TryAdd(MPEG4AVCH264StereoHighProfileLevel42.UID, MPEG4AVCH264StereoHighProfileLevel42);
+            Entries.TryAdd(FragmentableMPEG4AVCH264StereoHighProfileLevel42.UID, FragmentableMPEG4AVCH264StereoHighProfileLevel42);
+            Entries.TryAdd(HEVCH265MainProfileLevel51.UID, HEVCH265MainProfileLevel51);
+            Entries.TryAdd(HEVCH265Main10ProfileLevel51.UID, HEVCH265Main10ProfileLevel51);
+            Entries.TryAdd(HTJ2KLossless.UID, HTJ2KLossless);
+            Entries.TryAdd(HTJ2KLosslessRPCL.UID, HTJ2KLosslessRPCL);
+            Entries.TryAdd(HTJ2K.UID, HTJ2K);
+            Entries.TryAdd(JPIPHTJ2KReferenced.UID, JPIPHTJ2KReferenced);
+            Entries.TryAdd(JPIPHTJ2KReferencedDeflate.UID, JPIPHTJ2KReferencedDeflate);
+            Entries.TryAdd(RLELossless.UID, RLELossless);
+            Entries.TryAdd(RFC2557MIMEEncapsulation.UID, RFC2557MIMEEncapsulation);
+            Entries.TryAdd(XMLEncoding.UID, XMLEncoding);
+            Entries.TryAdd(Papyrus3ImplicitVRLittleEndianRetired.UID, Papyrus3ImplicitVRLittleEndianRetired);
 
             #endregion
         }
@@ -848,36 +849,23 @@ namespace FellowOakDicom
         /// <returns></returns>
         public static DicomTransferSyntax Register(DicomUID uid, Endian endian, bool isExplicitVR = true, bool isEncapsulated = true)
         {
-            lock (Entries)
+            if (uid == null)
             {
-                //  return cached transfer syntax from internal dictionary.
-                if (Entries.TryGetValue(uid, out DicomTransferSyntax tx))
-                {
-                    return tx;
-                }
-
-                if (uid == null)
-                {
-                    throw new ArgumentNullException(nameof(uid));
-                }
-
-                if (uid.Type != DicomUidType.TransferSyntax)
-                {
-                    throw new DicomDataException($"UID: {uid} is not a transfer syntax type.");
-                }
-
-                //  cache transfer syntax into internal dictionary.
-                tx = new DicomTransferSyntax(uid)
-                {
-                    IsRetired = uid.IsRetired,
-                    IsExplicitVR = isExplicitVR,
-                    IsEncapsulated = isEncapsulated,
-                    Endian = endian
-                };
-                Entries.Add(uid, tx);
-
-                return tx;
+                throw new ArgumentNullException(nameof(uid));
             }
+
+            if (uid.Type != DicomUidType.TransferSyntax)
+            {
+                throw new DicomDataException($"UID: {uid} is not a transfer syntax type.");
+            }
+
+            return Entries.GetOrAdd(uid, u => new DicomTransferSyntax(u)
+            {
+                IsRetired = u.IsRetired,
+                IsExplicitVR = isExplicitVR,
+                IsEncapsulated = isEncapsulated,
+                Endian = endian
+            });
         }
 
         /// <summary>
@@ -887,10 +875,7 @@ namespace FellowOakDicom
         /// <returns></returns>
         public static bool Unregister(DicomUID uid)
         {
-            lock (Entries)
-            {
-                return Entries.Remove(uid);
-            }
+            return Entries.TryRemove(uid, out _);
         }
 
         /// <summary>
@@ -908,11 +893,8 @@ namespace FellowOakDicom
         /// </summary>
         public static DicomTransferSyntax Query(DicomUID uid)
         {
-            lock (Entries)
-            {
-                Entries.TryGetValue(uid, out DicomTransferSyntax ts);
-                return ts;
-            }
+            Entries.TryGetValue(uid, out DicomTransferSyntax ts);
+            return ts;
         }
 
         #endregion

--- a/FO-DICOM.Core/DicomValidation.cs
+++ b/FO-DICOM.Core/DicomValidation.cs
@@ -1,17 +1,55 @@
-﻿// Copyright (c) 2012-2026 fo-dicom contributors.
+// Copyright (c) 2012-2026 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
 using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace FellowOakDicom
 {
 
-    public static class DicomValidation
+    public static partial class DicomValidation
     {
         internal static bool PerformValidation { get; set; } = true;
+
+        [GeneratedRegex(@"^\s*$")]
+        private static partial Regex AllWhitespaceRegex();
+
+        [GeneratedRegex(@"^\d\d\d[DWMY]$")]
+        private static partial Regex AgeStringRegex();
+
+        [GeneratedRegex("^[A-Z0-9_ ]*$")]
+        private static partial Regex CodeStringRegex();
+
+        [GeneratedRegex(@"^\d{8}$")]
+        private static partial Regex EightDigitsRegex();
+
+        [GeneratedRegex(@"^\d{4}$")]
+        private static partial Regex FourDigitsRegex();
+
+        [GeneratedRegex(@"^[+-]?((\d+(\.\d*)?)|(\.\d+))([eE][-+]?\d+)?$")]
+        private static partial Regex DecimalStringRegex();
+
+        [GeneratedRegex(@"^\d{4}$|^\d{6}$|^\d{8}$|^\d{10}$|^\d{12}$|^\d{14}$|^\d{14}\.\d{1,6}$")]
+        private static partial Regex DateTimeStringRegex();
+
+        [GeneratedRegex(@"^[+-]?\d+$")]
+        private static partial Regex IntegerStringRegex();
+
+        [GeneratedRegex(@"^\d{2}$|^\d{4}$|^\d{6}$|^\d{6}\.\d{1,6}$")]
+        private static partial Regex TimeStringRegex();
+
+        [GeneratedRegex(@"^[0-9.]*$")]
+        private static partial Regex UidCharsRegex();
+
+        [GeneratedRegex(@"\.0\d")]
+        private static partial Regex UidLeadingZeroComponentRegex();
+
+        [GeneratedRegex(@"^\.|\.\.|\.$")]
+        private static partial Regex UidEmptyComponentRegex();
+
+        [GeneratedRegex(@"^[+-]\d{4}$")]
+        private static partial Regex TimezoneOffsetRegex();
 
         public static void ValidateAE(string content)
         {
@@ -23,12 +61,12 @@ namespace FellowOakDicom
                 throw new DicomValidationException(content, DicomVR.AE, "value exceeds maximum length of 16 characters");
             }
             // may not contain only of spaces
-            if (Regex.IsMatch(content, @"^\s*$"))
+            if (AllWhitespaceRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.AE, "value may not consist only of spaces");
             }
             // Default Character Repertoire excluding character code 5CH (the BACKSLASH "\" in ISO-IR 6), and control characters LF, FF, CR and ESC.
-            if (content.Contains("\\") || content.ToCharArray().Any(char.IsControl))
+            if (content.Contains('\\') || ContainsControlChar(content))
             {
                 throw new DicomValidationException(content, DicomVR.AE, "value contains invalid control character");
             }
@@ -45,7 +83,7 @@ namespace FellowOakDicom
 
             // 4 charachters fixed
             // one of the following formats -- nnnD, nnnW, nnnM, nnnY; where nnn shall contain the number of days for D, weeks for W, months for M, or years for Y.
-            if (!Regex.IsMatch(content, @"^\d\d\d[DWMY]$"))
+            if (!AgeStringRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.AS, "value does not have pattern 000[DWMY]");
             }
@@ -62,7 +100,7 @@ namespace FellowOakDicom
                 throw new DicomValidationException(content, DicomVR.CS, "value exceeds maximum length of 16 characters");
             }
             // Uppercase characters, "0" - "9", the SPACE character, and underscore "_", of the Default Character Repertoire
-            if (!Regex.IsMatch(content, "^[A-Z0-9_ ]*$"))
+            if (!CodeStringRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.CS, "value contains invalid character. Only uppercase character, digits, space and underscore alre allowed");
             }
@@ -96,21 +134,21 @@ namespace FellowOakDicom
                 }
 
                 // Check Character Repertoire
-                if (!Regex.IsMatch(trimmedComponent, @"^\d{8}$"))
+                if (!EightDigitsRegex().IsMatch(trimmedComponent))
                 {
                     throw new DicomValidationException(content, DicomVR.DA, "one of the date values does not match the pattern YYYYMMDD");
                 }
 
                 // The date is in the numeric format, validate the month and day components
-                var month = trimmedComponent.Substring(4, 2);
-                var day = trimmedComponent.Substring(6, 2);
+                var monthSpan = trimmedComponent.AsSpan(4, 2);
+                var daySpan = trimmedComponent.AsSpan(6, 2);
 
-                if (int.Parse(month) > 12)
+                if (int.Parse(monthSpan) > 12)
                 {
                     throw new DicomValidationException(content, DicomVR.DA, "month component exceeds the value 12");
                 }
 
-                if (int.Parse(day) > 31)
+                if (int.Parse(daySpan) > 31)
                 {
                     throw new DicomValidationException(content, DicomVR.DA, "day component exceeds the value 31");
                 }
@@ -129,8 +167,7 @@ namespace FellowOakDicom
             }
 
             content = content.Trim();
-            // This is not very inefficient - uses .NET regex caching
-            if (!Regex.IsMatch(content, @"^[+-]?((\d+(\.\d*)?)|(\.\d+))([eE][-+]?\d+)?$"))
+            if (!DecimalStringRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.DS, "value is no decimal string");
             }
@@ -140,49 +177,6 @@ namespace FellowOakDicom
         public static void ValidateDT(string content)
         {
             HandleNullValue(content, DicomVR.DT);
-
-            /*
-             "0"-"9", "+", "-", "." and the SPACE character of Default Character Repertoire
-
-              26 bytes maximum. In the context of a Query with range matching (see PS3.4), the length is 54 bytes maximum.
-
-             A concatenated date-time character string in the format:
-             YYYYMMDDHHMMSS.FFFFFF&ZZXX
-
-             The components of this string, from left to right, are YYYY = Year, MM = Month, DD = Day,
-             HH = Hour (range "00" - "23"), MM = Minute (range "00" - "59"), SS = Second (range "00" - "60").
-
-             FFFFFF = Fractional Second contains a fractional part of a second as small as 1 millionth of
-             a second (range "000000" - "999999").
-
-             &ZZXX is an optional suffix for offset from Coordinated Universal Time (UTC), where & = "+"
-             or "-", and ZZ = Hours and XX = Minutes of offset.
-
-             The year, month, and day shall be interpreted as a date of the Gregorian calendar system.
-
-             A 24-hour clock is used. Midnight shall be represented by only "0000" since "2400" would
-             violate the hour range.
-
-             The Fractional Second component, if present, shall contain 1 to 6 digits. If Fractional
-             Second is unspecified the preceding "." shall not be included. The offset suffix, if present,
-             shall contain 4 digits. The string may be padded with trailing SPACE characters. Leading
-             and embedded spaces are not allowed.
-
-             A component that is omitted from the string is termed a null component. Trailing null
-             components of Date Time indicate that the value is not precise to the precision of those
-             components. The YYYY component shall not be null. Non-trailing null components are prohibited.
-             The optional suffix is not considered as a component.
-
-             A Date Time value without the optional suffix is interpreted to be in the local time zone
-             of the application creating the Data Element, unless explicitly specified by the Timezone
-             Offset From UTC (0008,0201).
-
-             UTC offsets are calculated as "local time minus UTC". The offset for a Date Time value in
-             UTC shall be +0000.
-
-             Used regex checking string: "YYYY[MM[DD[HH[MM[SS[.FFFFFF]]]]]][&ZZXX]"
-             If date is not empty, YYYY should not be null.
-             */
 
             if (content.Contains("-0000"))
             {
@@ -215,13 +209,13 @@ namespace FellowOakDicom
                 // Join 3 range separated components (X, Y, Z) into 2 range components with negative UTC (X-Y,Z) or (X,Y-Z)
                 string firstComponent;
                 string secondComponent;
-                if (Regex.IsMatch(dateTimeComponents[1], @"^\d{4}$") && int.Parse(dateTimeComponents[1]) <= 1200)
+                if (FourDigitsRegex().IsMatch(dateTimeComponents[1]) && int.Parse(dateTimeComponents[1]) <= 1200)
                 {
                     // Second component is UTC -> (X-Y,Z)
                     firstComponent = dateTimeComponents[0] + "-" + dateTimeComponents[1];
                     secondComponent = dateTimeComponents[2];
                 }
-                else if (Regex.IsMatch(dateTimeComponents[2], @"^\d{4}$") && int.Parse(dateTimeComponents[2]) <= 1200)
+                else if (FourDigitsRegex().IsMatch(dateTimeComponents[2]) && int.Parse(dateTimeComponents[2]) <= 1200)
                 {
                     // Third component is UTC -> (X,Y-Z)
                     firstComponent = dateTimeComponents[0];
@@ -237,7 +231,7 @@ namespace FellowOakDicom
             else if (dateTimeComponents.Length == 2)
             {
                 // Join 2 range separated components (X,Y) into one (X-Y) if Y is negative UTC (0000-1200)
-                if (Regex.IsMatch(dateTimeComponents[1], @"^\d{4}$") && int.Parse(dateTimeComponents[1]) <= 1200)
+                if (FourDigitsRegex().IsMatch(dateTimeComponents[1]) && int.Parse(dateTimeComponents[1]) <= 1200)
                 {
                     string newComponent = dateTimeComponents[0] + "-" + dateTimeComponents[1];
                     dateTimeComponents = new string[1] { newComponent };
@@ -265,15 +259,14 @@ namespace FellowOakDicom
                     string utcSuffixString = splittedDateTime[1];
 
                     // If optional UTC suffix is present
-                    if (!Regex.IsMatch(utcSuffixString, @"^\d{4}$"))
+                    if (!FourDigitsRegex().IsMatch(utcSuffixString))
                     {
                         throw new DicomValidationException(content, DicomVR.DT, "value does not match the UTC pattern &ZZXX");
                     }
 
-                    bool isPositiveOffset = trimmedComponent.Contains("+");
-                    var hours = utcSuffixString.Substring(0, 2);
-                    var minutes = utcSuffixString.Substring(2, 2);
-                    var hoursValue = int.Parse(hours);
+                    bool isPositiveOffset = trimmedComponent.Contains('+');
+                    var hoursValue = int.Parse(utcSuffixString.AsSpan(0, 2));
+                    var minutesValue = int.Parse(utcSuffixString.AsSpan(2, 2));
 
                     if (isPositiveOffset && hoursValue > 14)
                     {
@@ -284,7 +277,7 @@ namespace FellowOakDicom
                         throw new DicomValidationException(content, DicomVR.DT, "negative UTC hours component exceeds 12 (allowed range is -1200 to +1400)");
                     }
 
-                    if (int.Parse(minutes) > 59)
+                    if (minutesValue > 59)
                     {
                         throw new DicomValidationException(content, DicomVR.DT, "UTC minutes component exceeds 59");
                     }
@@ -293,7 +286,7 @@ namespace FellowOakDicom
                 string dateTimeString = splittedDateTime[0];
 
                 // Check Character Repertoire
-                if (!Regex.IsMatch(dateTimeString, @"^\d{4}$|^\d{6}$|^\d{8}$|^\d{10}$|^\d{12}$|^\d{14}$|^\d{14}\.\d{1,6}$"))
+                if (!DateTimeStringRegex().IsMatch(dateTimeString))
                 {
                     throw new DicomValidationException(content, DicomVR.DT, "value does not mach pattern YYYY[MM[DD[HH[MM[SS[.F{1-6}]]]]]]");
                 }
@@ -301,8 +294,7 @@ namespace FellowOakDicom
                 // The date is in the right numeric format, validate the components
                 if (dateTimeString.Length >= 14)
                 {
-                    var seconds = dateTimeString.Substring(12, 2);
-                    if (int.Parse(seconds) > 60)
+                    if (int.Parse(dateTimeString.AsSpan(12, 2)) > 60)
                     {
                         throw new DicomValidationException(content, DicomVR.DT, "seconds component exceeds 60");
                     }
@@ -310,8 +302,7 @@ namespace FellowOakDicom
 
                 if (dateTimeString.Length >= 12)
                 {
-                    var minutes = dateTimeString.Substring(10, 2);
-                    if (int.Parse(minutes) > 59)
+                    if (int.Parse(dateTimeString.AsSpan(10, 2)) > 59)
                     {
                         throw new DicomValidationException(content, DicomVR.DT, "minutes component exceeds 59");
                     }
@@ -319,8 +310,7 @@ namespace FellowOakDicom
 
                 if (dateTimeString.Length >= 10)
                 {
-                    var hours = dateTimeString.Substring(8, 2);
-                    if (int.Parse(hours) > 23)
+                    if (int.Parse(dateTimeString.AsSpan(8, 2)) > 23)
                     {
                         throw new DicomValidationException(content, DicomVR.DT, "hours component exceeds 23");
                     }
@@ -328,8 +318,7 @@ namespace FellowOakDicom
 
                 if (dateTimeString.Length >= 8)
                 {
-                    var day = dateTimeString.Substring(6, 2);
-                    var dayValue = int.Parse(day);
+                    var dayValue = int.Parse(dateTimeString.AsSpan(6, 2));
                     if (dayValue > 31)
                     {
                         throw new DicomValidationException(content, DicomVR.DT, "day component exceeds 31");
@@ -342,8 +331,7 @@ namespace FellowOakDicom
 
                 if (dateTimeString.Length >= 6)
                 {
-                    var month = dateTimeString.Substring(4, 2);
-                    var monthValue = int.Parse(month);
+                    var monthValue = int.Parse(dateTimeString.AsSpan(4, 2));
                     if (monthValue > 12)
                     {
                         throw new DicomValidationException(content, DicomVR.DT, "month component exceeds 12");
@@ -366,29 +354,15 @@ namespace FellowOakDicom
         {
             HandleNullValue(content, DicomVR.IS);
 
-            /* "0" - "9", "+", "-" of Default Character Repertoire
-
-            12 bytes maximum
-
-            A string of characters representing an Integer in base-10 (decimal), shall contain only the
-            characters 0 - 9, with an optional leading "+" or "-". It may be padded with leading and/or
-            trailing spaces. Embedded spaces are not allowed.
-
-            The integer, n, represented shall be in the range:
-
-            -2^31 <= n <= (2^31-1).
-             */
-
             if (string.IsNullOrEmpty(content))
             {
-                // empty value allowed
                 return;
             }
 
             // leading or trailing spaces allowed
             content = content.Trim(' ');
 
-            if (!Regex.IsMatch(content, @"^[+-]?\d+$"))
+            if (!IntegerStringRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.IS, "value is not an integer string");
             }
@@ -404,17 +378,6 @@ namespace FellowOakDicom
         {
             HandleNullValue(content, DicomVR.LO);
 
-            /*
-             * Default Character Repertoire and/or as defined by (0008,0005).
-             *
-             * 64 chars maximum (see Note in Section 6.2)
-             *
-             * A character string that may be padded with leading and/or trailing spaces. The character
-             * code 5CH (the BACKSLASH "\" in ISO-IR 6) shall not be present, as it is used as the
-             * delimiter between values in multiple valued data elements. The string shall not have
-             * Control Characters except for ESC.
-             */
-
             if (string.IsNullOrEmpty(content))
             {
                 return;
@@ -425,7 +388,7 @@ namespace FellowOakDicom
                 throw new DicomValidationException(content, DicomVR.LO, "value exceeds maximum length of 64 characters");
             }
 
-            if (content.Contains("\\") || content.ToCharArray().Any(IsControlExceptESC))
+            if (content.Contains('\\') || ContainsControlCharExceptEsc(content))
             {
                 throw new DicomValidationException(content, DicomVR.LO, "value contains invalid character");
             }
@@ -440,17 +403,6 @@ namespace FellowOakDicom
                 return;
             }
 
-            /*
-            A character string that may contain one or more paragraphs. It may contain the Graphic
-            Character set and the Control Characters, CR, LF, FF, and ESC. It may be padded with
-            trailing spaces, which may be ignored, but leading spaces are considered to be significant.
-            Data Elements with this VR shall not be multi - valued and therefore character code
-            5CH(the BACKSLASH "\" in ISO-IR 6) may be used.
- 
-            Default Character Repertoire and / or as defined by(0008, 0005).
- 
-            10240 chars maximum(see Note in Section 6.2) */
-
             if (content.Length > 10240)
             {
                 throw new DicomValidationException(content, DicomVR.LT, "value exceeds maximum length of 10240 characters");
@@ -461,51 +413,8 @@ namespace FellowOakDicom
         public static void ValidatePN(string content)
         {
             HandleNullValue(content, DicomVR.PN);
-            /*
-            A character string encoded using a 5 component convention. The character code 5CH (the
-            BACKSLASH "\" in ISO-IR 6) shall not be present, as it is used as the delimiter between
-            values in multiple valued data elements. The string may be padded with trailing spaces. For
-            human use, the five components in their order of occurrence are: family name complex, given
-            name complex, middle name, name prefix, name suffix.
-
-            Note
-            HL7 prohibits leading spaces within a component; DICOM allows leading and trailing spaces
-            and considers them insignificant.
-
-             Any of the five components may be an empty string. The component delimiter shall be the
-             caret "^" character (5EH). Delimiters are required for interior null components. Trailing
-             null components and their delimiters may be omitted. Multiple entries are permitted in
-             each component and are encoded as natural text strings, in the format preferred by the
-             named person.
-
-             For veterinary use, the first two of the five components in their order of occurrence
-             are: responsible party family name or responsible organization name, patient name. The
-             remaining components are not used and shall not be present.
-
-             This group of five components is referred to as a Person Name component group.
-
-             For the purpose of writing names in ideographic characters and in phonetic characters,
-             up to 3 groups of components (see Annexes H, I and J) may be used. The delimiter for
-             component groups shall be the equals character "=" (3DH). The three component groups
-             of components in their order of occurrence are: an alphabetic representation, an
-             ideographic representation, and a phonetic representation.
-
-             Any component group may be absent, including the first component group. In this case,
-             the person name may start with one or more "=" delimiters. Delimiters are required for
-             interior null component groups. Trailing null component groups and their delimiters may
-             be omitted.
-
-             Precise semantics are defined for each component group. See Section 6.2.1.2.
-
-             For examples and notes, see Section 6.2.1.1.
-
-             Default Character Repertoire and/or as defined by (0008,0005) excluding Control Characters
-             LF, FF, and CR but allowing Control Character ESC.
-
-             64 chars maximum per component group */
             if (string.IsNullOrEmpty(content))
             {
-                // empty values allowed
                 return;
             }
             var groups = content.Split('=');
@@ -519,15 +428,15 @@ namespace FellowOakDicom
                 {
                     throw new DicomValidationException(content, DicomVR.PN, "value exceeds maximum length of 64 characters");
                 }
-                if (group.ToCharArray().Any(IsControlExceptESC))
+                if (ContainsControlCharExceptEsc(group))
                 {
                     throw new DicomValidationException(content, DicomVR.PN, "value contains invalid control character");
                 }
-            }
-            var groupcomponents = groups.Select(group => group.Split('^').Length);
-            if (groupcomponents.Any(l => l > 5))
-            {
-                throw new DicomValidationException(content, DicomVR.PN, "value contains too many components");
+                // count('^') + 1 > 5  ==>  count('^') >= 5
+                if (group.AsSpan().Count('^') >= 5)
+                {
+                    throw new DicomValidationException(content, DicomVR.PN, "value contains too many components");
+                }
             }
         }
 
@@ -536,17 +445,7 @@ namespace FellowOakDicom
         {
             HandleNullValue(content, DicomVR.SH);
 
-            /*
-             A character string that may be padded with leading and/or trailing spaces. The character
-             code 05CH (the BACKSLASH "\" in ISO-IR 6) shall not be present, as it is used as the
-             delimiter between values for multiple data elements. The string shall not have Control
-             Characters except ESC.
-
-             Default Character Repertoire and/or as defined by (0008,0005).
-
-             16 chars maximum (see Note in Section 6.2)*/
-
-            if (content.Contains("\\") || content.ToCharArray().Any(IsControlExceptESC))
+            if (content.Contains('\\') || ContainsControlCharExceptEsc(content))
             {
                 throw new DicomValidationException(content, DicomVR.SH, "value contains invalid character");
             }
@@ -562,17 +461,6 @@ namespace FellowOakDicom
         {
             HandleNullValue(content, DicomVR.ST);
 
-            /*
-             A character string that may contain one or more paragraphs. It may contain the Graphic
-             Character set and the Control Characters, CR, LF, FF, and ESC. It may be padded with
-             trailing spaces, which may be ignored, but leading spaces are considered to be significant.
-             Data Elements with this VR shall not be multi-valued and therefore character code
-             5CH (the BACKSLASH "\" in ISO-IR 6) may be used.
-
-             Default Character Repertoire and/or as defined by (0008,0005).
-
-             1024 chars maximum (see Note in Section 6.2) */
-
             if (content?.Length > 1024)
             {
                 throw new DicomValidationException(content, DicomVR.ST, "value exceeds maximum length of 1024 characters");
@@ -584,41 +472,8 @@ namespace FellowOakDicom
         {
             HandleNullValue(content, DicomVR.TM);
 
-            /*
-             A string of characters of the format HHMMSS.FFFFFF; where HH contains hours (range "00" - "23"),
-             MM contains minutes (range "00" - "59"), SS contains seconds (range "00" - "60"), and FFFFFF
-             contains a fractional part of a second as small as 1 millionth of a second (range "000000" -
-             "999999"). A 24-hour clock is used. Midnight shall be represented by only "0000" since "2400"
-             would violate the hour range. The string may be padded with trailing spaces. Leading and
-             embedded spaces are not allowed.
-
-             One or more of the components MM, SS, or FFFFFF may be unspecified as long as every component
-             to the right of an unspecified component is also unspecified, which indicates that the value
-             is not precise to the precision of those unspecified components.
-
-             The FFFFFF component, if present, shall contain 1 to 6 digits. If FFFFFF is unspecified the
-             preceding "." shall not be included.
-
-             Examples:
-
-             "070907.0705 " represents a time of 7 hours, 9 minutes and 7.0705 seconds.
-
-             "1010" represents a time of 10 hours, and 10 minutes.
-
-             "021 " is an invalid value.
-
-             The SS component may have a value of 60 only for a leap second.
-
-             "0"-"9", "." and the SPACE character of Default Character Repertoire
-
-             In the context of a Query with range matching (see PS3.4), the character "-" is allowed.
-
-             16 bytes maximum
-             In the context of a Query with range matching (see PS3.4), the length is 28 bytes maximum.
-             */
-
-            var queryComponents = content.Split('-');
-            if (queryComponents.Count() > 2)
+            string[] queryComponents = content.Split('-');
+            if (queryComponents.Length > 2)
             {
                 throw new DicomValidationException(content, DicomVR.TM, "value contains too many range separators '-'");
             }
@@ -633,31 +488,28 @@ namespace FellowOakDicom
                 }
 
 
-                if (!Regex.IsMatch(cont, @"^\d{2}$|^\d{4}$|^\d{6}$|^\d{6}\.\d{1,6}$"))
+                if (!TimeStringRegex().IsMatch(cont))
                 {
                     throw new DicomValidationException(content, DicomVR.TM, "value does not mach pattern HH or HHMM or HHMMSS or HHMMSS.F{1-6}");
                 }
                 // validate the components, now that we know that there are only digits
                 if (cont.Length >= 2)
                 {
-                    var hh = cont.Substring(0, 2);
-                    if (int.Parse(hh) > 23)
+                    if (int.Parse(cont.AsSpan(0, 2)) > 23)
                     {
                         throw new DicomValidationException(content, DicomVR.TM, "hour component exceeds 23");
                     }
                 }
                 if (cont.Length >= 4)
                 {
-                    var mm = cont.Substring(2, 2);
-                    if (int.Parse(mm) > 59)
+                    if (int.Parse(cont.AsSpan(2, 2)) > 59)
                     {
                         throw new DicomValidationException(content, DicomVR.TM, "minutes component exceeds 59");
                     }
                 }
                 if (cont.Length >= 6)
                 {
-                    var ss = cont.Substring(4, 2);
-                    if (int.Parse(ss) > 60)
+                    if (int.Parse(cont.AsSpan(4, 2)) > 60)
                     {
                         throw new DicomValidationException(content, DicomVR.TM, "seconds component exceeds 60");
                     }
@@ -670,17 +522,6 @@ namespace FellowOakDicom
         {
             HandleNullValue(content, DicomVR.UI);
 
-            /*
-             The UID is a series of numeric components separated by the period "." character.
-             If a Value Field containing one or more UIDs is an odd number of bytes in length,
-             the Value Field shall be padded with a single trailing NULL (00H)
-             character to ensure that the Value Field is an even number of bytes in length.
-             See Section 9 and Annex B for a complete specification and examples.
-
-             "0"-"9", "." of Default Character Repertoire
-
-             64 bytes maximum */
-
             // trailling spaces are allowed
             content = content.TrimEnd(' ');
             if (string.IsNullOrEmpty(content))
@@ -692,15 +533,15 @@ namespace FellowOakDicom
             {
                 throw new DicomValidationException(content, DicomVR.UI, "value exceeds maximum length of 64 characters");
             }
-            if (!Regex.IsMatch(content, "^[0-9\\.]*$"))
+            if (!UidCharsRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.UI, "value contains invalid characters other than '0'-'9' and '.'");
             }
-            if (content.StartsWith("0") || Regex.IsMatch(content, @"[.]0\d"))
+            if (content[0] == '0' || UidLeadingZeroComponentRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.UI, "components must not have leading zeros");
             }
-            if (Regex.IsMatch(content, @"^[.]") || Regex.IsMatch(content, @"[.][.]") || Regex.IsMatch(content, @"[.]$"))
+            if (UidEmptyComponentRegex().IsMatch(content))
             {
                 throw new DicomValidationException(content, DicomVR.UI, "a component can not be empty");
             }
@@ -717,11 +558,26 @@ namespace FellowOakDicom
 
         public static bool IsValidTimezoneOffset(string content) =>
             // http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.12.html#sect_C.12.1.1.8
-            Regex.IsMatch(content, @"^[+-]\d{4}$");
+            TimezoneOffsetRegex().IsMatch(content);
 
 
-        private static bool IsControlExceptESC(char c)
-            => char.IsControl(c) && (c != '\u001b');
+        private static bool ContainsControlChar(string s)
+        {
+            foreach (var c in s)
+            {
+                if (char.IsControl(c)) return true;
+            }
+            return false;
+        }
+
+        private static bool ContainsControlCharExceptEsc(string s)
+        {
+            foreach (var c in s)
+            {
+                if (char.IsControl(c) && c != '') return true;
+            }
+            return false;
+        }
 
         private static void HandleNullValue(string content, DicomVR vr)
         {

--- a/FO-DICOM.Core/IO/Buffer/BulkDataUriByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/BulkDataUriByteBuffer.cs
@@ -108,7 +108,7 @@ namespace FellowOakDicom.IO.Buffer
 
             byte[] data = Data;
 
-            return stream.WriteAsync(data, 0, data.Length, cancellationToken);
+            return stream.WriteAsync(data.AsMemory(0, data.Length), cancellationToken).AsTask();
         }
 
         /// <summary>

--- a/FO-DICOM.Core/IO/Buffer/EndianByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/EndianByteBuffer.cs
@@ -149,7 +149,7 @@ namespace FellowOakDicom.IO.Buffer
 
                 GetByteRange(offset, count, buffer.Bytes);
 
-                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(buffer.Bytes.AsMemory(0, count), cancellationToken).ConfigureAwait(false);
 
                 offset += count;
             }

--- a/FO-DICOM.Core/IO/Buffer/FileByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/FileByteBuffer.cs
@@ -101,9 +101,9 @@ namespace FellowOakDicom.IO.Buffer
             int numberOfBytesRead;
             int numberOfBytesToRead = (int)Math.Min(Size, buffer.Length);
             while (numberOfBytesToRead > 0
-                   && (numberOfBytesRead = await fileStream.ReadAsync(buffer.Bytes, 0, numberOfBytesToRead, cancellationToken).ConfigureAwait(false)) > 0)
+                   && (numberOfBytesRead = await fileStream.ReadAsync(buffer.Bytes.AsMemory(0, numberOfBytesToRead), cancellationToken).ConfigureAwait(false)) > 0)
             {
-                await stream.WriteAsync(buffer.Bytes, 0, numberOfBytesRead, cancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(buffer.Bytes.AsMemory(0, numberOfBytesRead), cancellationToken).ConfigureAwait(false);
 
                 totalNumberOfBytesRead += numberOfBytesRead;
                 numberOfBytesToRead = (int)Math.Min(Size - totalNumberOfBytesRead, buffer.Length);

--- a/FO-DICOM.Core/IO/Buffer/LazyByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/LazyByteBuffer.cs
@@ -77,7 +77,7 @@ namespace FellowOakDicom.IO.Buffer
 
             byte[] data = Data;
 
-            await stream.WriteAsync(data, 0, data.Length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(data.AsMemory(0, data.Length), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/FO-DICOM.Core/IO/Buffer/MemoryByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/MemoryByteBuffer.cs
@@ -78,7 +78,7 @@ namespace FellowOakDicom.IO.Buffer
 
             byte[] data = Data;
 
-            await stream.WriteAsync(data, 0, data.Length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(data.AsMemory(0, data.Length), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/FO-DICOM.Core/IO/Buffer/RangeByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/RangeByteBuffer.cs
@@ -101,7 +101,7 @@ namespace FellowOakDicom.IO.Buffer
 
                 GetByteRange(offset, count, buffer.Bytes);
 
-                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(buffer.Bytes.AsMemory(0, count), cancellationToken).ConfigureAwait(false);
 
                 offset += count;
             }

--- a/FO-DICOM.Core/IO/Buffer/StreamByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/StreamByteBuffer.cs
@@ -150,9 +150,9 @@ namespace FellowOakDicom.IO.Buffer
                 int numberOfBytesRead;
                 while (numberOfBytesToRead > 0
                     && !cancellationToken.IsCancellationRequested
-                    && (numberOfBytesRead = await Stream.ReadAsync(buffer.Bytes, 0, numberOfBytesToRead, cancellationToken).ConfigureAwait(false)) > 0)
+                    && (numberOfBytesRead = await Stream.ReadAsync(buffer.Bytes.AsMemory(0, numberOfBytesToRead), cancellationToken).ConfigureAwait(false)) > 0)
                 {
-                    await stream.WriteAsync(buffer.Bytes, 0, numberOfBytesRead, cancellationToken).ConfigureAwait(false);
+                    await stream.WriteAsync(buffer.Bytes.AsMemory(0, numberOfBytesRead), cancellationToken).ConfigureAwait(false);
                     totalNumberOfBytesRead += numberOfBytesRead;
                     numberOfBytesToRead = (int)Math.Min(Size - totalNumberOfBytesRead, bufferSize);
                 }

--- a/FO-DICOM.Core/IO/Buffer/SwapByteBuffer.cs
+++ b/FO-DICOM.Core/IO/Buffer/SwapByteBuffer.cs
@@ -120,7 +120,7 @@ namespace FellowOakDicom.IO.Buffer
 
                 GetByteRange(offset, count, buffer.Bytes);
 
-                await stream.WriteAsync(buffer.Bytes, 0, count, cancellationToken).ConfigureAwait(false);
+                await stream.WriteAsync(buffer.Bytes.AsMemory(0, count), cancellationToken).ConfigureAwait(false);
 
                 offset += count;
             }

--- a/FO-DICOM.Core/IO/Endian.cs
+++ b/FO-DICOM.Core/IO/Endian.cs
@@ -3,9 +3,10 @@
 #nullable disable
 
 using System;
+using System.Buffers.Binary;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace FellowOakDicom.IO
 {
@@ -151,13 +152,11 @@ namespace FellowOakDicom.IO
         /// <param name="count">The maximum number of bytes in the array that should be processed</param>
         public static void SwapBytes2(byte[] bytes, int count)
         {
-            unchecked
+            var l = count - count % 2;
+            var span = MemoryMarshal.Cast<byte, ushort>(bytes.AsSpan(0, l));
+            for (var i = 0; i < span.Length; i++)
             {
-                var l = count - count % 2;
-                for (var i = 0; i < l; i += 2)
-                {
-                    (bytes[i + 1], bytes[i]) = (bytes[i], bytes[i + 1]);
-                }
+                span[i] = BinaryPrimitives.ReverseEndianness(span[i]);
             }
         }
 
@@ -174,18 +173,11 @@ namespace FellowOakDicom.IO
         /// <param name="count">The maximum number of bytes in the array that should be processed</param>
         public static void SwapBytes4(byte[] bytes, int count)
         {
-            unchecked
+            var l = count - (count % 4);
+            var span = MemoryMarshal.Cast<byte, uint>(bytes.AsSpan(0, l));
+            for (var i = 0; i < span.Length; i++)
             {
-                var l = count - (count % 4);
-                for (var i = 0; i < l; i += 4)
-                {
-                    var b = bytes[i + 3];
-                    bytes[i + 3] = bytes[i];
-                    bytes[i] = b;
-                    b = bytes[i + 2];
-                    bytes[i + 2] = bytes[i + 1];
-                    bytes[i + 1] = b;
-                }
+                span[i] = BinaryPrimitives.ReverseEndianness(span[i]);
             }
         }
 
@@ -264,9 +256,7 @@ namespace FellowOakDicom.IO
         /// <returns>Byte order swapped value.</returns>
         public static float Swap(float value)
         {
-            var b = BitConverter.GetBytes(value);
-            Array.Reverse(b);
-            return BitConverter.ToSingle(b, 0);
+            return BitConverter.Int32BitsToSingle(BinaryPrimitives.ReverseEndianness(BitConverter.SingleToInt32Bits(value)));
         }
 
         /// <summary>
@@ -276,9 +266,7 @@ namespace FellowOakDicom.IO
         /// <returns>Byte order swapped value.</returns>
         public static double Swap(double value)
         {
-            var b = BitConverter.GetBytes(value);
-            Array.Reverse(b);
-            return BitConverter.ToDouble(b, 0);
+            return BitConverter.Int64BitsToDouble(BinaryPrimitives.ReverseEndianness(BitConverter.DoubleToInt64Bits(value)));
         }
 
         /// <summary>
@@ -287,7 +275,7 @@ namespace FellowOakDicom.IO
         /// <param name="values">Array of <see cref="short"/> values.</param>
         public static void Swap(short[] values)
         {
-            Parallel.For(0, values.Length, i => values[i] = Swap(values[i]));
+            BinaryPrimitives.ReverseEndianness(values.AsSpan(), values);
         }
 
         /// <summary>
@@ -296,7 +284,7 @@ namespace FellowOakDicom.IO
         /// <param name="values">Array of <see cref="ushort"/> values.</param>
         public static void Swap(ushort[] values)
         {
-            Parallel.For(0, values.Length, i => values[i] = Swap(values[i]));
+            BinaryPrimitives.ReverseEndianness(values.AsSpan(), values);
         }
 
         /// <summary>
@@ -305,7 +293,7 @@ namespace FellowOakDicom.IO
         /// <param name="values">Array of <see cref="int"/> values.</param>
         public static void Swap(int[] values)
         {
-            Parallel.For(0, values.Length, i => values[i] = Swap(values[i]));
+            BinaryPrimitives.ReverseEndianness(values.AsSpan(), values);
         }
 
         /// <summary>
@@ -314,7 +302,7 @@ namespace FellowOakDicom.IO
         /// <param name="values">Array of <see cref="uint"/> values.</param>
         public static void Swap(uint[] values)
         {
-            Parallel.For(0, values.Length, i => values[i] = Swap(values[i]));
+            BinaryPrimitives.ReverseEndianness(values.AsSpan(), values);
         }
 
         /// <summary>
@@ -803,19 +791,6 @@ namespace FellowOakDicom.IO
 
         #endregion
 
-        #region Private Methods
-
-        private void WriteInternal(byte[] buffer)
-        {
-            if (_swapBytes)
-            {
-                Array.Reverse(buffer);
-            }
-            base.Write(buffer);
-        }
-
-        #endregion
-
         #region BinaryWriter Overrides
 
         /// <inheritdoc />
@@ -823,8 +798,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                var b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[8];
+                BinaryPrimitives.WriteDoubleBigEndian(b, value);
+                base.Write(b);
             }
             else
             {
@@ -837,8 +813,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                var b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[4];
+                BinaryPrimitives.WriteSingleBigEndian(b, value);
+                base.Write(b);
             }
             else
             {
@@ -851,8 +828,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                var b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[4];
+                BinaryPrimitives.WriteInt32BigEndian(b, value);
+                base.Write(b);
             }
             else
             {
@@ -865,8 +843,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                var b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[8];
+                BinaryPrimitives.WriteInt64BigEndian(b, value);
+                base.Write(b);
             }
             else
             {
@@ -879,8 +858,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                var b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[2];
+                BinaryPrimitives.WriteInt16BigEndian(b, value);
+                base.Write(b);
             }
             else
             {
@@ -893,8 +873,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                byte[] b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[4];
+                BinaryPrimitives.WriteUInt32BigEndian(b, value);
+                base.Write(b);
             }
             else
             {
@@ -907,8 +888,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                byte[] b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[8];
+                BinaryPrimitives.WriteUInt64BigEndian(b, value);
+                base.Write(b);
             }
             else
             {
@@ -921,8 +903,9 @@ namespace FellowOakDicom.IO
         {
             if (_swapBytes)
             {
-                byte[] b = BitConverter.GetBytes(value);
-                WriteInternal(b);
+                Span<byte> b = stackalloc byte[2];
+                BinaryPrimitives.WriteUInt16BigEndian(b, value);
+                base.Write(b);
             }
             else
             {

--- a/FO-DICOM.Core/IO/FileByteSource.cs
+++ b/FO-DICOM.Core/IO/FileByteSource.cs
@@ -27,8 +27,6 @@ namespace FellowOakDicom.IO
 
         private BinaryReader _reader;
 
-        private readonly object _lock;
-
         private bool _disposed;
 
         private readonly FileReadOption _readOption;
@@ -58,7 +56,6 @@ namespace FellowOakDicom.IO
 
             LargeObjectSize = largeObjectSize <= 0 ? 64 * 1024 : largeObjectSize;
 
-            _lock = new object();
             _disposed = false;
         }
 
@@ -74,11 +71,8 @@ namespace FellowOakDicom.IO
             {
                 if (_endian != value)
                 {
-                    lock (_lock)
-                    {
-                        _endian = value;
-                        _reader = EndianBinaryReader.Create(_stream, _endian, false);
-                    }
+                    _endian = value;
+                    _reader = EndianBinaryReader.Create(_stream, _endian, false);
                 }
             }
         }
@@ -153,7 +147,9 @@ namespace FellowOakDicom.IO
             {
                 if (count < MemoryByteBuffer.MaxArrayLength)
                 {
-                    buffer = new MemoryByteBuffer(GetBytes((int)count));
+                    var bytes = GC.AllocateUninitializedArray<byte>((int)count);
+                    _stream.ReadExactly(bytes);
+                    buffer = new MemoryByteBuffer(bytes);
                 }
                 else
                 {
@@ -183,16 +179,10 @@ namespace FellowOakDicom.IO
         public void GoTo(long position) => _stream.Position = position;
 
         /// <inheritdoc />
-        public bool Require(uint count) => Require(count, null, null);
+        public bool Require(uint count) => (_length - _stream.Position) >= count;
 
         /// <inheritdoc />
-        public bool Require(uint count, ByteSourceCallback callback, object state)
-        {
-            lock (_lock)
-            {
-                return (_length - _stream.Position) >= count;
-            }
-        }
+        public bool Require(uint count, ByteSourceCallback callback, object state) => (_length - _stream.Position) >= count;
 
         /// <inheritdoc />
         public void Dispose()

--- a/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomDatasetReaderObserver.cs
@@ -109,7 +109,7 @@ namespace FellowOakDicom.IO.Reader
         {
             DicomSequence sq = _sequences.Peek();
 
-            DicomDataset item = new DicomDataset().NotValidated();
+            DicomDataset item = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian, 16).NotValidated();
             sq.Items.Add(item);
 
             _datasets.Push(item);

--- a/FO-DICOM.Core/IO/Reader/DicomReader.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomReader.cs
@@ -329,7 +329,7 @@ namespace FellowOakDicom.IO.Reader
                     tag = entry.Tag; // Use dictionary tag
                 }
 
-                if (_stop?.Invoke(new ParseState { PreviousTag = _previousTag, Tag = tag, SequenceDepth = sequenceDepth }) ?? false)
+                if (_stop != null && _stop(new ParseState { PreviousTag = _previousTag, Tag = tag, SequenceDepth = sequenceDepth }))
                 {
                     // if a stop is requested, then move back to the beginning of the tag.
                     _result = DicomReaderResult.Stopped;
@@ -653,9 +653,8 @@ namespace FellowOakDicom.IO.Reader
                 // The VR of the private identification code shall be LO (Long String) and the VM shall be equal to 1.
                 if (tag.IsPrivate && tag.Element >= 0x0010 && tag.Element <= 0x00ff)
                 {
-                    var creator =
-                        DicomEncoding.Default.GetString(buffer.Data, 0, buffer.Data.Length)
-                            .TrimEnd((char)DicomVR.LO.PaddingValue);
+                    var creatorSpan = ((ReadOnlySpan<byte>)buffer.Data).TrimEnd(DicomVR.LO.PaddingValue);
+                    var creator = DicomEncoding.Default.GetString(creatorSpan);
                     var card = (uint)(tag.Group << 16) + tag.Element;
 
                     _private[card] = creator;
@@ -779,9 +778,8 @@ namespace FellowOakDicom.IO.Reader
                 // The VR of the private identification code shall be LO (Long String) and the VM shall be equal to 1.
                 if (tag.IsPrivate && tag.Element >= 0x0010 && tag.Element <= 0x00ff)
                 {
-                    var creator =
-                        DicomEncoding.Default.GetString(buffer.Data, 0, buffer.Data.Length)
-                            .TrimEnd((char)DicomVR.LO.PaddingValue);
+                    var creatorSpan = ((ReadOnlySpan<byte>)buffer.Data).TrimEnd(DicomVR.LO.PaddingValue);
+                    var creator = DicomEncoding.Default.GetString(creatorSpan);
                     var card = (uint)(tag.Group << 16) + tag.Element;
 
                     _private[card] = creator;

--- a/FO-DICOM.Core/IO/StreamByteSource.cs
+++ b/FO-DICOM.Core/IO/StreamByteSource.cs
@@ -23,8 +23,6 @@ namespace FellowOakDicom.IO
 
         private BinaryReader _reader;
 
-        private readonly object _lock;
-
         #endregion
 
         #region CONSTRUCTORS
@@ -44,8 +42,6 @@ namespace FellowOakDicom.IO
             ReadOption = (readOption == FileReadOption.Default) ? FileReadOption.ReadLargeOnDemand : readOption;
 
             LargeObjectSize = largeObjectSize <= 0 ? 64 * 1024 : largeObjectSize;
-
-            _lock = new object();
         }
 
         #endregion
@@ -60,11 +56,8 @@ namespace FellowOakDicom.IO
             {
                 if (_endian != value)
                 {
-                    lock (_lock)
-                    {
-                        _endian = value;
-                        _reader = EndianBinaryReader.Create(_stream, _endian, false);
-                    }
+                    _endian = value;
+                    _reader = EndianBinaryReader.Create(_stream, _endian, false);
                 }
             }
         }
@@ -143,7 +136,9 @@ namespace FellowOakDicom.IO
             {
                 if (count < MemoryByteBuffer.MaxArrayLength)
                 {
-                    buffer = new MemoryByteBuffer(GetBytes((int)count));
+                    var bytes = GC.AllocateUninitializedArray<byte>((int)count);
+                    _stream.ReadExactly(bytes);
+                    buffer = new MemoryByteBuffer(bytes);
                 }
                 else
                 {
@@ -173,16 +168,10 @@ namespace FellowOakDicom.IO
         public void GoTo(long position) => _stream.Position = position;
 
         /// <inheritdoc />
-        public bool Require(uint count) => Require(count, null, null);
+        public bool Require(uint count) => (_stream.Length - _stream.Position) >= count;
 
         /// <inheritdoc />
-        public bool Require(uint count, ByteSourceCallback callback, object state)
-        {
-            lock (_lock)
-            {
-                return (_stream.Length - Position) >= count;
-            }
-        }
+        public bool Require(uint count, ByteSourceCallback callback, object state) => (_stream.Length - _stream.Position) >= count;
 
         public Stream GetStream()
         {

--- a/FO-DICOM.Core/IO/Writer/DicomDatasetExtensions.cs
+++ b/FO-DICOM.Core/IO/Writer/DicomDatasetExtensions.cs
@@ -87,11 +87,14 @@ namespace FellowOakDicom.IO.Writer
             if (!firstLevelOnly)
             {
                 // remove group lengths from sequences
-                foreach (var sq in dataset.Where(x => x.ValueRepresentation == DicomVR.SQ).Cast<DicomSequence>())
+                foreach (var item in dataset)
                 {
-                    foreach (var item in sq.Items)
+                    if (item is DicomSequence sq)
                     {
-                        item.RemoveGroupLengths(firstLevelOnly);
+                        foreach (var sqItem in sq.Items)
+                        {
+                            sqItem.RemoveGroupLengths(firstLevelOnly);
+                        }
                     }
                 }
             }

--- a/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
+++ b/FO-DICOM.Core/Network/DicomPresentationContextCollection.cs
@@ -49,6 +49,15 @@ namespace FellowOakDicom.Network
         /// <returns>Presentation context associated with <paramref name="id"/></returns>
         public DicomPresentationContext this[byte id] =>_pc[id];
 
+        /// <summary>
+        /// Tries to get the presentation context associated with <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">Presentation context ID.</param>
+        /// <param name="presentationContext">When this method returns, the presentation context if found; otherwise, null.</param>
+        /// <returns><c>true</c> if the presentation context was found; otherwise, <c>false</c>.</returns>
+        public bool TryGetValue(byte id, out DicomPresentationContext presentationContext)
+            => _pc.TryGetValue(id, out presentationContext);
+
         #endregion
 
         #region PROPERTIES

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -507,7 +507,7 @@ namespace FellowOakDicom.Network
                     // This is the (extremely small) buffer we use to read the raw PDU header
                     using var rawPduCommonFieldsBuffer = _memoryProvider.Provide(RawPDU.CommonFieldsLength);
 
-                    var count = await stream.ReadAsync(rawPduCommonFieldsBuffer.Bytes, 0, rawPduCommonFieldsBuffer.Length).ConfigureAwait(false);
+                    var count = await stream.ReadAsync(rawPduCommonFieldsBuffer.Bytes.AsMemory(0, rawPduCommonFieldsBuffer.Length)).ConfigureAwait(false);
 
                     do
                     {
@@ -523,7 +523,7 @@ namespace FellowOakDicom.Network
 
                         if (_bytesToRead > 0)
                         {
-                            count = await stream.ReadAsync(rawPduCommonFieldsBuffer.Bytes, rawPduCommonFieldsBuffer.Length - _bytesToRead, _bytesToRead).ConfigureAwait(false);
+                            count = await stream.ReadAsync(rawPduCommonFieldsBuffer.Bytes.AsMemory(rawPduCommonFieldsBuffer.Length - _bytesToRead, _bytesToRead)).ConfigureAwait(false);
                         }
                     }
                     while (_bytesToRead > 0);
@@ -532,7 +532,7 @@ namespace FellowOakDicom.Network
                     // The second byte is reserved
                     // The remaining four bytes contain the PDU length
                     var pduTypeByte = rawPduCommonFieldsBuffer.Bytes[0];
-                    if (!Enum.IsDefined(typeof(RawPduType), pduTypeByte))
+                    if (!Enum.IsDefined((RawPduType)pduTypeByte))
                     {
                         throw new DicomNetworkException("Unknown PDU type: " + pduTypeByte);
                     }
@@ -553,7 +553,7 @@ namespace FellowOakDicom.Network
                     {
                         int bytesToRead = Math.Min(_bytesToRead, _maxBytesToRead);
 
-                        count = await stream.ReadAsync(rawPduBuffer.Bytes, rawPduOffset, bytesToRead).ConfigureAwait(false);
+                        count = await stream.ReadAsync(rawPduBuffer.Bytes.AsMemory(rawPduOffset, bytesToRead)).ConfigureAwait(false);
 
                         if (count == 0)
                         {
@@ -769,7 +769,8 @@ namespace FellowOakDicom.Network
                         // create stream for receiving command
                         if (_dimseStream == null)
                         {
-                            _dimseStream = new MemoryStream();
+                            // DIMSE command sets are typically small (~100-300 bytes); pre-sizing avoids MemoryStream resize allocations.
+                            _dimseStream = new MemoryStream(512);
                             _dimseStreamFile = null;
                         }
                     }
@@ -804,7 +805,7 @@ namespace FellowOakDicom.Network
                         }
                     }
 
-                    await _dimseStream.WriteAsync(pdv.Value.Bytes, 0, pdv.Value.Length).ConfigureAwait(false);
+                    await _dimseStream.WriteAsync(pdv.Value.Bytes.AsMemory(0, pdv.Value.Length)).ConfigureAwait(false);
 
                     if (pdv.IsLastFragment)
                     {

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -780,7 +780,7 @@ namespace FellowOakDicom.Network
                         {
                             if (_dimse.Type == DicomCommandField.CStoreRequest)
                             {
-                                var pc = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
+                                Association.PresentationContexts.TryGetValue(pdv.PCID, out var pc);
 
                                 var file = new DicomFile();
                                 if (_fallbackEncoding != null)
@@ -848,8 +848,8 @@ namespace FellowOakDicom.Network
                                 DicomCommandField.NSetResponse => new DicomNSetResponse(command),
                                 _ => new DicomMessage(command),
                             };
-                            _dimse.PresentationContext =
-                                Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
+                            Association.PresentationContexts.TryGetValue(pdv.PCID, out var dimsePC);
+                            _dimse.PresentationContext = dimsePC;
                             if (!_dimse.HasDataset)
                             {
                                 await PerformDimseAsync(_dimse).ConfigureAwait(false);
@@ -863,7 +863,7 @@ namespace FellowOakDicom.Network
                             {
                                 _dimseStream.Seek(0, SeekOrigin.Begin);
 
-                                var pc = Association.PresentationContexts.FirstOrDefault(x => x.ID == pdv.PCID);
+                                Association.PresentationContexts.TryGetValue(pdv.PCID, out var pc);
 
                                 _dimse.Dataset = new DicomDataset { InternalTransferSyntax = pc.AcceptedTransferSyntax };
 
@@ -946,7 +946,15 @@ namespace FellowOakDicom.Network
                 DicomRequest req;
                 lock (_lock)
                 {
-                    req = _pending.FirstOrDefault(x => x.MessageID == rsp.RequestMessageID);
+                    req = null;
+                    foreach (var p in _pending)
+                    {
+                        if (p.MessageID == rsp.RequestMessageID)
+                        {
+                            req = p;
+                            break;
+                        }
+                    }
                 }
 
                 if (req != null)
@@ -1153,8 +1161,7 @@ namespace FellowOakDicom.Network
                     }
 
                     if (Association.MaxAsyncOpsInvoked > 0
-                        && _pending.Count(req => req.Type != DicomCommandField.CGetRequest && req.Type != DicomCommandField.NActionRequest)
-                        >= Association.MaxAsyncOpsInvoked)
+                        && CountPendingExcluding(_pending) >= Association.MaxAsyncOpsInvoked)
                     {
                         break;
                     }
@@ -1214,14 +1221,21 @@ namespace FellowOakDicom.Network
             DicomPresentationContext pc;
             if (msg is DicomCStoreRequest dicomCStoreRequest)
             {
-                var accpetedPcs = Association.PresentationContexts
-                    .Where(x =>
-                        x.Result == DicomPresentationContextResult.Accept &&
-                        x.AbstractSyntax == msg.SOPClassUID
-                    );
-
-                pc = accpetedPcs.FirstOrDefault(x => x.AcceptedTransferSyntax == dicomCStoreRequest.TransferSyntax)
-                    ?? accpetedPcs.FirstOrDefault();
+                pc = null;
+                DicomPresentationContext firstAccepted = null;
+                foreach (var x in Association.PresentationContexts)
+                {
+                    if (x.Result == DicomPresentationContextResult.Accept && x.AbstractSyntax == msg.SOPClassUID)
+                    {
+                        firstAccepted ??= x;
+                        if (x.AcceptedTransferSyntax == dicomCStoreRequest.TransferSyntax)
+                        {
+                            pc = x;
+                            break;
+                        }
+                    }
+                }
+                pc ??= firstAccepted;
             }
             else if (msg is DicomResponse)
             {
@@ -1454,6 +1468,19 @@ namespace FellowOakDicom.Network
             }
         }
 
+        private static int CountPendingExcluding(List<DicomRequest> pending)
+        {
+            var count = 0;
+            foreach (var req in pending)
+            {
+                if (req.Type != DicomCommandField.CGetRequest && req.Type != DicomCommandField.NActionRequest)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+
         private async Task CheckForTimeouts()
         {
             while (true)
@@ -1475,15 +1502,23 @@ namespace FellowOakDicom.Network
                     List<DicomRequest> timedOutPendingRequests;
                     lock (_lock)
                     {
-                        if (!_pending.Any())
+                        if (_pending.Count == 0)
                         {
                             return;
                         }
 
-                        timedOutPendingRequests = _pending.Where(p => p.IsTimedOut(requestTimeout)).ToList();
+                        timedOutPendingRequests = null;
+                        foreach (var p in _pending)
+                        {
+                            if (p.IsTimedOut(requestTimeout))
+                            {
+                                timedOutPendingRequests ??= new List<DicomRequest>();
+                                timedOutPendingRequests.Add(p);
+                            }
+                        }
                     }
 
-                    if (timedOutPendingRequests.Any())
+                    if (timedOutPendingRequests != null && timedOutPendingRequests.Count > 0)
                     {
                         for (var i = timedOutPendingRequests.Count - 1; i >= 0; i--)
                         {

--- a/FO-DICOM.Core/Network/DicomService.cs
+++ b/FO-DICOM.Core/Network/DicomService.cs
@@ -1177,8 +1177,13 @@ namespace FellowOakDicom.Network
 
                         dicomRequest.PendingSince = DateTime.Now;
 
-                        // This call should not be awaited because it can only complete when the pending queue is empty
-                        Task.Factory.StartNew(CheckForTimeouts, TaskCreationOptions.LongRunning).ConfigureAwait(false);
+                        // Only spawn the long-running timeout watcher if a timeout is actually configured;
+                        // otherwise CheckForTimeouts returns immediately and the thread creation is wasted.
+                        if (Options?.RequestTimeout != null)
+                        {
+                            // This call should not be awaited because it can only complete when the pending queue is empty
+                            Task.Factory.StartNew(CheckForTimeouts, TaskCreationOptions.LongRunning).ConfigureAwait(false);
+                        }
                     }
                 }
 
@@ -1391,7 +1396,10 @@ namespace FellowOakDicom.Network
                     throw new DicomNetworkException($"Failed to send {msg} because the connection to the DICOM server was lost");
                 }
 
-                Logger.LogInformation("{logId} -> {dicomMessage}", LogID, msg.ToString(Options.LogDimseDatasets));
+                if (Logger.IsEnabled(LogLevel.Information))
+                {
+                    Logger.LogInformation("{logId} -> {dicomMessage}", LogID, msg.ToString(Options.LogDimseDatasets));
+                }
 
                 try
                 {
@@ -2005,7 +2013,10 @@ namespace FellowOakDicom.Network
                 throw new NotSupportedException();
             }
 
-            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
             {
                 try
                 {
@@ -2016,23 +2027,22 @@ namespace FellowOakDicom.Network
                         _memory = ProvideEvenLengthMemory(memoryLength);
                     }
 
-                    while (count >= _memory.Length - _length)
+                    while (source.Length >= _memory.Length - _length)
                     {
-                        var c = Math.Min(count, _memory.Length - _length);
+                        var c = Math.Min(source.Length, _memory.Length - _length);
 
-                        buffer.AsSpan(offset, c).CopyTo(_memory.Span.Slice(_length, c));
+                        source.Span.Slice(0, c).CopyTo(_memory.Span.Slice(_length, c));
 
                         _length += c;
-                        offset += c;
-                        count -= c;
+                        source = source.Slice(c);
 
                         await CreatePDVAsync(false).ConfigureAwait(false);
                     }
 
-                    if (count > 0)
+                    if (source.Length > 0)
                     {
-                        buffer.AsSpan(offset, count).CopyTo(_memory.Span.Slice(_length, count));
-                        _length += count;
+                        source.Span.CopyTo(_memory.Span.Slice(_length, source.Length));
+                        _length += source.Length;
 
                         if (_memory.Length == _length)
                         {

--- a/FO-DICOM.Core/Network/PDU.cs
+++ b/FO-DICOM.Core/Network/PDU.cs
@@ -540,7 +540,7 @@ namespace FellowOakDicom.Network
             Write(rawPdu);
             var length = (ushort)ms.Position;
             rawPdu.GetCommonFields(buffer, length);
-            await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.Bytes.AsMemory(0, RawPDU.CommonFieldsLength + length), cancellationToken).ConfigureAwait(false);
             return (uint)(RawPDU.CommonFieldsLength + length);
         }
 
@@ -908,7 +908,7 @@ namespace FellowOakDicom.Network
             Write(rawPdu);
             var length = (ushort)ms.Position;
             rawPdu.GetCommonFields(buffer, length);
-            await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.Bytes.AsMemory(0, RawPDU.CommonFieldsLength + length), cancellationToken).ConfigureAwait(false);
             return (uint)(RawPDU.CommonFieldsLength + length);
         }
 
@@ -1295,7 +1295,7 @@ namespace FellowOakDicom.Network
             await using var rawPdu = new RawPDU(RawPduType.A_ASSOCIATE_RJ, _memoryProvider, DicomEncoding.Default, ms, true);
             Write(rawPdu);
             rawPdu.GetCommonFields(buffer, length);
-            await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.Bytes.AsMemory(0, RawPDU.CommonFieldsLength + length), cancellationToken).ConfigureAwait(false);
             return RawPDU.CommonFieldsLength + length;
         }
 
@@ -1361,7 +1361,7 @@ namespace FellowOakDicom.Network
             await using var rawPdu = new RawPDU(RawPduType.A_RELEASE_RQ, _memoryProvider, DicomEncoding.Default, ms, true);
             Write(rawPdu);
             rawPdu.GetCommonFields(buffer, length);
-            await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.Bytes.AsMemory(0, RawPDU.CommonFieldsLength + length), cancellationToken).ConfigureAwait(false);
             return RawPDU.CommonFieldsLength + length;
         }
 
@@ -1418,7 +1418,7 @@ namespace FellowOakDicom.Network
             await using var rawPdu = new RawPDU(RawPduType.A_RELEASE_RP, _memoryProvider, DicomEncoding.Default, ms, true);
             Write(rawPdu);
             rawPdu.GetCommonFields(buffer, length);
-            await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.Bytes.AsMemory(0, RawPDU.CommonFieldsLength + length), cancellationToken).ConfigureAwait(false);
             return RawPDU.CommonFieldsLength + length;
         }
 
@@ -1530,7 +1530,7 @@ namespace FellowOakDicom.Network
             await using var rawPdu = new RawPDU(RawPduType.A_ABORT, _memoryProvider, DicomEncoding.Default, ms, true);
             Write(rawPdu);
             rawPdu.GetCommonFields(buffer, length);
-            await stream.WriteAsync(buffer.Bytes, 0, RawPDU.CommonFieldsLength + length, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.Bytes.AsMemory(0, RawPDU.CommonFieldsLength + length), cancellationToken).ConfigureAwait(false);
             return RawPDU.CommonFieldsLength + length;
         }
 

--- a/FO-DICOM.Core/StringExtensions.cs
+++ b/FO-DICOM.Core/StringExtensions.cs
@@ -3,6 +3,7 @@
 #nullable disable
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 namespace FellowOakDicom
@@ -26,10 +27,7 @@ namespace FellowOakDicom
             return false;
         }
 
-        /// <summary>
-        /// Array of valid wildcards
-        /// </summary>
-        private static char[] Wildcards = new char[] { '*', '?' };
+        private static readonly SearchValues<char> Wildcards = SearchValues.Create("*?");
 
         /// <summary>
         /// Returns true if the string matches the pattern which may contain * and ? wildcards.
@@ -63,7 +61,7 @@ namespace FellowOakDicom
             }
 
             // if pattern doesn't actually contain any wildcards, use simple equality
-            if (pattern.IndexOfAny(Wildcards) == -1) return (s == pattern);
+            if (pattern.AsSpan().IndexOfAny(Wildcards) == -1) return (s == pattern);
 
             // otherwise do pattern matching
             int i = 0;

--- a/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
@@ -77,7 +77,7 @@ namespace FellowOakDicom.StructuredReport
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Value, Scheme, Version, Meaning);
+            return HashCode.Combine(Value, Scheme, Version);
         }
 
         public override string ToString()

--- a/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
@@ -77,7 +77,7 @@ namespace FellowOakDicom.StructuredReport
 
         public override int GetHashCode()
         {
-            return ToString().GetHashCode();
+            return HashCode.Combine(Value, Scheme, Version, Meaning);
         }
 
         public override string ToString()

--- a/Tests/FO-DICOM.Benchmark/CompareDatasetBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/CompareDatasetBenchmark.cs
@@ -45,11 +45,7 @@ namespace FellowOakDicom.Benchmark
             _mrData = new MemoryStream(File.ReadAllBytes(Path.Combine(_rootpath, "Data\\mr.dcm")));
             _mgData = new MemoryStream(File.ReadAllBytes(Path.Combine(_rootpath, "Data\\mg.dcm")));
             _dicomdirData = new MemoryStream(File.ReadAllBytes(Path.Combine(_rootpath, "Data\\DICOMDIR")));
-        }
 
-        [IterationSetup]
-        public void IterationSetup()
-        {
             _ctDataset = DicomFile.Open(Path.Combine(_rootpath, "Data\\ct.dcm")).Dataset;
             _mrDataset = DicomFile.Open(Path.Combine(_rootpath, "Data\\mr.dcm")).Dataset;
             _mgDataset = DicomFile.Open(Path.Combine(_rootpath, "Data\\mg.dcm")).Dataset;

--- a/Tests/FO-DICOM.Benchmark/DatasetWorkloadBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/DatasetWorkloadBenchmark.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2012-2026 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using BenchmarkDotNet.Attributes;
+
+namespace FellowOakDicom.Benchmark
+{
+    [MemoryDiagnoser]
+    public class DatasetWorkloadBenchmark
+    {
+        private static readonly string[] _decimalParts = new[]
+        {
+            "1.0", "2.5", "3.7", "4.2", "5.0", "6.3", "7.1", "8.9",
+            "9.0", "10.5", "11.7", "12.2", "13.0", "14.3", "15.1", "16.9"
+        };
+
+        private static readonly string[] _decimalPartsComma = new[]
+        {
+            "1,0", "2,5", "3,7", "4,2", "5,0", "6,3", "7,1", "8,9",
+            "9,0", "10,5", "11,7", "12,2", "13,0", "14,3", "15,1", "16,9"
+        };
+
+        private static readonly string[] _integerParts = new[]
+        {
+            "1", "2", "3", "4", "5", "6", "7", "8",
+            "9", "10", "11", "12", "13", "14", "15", "16"
+        };
+
+        [Benchmark]
+        public DicomDataset BuildDataset_ValidationOn()
+        {
+            var ds = new DicomDataset();
+            ds.Add(DicomTag.SOPClassUID, "1.2.840.10008.5.1.4.1.1.2");
+            ds.Add(DicomTag.SOPInstanceUID, "1.2.3.4.5.6.7.8.9.10");
+            ds.Add(DicomTag.StudyDate, "20260513");
+            ds.Add(DicomTag.StudyTime, "120000.000000");
+            ds.Add(DicomTag.AccessionNumber, "ACC123456");
+            ds.Add(DicomTag.Modality, "CT");
+            ds.Add(DicomTag.Manufacturer, "fo-dicom");
+            ds.Add(DicomTag.ReferringPhysicianName, "Smith^Jane^^Dr^");
+            ds.Add(DicomTag.StudyInstanceUID, "1.2.3.4.5.6.7.8.9.11");
+            ds.Add(DicomTag.SeriesInstanceUID, "1.2.3.4.5.6.7.8.9.12");
+            ds.Add(DicomTag.PatientName, "Doe^John^^Mr^Jr");
+            ds.Add(DicomTag.PatientID, "PID-001");
+            ds.Add(DicomTag.PatientBirthDate, "19800101");
+            ds.Add(DicomTag.PatientSex, "M");
+            ds.Add(DicomTag.PatientAge, "045Y");
+            ds.Add(DicomTag.StudyDescription, "Routine chest CT");
+            ds.Add(DicomTag.SeriesDescription, "Axial 1mm");
+            ds.Add(DicomTag.InstanceNumber, "1");
+            ds.Add(DicomTag.PixelSpacing, "0.78125", "0.78125");
+            ds.Add(DicomTag.SliceThickness, "1.0");
+            return ds;
+        }
+
+        [Benchmark]
+        public decimal[] GetMultiValuedDecimalArray()
+        {
+            var element = new DicomDecimalString(DicomTag.PixelSpacing, _decimalParts);
+            return element.Get<decimal[]>();
+        }
+
+        [Benchmark]
+        public decimal[] GetMultiValuedDecimalArrayWithComma()
+        {
+            var element = new DicomDecimalString(DicomTag.PixelSpacing, _decimalPartsComma);
+            return element.Get<decimal[]>();
+        }
+
+        [Benchmark]
+        public int[] GetMultiValuedIntegerArray()
+        {
+            var element = new DicomIntegerString(DicomTag.ReferencedFrameNumber, _integerParts);
+            return element.Get<int[]>();
+        }
+
+        [Benchmark]
+        public DicomDataset BuildAndRemoveBySelector()
+        {
+            var ds = BuildLargePrivateDataset();
+            ds.Remove(item => item.Tag.Group == 0x3009);
+            return ds;
+        }
+
+        [Benchmark]
+        public DicomDataset BuildLargeDataset()
+        {
+            return BuildLargePrivateDataset();
+        }
+
+        private static DicomDataset BuildLargePrivateDataset()
+        {
+#pragma warning disable CS0618
+            var ds = new DicomDataset { AutoValidate = false };
+#pragma warning restore CS0618
+            for (ushort grp = 0x0008; grp <= 0x0028; grp += 8)
+            {
+                for (ushort elem = 0x0001; elem < 0x0080; elem++)
+                {
+                    ds.Add(new DicomLongString(new DicomTag(grp, elem), "value"));
+                }
+            }
+            for (ushort elem = 0x0001; elem < 0x0080; elem++)
+            {
+                ds.Add(new DicomLongString(new DicomTag(0x3009, elem), "value"));
+            }
+            return ds;
+        }
+    }
+}

--- a/Tests/FO-DICOM.Benchmark/DicomValidationBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/DicomValidationBenchmark.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2012-2026 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using BenchmarkDotNet.Attributes;
+
+namespace FellowOakDicom.Benchmark
+{
+    [MemoryDiagnoser]
+    public class DicomValidationBenchmark
+    {
+        private const string AE = "MY_AE_TITLE";
+        private const string AS = "030Y";
+        private const string CS = "ORIGINAL";
+        private const string DA = "20260513";
+        private const string DS = "1.234567";
+        private const string DT = "20260513120000.000000+0100";
+        private const string IS = "12345";
+        private const string LO = "Sample long string value";
+        private const string LT = "Sample long text value with multiple words.";
+        private const string PN = "Doe^John^^Mr^Jr";
+        private const string SH = "Short";
+        private const string ST = "Sample short text.";
+        private const string TM = "120000.000000";
+        private const string UI = "1.2.840.10008.5.1.4.1.1.2";
+        private const string TZ = "+0100";
+
+        [Benchmark]
+        public void ValidateAE() => DicomValidation.ValidateAE(AE);
+
+        [Benchmark]
+        public void ValidateAS() => DicomValidation.ValidateAS(AS);
+
+        [Benchmark]
+        public void ValidateCS() => DicomValidation.ValidateCS(CS);
+
+        [Benchmark]
+        public void ValidateDA() => DicomValidation.ValidateDA(DA);
+
+        [Benchmark]
+        public void ValidateDS() => DicomValidation.ValidateDS(DS);
+
+        [Benchmark]
+        public void ValidateDT() => DicomValidation.ValidateDT(DT);
+
+        [Benchmark]
+        public void ValidateIS() => DicomValidation.ValidateIS(IS);
+
+        [Benchmark]
+        public void ValidateLO() => DicomValidation.ValidateLO(LO);
+
+        [Benchmark]
+        public void ValidateLT() => DicomValidation.ValidateLT(LT);
+
+        [Benchmark]
+        public void ValidatePN() => DicomValidation.ValidatePN(PN);
+
+        [Benchmark]
+        public void ValidateSH() => DicomValidation.ValidateSH(SH);
+
+        [Benchmark]
+        public void ValidateST() => DicomValidation.ValidateST(ST);
+
+        [Benchmark]
+        public void ValidateTM() => DicomValidation.ValidateTM(TM);
+
+        [Benchmark]
+        public void ValidateUI() => DicomValidation.ValidateUI(UI);
+
+        [Benchmark]
+        public void ValidateTimezoneOffset() => DicomValidation.ValidateTimezoneOffset(TZ);
+
+        [Benchmark]
+        public void ValidateAllOnce()
+        {
+            DicomValidation.ValidateAE(AE);
+            DicomValidation.ValidateAS(AS);
+            DicomValidation.ValidateCS(CS);
+            DicomValidation.ValidateDA(DA);
+            DicomValidation.ValidateDS(DS);
+            DicomValidation.ValidateDT(DT);
+            DicomValidation.ValidateIS(IS);
+            DicomValidation.ValidateLO(LO);
+            DicomValidation.ValidateLT(LT);
+            DicomValidation.ValidatePN(PN);
+            DicomValidation.ValidateSH(SH);
+            DicomValidation.ValidateST(ST);
+            DicomValidation.ValidateTM(TM);
+            DicomValidation.ValidateUI(UI);
+            DicomValidation.ValidateTimezoneOffset(TZ);
+        }
+    }
+}

--- a/Tests/FO-DICOM.Benchmark/DictionaryLookupBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/DictionaryLookupBenchmark.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2012-2026 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using BenchmarkDotNet.Attributes;
+
+namespace FellowOakDicom.Benchmark
+{
+    [MemoryDiagnoser]
+    public class DictionaryLookupBenchmark
+    {
+        private DicomDictionary _dictionary;
+
+        // Common tags that are looked up during every DICOM parse
+        private static readonly DicomTag[] _commonTags = new[]
+        {
+            DicomTag.PatientID,
+            DicomTag.PatientName,
+            DicomTag.StudyInstanceUID,
+            DicomTag.SeriesInstanceUID,
+            DicomTag.SOPInstanceUID,
+            DicomTag.Modality,
+            DicomTag.Rows,
+            DicomTag.Columns,
+            DicomTag.BitsAllocated,
+            DicomTag.BitsStored,
+            DicomTag.PixelRepresentation,
+            DicomTag.PixelData,
+            DicomTag.TransferSyntaxUID,
+            DicomTag.SpecificCharacterSet,
+            DicomTag.ImageType,
+            DicomTag.StudyDate,
+        };
+
+        private static readonly string[] _commonKeywords = new[]
+        {
+            "PatientID",
+            "PatientName",
+            "StudyInstanceUID",
+            "SeriesInstanceUID",
+            "SOPInstanceUID",
+            "Modality",
+            "Rows",
+            "Columns",
+            "BitsAllocated",
+            "BitsStored",
+            "PixelRepresentation",
+            "PixelData",
+            "TransferSyntaxUID",
+            "SpecificCharacterSet",
+            "ImageType",
+            "StudyDate",
+        };
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _dictionary = DicomDictionary.Default;
+        }
+
+        [Benchmark]
+        public DicomDictionaryEntry Dictionary_LookupByTag()
+        {
+            DicomDictionaryEntry result = null;
+            foreach (var tag in _commonTags)
+            {
+                result = _dictionary[tag];
+            }
+            return result;
+        }
+
+        [Benchmark]
+        public DicomTag Dictionary_LookupByKeyword()
+        {
+            DicomTag result = null;
+            foreach (var keyword in _commonKeywords)
+            {
+                result = _dictionary[keyword];
+            }
+            return result;
+        }
+    }
+}

--- a/Tests/FO-DICOM.Benchmark/EndianArraySwapBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/EndianArraySwapBenchmark.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2012-2026 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using System;
+using BenchmarkDotNet.Attributes;
+using FellowOakDicom.IO;
+
+namespace FellowOakDicom.Benchmark
+{
+    [MemoryDiagnoser]
+    public class EndianArraySwapBenchmark
+    {
+        private short[] _shortArray;
+        private int[] _intArray;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Simulate typical pixel data: 512x512 image
+            _shortArray = new short[512 * 512];
+            _intArray = new int[512 * 512];
+
+            var rng = new Random(42);
+            for (int i = 0; i < _shortArray.Length; i++)
+            {
+                _shortArray[i] = (short)rng.Next(short.MinValue, short.MaxValue);
+            }
+            for (int i = 0; i < _intArray.Length; i++)
+            {
+                _intArray[i] = rng.Next();
+            }
+        }
+
+        [Benchmark]
+        public void SwapShortArray()
+        {
+            Endian.Swap(_shortArray);
+        }
+
+        [Benchmark]
+        public void SwapIntArray()
+        {
+            Endian.Swap(_intArray);
+        }
+    }
+}

--- a/Tests/FO-DICOM.Benchmark/EndianSwapBenchmark.cs
+++ b/Tests/FO-DICOM.Benchmark/EndianSwapBenchmark.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2012-2026 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using System;
+using BenchmarkDotNet.Attributes;
+using FellowOakDicom.IO;
+
+namespace FellowOakDicom.Benchmark
+{
+    [MemoryDiagnoser]
+    public class EndianSwapBenchmark
+    {
+        private byte[] _data2;
+        private byte[] _data4;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Simulate typical pixel data sizes
+            // 512x512 image with 2 bytes per pixel = 524,288 bytes
+            _data2 = new byte[512 * 512 * 2];
+            _data4 = new byte[512 * 512 * 4];
+
+            var rng = new Random(42);
+            rng.NextBytes(_data2);
+            rng.NextBytes(_data4);
+        }
+
+        [Benchmark]
+        public void SwapBytes2_PixelData()
+        {
+            Endian.SwapBytes2(_data2, _data2.Length);
+        }
+
+        [Benchmark]
+        public void SwapBytes4_PixelData()
+        {
+            Endian.SwapBytes4(_data4, _data4.Length);
+        }
+
+        [Benchmark]
+        public float SwapFloat()
+        {
+            float result = 0;
+            for (int i = 0; i < 1000; i++)
+            {
+                result = Endian.Swap(3.14159f + i);
+            }
+            return result;
+        }
+
+        [Benchmark]
+        public double SwapDouble()
+        {
+            double result = 0;
+            for (int i = 0; i < 1000; i++)
+            {
+                result = Endian.Swap(3.14159265358979 + i);
+            }
+            return result;
+        }
+    }
+}

--- a/Tests/FO-DICOM.Benchmark/Program.cs
+++ b/Tests/FO-DICOM.Benchmark/Program.cs
@@ -9,15 +9,14 @@ namespace FellowOakDicom.Benchmark
 {
     static class Program
     {
-        static void Main()
+        static void Main(string[] args)
         {
-            // Run all benchmarks in assembly
-            BenchmarkRunner.Run(typeof(Program).Assembly,
- //           BenchmarkRunner.Run<ParseDatasetBenchmark>(
-                ManualConfig.Create(DefaultConfig.Instance)
-                .WithOptions(ConfigOptions.JoinSummary)
-                .WithOptions(ConfigOptions.DisableOptimizationsValidator)
-                );
+            // Support --filter arg from command line, otherwise run all benchmarks
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
+                .Run(args,
+                    ManualConfig.Create(DefaultConfig.Instance)
+                        .WithOptions(ConfigOptions.JoinSummary)
+                        .WithOptions(ConfigOptions.DisableOptimizationsValidator));
         }
     }
 }

--- a/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
@@ -96,6 +96,12 @@ namespace FellowOakDicom.Tests.Bugs
                 shouldTimeoutNextRequest = true;
             };
 
+            // Released as soon as the second request's RequestTimeout fires, so the
+            // injected network "stall" does not have to wait out a fixed wall-clock
+            // sleep (which made the test flaky on slow CI runners).
+            using var unblockOnTimeout = new ManualResetEventSlim();
+            secondRequest.OnTimeout += (sender, args) => unblockOnTimeout.Set();
+
             var receivedRequests = new List<DicomCStoreRequest>();
             server.OnCStoreRequest = (association, storeRequest) =>
             {
@@ -109,11 +115,11 @@ namespace FellowOakDicom.Tests.Bugs
             var clientFactory = CreateClientFactory(new DicomClientTimeoutTest.ConfigurableNetworkManager(
                 () =>
                 {
-                    // Simulate a single network error after the first request
                     if (shouldTimeoutNextRequest)
                     {
                         shouldTimeoutNextRequest = false;
-                        Thread.Sleep(10_000);
+                        // Cap at 15s to keep the test bounded if the timeout never fires for some reason.
+                        unblockOnTimeout.Wait(TimeSpan.FromSeconds(15));
                     }
                 }
             ));

--- a/Tests/FO-DICOM.Tests/IO/EndianTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/EndianTest.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2012-2026 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using FellowOakDicom.IO;
+using Xunit;
+
+namespace FellowOakDicom.Tests.IO
+{
+    [Collection(TestCollections.General)]
+    public class EndianTest
+    {
+        [Fact]
+        public void SwapBytes2_EvenCount_SwapsAllPairs()
+        {
+            var bytes = new byte[] { 0x12, 0x34, 0x56, 0x78 };
+            Endian.SwapBytes2(bytes, 4);
+            Assert.Equal(new byte[] { 0x34, 0x12, 0x78, 0x56 }, bytes);
+        }
+
+        [Fact]
+        public void SwapBytes2_OddCount_LeavesTrailingByteUntouched()
+        {
+            var bytes = new byte[] { 0x12, 0x34, 0x56 };
+            Endian.SwapBytes2(bytes, 3);
+            // First pair swapped, last byte preserved.
+            Assert.Equal(new byte[] { 0x34, 0x12, 0x56 }, bytes);
+        }
+
+        [Fact]
+        public void SwapBytes2_CountLessThanArray_LeavesTrailingBytesUntouched()
+        {
+            var bytes = new byte[] { 0x12, 0x34, 0xAA, 0xBB };
+            Endian.SwapBytes2(bytes, 2);
+            Assert.Equal(new byte[] { 0x34, 0x12, 0xAA, 0xBB }, bytes);
+        }
+
+        [Fact]
+        public void SwapBytes4_AlignedCount_SwapsAllGroups()
+        {
+            var bytes = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x11, 0x22, 0x33, 0x44 };
+            Endian.SwapBytes4(bytes, 8);
+            Assert.Equal(new byte[] { 0x04, 0x03, 0x02, 0x01, 0x44, 0x33, 0x22, 0x11 }, bytes);
+        }
+
+        [Fact]
+        public void SwapBytes4_NonAlignedCount_LeavesTrailingBytesUntouched()
+        {
+            var bytes = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 };
+            Endian.SwapBytes4(bytes, 6);
+            // First quad swapped, remaining 2 bytes preserved.
+            Assert.Equal(new byte[] { 0x04, 0x03, 0x02, 0x01, 0x05, 0x06 }, bytes);
+        }
+
+        [Fact]
+        public void SwapShortArray_RoundTrip_RestoresOriginal()
+        {
+            var values = new short[] { 0x0102, 0x0304, -1, short.MinValue, short.MaxValue };
+            var original = (short[])values.Clone();
+
+            Endian.Swap(values);
+            Endian.Swap(values);
+
+            Assert.Equal(original, values);
+        }
+
+        [Fact]
+        public void SwapIntArray_RoundTrip_RestoresOriginal()
+        {
+            var values = new int[] { 0x01020304, -1, int.MinValue, int.MaxValue, 0 };
+            var original = (int[])values.Clone();
+
+            Endian.Swap(values);
+            Endian.Swap(values);
+
+            Assert.Equal(original, values);
+        }
+    }
+}

--- a/Tests/FO-DICOM.Tests/StructuredReport/DicomCodeItemTest.cs
+++ b/Tests/FO-DICOM.Tests/StructuredReport/DicomCodeItemTest.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2012-2026 fo-dicom contributors.
+// Licensed under the Microsoft Public License (MS-PL).
+#nullable disable
+
+using FellowOakDicom.StructuredReport;
+using Xunit;
+
+namespace FellowOakDicom.Tests.StructuredReport
+{
+    [Collection(TestCollections.General)]
+    public class DicomCodeItemTest
+    {
+        [Fact]
+        public void GetHashCode_IdenticalInstances_ReturnsEqualHashes()
+        {
+            var a = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
+            var b = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
+
+            Assert.True(a.Equals((object)b));
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_EqualInstancesWithDifferentMeaning_ReturnsEqualHashes()
+        {
+            var a = new DicomCodeItem("113820", "DCM", "Original meaning");
+            var b = new DicomCodeItem("113820", "DCM", "Reworded meaning");
+
+            Assert.True(a.Equals((object)b));
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_DifferentVersion_ReturnsDifferentHashes()
+        {
+            var a = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
+            var b = new DicomCodeItem("113820", "DCM", "CT Acquisition Type", "20240101");
+
+            Assert.False(a.Equals((object)b));
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_DifferentValue_ReturnsDifferentHashes()
+        {
+            var a = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
+            var b = new DicomCodeItem("113821", "DCM", "CT Acquisition Type");
+
+            Assert.False(a.Equals((object)b));
+            Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2088.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:

Targets the DICOM parsing pipeline, validation, network I/O, and endian-swap paths using APIs that became available when netstandard2.0 was dropped.

Results vs origin/development (BenchmarkDotNet) on my machine:
- DicomValidation per-VR: 2-5x faster, ~75% less allocation
- Endian array/scalar swaps: 50-88% faster
- JSON deserialization: -23 to -39% time, -5 to -13% alloc
- DICOM file parse (CT/MR/MG/DICOMDIR): -14 to -31% time
- C-ECHO send: -13% time

Notable changes:
- BinaryPrimitives.ReverseEndianness over Span<T> replaces Parallel.For loops and manual byte swaps
- FrozenDictionary<uint,DicomTag> for DicomTagsIndex
- [GeneratedRegex] source-gen in DicomValidation
- ReadOnlySpan<char> overloads of decimal/int.Parse (DS/IS)
- Stream.WriteAsync(Memory<byte>) / ReadAsync(Memory<byte>) in network and IByteBuffer family (ValueTask, no per-call Task allocation)
- LongRunning timeout thread now only spawned when RequestTimeout is set
- LINQ removed from hot paths (Validation, RemoveGroupLengths, encoding setup)

Two new benchmark suites (DicomValidationBenchmark, DatasetWorkloadBenchmark) plus baseline coverage in DictionaryLookup and Endian*Swap benchmarks.

Behavioural change:
* Removed the locks from FileByteSource and StreamByteSource. This is because there is no promise on the IByteSource that it is thread safe, and it is handled in a signle-threaded fashion everywhere. The locking mechanism before removal was broken, e.g. The lock on Require() protects nothing because the value it reads can change mid-call from an unlocked method.
* If a caller sets Options.RequestTimeout = TimeSpan.FromSeconds(30) after requests are already queued (very uncommon(?) but legal), those existing requests no longer get timeout enforcement.