### PR TITLE
DicomCodeItem handles CodeValue, LongCodeValue and UrnCodeValue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@
 - breaking change: DicomPixelData.Create(dataset, bool) is split up to DicomPixelData.CreateNew(dataset) and DicomPixelData.CreateFromDataset(dataset)
 - remove IEquatable<DicomDataset> from DicomDataset, because this prevents the overloaded Equals methods from being invoked (#2119)
 - Release resource and semaphore if creating a SCP failes (#2116)
+- DicomCodeValue now also handles LongCodeValue and UrnCodeValue correctly (#2125)
 
 ### 5.2.6 (2026-03-30)
 - Fix FrameGeometry initialization to handle empty position and orientation arrays (#2067)

--- a/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
@@ -34,8 +34,26 @@ namespace FellowOakDicom.StructuredReport
             }
         }
 
-        public string Value => GetValueOrDefault(DicomTag.CodeValue, 0, string.Empty);
-
+        public string Value
+        {
+            get
+            {
+                if (TryGetValue<string>(DicomTag.CodeValue, 0, out var codeValue))
+                {
+                    return codeValue;
+                }
+                if (TryGetValue<string>(DicomTag.LongCodeValue, 0, out var longCodeValue))
+                {
+                    return longCodeValue;
+                }
+                if (TryGetValue<string>(DicomTag.URNCodeValue, 0, out var urnCodeValue))
+                {
+                    return urnCodeValue;
+                }
+                return string.Empty;
+            }
+        }
+            
         public string Scheme => GetValueOrDefault(DicomTag.CodingSchemeDesignator, 0, string.Empty);
 
         public string Meaning => GetValueOrDefault(DicomTag.CodeMeaning, 0, string.Empty);

--- a/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
@@ -41,8 +41,8 @@ namespace FellowOakDicom.StructuredReport
             }
             else
             {
-            Add(DicomTag.CodeValue, value);
-            Add(DicomTag.CodingSchemeDesignator, scheme);
+                Add(DicomTag.CodeValue, value);
+                Add(DicomTag.CodingSchemeDesignator, scheme);
             }
 
             Add(DicomTag.CodeMeaning, meaning);
@@ -51,6 +51,14 @@ namespace FellowOakDicom.StructuredReport
                 Add(DicomTag.CodingSchemeVersion, version);
             }
         }
+
+        public static DicomCodeItem FromUrn(string urn, string meaning)
+            => new DicomCodeItem(new DicomDataset
+            {
+                {DicomTag.URNCodeValue, urn },
+                {DicomTag.CodeMeaning, meaning }
+            });
+
 
         public string Value
         {

--- a/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
+++ b/FO-DICOM.Core/StructuredReport/DicomCodeItem.cs
@@ -25,8 +25,26 @@ namespace FellowOakDicom.StructuredReport
 
         public DicomCodeItem(string value, string scheme, string meaning, string version = null)
         {
+            value ??= string.Empty; // avoid null value
+            if (value.StartsWith("http", StringComparison.InvariantCultureIgnoreCase) || value.StartsWith("urn:", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Add(DicomTag.URNCodeValue, value);
+                if (!string.IsNullOrEmpty(scheme))
+                {
+                    Add(DicomTag.CodingSchemeDesignator, scheme);
+                }
+            }
+            else if (value.Length > 16)
+            {
+                Add(DicomTag.LongCodeValue, value);
+                Add(DicomTag.CodingSchemeDesignator, scheme);
+            }
+            else
+            {
             Add(DicomTag.CodeValue, value);
             Add(DicomTag.CodingSchemeDesignator, scheme);
+            }
+
             Add(DicomTag.CodeMeaning, meaning);
             if (version != null)
             {

--- a/Tests/FO-DICOM.Tests/StructuredReport/DicomCodeItemTest.cs
+++ b/Tests/FO-DICOM.Tests/StructuredReport/DicomCodeItemTest.cs
@@ -16,7 +16,7 @@ namespace FellowOakDicom.Tests.StructuredReport
             var a = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
             var b = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
 
-            Assert.True(a.Equals((object)b));
+            Assert.True(a.Equals(b));
             Assert.Equal(a.GetHashCode(), b.GetHashCode());
         }
 
@@ -26,7 +26,7 @@ namespace FellowOakDicom.Tests.StructuredReport
             var a = new DicomCodeItem("113820", "DCM", "Original meaning");
             var b = new DicomCodeItem("113820", "DCM", "Reworded meaning");
 
-            Assert.True(a.Equals((object)b));
+            Assert.True(a.Equals(b));
             Assert.Equal(a.GetHashCode(), b.GetHashCode());
         }
 
@@ -36,7 +36,7 @@ namespace FellowOakDicom.Tests.StructuredReport
             var a = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
             var b = new DicomCodeItem("113820", "DCM", "CT Acquisition Type", "20240101");
 
-            Assert.False(a.Equals((object)b));
+            Assert.False(a.Equals(b));
             Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
         }
 
@@ -46,8 +46,84 @@ namespace FellowOakDicom.Tests.StructuredReport
             var a = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
             var b = new DicomCodeItem("113821", "DCM", "CT Acquisition Type");
 
-            Assert.False(a.Equals((object)b));
+            Assert.False(a.Equals(b));
             Assert.NotEqual(a.GetHashCode(), b.GetHashCode());
         }
