### PR TITLE
New encapsulated PixelData is now always stored correctly as OB

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 - Performance optimizations in FO-DICOM.Core
 - use decimal in FrameGeometry instead of double to avoid rounding erors (#2085)
 - breaking change: types `Geometry3D`, `Point3D`, etc are replaced by generic `Geometry<T>`, `Point3<T>`etc.
+- new encapsulated pixeldata is now always stored correctly as OB (#2117)
+- breaking change: DicomPixelData.Create(dataset, bool) is split up to DicomPixelData.CreateNew(dataset) and DicomPixelData.CreateFromDataset(dataset)
 
 ### 5.2.6 (2026-03-30)
 - Fix FrameGeometry initialization to handle empty position and orientation arrays (#2067)

--- a/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
+++ b/FO-DICOM.Core/Imaging/Codec/DicomTranscoder.cs
@@ -2,12 +2,12 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 using FellowOakDicom.Imaging.Render;
 using FellowOakDicom.IO.Buffer;
 using FellowOakDicom.IO.Writer;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 
 namespace FellowOakDicom.Imaging.Codec
 {
@@ -122,8 +122,8 @@ namespace FellowOakDicom.Imaging.Codec
                 var newDataset = dataset.Clone();
                 newDataset.InternalTransferSyntax = OutputSyntax;
 
-                var oldPixelData = DicomPixelData.Create(dataset, false);
-                var newPixelData = DicomPixelData.Create(newDataset, true);
+                var oldPixelData = DicomPixelData.CreateFromDataset(dataset);
+                var newPixelData = DicomPixelData.CreateNew(newDataset);
 
                 for (int i = 0; i < oldPixelData.NumberOfFrames; i++)
                 {
@@ -163,7 +163,7 @@ namespace FellowOakDicom.Imaging.Codec
         /// <inheritdoc />
         public IByteBuffer DecodeFrame(DicomDataset dataset, int frame)
         {
-            var pixelData = DicomPixelData.Create(dataset);
+            var pixelData = DicomPixelData.CreateFromDataset(dataset);
             var buffer = pixelData.GetFrame(frame);
 
             // is pixel data already uncompressed?
@@ -175,11 +175,11 @@ namespace FellowOakDicom.Imaging.Codec
             // clone dataset to prevent changes to source
             var cloneDataset = dataset.Clone();
 
-            var oldPixelData = DicomPixelData.Create(cloneDataset, true);
+            var oldPixelData = DicomPixelData.CreateNew(cloneDataset);
             oldPixelData.AddFrame(buffer);
 
             var newDataset = Decode(cloneDataset, OutputSyntax, InputCodec, InputCodecParams);
-            var newPixelData = DicomPixelData.Create(newDataset);
+            var newPixelData = DicomPixelData.CreateFromDataset(newDataset);
 
             return newPixelData.GetFrame(0);
         }
@@ -187,7 +187,7 @@ namespace FellowOakDicom.Imaging.Codec
         /// <inheritdoc />
         public IPixelData DecodePixelData(DicomDataset dataset, int frame)
         {
-            var pixelData = DicomPixelData.Create(dataset);
+            var pixelData = DicomPixelData.CreateFromDataset(dataset);
 
             // is pixel data already uncompressed?
             if (!dataset.InternalTransferSyntax.IsEncapsulated)
@@ -200,11 +200,11 @@ namespace FellowOakDicom.Imaging.Codec
             // clone dataset to prevent changes to source
             var cloneDataset = dataset.Clone();
 
-            var oldPixelData = DicomPixelData.Create(cloneDataset, true);
+            var oldPixelData = DicomPixelData.CreateNew(cloneDataset);
             oldPixelData.AddFrame(buffer);
 
             var newDataset = Decode(cloneDataset, OutputSyntax, InputCodec, InputCodecParams);
-            var newPixelData = DicomPixelData.Create(newDataset);
+            var newPixelData = DicomPixelData.CreateFromDataset(newDataset);
 
             return PixelDataFactory.Create(newPixelData, 0);
         }
@@ -235,11 +235,11 @@ namespace FellowOakDicom.Imaging.Codec
                 throw new DicomCodecException($"Decoding dataset with transfer syntax: {oldDataset.InternalTransferSyntax} is not supported.");
             }
 
-            var oldPixelData = DicomPixelData.Create(oldDataset);
+            var oldPixelData = DicomPixelData.CreateFromDataset(oldDataset);
 
             var newDataset = oldDataset.Clone();
             newDataset.InternalTransferSyntax = outSyntax;
-            var newPixelData = DicomPixelData.Create(newDataset, true);
+            var newPixelData = DicomPixelData.CreateNew(newDataset);
 
             codec.Decode(oldPixelData, newPixelData, parameters);
 
@@ -261,11 +261,11 @@ namespace FellowOakDicom.Imaging.Codec
                 throw new DicomCodecException($"Encoding dataset to transfer syntax {outSyntax} is not supported.");
             }
 
-            var oldPixelData = DicomPixelData.Create(oldDataset);
+            var oldPixelData = DicomPixelData.CreateFromDataset(oldDataset);
 
             var newDataset = oldDataset.Clone();
             newDataset.InternalTransferSyntax = outSyntax;
-            var newPixelData = DicomPixelData.Create(newDataset, true);
+            var newPixelData = DicomPixelData.CreateNew(newDataset);
 
             codec.Encode(oldPixelData, newPixelData, parameters);
 
@@ -290,7 +290,7 @@ namespace FellowOakDicom.Imaging.Codec
                 {
                     ratios.AddRange(newDataset.GetValues<string>(DicomTag.LossyImageCompressionRatio));
                 }
-                
+
                 ratios.Add(string.Format(CultureInfo.InvariantCulture, "{0:0.000}", oldSize / newSize));
                 newDataset.AddOrUpdate(new DicomDecimalString(DicomTag.LossyImageCompressionRatio, ratios.ToArray()));
             }

--- a/FO-DICOM.Core/Imaging/DicomIconImage.cs
+++ b/FO-DICOM.Core/Imaging/DicomIconImage.cs
@@ -30,7 +30,7 @@ namespace FellowOakDicom.Imaging
                     return true;
                 }
                 catch
-                { 
+                {
                     // Failed to create Icon from dataset
                 }
             }
@@ -153,7 +153,7 @@ namespace FellowOakDicom.Imaging
                 }
             }
 
