### PR TITLE
Bound the inflated size of a deflated dataset in DicomReader

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
-### 6.0.0-alpha1 (TBD)
+﻿### 6.0.0-alpha1 (TBD)
+- Bound the inflated size of a deflated dataset in DicomReader to prevent memory exhaustion from a crafted Deflated Explicit VR Little Endian file (#2166)
 - breaking change: remove obsolete classes and methods (#2124)
 - Observe per-connection RunningDicomService task exception in DicomServer to prevent UnobservedTaskException leaks on malformed PDUs (#2149)
 - Fix RawPDU.ToString throwing FormatException on .NET 8+ (Enum.TryFormat now rejects multi-character format specs like `X2`) by casting the enum to its underlying byte (#2147)

--- a/FO-DICOM.Core/IO/Reader/DicomReader.cs
+++ b/FO-DICOM.Core/IO/Reader/DicomReader.cs
@@ -52,6 +52,21 @@ namespace FellowOakDicom.IO.Reader
         public bool IsDeflated { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of bytes a deflated dataset may inflate to,
+        /// 512 MiB by default.
+        /// </summary>
+        /// <remarks>
+        /// A deflated stream is inflated in full before the first element is parsed, so no
+        /// other validation is reachable in time to reject an oversized one, and DEFLATE
+        /// reaches about 1029:1 on repetitive input. Without a bound the effective ceiling
+        /// is <see cref="MemoryStream"/>'s, just under 2 GiB, which a crafted file of a
+        /// couple of megabytes reaches. Peak memory while inflating is a multiple of this
+        /// value - measured at 2.4x for the default - because the buffer grows by doubling
+        /// and copying and the superseded buffers are not collected immediately.
+        /// </remarks>
+        internal long MaxInflatedDatasetLength { get; set; } = 512L * 1024 * 1024;
+
+        /// <summary>
         /// Gets or sets the DICOM dictionary to be used by the reader.
         /// </summary>
         public DicomDictionary Dictionary { get; set; }
@@ -69,7 +84,7 @@ namespace FellowOakDicom.IO.Reader
         /// <returns>Reader resulting status.</returns>
         public DicomReaderResult Read(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null)
         {
-            var worker = new DicomReaderWorker(observer, stop, Dictionary, IsExplicitVR, IsDeflated, _private, _memoryProvider);
+            var worker = new DicomReaderWorker(observer, stop, Dictionary, IsExplicitVR, IsDeflated, _private, _memoryProvider, MaxInflatedDatasetLength);
             return worker.DoWork(source);
         }
 
@@ -82,7 +97,7 @@ namespace FellowOakDicom.IO.Reader
         /// <returns>Awaitable reader resulting status.</returns>
         public Task<DicomReaderResult> ReadAsync(IByteSource source, IDicomReaderObserver observer, Func<ParseState, bool> stop = null)
         {
-            var worker = new DicomReaderWorker(observer, stop, Dictionary, IsExplicitVR, IsDeflated, _private, _memoryProvider);
+            var worker = new DicomReaderWorker(observer, stop, Dictionary, IsExplicitVR, IsDeflated, _private, _memoryProvider, MaxInflatedDatasetLength);
             return worker.DoWorkAsync(source);
         }
 
@@ -113,6 +128,12 @@ namespace FellowOakDicom.IO.Reader
             /// </summary>
             private const int _maxSequenceDepth = 256;
 
+            /// <summary>
+            /// Buffer size used when inflating a deflated dataset. Same value as the
+            /// default of <see cref="Stream.CopyTo(Stream)"/>, which this replaces.
+            /// </summary>
+            private const int _inflateBufferSize = 81920;
+
             private readonly IDicomReaderObserver _observer;
 
             private readonly Func<ParseState, bool> _stop;
@@ -125,6 +146,8 @@ namespace FellowOakDicom.IO.Reader
             private readonly bool _isExplicitVR;
 
             private readonly bool _isDeflated;
+
+            private readonly long _maxInflatedDatasetLength;
 
             private DicomReaderResult _result;
 
@@ -144,7 +167,8 @@ namespace FellowOakDicom.IO.Reader
                 bool isExplicitVR,
                 bool isDeflated,
                 Dictionary<uint, string> @private,
-                IMemoryProvider memoryProvider)
+                IMemoryProvider memoryProvider,
+                long maxInflatedDatasetLength)
             {
                 _observer = observer;
                 _stop = stop;
@@ -153,6 +177,7 @@ namespace FellowOakDicom.IO.Reader
                 _isDeflated = isDeflated;
                 _private = @private;
                 _memoryProvider = memoryProvider ?? throw new ArgumentNullException(nameof(memoryProvider));
+                _maxInflatedDatasetLength = maxInflatedDatasetLength;
             }
 
             #endregion
@@ -292,7 +317,22 @@ namespace FellowOakDicom.IO.Reader
                 var decompressed = new MemoryStream();
                 using (var decompressor = new DeflateStream(compressed, CompressionMode.Decompress, true))
                 {
-                    decompressor.CopyTo(decompressed);
+                    // Inflate in chunks rather than with Stream.CopyTo so that the length can
+                    // be checked as it grows: CopyTo inflates to completion before anything
+                    // can inspect the result, which is the allocation this bound exists to
+                    // prevent. The cost is DeflateStream's CopyTo override, which inflates
+                    // straight into the destination and is given up here.
+                    using var buffer = _memoryProvider.Provide(_inflateBufferSize);
+                    int read;
+                    while ((read = decompressor.Read(buffer.Bytes, 0, buffer.Length)) > 0)
+                    {
+                        if (decompressed.Length + read > _maxInflatedDatasetLength)
+                        {
+                            throw new DicomReaderException($"Deflated dataset exceeded maximum inflated length of {_maxInflatedDatasetLength} bytes.");
+                        }
+
+                        decompressed.Write(buffer.Bytes, 0, read);
+                    }
                 }
 
                 decompressed.Seek(0, SeekOrigin.Begin);

--- a/Tests/FO-DICOM.Tests/IO/Reader/DicomReaderTest.cs
+++ b/Tests/FO-DICOM.Tests/IO/Reader/DicomReaderTest.cs
@@ -8,6 +8,7 @@ using FellowOakDicom.IO.Reader;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Text;
 using System.Threading.Tasks;
 using FellowOakDicom.Memory;
@@ -177,6 +178,115 @@ namespace FellowOakDicom.Tests.IO.Reader
                 BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(offset + 12, 4), 0xFFFFFFFFu);
             }
             return buffer;
+        }
+
+        [Fact]
+        public void Read_DeflatedDatasetInflatingBeyondTheLimit_ThrowsDicomReaderException()
+        {
+            // The whole dataset is inflated in ConvertSource before the first element is
+            // parsed, so the inflated length has to be bounded while inflating rather than
+            // checked afterwards: 64 KiB of zeroes is 78 deflated bytes here. The limit is
+            // lowered so the bound is exercised without the test allocating the default
+            // half gigabyte.
+            const long limit = 4 * 1024;
+            var source = new StreamByteSource(new MemoryStream(BuildDeflatedZeroes(64 * 1024)));
+            var reader = new DicomReader(new ArrayPoolMemoryProvider())
+            {
+                IsExplicitVR = true,
+                IsDeflated = true,
+                MaxInflatedDatasetLength = limit
+            };
+
+            var exception = Assert.Throws<DicomReaderException>(() => reader.Read(source, new MockObserver()));
+
+            Assert.Contains(limit.ToString(), exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadAsync_DeflatedDatasetInflatingBeyondTheLimit_ThrowsDicomReaderException()
+        {
+            const long limit = 4 * 1024;
+            var source = new StreamByteSource(new MemoryStream(BuildDeflatedZeroes(64 * 1024)));
+            var reader = new DicomReader(new ArrayPoolMemoryProvider())
+            {
+                IsExplicitVR = true,
+                IsDeflated = true,
+                MaxInflatedDatasetLength = limit
+            };
+
+            await Assert.ThrowsAsync<DicomReaderException>(() => reader.ReadAsync(source, new MockObserver()));
+        }
+
+        [Theory]
+        [InlineData(0, false)]  // an inflated length exactly at the limit is accepted
+        [InlineData(1, true)]   // one byte beyond it is not
+        public void Read_DeflatedDatasetAtTheLimitBoundary_BoundFiresOnlyWhenExceeded(int excess, bool boundShouldFire)
+        {
+            // Pins the inclusive/exclusive semantics of the bound: flipping > to >= in the
+            // guard, or drifting by a whole buffer, passes every other test here.
+            // The inflated bytes are zeroes and so are not parseable, which is deliberate -
+            // asserting on the bound's own message rather than on whether anything threw
+            // keeps the unrelated parse failure in the accepted case from masking a
+            // regression.
+            const int inflatedLength = 200 * 1024;
+            var limit = inflatedLength - excess;
+            var reader = new DicomReader(new ArrayPoolMemoryProvider())
+            {
+                IsExplicitVR = true,
+                IsDeflated = true,
+                MaxInflatedDatasetLength = limit
+            };
+            var source = new StreamByteSource(new MemoryStream(BuildDeflatedZeroes(inflatedLength)));
+
+            var thrown = Record.Exception(() => reader.Read(source, new MockObserver()));
+            var boundFired = thrown is DicomReaderException
+                && thrown.Message.Contains("maximum inflated length");
+
+            Assert.Equal(boundShouldFire, boundFired);
+        }
+
+        [Fact]
+        public void MaxInflatedDatasetLength_DefaultsToHalfAGibibyte()
+        {
+            // The two bound tests above inject a small limit, so without this nothing pins
+            // the value that actually ships and raising it would silently disable the guard.
+            Assert.Equal(512L * 1024 * 1024, new DicomReader(new ArrayPoolMemoryProvider()).MaxInflatedDatasetLength);
+        }
+
+        [Fact]
+        public void Open_DeflatedFileWithinTheLimit_YieldsTheIdenticalBytes()
+        {
+            // Guards the chunked inflate against truncating, reordering or duplicating
+            // data, and against the bound firing on a legitimate file. The payload is
+            // incompressible and several times the inflate buffer, so the copy loop runs
+            // multiple iterations.
+            var payload = new byte[3 * 81920];
+            new Random(20260730).NextBytes(payload);
+            var dataset = new DicomDataset
+            {
+                { DicomTag.SOPClassUID, DicomUID.SecondaryCaptureImageStorage },
+                { DicomTag.SOPInstanceUID, DicomUID.Generate() },
+                new DicomOtherByte(DicomTag.ICCProfile, payload)
+            };
+            dataset.InternalTransferSyntax = DicomTransferSyntax.DeflatedExplicitVRLittleEndian;
+
+            using var stream = new MemoryStream();
+            new DicomFile(dataset).Save(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            var reloaded = DicomFile.Open(stream);
+
+            Assert.Equal(DicomTransferSyntax.DeflatedExplicitVRLittleEndian, reloaded.Dataset.InternalTransferSyntax);
+            Assert.Equal(payload, reloaded.Dataset.GetDicomItem<DicomElement>(DicomTag.ICCProfile).Buffer.Data);
+        }
+
+        private static byte[] BuildDeflatedZeroes(int inflatedLength)
+        {
+            var compressed = new MemoryStream();
+            using (var deflater = new DeflateStream(compressed, CompressionLevel.Optimal, true))
+            {
+                deflater.Write(new byte[inflatedLength], 0, inflatedLength);
+            }
+            return compressed.ToArray();
         }
 
         #endregion


### PR DESCRIPTION
Closes #2165.

**Process note first:** `SECURITY.md` landed three days before I filed #2165, and I
missed it — it asks for private vulnerability reporting rather than a public issue or PR.
The vector is already public in #2165, so this PR does not widen exposure, but the call is
yours: if you would rather handle it as an advisory, say so and I will close both and
re-file through PVR.

## The defect

`DicomReaderWorker.Decompress` inflates a deflated dataset into a `MemoryStream` with
`Stream.CopyTo` and no bound. It is called from `ConvertSource`, i.e. before the first
element is parsed, so the inflated bytes need not be valid DICOM and no later validation is
reachable in time to reject the file.

The prior ceiling was therefore `MemoryStream`'s own, just under 2 GiB — reachable from a
file of about a megabyte. In the worst case `DicomFile.Open` **returns successfully**: no
exception for a caller to catch, and nothing that marks the input as hostile. Reachable
wherever untrusted DICOM is opened, including the C-STORE receive path
(`DicomService.GetCStoreDicomFile` -> `DicomFile.Open`).

## The change

`CopyTo` becomes a chunked copy that stops as soon as the inflated length would exceed
`DicomReader.MaxInflatedDatasetLength` (new internal property, default 512 MiB) and throws
`DicomReaderException` — same file, same exception type and the same message shape as the
`_maxSequenceDepth` guard above it.

This is the only `CompressionMode.Decompress` deflate site in `FO-DICOM.Core`.

## Measured

Same harness both times, only `Decompress` differing. .NET 8 x64 Release, peak working set
sampled every 20 ms. The exception seen by a caller of `DicomFile.Open` is
`DicomFileException` wrapping the `DicomReaderException`, as with every other reader error.

| Input on disk | before                                            | after                                   |
| ------------- | ------------------------------------------------- | --------------------------------------- |
| 1.04 MB       | 2085 MiB peak, **opens successfully**, 23.3 s     | 1210 MiB peak, throws, 1.5 s            |
| 2.09 MB       | 4067 MiB peak, `IOException: Stream was too long` | 1210 MiB peak, throws, 1.5 s            |
| 8.35 MB       | 4068 MiB peak, `IOException: Stream was too long` | 1211 MiB peak, throws, 1.5 s            |

With `DOTNET_GCHeapHardLimit` at 1.5 GiB — roughly a container with a memory limit — the
2.09 MB input raises `OutOfMemoryException` before the change and the bounded
`DicomReaderException` after it.

On the SCP side this degrades gracefully rather than aborting the association:
`DicomService` already catches the parse exception and answers C-STORE with
`ProcessingFailure`, and the message is short enough to survive the `LO` truncation of the
error comment.

## Why an absolute limit and not a compression ratio

A ratio cap looks like the natural fit and cannot work here. The crafted files and a
legitimate all-zero volume compress **identically**, both at 1029:1, because both sit on
DEFLATE's ceiling (a 258-byte match per ~2 bits — 64 MiB of zeroes compresses 1028.8:1).
There is no ratio that admits the one and rejects the other.

Ratio is also the wrong quantity: the harm is an absolute allocation. For what it is worth,
the deflated fixtures already in this repo span a wide range on their own — `GH227.dcm`
inflates 61:1 and `Tests/FO-DICOM.Benchmark/Data/Deflated.dcm` 1.16:1.

Peak memory lands around 2.4x the limit rather than 1x because `MemoryStream` grows by
doubling and copying and the superseded buffers are garbage not yet collected; the live set
is bounded by the limit. Decoupling peak from the limit would mean not buffering the
inflated dataset in one contiguous `MemoryStream`, which seemed like a separate change.

## Tests

In `DicomReaderTest`, next to the existing depth-guard tests:

- `Read_DeflatedDatasetInflatingBeyondTheLimit_ThrowsDicomReaderException` and its
  `ReadAsync` twin — both fail against `CopyTo`, verified by reverting just that line.
- `Read_DeflatedDatasetAtTheLimitBoundary_BoundFiresOnlyWhenExceeded` — pins that exactly
  the limit is accepted and one byte more is not. Verified to fail when `>` is changed to
  `>=`.
- `MaxInflatedDatasetLength_DefaultsToHalfAGibibyte` — pins the shipped value, since the
  tests above inject a small limit and would otherwise all pass with the guard effectively
  disabled.
- `Open_DeflatedFileWithinTheLimit_YieldsTheIdenticalBytes` — an incompressible payload
  several times the copy buffer, round-tripped through Deflated Explicit VR LE and compared
  byte for byte, so a truncating or duplicating copy loop fails here.

## Open questions

1. **This is a deliberate narrowing, not purely a new bound**, and it is the part I would
   most like your read on. The effective ceiling moves from ~2 GiB to 512 MiB, so a
   legitimate deflated instance inflating into that gap now throws where it previously
   opened. PS3.5 puts no SOP-class restriction on Deflated Explicit VR LE, so such
   instances are possible even if I have not seen one. Is 512 MiB right, or would you
   rather sit closer to the old ceiling?
2. **No escape hatch.** `MaxInflatedDatasetLength` is internal and every construction site
   is inside the library, so in production the value is always the default; the setter
   exists so the bound can be tested without allocating half a gigabyte in CI. That
   matches `_maxSequenceDepth`, which is also unconfigurable — but if you would rather this
   were reachable, the natural place looks like a parameter alongside `largeObjectSize` on
   `DicomFile.Open`, which is a larger change I am happy to make instead.
3. The chunked copy gives up `DeflateStream`'s `CopyTo` override, which inflates straight
   into the destination. A small write-bounded wrapper stream would keep both that
   optimisation and the bound at the cost of ~20 lines of `Stream` boilerplate — worth it?

I will append the `ChangeLog.md` entry once this has a number, as with #2149.