+
+        [Fact]
+        public void DicomCodeItem_ParseShortCodeValue()
+        {
+            var ds = new DicomDataset
+            {
+                {DicomTag.CodeValue, "113820" },
+                {DicomTag.CodingSchemeDesignator, "DCM" },
+                {DicomTag.CodeMeaning, "CT Acquisition Type" }
+            };
+            var codeItem = new DicomCodeItem(ds);
+
+            Assert.Equal("113820", codeItem.Value);
+        }
+
+        [Fact]
+        public void DicomCodeItem_WriteShortCodeValue()
+        {
+            var codeItem = new DicomCodeItem("113820", "DCM", "CT Acquisition Type");
+
+            Assert.True(codeItem.Contains(DicomTag.CodeValue));
+            Assert.False(codeItem.Contains(DicomTag.LongCodeValue));
+            Assert.False(codeItem.Contains(DicomTag.URNCodeValue));
+            Assert.Equal("113820", codeItem.GetString(DicomTag.CodeValue));
+        }
+
+        [Fact]
+        public void DicomCodeItem_ParseLongCodeValue()
+        {
+            var ds = new DicomDataset
+            {
+                {DicomTag.LongCodeValue, "113820113820113820" },
+                {DicomTag.CodingSchemeDesignator, "DCM" },
+                {DicomTag.CodeMeaning, "CT Acquisition Type" }
+            };
+            var codeItem = new DicomCodeItem(ds);
+
+            Assert.Equal("113820113820113820", codeItem.Value);
+        }
+
+        [Fact]
+        public void DicomCodeItem_WriteLongCodeValue()
+        {
+            var codeItem = new DicomCodeItem("113820113820113820", "DCM", "CT Acquisition Type");
+
+            Assert.False(codeItem.Contains(DicomTag.CodeValue));
+            Assert.True(codeItem.Contains(DicomTag.LongCodeValue));
+            Assert.False(codeItem.Contains(DicomTag.URNCodeValue));
+            Assert.Equal("113820113820113820", codeItem.GetString(DicomTag.LongCodeValue));
+        }
+
+        [Fact]
+        public void DicomCodeItem_ParseURNCodeValue()
+        {
+            var ds = new DicomDataset
+            {
+                {DicomTag.URNCodeValue, "urn:lex:us:federal:codified.regulation:2013-04-25;45CFR164" },
+                {DicomTag.CodingSchemeDesignator, "DCM" },
+                {DicomTag.CodeMeaning, "HIPAA Privacy Rule" }
+            };
+            var codeItem = new DicomCodeItem(ds);
+
+            Assert.Equal("urn:lex:us:federal:codified.regulation:2013-04-25;45CFR164", codeItem.Value);
+        }
+
+        [Fact]
+        public void DicomCodeItem_WriteURNCodeValue()
+        {
+            var codeItem = new DicomCodeItem("urn:lex:us:federal:codified.regulation:2013-04-25;45CFR164", "DCM", "HIPAA Privacy Rule");
+
+            Assert.False(codeItem.Contains(DicomTag.CodeValue));
+            Assert.False(codeItem.Contains(DicomTag.LongCodeValue));
+            Assert.True(codeItem.Contains(DicomTag.URNCodeValue));
+            Assert.Equal("urn:lex:us:federal:codified.regulation:2013-04-25;45CFR164", codeItem.GetString(DicomTag.URNCodeValue));
+        }
+
     }
 }