-            var pixelData = DicomPixelData.Create(dataset, false);
+            var pixelData = DicomPixelData.CreateFromDataset(dataset);
 
             // Number of frames is not part of the Image Icon Sequence
             // Set to 1 to be able to use the standard rendering functions

--- a/FO-DICOM.Core/Imaging/DicomImage.cs
+++ b/FO-DICOM.Core/Imaging/DicomImage.cs
@@ -122,7 +122,7 @@ namespace FellowOakDicom.Imaging
             get => (GetOrCreateCachedFramePipeline(CurrentFrame) as GenericGrayscalePipeline)?.WindowWidth ?? 255;
             set
             {
-                var (from, to) = AutoApplyLUTToAllFrames ? (0, NumberOfFrames-1) : (CurrentFrame, CurrentFrame);
+                var (from, to) = AutoApplyLUTToAllFrames ? (0, NumberOfFrames - 1) : (CurrentFrame, CurrentFrame);
                 for (var frame = from; frame <= to; frame++)
                 {
                     if (GetOrCreateCachedFramePipeline(frame) is GenericGrayscalePipeline pipeline && pipeline.WindowWidth != value)
@@ -209,7 +209,7 @@ namespace FellowOakDicom.Imaging
 
         /// <summary>Show or hide DICOM overlays</summary>
         public bool ShowOverlays
-        { 
+        {
             get => _showOverlays;
             set
             {
@@ -267,7 +267,7 @@ namespace FellowOakDicom.Imaging
             var pipeline = GetOrCreateCachedFramePipeline(frame);
 
             var graphic = new ImageGraphic(pixels);
-            
+
             if (ShowOverlays)
             {
                 foreach (var overlay in _overlays.Value)
@@ -276,7 +276,7 @@ namespace FellowOakDicom.Imaging
                     {
                         continue;
                     }
-                    
+
                     // #1728 ignore overlay data that is too small
                     if (overlay.Data.Size * 8 < overlay.Rows * overlay.Columns)
                     {
@@ -389,14 +389,14 @@ namespace FellowOakDicom.Imaging
             var inputTransferSyntax = dataset.InternalTransferSyntax;
             if (!inputTransferSyntax.IsEncapsulated)
             {
-                return DicomPixelData.Create(dataset);
+                return DicomPixelData.CreateFromDataset(dataset);
             }
 
             // Clone the encapsulated dataset because modifying the pixel data modifies the dataset
             var clone = dataset.Clone();
             clone.InternalTransferSyntax = DicomTransferSyntax.ExplicitVRLittleEndian;
 
-            var pixelData = DicomPixelData.Create(clone, true);
+            var pixelData = DicomPixelData.CreateNew(clone);
 
             return pixelData;
         }

--- a/FO-DICOM.Core/Imaging/DicomOverlayData.cs
+++ b/FO-DICOM.Core/Imaging/DicomOverlayData.cs
@@ -297,7 +297,7 @@ namespace FellowOakDicom.Imaging
                         "Attempted to extract embedded overlay from compressed pixel data. Decompress pixel data before attempting this operation.");
                 }
 
-                var pixels = DicomPixelData.Create(Dataset);
+                var pixels = DicomPixelData.CreateFromDataset(Dataset);
 
                 // (1,1) indicates top left pixel of image
                 var ox = Math.Max(0, OriginX - 1);

--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -309,7 +309,7 @@ namespace FellowOakDicom.Imaging
                         throw new DicomImagingException($"Cannot represent pixel data with Bits Allocated: {bitsAllocated} > 16");
                     }
 
-                    return new EncapsulatedPixelData(dataset, bitsAllocated);
+                return new EncapsulatedPixelData(dataset, true);
                 }
                 else if (syntax == DicomTransferSyntax.ImplicitVRLittleEndian)
                 {
@@ -343,7 +343,7 @@ namespace FellowOakDicom.Imaging
 
             if (item is DicomOtherByteFragment || item is DicomOtherWordFragment)
             {
-                return new EncapsulatedPixelData(dataset);
+                return new EncapsulatedPixelData(dataset, false);
             }
 
             throw new DicomImagingException($"Unexpected or unhandled pixel data element type: {item.GetType()}");
@@ -509,47 +509,31 @@ namespace FellowOakDicom.Imaging
         /// </summary>
         private sealed class EncapsulatedPixelData : DicomPixelData
         {
-            #region FIELDS
-
             /// <summary>
             /// The pixel data fragment sequence element
             /// </summary>
             private readonly DicomFragmentSequence _element;
 
-            #endregion
-
-            #region CONSTRUCTORS
-
             /// <summary>
-            /// Initialize new instance of EncapsulatedPixelData with new empty pixel data.
+            /// Initialize new instance of EncapsulatedPixelData
             /// </summary>
             /// <param name="dataset">The source dataset where to create new pixel data.</param>
-            /// <param name="bitsAllocated">Bits allocated for the pixel data.</param>
-            public EncapsulatedPixelData(DicomDataset dataset, int bitsAllocated)
+            /// <param name="newPixelData">True to create new pixel data, false to read pixel data from <paramref name="dataset"/></param>
+            public EncapsulatedPixelData(DicomDataset dataset, bool newPixelData)
                 : base(dataset)
             {
+                if (newPixelData)
+                {
                 NumberOfFrames = 0;
-
-                _element = bitsAllocated > 8
-                    ? (DicomFragmentSequence)new DicomOtherWordFragment(DicomTag.PixelData)
-                    : new DicomOtherByteFragment(DicomTag.PixelData);
-
+                    _element = new DicomOtherByteFragment(DicomTag.PixelData);
                 Dataset.AddOrUpdate(_element);
             }
-
-            /// <summary>
-            /// Initialize new instance of EncapsulatedPixelData based on existing pixel data.
-            /// </summary>
-            /// <param name="dataset">The source dataset to extract pixel data from.</param>
-            public EncapsulatedPixelData(DicomDataset dataset)
-                : base(dataset)
+                else
             {
                 _element = dataset.GetDicomItem<DicomFragmentSequence>(DicomTag.PixelData);
             }
+            }
 
-            #endregion
-
-            #region METHODS
 
             /// <inheritdoc />
             public override IByteBuffer GetFrame(int frame)
@@ -658,7 +642,6 @@ namespace FellowOakDicom.Imaging
                 _element.Fragments.Add(data);
             }
 
-            #endregion
         }
     }
 }

