### PR TITLE
Release resource and semaphore if creating a SCP failes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@
 - new encapsulated pixeldata is now always stored correctly as OB (#2117)
 - breaking change: DicomPixelData.Create(dataset, bool) is split up to DicomPixelData.CreateNew(dataset) and DicomPixelData.CreateFromDataset(dataset)
 - remove IEquatable<DicomDataset> from DicomDataset, because this prevents the overloaded Equals methods from being invoked (#2119)
+- Release resource and semaphore if creating a SCP failes (#2116)
 
 ### 5.2.6 (2026-03-30)
 - Fix FrameGeometry initialization to handle empty position and orientation arrays (#2067)

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -302,10 +302,12 @@ namespace FellowOakDicom.Network
                         // Process incoming TcpClient in a background task to not block the main listener
                         _ = Task.Run(() =>
                         {
+                            INetworkStream networkStream = null;
+                            RunningDicomService runningService = null;
                             try
                             {
                                 // let the INetworkStream dispose the TcpClient
-                                var networkStream = _networkManager.CreateNetworkStream(tcpClient, _tlsAcceptor, ownsTcpClient: true);
+                                networkStream = _networkManager.CreateNetworkStream(tcpClient, _tlsAcceptor, ownsTcpClient: true);
 
                                 var scp = CreateScp(networkStream);
                                 scp.RunsAsServer = true;
@@ -316,7 +318,7 @@ namespace FellowOakDicom.Network
 
                                 var serviceTask = scp.RunAsync();
                                 int numberOfServices;
-                                var runningService = new RunningDicomService(scp, serviceTask);
+                                runningService = new RunningDicomService(scp, serviceTask);
                                 lock (_services)
                                 {
                                     _services.Add(runningService);
@@ -342,6 +344,8 @@ namespace FellowOakDicom.Network
                             {
                                 Logger.LogError(e, "An exception occurred while accepting an incoming client connection");
                                 tcpClient.Close();
+                                networkStream?.Dispose();
+                                RemoveCompletedService(runningService);
                             }
                         }, _cancellationToken);
                     }
@@ -372,9 +376,12 @@ namespace FellowOakDicom.Network
             {
                 _maxClientsSemaphore?.Release(1);
             }
-            lock (_services)
+            if (runningService != null)
             {
-                _services.Remove(runningService);
+                lock (_services)
+                {
+                    _services.Remove(runningService);
+                }
             }
         }
 

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -811,9 +811,9 @@ namespace FellowOakDicom.Tests.Network
             AppDomain.CurrentDomain.UnhandledException += (sender, args) => unhandledExceptionObject = args.ExceptionObject;
             TaskScheduler.UnobservedTaskException += (sender, args) => unhandledExceptionObject = args.Exception;
 
-            await Task.Factory.StartNew(() => {
+            await Task.Factory.StartNew(async () => {
                 var server = DicomServerFactory.Create<DicomCEchoProvider>(0);
-                Thread.Sleep(500);
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
                 server.Stop();
             });
 

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -759,27 +759,67 @@ namespace FellowOakDicom.Tests.Network
             Assert.Equal(100, uniqueDisposedServices.Count);
         }
 
-        private void TestFoDicomUnhandledException(int port)
+        [Fact]
+        public async Task FailingDicomServiceShouldReleaseSemaphore()
         {
-            var server = DicomServerFactory.Create<DicomCEchoProvider>(port);
-            Thread.Sleep(500);
-            server.Stop();
+            IDicomClient client;
+
+            const int maxClients = 2;
+            using var server = DicomServerFactory.Create<ThrowingDicomService>(0, configure: o => o.MaxClientsAllowed = maxClients);
+            await AsyncTestHelper.WaitForServerListeningAsync(server);
+
+            // call 2 echos - both of them will cause the dicomservice constructor to fail
+            for (int i = 1; i <= maxClients; i++)
+            {
+                client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "SCU", "ANY-SCP");
+                client.ClientOptions.AssociationRequestTimeoutInMs = 5_000;
+                client.ClientOptions.MaximumNumberOfRequestsPerAssociation = 1;
+                await client.AddRequestAsync(new DicomCEchoRequest());
+                try
+                {
+                    using var ctsreq = new CancellationTokenSource(TimeSpan.FromMilliseconds(6_000));
+                    await client.SendAsync(ctsreq.Token);
+                }
+                catch (Exception) { /* ignore */ }
+                await Task.Delay(100);
+            }
+
+            // now after the two failed echos, there should still be some echos possible without timeout
+            Exception ex = null;
+            client = DicomClientFactory.Create("127.0.0.1", server.Port, false, "SCU", "ANY-SCP");
+            client.ClientOptions.AssociationRequestTimeoutInMs = 5_000;
+            client.ClientOptions.MaximumNumberOfRequestsPerAssociation = 1;
+            await client.AddRequestAsync(new DicomCEchoRequest());
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(6_000));
+            try
+            {
+                await client.SendAsync(cts.Token);
+            }
+            catch (Exception e) { ex = e; }
+
+            Assert.Null(ex);
+            Assert.False(cts.Token.IsCancellationRequested);
         }
+
 
         [Fact(Skip = "This test is flaky because it crashes whenever a parallel test happens to have an unobserved exception")]
         public async Task StopServerWithoutException()
         {
-            object ue = null;
-            AppDomain.CurrentDomain.UnhandledException += (sender, args) => ue = args.ExceptionObject;
-            TaskScheduler.UnobservedTaskException += (sender, args) => ue = args.Exception;
+            object unhandledExceptionObject = null;
+            AppDomain.CurrentDomain.UnhandledException += (sender, args) => unhandledExceptionObject = args.ExceptionObject;
+            TaskScheduler.UnobservedTaskException += (sender, args) => unhandledExceptionObject = args.Exception;
 
-            await Task.Factory.StartNew(() => TestFoDicomUnhandledException(0));
+            await Task.Factory.StartNew(() => {
+                var server = DicomServerFactory.Create<DicomCEchoProvider>(0);
+                Thread.Sleep(500);
+                server.Stop();
+            });
 
             await Task.Delay(2000);
             GC.Collect();
             GC.WaitForPendingFinalizers();
 
-            Assert.Null(ue);
+            Assert.Null(unhandledExceptionObject);
         }
 
         #endregion
@@ -872,6 +912,29 @@ namespace FellowOakDicom.Tests.Network
             }
         }
 
+
+        /// <summary>
+        /// A DicomService subclass whose constructor always throws, simulating a DI
+        /// resolution failure or any other constructor error.
+        /// </summary>
+        public class ThrowingDicomService : DicomService, IDicomServiceProvider, IDicomCEchoProvider
+        {
+            public ThrowingDicomService(
+                INetworkStream stream,
+                Encoding fallbackEncoding,
+                ILogger logger,
+                DicomServiceDependencies dependencies)
+                : base(stream, fallbackEncoding, logger, dependencies)
+            {
+                throw new InvalidOperationException("Simulated constructor failure in ThrowingDicomService");
+            }
+
+            public Task OnReceiveAssociationRequestAsync(DicomAssociation association) => throw new NotImplementedException();
+            public Task OnReceiveAssociationReleaseRequestAsync() => throw new NotImplementedException();
+            public void OnReceiveAbort(DicomAbortSource source, DicomAbortReason reason) { }
+            public void OnConnectionClosed(Exception exception) { }
+            public Task<DicomCEchoResponse> OnCEchoRequestAsync(DicomCEchoRequest request) => throw new NotImplementedException();
+        }
 
         #endregion
     }

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -797,7 +797,9 @@ namespace FellowOakDicom.Tests.Network
             }
             catch (Exception e) { ex = e; }
 
-            Assert.Null(ex);
+            // there has to be an exception, because the DicomServer threw an exception in constructor of SCP
+            Assert.NotNull(ex);
+            // but the client should not have run into a timeout, which would indicate that the server's semaphore was not released after the exception in the DicomService constructor
             Assert.False(cts.Token.IsCancellationRequested);
         }
 


### PR DESCRIPTION
Fixes #2116 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [ ] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- variables are defined outside the try-block, so they can be disposed in catch-block
- the catch-block also releases a maxclientsemaphore