--- a/Tests/FO-DICOM.Tests/StructuredReport/DicomCodeItemTest.cs
+++ b/Tests/FO-DICOM.Tests/StructuredReport/DicomCodeItemTest.cs
@@ -80,24 +80,24 @@ namespace FellowOakDicom.Tests.StructuredReport
         {
             var ds = new DicomDataset
             {
-                {DicomTag.LongCodeValue, "113820113820113820" },
-                {DicomTag.CodingSchemeDesignator, "DCM" },
-                {DicomTag.CodeMeaning, "CT Acquisition Type" }
+                {DicomTag.LongCodeValue, "621566751000087104" },
+                {DicomTag.CodingSchemeDesignator, "SCT" },
+                {DicomTag.CodeMeaning, "Invasive diagnostic procedure" }
             };
             var codeItem = new DicomCodeItem(ds);
 
-            Assert.Equal("113820113820113820", codeItem.Value);
+            Assert.Equal("621566751000087104", codeItem.Value);
         }
 
         [Fact]
         public void DicomCodeItem_WriteLongCodeValue()
         {
-            var codeItem = new DicomCodeItem("113820113820113820", "DCM", "CT Acquisition Type");
+            var codeItem = new DicomCodeItem("621566751000087104", "SCT", "Invasive diagnostic procedure");
 
             Assert.False(codeItem.Contains(DicomTag.CodeValue));
             Assert.True(codeItem.Contains(DicomTag.LongCodeValue));
             Assert.False(codeItem.Contains(DicomTag.URNCodeValue));
-            Assert.Equal("113820113820113820", codeItem.GetString(DicomTag.LongCodeValue));
+            Assert.Equal("621566751000087104", codeItem.GetString(DicomTag.LongCodeValue));
         }
 
         [Fact]
@@ -124,6 +124,18 @@ namespace FellowOakDicom.Tests.StructuredReport
             Assert.True(codeItem.Contains(DicomTag.URNCodeValue));
             Assert.Equal("urn:lex:us:federal:codified.regulation:2013-04-25;45CFR164", codeItem.GetString(DicomTag.URNCodeValue));
         }
+
+        [Fact]
+        public void DicomCodeItem_WriteURNCodeValueFromFactoryMethod()
+        {
+            var codeItem = DicomCodeItem.FromUrn("urn:lex:us:federal:codified.regulation:2013-04-25;45CFR164", "HIPAA Privacy Rule");
+
+            Assert.False(codeItem.Contains(DicomTag.CodeValue));
+            Assert.False(codeItem.Contains(DicomTag.LongCodeValue));
+            Assert.True(codeItem.Contains(DicomTag.URNCodeValue));
+            Assert.Equal("urn:lex:us:federal:codified.regulation:2013-04-25;45CFR164", codeItem.GetString(DicomTag.URNCodeValue));
+        }
+
 
     }
 }


### PR DESCRIPTION
Fixes #2125 

#### Checklist
- [x] The pull request branch is in sync with latest commit on the *fo-dicom/development* branch
- [x] I have updated API documentation
- [x] I have included unit tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file

#### Changes proposed in this pull request:
- the value property returns the value from codevalue, longcodevalue or urncodevalue
- depending on the content of value the constructor now stores the value in the correct dicomitem