--- a/FO-DICOM.Core/Imaging/DicomPixelData.cs
+++ b/FO-DICOM.Core/Imaging/DicomPixelData.cs
@@ -2,9 +2,9 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
+using FellowOakDicom.IO.Buffer;
 using System;
 using System.Linq;
-using FellowOakDicom.IO.Buffer;
 
 namespace FellowOakDicom.Imaging
 {
@@ -188,7 +188,7 @@ namespace FellowOakDicom.Imaging
                 {
                     ++actualWidth;
                 }
-                
+
                 // Issue #645, handle special case with uncompressed YBR_FULL_422 images
                 // chrominance channels are downsampled to 2 (nominally still 3)
                 if (PhotometricInterpretation == PhotometricInterpretation.YbrFull422)
@@ -287,44 +287,49 @@ namespace FellowOakDicom.Imaging
         public abstract void AddFrame(IByteBuffer data);
 
         /// <summary>
-        /// A factory method to initialize new instance of <see cref="DicomPixelData"/> implementation either 
-        /// <see cref="OtherWordPixelData"/>, <see cref="OtherBytePixelData"/>, or <see cref="EncapsulatedPixelData"/>
+        /// A factory method to create new instance of <see cref="DicomPixelData"/> and add it to the <paramref name="dataset"/>, 
+        /// implementation either <see cref="OtherWordPixelData"/>, <see cref="OtherBytePixelData"/>, or 
+        /// <see cref="EncapsulatedPixelData"/>
         /// </summary>
         /// <param name="dataset">Source DICOM Dataset</param>
-        /// <param name="newPixelData">true if new <see cref="DicomPixelData"/>will be created for current dataset,
-        /// false to read <see cref="DicomPixelData"/> from <paramref name="dataset"/>.
-        /// Default is false (read)</param>
         /// <returns>New instance of DicomPixelData</returns>
-        public static DicomPixelData Create(DicomDataset dataset, bool newPixelData = false)
+        public static DicomPixelData CreateNew(DicomDataset dataset)
         {
-            if (newPixelData)
-            {
-                var syntax = dataset.InternalTransferSyntax;
-                var bitsAllocated = dataset.GetSingleValue<ushort>(DicomTag.BitsAllocated);
+            var syntax = dataset.InternalTransferSyntax;
+            var bitsAllocated = dataset.GetSingleValue<ushort>(DicomTag.BitsAllocated);
 
-                if (syntax.IsEncapsulated)
+            if (syntax.IsEncapsulated)
+            {
+                if (bitsAllocated > 16)
                 {
-                    if (bitsAllocated > 16)
-                    {
-                        throw new DicomImagingException($"Cannot represent pixel data with Bits Allocated: {bitsAllocated} > 16");
-                    }
+                    throw new DicomImagingException($"Cannot represent pixel data with Bits Allocated: {bitsAllocated} > 16");
+                }
 
                 return new EncapsulatedPixelData(dataset, true);
-                }
-                else if (syntax == DicomTransferSyntax.ImplicitVRLittleEndian)
-                {
-                    //  DICOM 3.5 A.1
-                    return new OtherWordPixelData(dataset, true);
-                }
-                else
-                {
-                    //  DICOM 3.5 A.2
-                    return bitsAllocated > 8
-                        ? (DicomPixelData)new OtherWordPixelData(dataset, true)
-                        : new OtherBytePixelData(dataset, true);
-                }
             }
+            else if (syntax == DicomTransferSyntax.ImplicitVRLittleEndian)
+            {
+                //  DICOM 3.5 A.1
+                return new OtherWordPixelData(dataset, true);
+            }
+            else
+            {
+                //  DICOM 3.5 A.2
+                return bitsAllocated > 8
+                    ? (DicomPixelData)new OtherWordPixelData(dataset, true)
+                    : new OtherBytePixelData(dataset, true);
+            }
+        }
 
+        /// <summary>
+        /// A factory method to initialize new instance of <see cref="DicomPixelData"/> to read <see cref="DicomPixelData"/> 
+        /// from <paramref name="dataset"/>, implementation either <see cref="OtherWordPixelData"/>, 
+        /// <see cref="OtherBytePixelData"/>, or <see cref="EncapsulatedPixelData"/>
+        /// </summary>
+        /// <param name="dataset">Source DICOM Dataset</param>
+        /// <returns>New instance of DicomPixelData</returns>
+        public static DicomPixelData CreateFromDataset(DicomDataset dataset)
+        {
             var item = dataset.GetDicomItem<DicomItem>(DicomTag.PixelData);
             if (item == null)
             {
@@ -524,14 +529,14 @@ namespace FellowOakDicom.Imaging
             {
                 if (newPixelData)
                 {
-                NumberOfFrames = 0;
+                    NumberOfFrames = 0;
                     _element = new DicomOtherByteFragment(DicomTag.PixelData);
-                Dataset.AddOrUpdate(_element);
-            }
+                    Dataset.AddOrUpdate(_element);
+                }
                 else
-            {
-                _element = dataset.GetDicomItem<DicomFragmentSequence>(DicomTag.PixelData);
-            }
+                {
+                    _element = dataset.GetDicomItem<DicomFragmentSequence>(DicomTag.PixelData);
+                }
             }
 
 
@@ -546,13 +551,13 @@ namespace FellowOakDicom.Imaging
                 IByteBuffer buffer;
 
                 var fragments = _element.Fragments;
-                
+
                 // GH-1586 Ignore last fragment if it is empty
                 if (fragments.Count > 0 && fragments[fragments.Count - 1].Size == 0)
                 {
                     fragments.RemoveAt(fragments.Count - 1);
                 }
-                
+
                 if (NumberOfFrames == 1)
                 {
                     buffer = fragments.Count == 1

--- a/FO-DICOM.Core/Imaging/Reconstruction/DicomGenerator.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/DicomGenerator.cs
@@ -68,7 +68,7 @@ namespace FellowOakDicom.Imaging.Reconstruction
 
                 dataset.AddOrUpdate(DicomTag.PatientPosition, (string)null);
 
-                var pixelData = DicomPixelData.Create(dataset, newPixelData: true);
+                var pixelData = DicomPixelData.CreateNew(dataset);
 
                 pixelData.AddFrame(new MemoryByteBuffer(slice.RenderRawData(pixelData.BytesAllocated)));
 

--- a/FO-DICOM.Core/Imaging/Reconstruction/ImageData.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/ImageData.cs
@@ -38,7 +38,7 @@ namespace FellowOakDicom.Imaging.Reconstruction
                 .Clone(DicomTransferSyntax.ExplicitVRLittleEndian) // ensure decompressed
                 .Dataset; // the dataset of the decompressed file
             Geometry = new FrameGeometry(Dataset);
-            PixelData = DicomPixelData.Create(Dataset);
+            PixelData = DicomPixelData.CreateFromDataset(Dataset);
             Pixels = PixelDataFactory.Create(PixelData, 0);
 
             SortingValue = Geometry.DirectionNormal.DotProduct(Geometry.PointTopLeft);
@@ -50,30 +50,30 @@ namespace FellowOakDicom.Imaging.Reconstruction
             Dataset = dataset
                 .Clone(DicomTransferSyntax.ExplicitVRLittleEndian); // ensure decompressed
             Geometry = new FrameGeometry(Dataset);
-            PixelData = DicomPixelData.Create(Dataset);
+            PixelData = DicomPixelData.CreateFromDataset(Dataset);
             Pixels = PixelDataFactory.Create(PixelData, 0);
 
             SortingValue = Geometry.DirectionNormal.DotProduct(Geometry.PointTopLeft);
         }
-        
+
         public ImageData(DicomDataset dataset, int frame)
         {
             Dataset = dataset
                 .Clone(DicomTransferSyntax.ExplicitVRLittleEndian); // ensure decompressed
             Geometry = new FrameGeometry(Dataset, frame);
-            PixelData = DicomPixelData.Create(Dataset);
+            PixelData = DicomPixelData.CreateFromDataset(Dataset);
             Pixels = PixelDataFactory.Create(PixelData, frame);
 
             SortingValue = Geometry.DirectionNormal.DotProduct(Geometry.PointTopLeft);
         }
-        
+
         public ImageData(DicomDataset dataset, DicomPixelData dicomPixelData, int frame)
         {
             if (dicomPixelData.Syntax.IsEncapsulated)
             {
                 throw new DicomDataException("The PixelData given to the ImageData constructor must not be compressed");
             }
-            
+
             Dataset = dataset;
             Geometry = new FrameGeometry(Dataset, frame);
             PixelData = dicomPixelData;

--- a/FO-DICOM.Core/Imaging/Reconstruction/VolumeData.cs
+++ b/FO-DICOM.Core/Imaging/Reconstruction/VolumeData.cs
@@ -71,7 +71,7 @@ namespace FellowOakDicom.Imaging.Reconstruction
             ValidateInput(dataset.Contains(DicomTag.NumberOfFrames), "Given dataset must contain multiple frames");
 
             var numberOfFrames = dataset.GetSingleValue<int>(DicomTag.NumberOfFrames);
-            var pixelData = DicomPixelData.Create(dataset);
+            var pixelData = DicomPixelData.CreateFromDataset(dataset);
 
             return Enumerable.Range(0, numberOfFrames)
                 .Select(frame => new ImageData(dataset, pixelData, frame));

--- a/Tests/FO-DICOM.Tests/Bugs/GH1049.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1049.cs
@@ -19,7 +19,7 @@ namespace FellowOakDicom.Tests.Bugs
             var dicomFile = DicomFile.Open(TestData.Resolve("GH1049_planar_0.dcm"));
 
             // Act
-            var pixelData = PixelDataFactory.Create(DicomPixelData.Create(dicomFile.Dataset), 0);
+            var pixelData = PixelDataFactory.Create(DicomPixelData.CreateFromDataset(dicomFile.Dataset), 0);
 
             // Assert
             Assert.NotNull(pixelData);
@@ -33,7 +33,7 @@ namespace FellowOakDicom.Tests.Bugs
 
             // Act
             Assert.Throws<DicomImagingException>(() =>
-                PixelDataFactory.Create(DicomPixelData.Create(dicomFile.Dataset), 0));
+                PixelDataFactory.Create(DicomPixelData.CreateFromDataset(dicomFile.Dataset), 0));
         }
     }
 

