### PR TITLE
Observe per-connection service task exception in DicomServer

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 ### 6.0.0-alpha1 (TBD)
 - breaking change: remove obsolete classes and methods (#2124)
-- Observe per-connection RunningDicomService task exception in DicomServer to prevent UnobservedTaskException leaks on malformed PDUs
+- Observe per-connection RunningDicomService task exception in DicomServer to prevent UnobservedTaskException leaks on malformed PDUs (#2149)
 - Add depth guard to DicomReader to prevent unbounded SQ recursion (#2114)
 - breaking change: update targetframeworks to net8, net9 and net10, netstandard2.0 is dropped
 - make fo-dicom.core AOT compilant (#2005)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 ### 6.0.0-alpha1 (TBD)
 - breaking change: remove obsolete classes and methods (#2124)
+- Observe per-connection RunningDicomService task exception in DicomServer to prevent UnobservedTaskException leaks on malformed PDUs
 - Add depth guard to DicomReader to prevent unbounded SQ recursion (#2114)
 - breaking change: update targetframeworks to net8, net9 and net10, netstandard2.0 is dropped
 - make fo-dicom.core AOT compilant (#2005)

--- a/FO-DICOM.Core/Network/DicomServer.cs
+++ b/FO-DICOM.Core/Network/DicomServer.cs
@@ -324,7 +324,22 @@ namespace FellowOakDicom.Network
                                     _services.Add(runningService);
                                     numberOfServices = _services.Count;
                                 }
-                                runningService.Task.ContinueWith((t) => RemoveCompletedService(runningService), TaskContinuationOptions.PreferFairness | TaskContinuationOptions.RunContinuationsAsynchronously);
+                                runningService.Task.ContinueWith(
+                                    (t) =>
+                                    {
+                                        // Observe and log any faulted Task. ListenAndProcessPDUAsync re-throws the
+                                        // original cause via ExceptionDispatchInfo at the end of TryCloseConnectionAsync,
+                                        // so without observing it here every malformed-PDU disconnect would leak an
+                                        // UnobservedTaskException once the Task is garbage-collected.
+                                        if (t.IsFaulted && t.Exception != null)
+                                        {
+                                            Logger.LogInformation(
+                                                t.Exception.GetBaseException(),
+                                                "DICOM service task completed with exception (peer disconnected with error)");
+                                        }
+                                        RemoveCompletedService(runningService);
+                                    },
+                                    TaskContinuationOptions.PreferFairness | TaskContinuationOptions.RunContinuationsAsynchronously);
 
                                 Logger.LogDebug(
                                     "Accepted an incoming client connection, there are now {NumberOfServices} connected clients",

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -822,6 +823,69 @@ namespace FellowOakDicom.Tests.Network
             GC.WaitForPendingFinalizers();
 
             Assert.Null(unhandledExceptionObject);
+        }
+
+        [Fact]
+        public async Task MalformedPdu_ListenAndProcessPDUAsyncException_IsObservedByContinuation()
+        {
+            // Regression for the unobserved-task leak: when ListenAndProcessPDUAsync
+            // throws (e.g. on an unknown PDU type), TryCloseConnectionAsync re-throws
+            // the original cause via ExceptionDispatchInfo. Without observing
+            // RunningDicomService.Task.Exception in the ContinueWith continuation,
+            // every faulted connection task leaks an UnobservedTaskException when
+            // the Task is finalized.
+            var capturedDicomExceptions = new ConcurrentBag<Exception>();
+            void Handler(object sender, UnobservedTaskExceptionEventArgs args)
+            {
+                foreach (var inner in args.Exception.InnerExceptions)
+                {
+                    if (inner is DicomNetworkException)
+                    {
+                        capturedDicomExceptions.Add(inner);
+                    }
+                }
+                // Always mark observed so we do not crash other parallel tests
+                // that may be in the middle of their own UnobservedTaskException
+                // race.
+                args.SetObserved();
+            }
+
+            TaskScheduler.UnobservedTaskException += Handler;
+            try
+            {
+                using (var server = DicomServerFactory.Create<DicomCEchoProvider>(0, logger: _logger.IncludePrefix("DicomServer")))
+                {
+                    await AsyncTestHelper.WaitForServerListeningAsync(server, 30);
+
+                    // Each connection sends a 6-byte PDU header with an invalid
+                    // type byte (anything outside 0x01..0x07). ListenAndProcessPDUAsync
+                    // throws DicomNetworkException("Unknown PDU type: ..."), which
+                    // would previously leak as an unobserved Task exception.
+                    for (var i = 0; i < 8; i++)
+                    {
+                        using var client = new TcpClient();
+                        await client.ConnectAsync("127.0.0.1", server.Port);
+                        await client.GetStream().WriteAsync(new byte[] { 0x9A, 0, 0, 0, 0, 0 }, 0, 6);
+                        // Read a few bytes / let the server close before disposing.
+                        try { await client.GetStream().ReadAsync(new byte[8], 0, 8); } catch { /* expected */ }
+                    }
+                }
+
+                // Force GC + finalizer drain so any leaked unobserved Task surfaces
+                // now rather than at some later point.
+                for (var i = 0; i < 4; i++)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    await Task.Delay(50);
+                }
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= Handler;
+            }
+
+            Assert.Empty(capturedDicomExceptions);
         }
 
         #endregion

--- a/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
+++ b/Tests/FO-DICOM.Tests/Network/DicomServerTest.cs
@@ -805,7 +805,7 @@ namespace FellowOakDicom.Tests.Network
         }
 
 
-        [Fact(Skip = "This test is flaky because it crashes whenever a parallel test happens to have an unobserved exception")]
+        [Fact]
         public async Task StopServerWithoutException()
         {
             object unhandledExceptionObject = null;


### PR DESCRIPTION
Fixes #2148.

## Summary

`DicomServer.ListenForConnectionsAsync` spawns a `ListenAndProcessPDUAsync` Task per connection (`DicomServer.cs:319`), wraps it in a `RunningDicomService`, and attaches a `ContinueWith` that removes the service from `_services` (`DicomServer.cs:327`). The continuation previously did not read `t.Exception`, so any faulted per-connection Task was eventually GC'd unobserved and triggered `TaskScheduler.UnobservedTaskException`.

`DicomService.TryCloseConnectionAsync` deliberately re-throws the original cause via `ExceptionDispatchInfo.Capture(exception).Throw();` (`DicomService.cs:1635`), so any exception thrown from inside `ListenAndProcessPDUAsync` -- including the `DicomNetworkException("Unknown PDU type: ...")` thrown for malformed PDUs -- escapes the Task without being awaited.

The fix logs the faulted exception at Information level (peer protocol errors are routine and shouldn't be surfaced louder) and lets `RemoveCompletedService` continue as before. Reading `t.Exception` is enough to mark the Task observed; logging makes the error class diagnosable.

## Files changed

- `FO-DICOM.Core/Network/DicomServer.cs` -- expand the `ContinueWith` from a one-liner to observe and log on `IsFaulted`.
- `Tests/FO-DICOM.Tests/Network/DicomServerTest.cs` -- 1 new test `MalformedPdu_ListenAndProcessPDUAsyncException_IsObservedByContinuation`. Subscribes to `TaskScheduler.UnobservedTaskException`, drives 8 `TcpClient` connections that send invalid PDU type bytes, forces GC + finalizer drain, and asserts no `DicomNetworkException` leaked unobserved. Uses `SetObserved()` so the test never breaks neighbouring tests that may be in their own race window.
- `ChangeLog.md` -- entry under 6.0.0-alpha1.

## Test plan

- [x] `dotnet build Tests/FO-DICOM.Tests/FO-DICOM.Tests.csproj -c Release` -- 0 errors.
- [x] New test passes on net8.0, net9.0, net10.0.
- [x] Full `DicomServerTest` suite -- 28 passed, 2 pre-existing skips (`Stop_IsListening_TrueUntilStopRequested` and `StopServerWithoutException`), 0 failures.
- [x] Branch is up to date with `upstream/development` (`291748ec`).

## Related test signal

`DicomServerTest.StopServerWithoutException` (line 807 on `development`) already attempts to assert that no `TaskScheduler.UnobservedTaskException` fires during a clean server lifecycle. It is annotated:

```csharp
[Fact(Skip = "This test is flaky because it crashes whenever a parallel test happens to have an unobserved exception")]
```

The "parallel test happens to have an unobserved exception" race is exactly this bug class. With this PR, that source of flakiness is removed -- the maintainer can decide in a follow-up whether to un-skip that test or leave it as-is.

## Discovery

Surfaced during the same black-box network fuzzing campaign against an SCP built on `DicomServer<TServiceProvider>` on fo-dicom 5.2.6 that produced #2114 and #2146 / #2147.