### PR TITLE
Remove IEquatable<DicomDataset> from DicomDataset

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@
 - breaking change: types `Geometry3D`, `Point3D`, etc are replaced by generic `Geometry<T>`, `Point3<T>`etc.
 - new encapsulated pixeldata is now always stored correctly as OB (#2117)
 - breaking change: DicomPixelData.Create(dataset, bool) is split up to DicomPixelData.CreateNew(dataset) and DicomPixelData.CreateFromDataset(dataset)
+- remove IEquatable<DicomDataset> from DicomDataset, because this prevents the overloaded Equals methods from being invoked (#2119)
 
 ### 5.2.6 (2026-03-30)
 - Fix FrameGeometry initialization to handle empty position and orientation arrays (#2067)

--- a/FO-DICOM.Core/DicomDataset.cs
+++ b/FO-DICOM.Core/DicomDataset.cs
@@ -17,7 +17,7 @@ namespace FellowOakDicom
     /// <summary>
     /// A collection of <see cref="DicomItem">DICOM items</see>.
     /// </summary>
-    public partial class DicomDataset : IEnumerable<DicomItem>, IEquatable<DicomDataset>
+    public partial class DicomDataset : IEnumerable<DicomItem>
     {
         #region Static Properties
 
@@ -1633,19 +1633,15 @@ namespace FellowOakDicom
 
         public override bool Equals(object obj)
         {
-            if (Object.ReferenceEquals(obj, null)) return false;
+            if (obj is null) return false;
             if (Object.ReferenceEquals(this, obj)) return true;
             if (GetType() != obj.GetType()) return false;
             return Equals(obj as DicomDataset);
         }
 
-        public bool Equals(DicomDataset other)
-        {
-            return
-                CompareInstancesByContent
+        private bool Equals(DicomDataset other) => CompareInstancesByContent
                 ? DicomDatasetComparer.DefaultInstance.Equals(this, other)
                 : ReferenceEquals(this, other);
-        }
 
         public static bool operator ==(DicomDataset a, DicomDataset b)
         {

--- a/Tests/FO-DICOM.Tests/DicomDatasetComparisonTest.cs
+++ b/Tests/FO-DICOM.Tests/DicomDatasetComparisonTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2012-2026 fo-dicom contributors.
 // Licensed under the Microsoft Public License (MS-PL).
 
+using FellowOakDicom.StructuredReport;
 using Xunit;
 
 namespace FellowOakDicom.Tests
@@ -122,5 +123,27 @@ namespace FellowOakDicom.Tests
 
             Assert.False(dataset1 != dataset2);
         }
+
+
+        [Fact]
+        public void DicomCodeItem_EqualityDependsOnStaticType()
+        {
+            var a = new DicomCodeItem("113820", "DCM", "Meaning A");
+            var b = new DicomCodeItem("113820", "DCM", "Meaning B");
+
+            // various ways to compare the two items
+            bool asDataset = ((DicomDataset)a).Equals((DicomDataset)b);
+            bool asObject = a.Equals((object)b);
+            bool asConcrete = a.Equals(b);
+            bool viaOperator = a == b;
+
+            // All four should be equal.
+            Assert.True(asDataset);
+            Assert.True(asObject);
+            Assert.True(asConcrete);
+            Assert.True(viaOperator);
+        }
+
+
     }
 }


### PR DESCRIPTION
Fixes #2119 

the interface IEquatable<DicomDataset> makes the compiler to invoke the method `Equals(DicomDataset other)` whenever this class or any inherited is compared. The Equals(DicomDataset) always does a deep comparison of every item.

DicomCodeItem inherits from DicomDataset, because it has be be able to be added into a DicomSequence. DicomCodeItem has a overloaded Equals method, but because of the more dominant interface this overloaded Equals method is not invoked.

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- remove IEquatable<DicomDataset> from DicomDataset