--- a/Tests/FO-DICOM.Tests/Bugs/GH1264.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1264.cs
@@ -37,9 +37,9 @@ namespace FellowOakDicom.Tests.Bugs
             var reopenedDicomFile = DicomFile.Open(outputFile.FullName);
 
             // Assert
-            var fileBytePixelData = DicomPixelData.Create(fileByteDicomFile.Dataset);
-            var streamBytePixelData = DicomPixelData.Create(streamByteDicomFile.Dataset);
-            var reopenedPixelData = DicomPixelData.Create(reopenedDicomFile.Dataset);
+            var fileBytePixelData = DicomPixelData.CreateFromDataset(fileByteDicomFile.Dataset);
+            var streamBytePixelData = DicomPixelData.CreateFromDataset(streamByteDicomFile.Dataset);
+            var reopenedPixelData = DicomPixelData.CreateFromDataset(reopenedDicomFile.Dataset);
 
             Assert.Equal(79, fileBytePixelData.NumberOfFrames);
             Assert.Equal(79, streamBytePixelData.NumberOfFrames);
@@ -85,9 +85,9 @@ namespace FellowOakDicom.Tests.Bugs
             var reopenedDicomFile = await DicomFile.OpenAsync(outputFile.FullName);
 
             // Assert
-            var fileBytePixelData = DicomPixelData.Create(fileByteDicomFile.Dataset);
-            var streamBytePixelData = DicomPixelData.Create(streamByteDicomFile.Dataset);
-            var reopenedPixelData = DicomPixelData.Create(reopenedDicomFile.Dataset);
+            var fileBytePixelData = DicomPixelData.CreateFromDataset(fileByteDicomFile.Dataset);
+            var streamBytePixelData = DicomPixelData.CreateFromDataset(streamByteDicomFile.Dataset);
+            var reopenedPixelData = DicomPixelData.CreateFromDataset(reopenedDicomFile.Dataset);
 
             Assert.Equal(79, fileBytePixelData.NumberOfFrames);
             Assert.Equal(79, streamBytePixelData.NumberOfFrames);

--- a/Tests/FO-DICOM.Tests/Bugs/GH1339.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1339.cs
@@ -19,7 +19,7 @@ namespace FellowOakDicom.Tests.Bugs
 
             // Act
             DicomFile dicomFile;
-            if(async)
+            if (async)
             {
                 dicomFile = await DicomFile.OpenAsync(file);
             }
@@ -29,7 +29,7 @@ namespace FellowOakDicom.Tests.Bugs
                 dicomFile = DicomFile.Open(file);
                 // ReSharper restore MethodHasAsyncOverload
             }
-            var pixelData = DicomPixelData.Create(dicomFile.Dataset);
+            var pixelData = DicomPixelData.CreateFromDataset(dicomFile.Dataset);
             var frame = pixelData.GetFrame(0);
 
             // Assert

--- a/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1359.cs
@@ -2,6 +2,15 @@
 // Licensed under the Microsoft Public License (MS-PL).
 #nullable disable
 
+using FellowOakDicom.Imaging;
+using FellowOakDicom.Network;
+using FellowOakDicom.Network.Client;
+using FellowOakDicom.Network.Client.Advanced.Connection;
+using FellowOakDicom.Tests.Helpers;
+using FellowOakDicom.Tests.Network.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -9,16 +18,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using FellowOakDicom.Imaging;
-using FellowOakDicom.Network;
-using FellowOakDicom.Network.Client;
-using FellowOakDicom.Network.Client.Advanced.Connection;
-using FellowOakDicom.Tests.Helpers;
-using FellowOakDicom.Tests.Network;
-using FellowOakDicom.Tests.Network.Client;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -52,7 +51,7 @@ namespace FellowOakDicom.Tests.Bugs
         public async Task SendingCStoreRequest_AfterPreviousCStoreRequestTimedOut_ShouldUseSeparateAssociation(int asyncInvoked)
         {
             // Arrange
-            using var server = (ConfigurableDicomCStoreServer) DicomServerFactory.Create<ConfigurableDicomCStoreProvider, ConfigurableDicomCStoreServer>("127.0.0.1", 0);
+            using var server = (ConfigurableDicomCStoreServer)DicomServerFactory.Create<ConfigurableDicomCStoreProvider, ConfigurableDicomCStoreServer>("127.0.0.1", 0);
             server.Options.MaxPDULength = 1024;
             server.Options.LogDimseDatasets = false;
             server.Options.LogDataPDUs = false;
@@ -166,7 +165,7 @@ namespace FellowOakDicom.Tests.Bugs
                 .Where(r => !messageIdsThatTimedOut.Contains(r.MessageID))
                 .ToList();
 
-            var expectedPixelData = DicomPixelData.Create(originalDicomFile.Dataset);
+            var expectedPixelData = DicomPixelData.CreateFromDataset(originalDicomFile.Dataset);
             var expectedNumberOfFrames = expectedPixelData.NumberOfFrames;
             var expectedWidth = expectedPixelData.Width;
             var expectedHeight = expectedPixelData.Height;
@@ -176,10 +175,10 @@ namespace FellowOakDicom.Tests.Bugs
 
             Parallel.For((long)0, receivedRequestsThatSucceeded.Count, i =>
             {
-                var request = receivedRequestsThatSucceeded[(int) i];
+                var request = receivedRequestsThatSucceeded[(int)i];
                 _logger.LogInformation($"Verifying pixel data of request [{request.MessageID}]");
 
-                var actualPixelData = DicomPixelData.Create(request.File.Dataset);
+                var actualPixelData = DicomPixelData.CreateFromDataset(request.File.Dataset);
 
                 var expectedPhotometricInterpretation = expectedPixelData.PhotometricInterpretation.Value;
                 Assert.Equal(expectedPhotometricInterpretation, actualPixelData.PhotometricInterpretation.Value);
@@ -198,10 +197,10 @@ namespace FellowOakDicom.Tests.Bugs
                     var expectedData = expectedFrame.Data;
 
                     var actualFirstByte = actualData[0];
-                    var actualMiddleByte = actualData[(int) (actualData.Length / 2.0)];
+                    var actualMiddleByte = actualData[(int)(actualData.Length / 2.0)];
                     var actualLastByte = actualData[actualData.Length - 1];
                     var expectedFirstByte = expectedData[0];
-                    var expectedMiddleByte = expectedData[(int) (expectedData.Length / 2.0)];
+                    var expectedMiddleByte = expectedData[(int)(expectedData.Length / 2.0)];
                     var expectedLastByte = expectedData[expectedData.Length - 1];
                     Assert.Equal(expectedData.Length, actualData.Length);
                     Assert.Equal(expectedFirstByte, actualFirstByte);
@@ -221,7 +220,7 @@ namespace FellowOakDicom.Tests.Bugs
         public Action<DicomAssociation> OnAssociationRequest { get; set; }
 
         public ConfigurableDicomCStoreServer(DicomServerDependencies dependencies,
-            DicomServiceDependencies dicomServiceDependencies): base(dependencies)
+            DicomServiceDependencies dicomServiceDependencies) : base(dependencies)
         {
             _dicomServiceDependencies = dicomServiceDependencies ?? throw new ArgumentNullException(nameof(dicomServiceDependencies));
         }

--- a/Tests/FO-DICOM.Tests/Bugs/GH1653.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH1653.cs
@@ -29,7 +29,7 @@ namespace FellowOakDicom.Tests.Bugs
             var streamByteDicomFile = DicomFile.Open(ms);
 
             var referencePixelData = streamByteDicomFile.Dataset.GetDicomItem<DicomOtherWord>(DicomTag.PixelData);
-            var pixelData = DicomPixelData.Create(streamByteDicomFile.Dataset);
+            var pixelData = DicomPixelData.CreateFromDataset(streamByteDicomFile.Dataset);
             var numberOfFrames = streamByteDicomFile.Dataset.GetSingleValue<int>(DicomTag.NumberOfFrames);
             var referenceBytes = Enumerable.Range(0, numberOfFrames).Select(x =>
                 {

--- a/Tests/FO-DICOM.Tests/Bugs/GH340.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH340.cs
@@ -20,7 +20,7 @@ namespace FellowOakDicom.Tests.Bugs
             var file = DicomFile.Open(TestData.Resolve("GH340.dcm"));
 
             // Loop over last quarter of pixels; if one is non-zero test passes.
-            var pixelData = PixelDataFactory.Create(DicomPixelData.Create(file.Dataset), 0);
+            var pixelData = PixelDataFactory.Create(DicomPixelData.CreateFromDataset(file.Dataset), 0);
             for (var y = 3 * pixelData.Height / 4; y < pixelData.Height; ++y)
             {
                 for (var x = 0; x < pixelData.Width; ++x)

--- a/Tests/FO-DICOM.Tests/Bugs/GH645.cs
+++ b/Tests/FO-DICOM.Tests/Bugs/GH645.cs
@@ -17,7 +17,7 @@ namespace FellowOakDicom.Tests.Bugs
             var dicomFile = DicomFile.Open(TestData.Resolve("GH645.dcm"));
 
             // Act
-            var pixelData = DicomPixelData.Create(dicomFile.Dataset);
+            var pixelData = DicomPixelData.CreateFromDataset(dicomFile.Dataset);
             var uncompressedFrameSize = pixelData.UncompressedFrameSize;
 
             // Assert

--- a/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetTest.cs
@@ -406,7 +406,7 @@ namespace FellowOakDicom.Tests
             var data = new MemoryByteBuffer(new byte[] { 255 }); //dummy data
 
             ds.AddOrUpdate(DicomTag.BitsAllocated, (ushort)8);
-            var pixelData = DicomPixelData.Create(ds, true);
+            var pixelData = DicomPixelData.CreateNew(ds);
             pixelData.AddFrame(data);
 
             Assert.Equal(DicomTransferSyntax.ExplicitVRLittleEndian, ds.InternalTransferSyntax);
@@ -921,7 +921,7 @@ namespace FellowOakDicom.Tests
             );
             Assert.False(dataset.TryGetSingleValue(DicomTag.SeriesNumber, out int _));
         }
-        
+
         [Fact]
         public void FunctionalGroupValues_ShouldNotCrashWithEmptySharedFunctionalGroupsSequence()
         {
@@ -929,10 +929,10 @@ namespace FellowOakDicom.Tests
             var dataset = new DicomDataset();
             var sequence = new DicomSequence(DicomTag.SharedFunctionalGroupsSequence);
             dataset.Add(sequence);
-            
+
             //Act
             var result = dataset.FunctionalGroupValues(0);
-            
+
             //Assert
             Assert.Empty(result);
         }

--- a/Tests/FO-DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Codec/DicomCodecExtensionsTest.cs
@@ -26,7 +26,7 @@ namespace FellowOakDicom.Tests.Imaging.Codec
             var oldRatios = file.Dataset.GetValues<string>(DicomTag.LossyImageCompressionRatio);
             var ds = file.Clone(DicomTransferSyntax.JPEGProcess1).Dataset;
             var newRatios = ds.GetValues<string>(DicomTag.LossyImageCompressionRatio);
-            Assert.Equal(oldRatios.Length+1, newRatios.Length);
+            Assert.Equal(oldRatios.Length + 1, newRatios.Length);
         }
 
         [FactWithCodec]
@@ -93,7 +93,7 @@ namespace FellowOakDicom.Tests.Imaging.Codec
             var file = DicomFile.Open(TestData.Resolve("" + filename));
 
             // when converting to JpegBaseline the Photometric interpretation has to be updated
-            var newDataset = file.Dataset.Clone(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { ConvertColorspaceToRGB=false, Quality = 90,  SampleFactor = DicomJpegSampleFactor.SF422 });
+            var newDataset = file.Dataset.Clone(DicomTransferSyntax.JPEGProcess2_4, new DicomJpegParams { ConvertColorspaceToRGB = false, Quality = 90, SampleFactor = DicomJpegSampleFactor.SF422 });
             Assert.Equal("YBR_FULL_422", newDataset.GetString(DicomTag.PhotometricInterpretation));
 
             // when converting to other jpeg coded that does not automatically convert to 8bitcolor the Photometric Interpretation has to stay the same.
@@ -119,8 +119,8 @@ namespace FellowOakDicom.Tests.Imaging.Codec
                     var myBitsAllocated = myResFile.Dataset.GetSingleValue<ushort>(DicomTag.BitsAllocated);
                     if (myBitsAllocated == 16)
                     {
-                        byte[] myOriginalBytes = DicomPixelData.Create(myOriginalDicomFile.Dataset).GetFrame(0).Data;
-                        byte[] myResBytes = DicomPixelData.Create(myResFile.Dataset).GetFrame(0).Data;
+                        byte[] myOriginalBytes = DicomPixelData.CreateFromDataset(myOriginalDicomFile.Dataset).GetFrame(0).Data;
+                        byte[] myResBytes = DicomPixelData.CreateFromDataset(myResFile.Dataset).GetFrame(0).Data;
 
                         if (!myOriginalBytes.SequenceEqual(myResBytes))
                         {
@@ -186,12 +186,12 @@ namespace FellowOakDicom.Tests.Imaging.Codec
                 for (var k = 0; k < 100; k++)
                 {
                     var bytes = new byte[i * 2];
-                    for (var j = 0; j < 2*i; j++)
+                    for (var j = 0; j < 2 * i; j++)
                     {
                         bytes[j] = (byte)(r.Next() % 2);
                     }
 
-                    CheckData(i,1, bytes, DicomTransferSyntax.RLELossless);
+                    CheckData(i, 1, bytes, DicomTransferSyntax.RLELossless);
                 }
             }
         }
@@ -216,14 +216,14 @@ namespace FellowOakDicom.Tests.Imaging.Codec
             ds.AddOrUpdate(DicomVR.IS, DicomTag.PixelRepresentation, 1);
             ds.AddOrUpdate(DicomVR.CS, DicomTag.PhotometricInterpretation, "MONOCHROME2");
             ds.AddOrUpdate(DicomVR.IS, DicomTag.SamplesPerPixel, 1);
-            var pixelData = DicomPixelData.Create(ds, true);
+            var pixelData = DicomPixelData.CreateNew(ds);
             pixelData.AddFrame(memoryBB);
 
             var ds2 = ds.Clone(syntax);
             var dsOrig = ds2.Clone(DicomTransferSyntax.ExplicitVRLittleEndian);
 
-            var origPixData = DicomPixelData.Create(ds);
-            var origPixData2 = DicomPixelData.Create(dsOrig);
+            var origPixData = DicomPixelData.CreateFromDataset(ds);
+            var origPixData2 = DicomPixelData.CreateFromDataset(dsOrig);
 
             var byteBuffer = origPixData.GetFrame(0);
             var byteBuffer2 = origPixData2.GetFrame(0);
@@ -241,6 +241,6 @@ namespace FellowOakDicom.Tests.Imaging.Codec
             }
         }
 
-#endregion
+        #endregion
     }
 }

--- a/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/DicomPixelDataTest.cs
@@ -17,7 +17,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ImplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, (ushort)8);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             Assert.Equal("OtherWordPixelData", pixelData.GetType().Name);
         }
@@ -30,7 +30,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, (ushort)32);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             Assert.Equal("OtherWordPixelData", pixelData.GetType().Name);
         }
@@ -44,7 +44,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             Assert.Equal("OtherWordPixelData", pixelData.GetType().Name);
         }
@@ -58,7 +58,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             Assert.Equal("OtherBytePixelData", pixelData.GetType().Name);
         }
@@ -70,7 +70,7 @@ namespace FellowOakDicom.Tests.Imaging
             {
                 { DicomTag.BitsAllocated, (ushort)1 }
             };
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             Assert.Equal("OtherBytePixelData", pixelData.GetType().Name);
 
@@ -87,7 +87,7 @@ namespace FellowOakDicom.Tests.Imaging
             {
                 { DicomTag.BitsAllocated, (ushort)1 }
             };
-            pixelData = DicomPixelData.Create(dataset, true);
+            pixelData = DicomPixelData.CreateNew(dataset);
 
             Assert.Equal("OtherBytePixelData", pixelData.GetType().Name);
 
@@ -110,7 +110,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             var exception = Record.Exception(() => pixelData.BitsStored = bitsStored);
             Assert.Null(exception);
@@ -124,7 +124,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             var exception = Record.Exception(() => pixelData.BitsStored = bitsStored);
             Assert.NotNull(exception);
@@ -137,7 +137,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             var exception = Record.Exception(() => pixelData.HighBit = highBit);
             Assert.Null(exception);
@@ -153,7 +153,7 @@ namespace FellowOakDicom.Tests.Imaging
         {
             var dataset = new DicomDataset(DicomTransferSyntax.ExplicitVRLittleEndian);
             dataset.Add(DicomTag.BitsAllocated, bitsAllocated);
-            var pixelData = DicomPixelData.Create(dataset, true);
+            var pixelData = DicomPixelData.CreateNew(dataset);
 
             var exception = Record.Exception(() => pixelData.HighBit = highBit);
             Assert.NotNull(exception);

--- a/Tests/FO-DICOM.Tests/Imaging/Reconstruction/ImageDataMultiFrameDatasetTests.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Reconstruction/ImageDataMultiFrameDatasetTests.cs
@@ -25,18 +25,18 @@ namespace FellowOakDicom.Tests.Imaging.Reconstruction
             // Assert
             Assert.NotNull(firstFrameImageData);
             Assert.NotNull(secondFrameImageData);
-            
+
             Assert.NotEqual(firstFrameImageData.Geometry.PointBottomLeft, secondFrameImageData.Geometry.PointBottomLeft);
         }
-        
+
         [Fact]
         public async Task ImageData_GivenImageDataConstructedFromMultiFrameFile_WhenPixelDataIsOnlyCreatedOnce_ShouldReadCorrectly()
         {
             var testFile = TestData.Resolve("GH1876.dcm");
             var dicomFile = await DicomFile.OpenAsync(testFile, FileReadOption.ReadAll);
 
-            var pixelData = DicomPixelData.Create(dicomFile.Dataset);
-            
+            var pixelData = DicomPixelData.CreateFromDataset(dicomFile.Dataset);
+
             // Act
             var firstFrameImageData = new ImageData(dicomFile.Dataset, pixelData, 1);
             var secondFrameImageData = new ImageData(dicomFile.Dataset, pixelData, 0);
@@ -44,10 +44,10 @@ namespace FellowOakDicom.Tests.Imaging.Reconstruction
             // Assert
             Assert.NotNull(firstFrameImageData);
             Assert.NotNull(secondFrameImageData);
-            
+
             Assert.NotEqual(firstFrameImageData.Geometry.PointBottomLeft, secondFrameImageData.Geometry.PointBottomLeft);
         }
-        
+
         [Fact]
         public async Task ImageData_GivenCompressedImageDataConstructedFromMultiFrameFile_WhenPixelDataIsOnlyCreatedOnce_ShouldDecompressAndReadCorrectly()
         {
@@ -56,9 +56,9 @@ namespace FellowOakDicom.Tests.Imaging.Reconstruction
 
             var transcoder = new DicomTranscoder(dicomFile.Dataset.InternalTransferSyntax, DicomTransferSyntax.RLELossless);
             var rleDataset = transcoder.Transcode(dicomFile.Dataset);
-            
-            var pixelData = DicomPixelData.Create(rleDataset);
-            
+
+            var pixelData = DicomPixelData.CreateFromDataset(rleDataset);
+
             // Act
             Func<ImageData> act = () => new ImageData(rleDataset, pixelData, 0);
 

--- a/Tests/FO-DICOM.Tests/Imaging/Render/PixelDataTest.cs
+++ b/Tests/FO-DICOM.Tests/Imaging/Render/PixelDataTest.cs
@@ -293,7 +293,7 @@ namespace FellowOakDicom.Tests.Imaging.Render
         {
             return
                 PixelDataFactory.Create(
-                    DicomPixelData.Create(
+                    DicomPixelData.CreateFromDataset(
                         new DicomDataset
                             {
                                 {


### PR DESCRIPTION
Fixes #2117 

the factory method for new pixeldata with encapsulated used to evaluate the bitsstored, but now always creates OB as described in DICOM standard.

The factory method DicomPixelData.Create ans one bool-parameter "createnew", which basically is then only used once in a big if-statement, which devides the body of the Create-method into two separate parts. So this method is now separated into two methods DicomPixelData.CreateNew and DicomPixelData.CreateFromDataset

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

